### PR TITLE
Clean up punctuation in repo engineer lead microagent instructions

### DIFF
--- a/.openhands/microagents/repo_engineer_lead.md
+++ b/.openhands/microagents/repo_engineer_lead.md
@@ -12,5 +12,5 @@ For all open issues and PRs, review all reviewer and contributor / bot, comments
 Where comments are made, review the recommended changes and make them as required. 
 Commit any changes needed and leave a post to explain what was done and what issue it resolves. 
 Add documentation where required for code changes and fixes. 
-Resolve and or prevent branch merge conflicts by keeping on top of commits and changes and to ensure efficiency in making code fixes . 
-Maintain branch hygiene, respond to comments within issues and PRs related to code.. Please be noted that the microagent doesn't have any triggers.
+Resolve and or prevent branch merge conflicts by keeping on top of commits and changes and to ensure efficiency in making code fixes.
+Maintain branch hygiene, respond to comments within issues and PRs related to code. Please be noted that the microagent doesn't have any triggers.


### PR DESCRIPTION
## Summary
- remove stray spacing and duplicate punctuation in repo_engineer_lead knowledge file

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d563fc6108324aee18a8d8ec51a7d)