### PR TITLE
docs: replace literal git conflict markers in MERGE_CONFLICT_RESOLUTION.md

### DIFF
--- a/MERGE_CONFLICT_RESOLUTION.md
+++ b/MERGE_CONFLICT_RESOLUTION.md
@@ -8,15 +8,15 @@
 
 ## Issue Encountered
 
-After the initial merge of PR #181 (patch branch), a merge conflict marker was discovered in `bandit-report.json`:
+After the initial merge of PR #181 (patch branch), conflict marker text was discovered in `bandit-report.json`:
 
 ```json
   "results": []
-<<<<<<< HEAD
+CONFLICT_MARKER_START
 }
-=======
+CONFLICT_MARKER_MID
 }
->>>>>>> patch
+CONFLICT_MARKER_END
 ```
 
 This conflict marker was left unresolved during the automated conflict resolution process.
@@ -110,8 +110,7 @@ git commit -m "Fix merge conflict in bandit-report.json"
    ```bash
    # Search for conflict markers
    git diff --check
-   grep -r "<<<<<<< HEAD" .
-   grep -r ">>>>>>> " .
+   grep -r -e "CONFLICT_MARKER_START" -e "CONFLICT_MARKER_MID" -e "CONFLICT_MARKER_END" .
    ```
 
 3. **Validate all file types**
@@ -151,12 +150,12 @@ git add -A
 echo "Validating conflict resolution..."
 
 # Check for merge markers
-if grep -r "<<<<<<< HEAD" . --exclude-dir=.git; then
+if grep -r "CONFLICT_MARKER_START" . --exclude-dir=.git; then
     echo "❌ ERROR: Merge conflict markers found!"
     exit 1
 fi
 
-if grep -r ">>>>>>> " . --exclude-dir=.git; then
+if grep -r "CONFLICT_MARKER_END" . --exclude-dir=.git; then
     echo "❌ ERROR: Merge conflict markers found!"
     exit 1
 fi


### PR DESCRIPTION
## **User description**
### **User description**
## Summary

- `MERGE_CONFLICT_RESOLUTION.md` contained literal `<<<<<<< HEAD` / `=======` / `>>>>>>> patch` strings inside a code fence (illustrating a past conflict resolution)
- These strings caused the `check-merge-conflict` pre-commit hook to flag the file on every commit to `main`
- Replaces the three markers with `CONFLICT_MARKER_START` / `CONFLICT_MARKER_MID` / `CONFLICT_MARKER_END` placeholders so the document remains illustrative without tripping the hook

Closes #790 (the PR this salvages the doc fix from; that PR was closed because its code changes were anti-Black formatting regressions).

## Test plan

- [ ] Verify pre-commit `check-merge-conflict` hook passes on this branch
- [ ] Confirm document still reads correctly as documentation of past conflict resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Replaced literal conflict markers in `MERGE_CONFLICT_RESOLUTION.md` to avoid triggering pre-commit hooks.
- Introduced placeholders for better documentation clarity.
- Ensured the document remains illustrative of past conflict resolutions.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MERGE_CONFLICT_RESOLUTION.md</strong><dd><code>Update conflict markers in MERGE_CONFLICT_RESOLUTION.md</code>&nbsp; &nbsp; </dd></summary>
<hr>

MERGE_CONFLICT_RESOLUTION.md
<li>Replaced literal git conflict markers with placeholders.<br> <li> Updated conflict resolution examples to use <code>CONFLICT_MARKER_START</code>, <br><code>CONFLICT_MARKER_MID</code>, and <code>CONFLICT_MARKER_END</code>.<br> <li> Adjusted grep commands in examples to search for new placeholders.<br>


</details>


  </td>
  <td><a href="https://github.com/DashFin-FarDb/financial-asset-relationship-db/pull/924/files#diff-6a6abd0f2719d03dd16d0e51d4ca1329b385c8324141f665170b9d27bb8a0223">+7/-8</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced literal Git conflict markers in MERGE_CONFLICT_RESOLUTION.md with safe placeholders so the pre-commit check-merge-conflict hook no longer flags the docs. The doc still shows the conflict example without breaking checks.

- **Bug Fixes**
  - Swapped <<<<<<< HEAD / ======= / >>>>>>> with CONFLICT_MARKER_START / MID / END in the JSON snippet.
  - Updated grep and validation examples to search for placeholders instead of real conflict markers.

<sup>Written for commit 8b23a8cacf7e23dc7abef6e2d40ef13a40a2c899. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/924">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Replace literal git conflict markers in documentation to avoid triggering hooks**

### What Changed
- Replaced literal "<<<<<<< HEAD", "=======", and ">>>>>>> patch" strings in MERGE_CONFLICT_RESOLUTION.md with CONFLICT_MARKER_START / CONFLICT_MARKER_MID / CONFLICT_MARKER_END so the example no longer contains actual conflict markers
- Updated repository search and validation examples to look for the new placeholder markers instead of the real conflict markers
- Prevents the pre-commit check that scans for conflict markers from flagging this documentation file

### Impact
`✅ Fewer pre-commit failures on main`
`✅ Documentation examples remain illustrative without blocking commits`
`✅ Shorter commit cycles by avoiding false-positive conflict checks`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
