### PR TITLE
feat(frontend): apply additive Jest improvements from PR #339

### DIFF
--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -17,8 +17,17 @@ const customJestConfig = {
     'app/**/*.{js,jsx,ts,tsx}',
     '!app/**/*.d.ts',
     '!app/**/_*.{js,jsx,ts,tsx}',
+    '!app/**/*.stories.{js,jsx,ts,tsx}',
     '!**/node_modules/**'
-  ]
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 50,
+      functions: 50,
+      lines: 50,
+      statements: 50
+    }
+  }
 }
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,6 +1,16 @@
 // Learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
 
+// Provide default environment values used throughout the app so tests
+// do not fail due to a missing NEXT_PUBLIC_API_URL/NEXT_PUBLIC_API_BASE_URL.
+const defaultApiBaseUrl =
+  process.env.NEXT_PUBLIC_API_URL ||
+  process.env.NEXT_PUBLIC_API_BASE_URL ||
+  'http://localhost:8000'
+
+process.env.NEXT_PUBLIC_API_URL = defaultApiBaseUrl
+process.env.NEXT_PUBLIC_API_BASE_URL = defaultApiBaseUrl
+
 /**
  * Creates a mock matchMedia function for testing.
  * @param {Object} [options] Configuration options.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.1.5",
+    "@types/jest": "^29.5.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.1",
     "@types/node": "^20.19.28",


### PR DESCRIPTION
## **User description**
### **User description**
## Summary

Cherry-picks the net-positive changes from PR #339 that were absent from `main`, without regressing the more complete browser-mock implementations already present.

| File | Change |
|------|--------|
| `frontend/jest.config.js` | Add 50% global `coverageThreshold` (branches/functions/lines/statements); exclude `*.stories.*` from coverage |
| `frontend/jest.setup.js` | Set `NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_API_BASE_URL` defaults so tests don't fail when env vars are absent |
| `frontend/package.json` | Add `@types/jest ^29.5.0` for TypeScript test type support |

## What was intentionally NOT applied from PR #339

| Change | Reason skipped |
|--------|---------------|
| Module alias `<rootDir>/app/$1` | Conflicts with `tsconfig.json` which maps `@/*` → `./*`; current `<rootDir>/$1` is correct |
| Simplified matchMedia / IntersectionObserver mocks | `main`'s implementation is more complete (listener tracking, `triggerCallback`, `afterEach` reset) |
| Removal of `@testing-library/jest-dom`, `react`, `user-event` | Still required by the existing test suite |

## Test plan

- [x] `frontend/jest.config.js` is valid JS (no syntax errors)
- [x] `frontend/package.json` is valid JSON
- [x] `frontend/jest.setup.js` preserves all existing mocks, only prepends env defaults

Closes / supersedes the additive parts of #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **Description**
- Enhanced Jest configuration by adding a global `coverageThreshold` of 50% for branches, functions, lines, and statements.
- Updated Jest setup to provide default values for `NEXT_PUBLIC_API_URL` and `NEXT_PUBLIC_API_BASE_URL`, preventing test failures due to missing environment variables.
- Added `@types/jest` to `package.json` for improved TypeScript support in tests.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>jest.config.js</strong><dd><code>Enhance Jest Configuration with Coverage Thresholds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/jest.config.js
<li>Added global <code>coverageThreshold</code> for branches, functions, lines, and <br>statements.<br> <li> Excluded <code>*.stories.*</code> files from coverage collection.<br>


</details>


  </td>
  <td><a href="https://github.com/DashFin-FarDb/financial-asset-relationship-db/pull/927/files#diff-64b6af65ba015c0cadc7c871d90a22800edf7316d4ff12361be6af9c8607efa3">+10/-1</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>jest.setup.js</strong><dd><code>Improve Jest Setup with Default Environment Variables</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/jest.setup.js
<li>Set default values for <code>NEXT_PUBLIC_API_URL</code> and <br><code>NEXT_PUBLIC_API_BASE_URL</code>.<br> <li> Ensured tests do not fail when environment variables are absent.<br>


</details>


  </td>
  <td><a href="https://github.com/DashFin-FarDb/financial-asset-relationship-db/pull/927/files#diff-5eeb461cfab3d3b569d637add6bf89a9326afbce6cef4ad7ed722fc7cc4997cf">+10/-0</a>&nbsp; &nbsp; </td>
</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update Package Dependencies for TypeScript Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/package.json
- Added `@types/jest` for TypeScript test type support.



</details>


  </td>
  <td><a href="https://github.com/DashFin-FarDb/financial-asset-relationship-db/pull/927/files#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>
</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **Penify usage**:
>Comment `/help` on the PR to get a list of all available Penify tools and their descriptions


___

## **CodeAnt-AI Description**
**Provide default API envs for tests, enforce 50% Jest coverage, and add Jest types**

### What Changed
- Tests now set default NEXT_PUBLIC_API_URL and NEXT_PUBLIC_API_BASE_URL to http://localhost:8000 when those env vars are not present, preventing failures caused by missing API environment variables.
- Jest coverage excludes story files and enforces a global 50% minimum for branches, functions, lines, and statements, causing CI to fail if coverage drops below this threshold.
- Adds @types/jest as a dev dependency so TypeScript-aware test tooling and editors recognize Jest types.

### Impact
`✅ Prevents test failures caused by missing API env vars`
`✅ Enforces minimum test coverage in CI (50%)`
`✅ Better TypeScript support when writing tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
