### PR TITLE
Add review plan for gitauto issue 133 branch

### DIFF
--- a/branch_reviews/gitauto-issue-133-review.md
+++ b/branch_reviews/gitauto-issue-133-review.md
@@ -1,0 +1,37 @@
+# Review: `gitauto/issue-133-20251112-094229-rqAp`
+
+## Status Summary
+- The branch is reported as **630 commits ahead of `main`** but only has changes across two files.
+- The branch reference is **not present in the current local repository snapshot**, so its commits are unavailable for direct inspection.
+
+## Recommended Merge Validation Steps
+1. **Fetch the branch from the remote**
+   ```bash
+   git fetch origin gitauto/issue-133-20251112-094229-rqAp
+   git checkout gitauto/issue-133-20251112-094229-rqAp
+   ```
+   Confirm the branch tip by running `git status -sb` and `git log --oneline --decorate -5`.
+
+2. **Inspect the branch diff against `main`**
+   ```bash
+   git diff --stat origin/main..HEAD
+   git diff origin/main..HEAD
+   ```
+   Pay particular attention to the two modified files to verify their intent and ensure they align with current project conventions.
+
+3. **Verify compatibility with `main`**
+   - Rebase or merge the latest `main` into the branch if it has diverged.
+   - Resolve any conflicts locally and run the full test suite (`make test`, `pytest`, or other project-specific checks).
+
+4. **Code review focus areas**
+   - Confirm the two touched files have necessary tests or documentation updates.
+   - Check for dependency or configuration drift that could arise from the 630 intermediate commits.
+   - Ensure formatting and linting rules are satisfied (`make lint`, `make format-check`, or equivalent).
+
+5. **Prepare the merge**
+   - Update PR description with a concise summary of the changes, highlighting why only two files changed despite the long commit history.
+   - Request reviews from relevant code owners or subject-matter experts for those files.
+   - Confirm CI pipelines pass on the branch head.
+
+## Merge Recommendation
+Until the branch is fetched and validated locally, **do not merge**. The discrepancy between the large commit divergence and the small change set warrants double-checking that the branch was created from the correct base and that no required work was dropped. Once the above steps show a clean diff, passing tests, and up-to-date branch base, merging into `main` should be safe.


### PR DESCRIPTION
## Summary
- add a review note describing how to validate branch `gitauto/issue-133-20251112-094229-rqAp`
- capture recommended git commands and checks before merging back to main

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917a191971c8324bf28a69f59377979)

## Summary by Sourcery

Documentation:
- Add a detailed branch review plan file outlining validation steps, review focus areas, and merge recommendations for the gitauto/issue-133 branch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a branch review plan for gitauto/issue-133-20251112-094229-rqAp, with clear git commands and checks to validate the branch before merging into main. Calls out the large commit divergence vs small change set and advises holding merge until local validation passes.

<sup>Written for commit 22339db501347eefdc651b4a953c228207228b48. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

