### PR TITLE
Fix indentation error in dividend_stock fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,18 +59,6 @@ def _reset_graph():
 
 @pytest.fixture
 def dividend_stock():
-return Equity(
-        id="DIV_STOCK",
-        symbol="DIVS",
-        name="Dividend Stock",
-        asset_class=AssetClass.EQUITY,
-        sector="Utilities",
-        price=100.0,
-        market_cap=1e10,
-        pe_ratio=15.0,
-        dividend_yield=0.04,
-        earnings_per_share=6.67,
-    )
     return Equity(
         id="DIV_STOCK",
         symbol="DIVS",


### PR DESCRIPTION
## Summary
- remove the stray unindented return statement from the `dividend_stock` fixture so the test suite can be collected

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69178a207ca083248fb2d446c45f4e6e)

## Summary by Sourcery

Bug Fixes:
- Remove stray unindented return in dividend_stock fixture to ensure proper fixture setup

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the indentation error in the dividend_stock pytest fixture. Removes a stray unindented return so tests collect and the fixture initializes correctly.

<sup>Written for commit 4098c509f40effe908a0b7f5280addee98fc420b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

