### PR TITLE
fix: break circular import between database, repository, and db_models

### DIFF
--- a/src/data/base.py
+++ b/src/data/base.py
@@ -1,0 +1,5 @@
+"""SQLAlchemy declarative base shared across ORM models and database helpers."""
+
+from sqlalchemy.orm import declarative_base
+
+Base = declarative_base()

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -6,14 +6,14 @@ import os
 
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
-from sqlalchemy.orm import Session, declarative_base, sessionmaker
+from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
+
+from .base import Base  # noqa: F401 – re-exported for backward compatibility
 
 # Canonical transaction helper lives in repository.py per tech spec.
 # Re-export here for backward compatibility with older imports.
 from .repository import session_scope  # noqa: F401
-
-Base = declarative_base()
 
 DEFAULT_DATABASE_URL = os.getenv(
     "ASSET_GRAPH_DATABASE_URL",

--- a/src/data/db_models.py
+++ b/src/data/db_models.py
@@ -7,7 +7,7 @@ from typing import List
 from sqlalchemy import Boolean, Float, ForeignKey, Integer, String, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from .database import Base
+from .base import Base
 
 # ---------------------------------------------------------------------------
 # Foreign key target constants (avoid duplicated string literals – Sonar S1192)


### PR DESCRIPTION
## **User description**
## Summary

- Introduces `src/data/base.py` to own the SQLAlchemy `declarative_base()` / `Base`
- Updates `db_models.py` to import `Base` from `base.py` instead of `database.py`
- Updates `database.py` to import `Base` from `base.py` (still re-exports it for backward compat)

This breaks the cycle:
```
database.py → repository.py → db_models.py → database.py  ❌ (circular)
```
Becomes:
```
database.py → base.py  ✓
database.py → repository.py → db_models.py → base.py  ✓
```

All existing callers that import `Base` or `session_scope` from `src.data.database` continue to work unchanged.

## Root cause

Identified in PR #887 CI: `conftest.py` triggered a full import of `src.data.database`, which re-exported `session_scope` from `repository.py`, which imported `db_models.py`, which imported `Base` from the partially-initialised `database.py` — raising `ImportError: cannot import name 'Base' from partially initialized module`.

## Test plan
- [x] `python -c "from src.data.database import Base, session_scope"` passes
- [x] `python -c "from src.data.db_models import AssetORM"` passes
- [x] `python -c "import conftest"` passes
- [ ] Full pytest suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved the SQLAlchemy Base to src/data/base.py to break a circular import between database, repository, and db_models that caused an ImportError during test discovery. database.py now imports and re-exports Base so existing imports keep working.

- **Bug Fixes**
  - Broke the cycle by introducing base.py for the declarative Base.
  - Updated db_models.py to import Base from base.py; database.py no longer defines Base.
  - Resolves ImportError from partially initialized database when pytest loads conftest.

<sup>Written for commit d3e8a794dbba46129a6acbc88c76c044192e2601. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/891">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Break circular import so test discovery and model imports no longer fail

### What Changed
- Moved the SQLAlchemy declarative Base to a dedicated module so importing ORM models no longer triggers a circular import and ImportError during test discovery
- database module now re-exports Base and the session helper so existing imports continue to work unchanged
- Importing models or loading test fixtures (e.g., importing conftest) succeeds where it previously raised an ImportError

### Impact
`✅ Fewer test discovery failures`
`✅ Can import ORM models during test setup`
`✅ Existing imports of Base and session helper keep working`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
