### PR TITLE
Allow rendering node-only network visualizations

### DIFF
--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -20,9 +20,22 @@ jest.mock('react-plotly.js', () => {
 });
 
 describe('NetworkVisualization Component', () => {
-  it('should show empty data message when nodes or edges are missing', () => {
+  it('should show empty data message when nodes are missing', () => {
     render(<NetworkVisualization data={{ nodes: [], edges: [] }} />);
-    expect(screen.getByText('Visualization data is missing nodes or edges.')).toBeInTheDocument();
+    expect(screen.getByText('Visualization data is missing nodes.')).toBeInTheDocument();
+  });
+
+  it('should render node-only data without showing an empty message', async () => {
+    const nodeOnlyData: VisualizationData = {
+      nodes: mockVisualizationData.nodes,
+      edges: [],
+    };
+
+    render(<NetworkVisualization data={nodeOnlyData} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('mock-plot')).toBeInTheDocument();
+    });
   });
 
   it('should render plot with data', async () => {
@@ -61,7 +74,7 @@ describe('NetworkVisualization Component', () => {
     };
 
     rerender(<NetworkVisualization data={newData} />);
-    expect(screen.getByText('Visualization data is missing nodes or edges.')).toBeInTheDocument();
+    expect(screen.getByText('Visualization data is missing nodes.')).toBeInTheDocument();
   });
 
   it('should show a helpful message when dataset is too large', () => {

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -55,10 +55,10 @@ const [plotData, setPlotData] = useState<(EdgeTrace | NodeTrace)[]>([]);
     const nodes = Array.isArray(data.nodes) ? data.nodes : [];
     const edges = Array.isArray(data.edges) ? data.edges : [];
 
-    if (nodes.length === 0 || edges.length === 0) {
+    if (nodes.length === 0) {
       setPlotData([]);
       setStatus('empty');
-      setMessage('Visualization data is missing nodes or edges.');
+      setMessage('Visualization data is missing nodes.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- adjust network visualization to render when nodes exist even without edges
- clarify empty-state message for missing nodes and keep safety checks
- add unit coverage ensuring node-only input renders the plot

## Testing
- npm test -- NetworkVisualization.test.tsx

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d57a61e6483249b927b1edbdba55c)