### PR TITLE
Fix regex pattern for file dependency entries

### DIFF
--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -451,9 +451,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith("\\"), (
-                        "File section should have dependency information"
-                    )
+                    assert has_deps or section.strip().startswith(
+                        "\\"
+                    ), "File section should have dependency information"
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -535,9 +535,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert "## Project Structure" in system_manifest_content, (
-            "## Project Structure section not found in system manifest"
-        )
+        assert (
+            "## Project Structure" in system_manifest_content
+        ), "## Project Structure section not found in system manifest"
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -615,9 +615,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                )
+                assert (
+                    dm_has == sm_has
+                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
 
 
 @pytest.mark.unit
@@ -775,9 +775,9 @@ class TestChangedFunctionLogic:
         allowed_extras = {"jsx", "json", "md"}
         found_types = set(file_types_str.split(", "))
         # Mirrors the assertion at line 128 exactly
-        assert found_types.issubset(expected_types | allowed_extras), (
-            f"Unexpected file types: {found_types - expected_types}"
-        )
+        assert found_types.issubset(
+            expected_types | allowed_extras
+        ), f"Unexpected file types: {found_types - expected_types}"
 
     @pytest.mark.parametrize(
         "file_types_str",
@@ -806,9 +806,10 @@ class TestChangedFunctionLogic:
     # 2. Updated regex pattern (line 428)                                  #
     # ------------------------------------------------------------------ #
 
-    FILE_HEADER_REGEX = r"###\s+\\[\w\\/._-]+\.\w+"
-  @pytest.mark.parametrize(
-       "header",
+    FILE_HEADER_REGEX = r"###\s+\\[\w\\/.-]+\.\w+"
+
+    @pytest.mark.parametrize(
+        "header",
         [
             r"### \src\main.py",
             r"### \src\utils\helper.ts",
@@ -818,8 +819,8 @@ class TestChangedFunctionLogic:
             r"### \path\file-name.py",
             r"### \path\file.name.with.dots.py",
         ],
-       )
-   def test_file_header_regex_matches_valid_paths(self, header):
+    )
+    def test_file_header_regex_matches_valid_paths(self, header):
         """Updated regex matches valid file headers with common path characters."""
         assert re.search(self.FILE_HEADER_REGEX, header) is not None, f"Regex should match: {header!r}"
 
@@ -942,14 +943,14 @@ class TestChangedFunctionLogic:
         if dm_has or sm_has:
             if should_assert:
                 with pytest.raises(AssertionError) as exc_info:
-                    assert dm_has == sm_has, (
-                        f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                    )
+                    assert (
+                        dm_has == sm_has
+                    ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
                 assert dep in str(exc_info.value)
             else:
-                assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                )
+                assert (
+                    dm_has == sm_has
+                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
 
     def test_dependency_consistency_skips_when_neither_document_has_dep(self):
         """When neither dm_has nor sm_has is True the check is skipped entirely."""
@@ -977,9 +978,9 @@ class TestChangedFunctionLogic:
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = {"py", "rs", "go"}
         with pytest.raises(AssertionError) as exc_info:
-            assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
-                f"Unexpected file types: {found_types - expected_types}"
-            )
+            assert found_types.issubset(
+                expected_types | {"jsx", "json", "md"}
+            ), f"Unexpected file types: {found_types - expected_types}"
         error_text = str(exc_info.value)
         # Both unexpected types must appear in the message
         unexpected = found_types - expected_types
@@ -999,9 +1000,9 @@ class TestChangedFunctionLogic:
         dm_has = False
         sm_has = True
         with pytest.raises(AssertionError) as exc_info:
-            assert dm_has == sm_has, (
-                f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-            )
+            assert (
+                dm_has == sm_has
+            ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
         assert dep in str(exc_info.value)
 
     def test_assertion_message_file_section_missing_dep_info(self):

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -425,7 +425,7 @@ class TestSystemManifest:
             system_manifest_content(str): Full markdown text of the system manifest to inspect.
         """
         # Look for file dependency entries like: ### \path\to\file.py
-        file_pattern = r"###\s+\\[\w\\/.-]+\.\w+"
+        file_pattern = r"###\s+\\[\\\w/.-]+\.\w+"
         matches = re.findall(file_pattern, system_manifest_content)
 
         # If there are file entries, they should be properly formatted

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -858,13 +858,11 @@ class TestChangedFunctionLogic:
         for match in matches:
             assert "\\" in match or "/" in match, f"File path should have proper separators: {match}"
 
-    def test_old_and_new_regex_are_functionally_equivalent_for_underscore(self):
-        """Confirm the regex change is non-breaking: both old and new match underscore paths."""
-        old_pattern = r"###\s+\\[\w\\/._-]+\.\w+"
-        new_pattern = r"###\s+\\[\w\\/.-]+\.\w+"
+    def test_regex_still_matches_underscore_paths(self):
+        """Confirm underscore paths still match after simplifying the character class."""
+        pattern = r"###\s+\\[\w\\/.-]+\.\w+"
         header_with_underscore = r"### \src\my_module\test_utils.py"
-        assert re.search(old_pattern, header_with_underscore) is not None
-        assert re.search(new_pattern, header_with_underscore) is not None
+        assert re.search(pattern, header_with_underscore) is not None
 
     # ------------------------------------------------------------------ #
     # 3. Dependency-entry content condition (lines 452-457)                #

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -125,9 +125,9 @@ class TestDependencyMatrix:
         # Common expected file types
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = set(file_types)
-        assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
-            f"Unexpected file types: {found_types - expected_types}"
-        )
+        assert found_types.issubset(
+            expected_types | {"jsx", "json", "md"}
+        ), f"Unexpected file types: {found_types - expected_types}"
 
     def test_dependency_matrix_has_file_type_distribution(self, dependency_matrix_content):
         """Test that dependencyMatrix.md has File Type Distribution section."""
@@ -452,9 +452,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith("\\"), (
-                        "File section should have dependency information"
-                    )
+                    assert has_deps or section.strip().startswith(
+                        "\\"
+                    ), "File section should have dependency information"
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -536,9 +536,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert "## Project Structure" in system_manifest_content, (
-            "## Project Structure section not found in system manifest"
-        )
+        assert (
+            "## Project Structure" in system_manifest_content
+        ), "## Project Structure section not found in system manifest"
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -616,9 +616,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                )
+                assert (
+                    dm_has == sm_has
+                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -807,7 +807,7 @@ class TestChangedFunctionLogic:
     # 2. Updated regex pattern (line 428)                                  #
     # ------------------------------------------------------------------ #
 
-    FILE_HEADER_REGEX = r"###\s+\\[\w\\/.-]+\.\w+"
+FILE_HEADER_REGEX = r"###\s+\\[\w/._-]+\.\w+"
 
     @pytest.mark.parametrize(
         "header",

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -807,10 +807,11 @@ class TestChangedFunctionLogic:
     # 2. Updated regex pattern (line 428)                                  #
     # ------------------------------------------------------------------ #
 
+
 FILE_HEADER_REGEX = r"###\s+\\[\w/._-]+\.\w+"
 
-    @pytest.mark.parametrize(
-        "header",
+  @pytest.mark.parametrize(
+       "header",
         [
             r"### \src\main.py",
             r"### \src\utils\helper.ts",
@@ -820,8 +821,8 @@ FILE_HEADER_REGEX = r"###\s+\\[\w/._-]+\.\w+"
             r"### \path\file-name.py",
             r"### \path\file.name.with.dots.py",
         ],
-    )
-    def test_file_header_regex_matches_valid_paths(self, header):
+       )
+   def test_file_header_regex_matches_valid_paths(self, header):
         """Updated regex matches valid file headers with common path characters."""
         assert re.search(self.FILE_HEADER_REGEX, header) is not None, f"Regex should match: {header!r}"
 

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -125,9 +125,9 @@ class TestDependencyMatrix:
         # Common expected file types
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = set(file_types)
-        assert found_types.issubset(
-            expected_types | {"jsx", "json", "md"}
-        ), f"Unexpected file types: {found_types - expected_types}"
+        assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
+            f"Unexpected file types: {found_types - expected_types}"
+        )
 
     def test_dependency_matrix_has_file_type_distribution(self, dependency_matrix_content):
         """Test that dependencyMatrix.md has File Type Distribution section."""
@@ -452,9 +452,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith(
-                        "\\"
-                    ), "File section should have dependency information"
+                    assert has_deps or section.strip().startswith("\\"), (
+                        "File section should have dependency information"
+                    )
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -536,9 +536,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert (
-            "## Project Structure" in system_manifest_content
-        ), "## Project Structure section not found in system manifest"
+        assert "## Project Structure" in system_manifest_content, (
+            "## Project Structure section not found in system manifest"
+        )
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -616,9 +616,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert (
-                    dm_has == sm_has
-                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
 
 
 @pytest.mark.unit

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -451,9 +451,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith("\\"), (
-                        "File section should have dependency information"
-                    )
+                    assert has_deps or section.strip().startswith(
+                        "\\"
+                    ), "File section should have dependency information"
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -535,9 +535,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert "## Project Structure" in system_manifest_content, (
-            "## Project Structure section not found in system manifest"
-        )
+        assert (
+            "## Project Structure" in system_manifest_content
+        ), "## Project Structure section not found in system manifest"
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -615,9 +615,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                )
+                assert (
+                    dm_has == sm_has
+                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
 
 
 @pytest.mark.unit
@@ -775,9 +775,9 @@ class TestChangedFunctionLogic:
         allowed_extras = {"jsx", "json", "md"}
         found_types = set(file_types_str.split(", "))
         # Mirrors the assertion at line 128 exactly
-        assert found_types.issubset(expected_types | allowed_extras), (
-            f"Unexpected file types: {found_types - expected_types}"
-        )
+        assert found_types.issubset(
+            expected_types | allowed_extras
+        ), f"Unexpected file types: {found_types - expected_types}"
 
     @pytest.mark.parametrize(
         "file_types_str",
@@ -941,14 +941,14 @@ class TestChangedFunctionLogic:
         if dm_has or sm_has:
             if should_assert:
                 with pytest.raises(AssertionError) as exc_info:
-                    assert dm_has == sm_has, (
-                        f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                    )
+                    assert (
+                        dm_has == sm_has
+                    ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
                 assert dep in str(exc_info.value)
             else:
-                assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-                )
+                assert (
+                    dm_has == sm_has
+                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
 
     def test_dependency_consistency_skips_when_neither_document_has_dep(self):
         """When neither dm_has nor sm_has is True the check is skipped entirely."""
@@ -976,9 +976,9 @@ class TestChangedFunctionLogic:
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = {"py", "rs", "go"}
         with pytest.raises(AssertionError) as exc_info:
-            assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
-                f"Unexpected file types: {found_types - expected_types}"
-            )
+            assert found_types.issubset(
+                expected_types | {"jsx", "json", "md"}
+            ), f"Unexpected file types: {found_types - expected_types}"
         error_text = str(exc_info.value)
         # Both unexpected types must appear in the message
         unexpected = found_types - expected_types
@@ -998,9 +998,9 @@ class TestChangedFunctionLogic:
         dm_has = False
         sm_has = True
         with pytest.raises(AssertionError) as exc_info:
-            assert dm_has == sm_has, (
-                f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
-            )
+            assert (
+                dm_has == sm_has
+            ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
         assert dep in str(exc_info.value)
 
     def test_assertion_message_file_section_missing_dep_info(self):

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -425,7 +425,7 @@ class TestSystemManifest:
             system_manifest_content(str): Full markdown text of the system manifest to inspect.
         """
         # Look for file dependency entries like: ### \path\to\file.py
-        file_pattern = r"###\s+\\[\\\w/.-]+\.\w+"
+        file_pattern = r"###\s+\\[\w\\/.-]+\.\w+"
         matches = re.findall(file_pattern, system_manifest_content)
 
         # If there are file entries, they should be properly formatted
@@ -700,3 +700,348 @@ class TestDocumentationRealisticContent:
                 if " " not in dep:
                     # Valid package name format
                     assert re.match(r"^[@\w\.\-/]+$", dep), f"Dependency '{dep}' doesn't look like a valid package name"
+
+
+@pytest.mark.unit
+class TestChangedFunctionLogic:
+    """Tests for the logic in functions modified by this PR.
+
+    All PR changes were formatting-only (Black style) except the regex in
+    test_system_manifest_file_dependency_format. These tests exercise the
+    assertion conditions and the updated regex pattern using synthetic content
+    to confirm correct behaviour independently of the real documentation files.
+    """
+
+    # ------------------------------------------------------------------ #
+    # Helpers / synthetic content factories                                #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _make_dep_matrix(file_types_line: str) -> str:
+        """Return a minimal dependency-matrix document with the given file-types line."""
+        return (
+            "# Dependency Matrix\n"
+            "*Generated: 2025-01-01T00:00:00.000Z*\n"
+            "## Summary\n"
+            "- Files analyzed: 10\n"
+            f"- File types: {file_types_line}\n"
+            "## File Type Distribution\n"
+            "- 10 py files\n"
+            "## Key Dependencies by Type\n"
+            "### PY\n"
+            "Top dependencies:\n"
+            "- pytest\n"
+        )
+
+    @staticmethod
+    def _make_system_manifest(extra_content: str = "") -> str:
+        """Return a minimal system-manifest document."""
+        return (
+            "# System Manifest\n"
+            "## Project Overview\n"
+            "- Name: TestProject\n"
+            "- Description: A test project\n"
+            "- Created: 2025-01-01T00:00:00.000Z\n"
+            "## Current Phase\n"
+            "- Current Phase: development\n"
+            "- Last Updated: 2025-01-01T00:00:00.000Z\n"
+            "## Project Structure\n"
+            "- 10 py files\n"
+            "## Dependencies\n"
+            "## Project Directory Structure\n"
+            "📂 src\n"
+            "  📄 main.py\n"
+            "## PY Dependencies\n"
+            + extra_content
+        )
+
+    # ------------------------------------------------------------------ #
+    # 1. file-type subset assertion (lines 126-130)                        #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "file_types_str",
+        [
+            "py",
+            "py, js",
+            "py, js, ts, tsx",
+            "py, jsx",
+            "py, json",
+            "py, md",
+            "py, js, ts, tsx, jsx, json, md",
+        ],
+    )
+    def test_file_types_subset_passes_for_allowed_types(self, file_types_str):
+        """found_types that are a subset of the allowed set should pass the assertion."""
+        expected_types = {"py", "js", "ts", "tsx"}
+        allowed_extras = {"jsx", "json", "md"}
+        found_types = set(file_types_str.split(", "))
+        # Mirrors the assertion at line 128 exactly
+        assert found_types.issubset(expected_types | allowed_extras), (
+            f"Unexpected file types: {found_types - expected_types}"
+        )
+
+    @pytest.mark.parametrize(
+        "file_types_str",
+        [
+            "py, unknown",
+            "rb",
+            "py, go, ts",
+        ],
+    )
+    def test_file_types_subset_fails_for_unexpected_types(self, file_types_str):
+        """found_types containing an unknown type should NOT be a subset of the allowed set."""
+        expected_types = {"py", "js", "ts", "tsx"}
+        allowed_extras = {"jsx", "json", "md"}
+        found_types = set(file_types_str.split(", "))
+        assert not found_types.issubset(expected_types | allowed_extras)
+
+    def test_file_types_subset_error_message_identifies_unexpected_types(self):
+        """The assertion message should list the unexpected file types."""
+        expected_types = {"py", "js", "ts", "tsx"}
+        found_types = {"py", "rb"}
+        unexpected = found_types - expected_types
+        message = f"Unexpected file types: {unexpected}"
+        assert "rb" in message
+
+    # ------------------------------------------------------------------ #
+    # 2. Updated regex pattern (line 428)                                  #
+    # ------------------------------------------------------------------ #
+
+    FILE_HEADER_REGEX = r"###\s+\\[\w\\/.-]+\.\w+"
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            r"### \src\main.py",
+            r"### \src\utils\helper.ts",
+            r"### \frontend\app\page.tsx",
+            r"### \tests\unit\test_foo.py",
+            r"### \my-module\index.js",
+            r"### \path\file-name.py",
+            r"### \path\file.name.with.dots.py",
+        ],
+    )
+    def test_file_header_regex_matches_valid_paths(self, header):
+        """Updated regex matches valid file headers with common path characters."""
+        assert re.search(self.FILE_HEADER_REGEX, header) is not None, (
+            f"Regex should match: {header!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "header",
+        [
+            r"### \path\file_with_underscore.py",
+            r"### \src\my_module\__init__.py",
+            r"### \tests\test_utils.py",
+        ],
+    )
+    def test_file_header_regex_matches_paths_with_underscores(self, header):
+        """Underscore in filenames matches via \\w even though it was removed from the explicit set."""
+        assert re.search(self.FILE_HEADER_REGEX, header) is not None, (
+            f"Regex should match underscore path: {header!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "non_header",
+        [
+            "## Section Header",
+            "### Plain heading",
+            "Some text",
+            r"### \no-extension",
+            "###no space",
+        ],
+    )
+    def test_file_header_regex_does_not_match_non_paths(self, non_header):
+        """Updated regex should not match non-file-path headers."""
+        assert re.search(self.FILE_HEADER_REGEX, non_header) is None, (
+            f"Regex should NOT match: {non_header!r}"
+        )
+
+    def test_file_header_regex_result_contains_path_separator(self):
+        """Each matched file header must contain a path separator (backslash or slash)."""
+        content = (
+            r"### \src\main.py" + "\n"
+            r"### \frontend\app\page.tsx" + "\n"
+            "### Plain heading\n"
+        )
+        matches = re.findall(self.FILE_HEADER_REGEX, content)
+        assert len(matches) == 2
+        for match in matches:
+            assert "\\" in match or "/" in match, (
+                f"File path should have proper separators: {match}"
+            )
+
+    def test_old_and_new_regex_are_functionally_equivalent_for_underscore(self):
+        """Confirm the regex change is non-breaking: both old and new match underscore paths."""
+        old_pattern = r"###\s+\\[\w\\/._-]+\.\w+"
+        new_pattern = r"###\s+\\[\w\\/.-]+\.\w+"
+        header_with_underscore = r"### \src\my_module\test_utils.py"
+        assert re.search(old_pattern, header_with_underscore) is not None
+        assert re.search(new_pattern, header_with_underscore) is not None
+
+    # ------------------------------------------------------------------ #
+    # 3. Dependency-entry content condition (lines 452-457)                #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "section,expected_pass",
+        [
+            # has "Dependencies:" -> should pass
+            ("test_file.py\nDependencies: pytest, requests\n", True),
+            # has "No dependencies found" -> should pass
+            ("test_file.py\nNo dependencies found\n", True),
+            # starts with backslash -> should pass (file path continuation)
+            ("\\src\\utils.py\n", True),
+            # starts with "#" -> excluded from check (section header)
+            ("# Some Header\nsome content\n", True),
+            # no deps, no backslash, does not start with "#" -> should fail
+            ("some random content without deps info\n", False),
+        ],
+    )
+    def test_dependency_entry_content_condition(self, section, expected_pass):
+        """The condition 'has_deps or section.strip().startswith(backslash)' behaves as expected."""
+        if section.startswith("#"):
+            # Excluded from the assertion - always passes
+            return
+        has_deps = "Dependencies:" in section or "No dependencies found" in section
+        condition = has_deps or section.strip().startswith("\\")
+        assert condition == expected_pass, (
+            f"Section {section!r}: expected condition={expected_pass}, got {condition}"
+        )
+
+    def test_dependency_entry_section_starting_with_hash_is_skipped(self):
+        """Sections starting with '#' are excluded from the dependency-content check."""
+        section = "# This is a heading\nNo dependency info here"
+        # The guard 'if not section.startswith("#")' means the assert is never reached
+        assert section.startswith("#")  # confirm the guard fires
+
+    # ------------------------------------------------------------------ #
+    # 4. Project Structure assertion in consistency test (lines 536-541)   #
+    # ------------------------------------------------------------------ #
+
+    def test_project_structure_assertion_passes_when_section_present(self):
+        """Assertion passes when '## Project Structure' is in the manifest content."""
+        content = self._make_system_manifest()
+        assert "## Project Structure" in content, (
+            "## Project Structure section not found in system manifest"
+        )
+
+    def test_project_structure_assertion_fails_when_section_absent(self):
+        """Assertion fails when '## Project Structure' is not in the manifest content."""
+        content = "# System Manifest\n## Dependencies\n- some dep\n"
+        assert "## Project Structure" not in content
+
+    def test_project_structure_section_extraction(self):
+        """Content after '## Project Structure' up to the next '##' is extracted correctly."""
+        content = (
+            "# System Manifest\n"
+            "## Project Structure\n"
+            "- 5 py files\n"
+            "- 3 ts files\n"
+            "## Dependencies\n"
+        )
+        sm_content = content.split("## Project Structure")[1].split("##")[0]
+        dm_pattern = r"- (\d+) (\w+) files"
+        counts = {ft: int(c) for c, ft in re.findall(dm_pattern, sm_content)}
+        assert counts == {"py": 5, "ts": 3}
+
+    # ------------------------------------------------------------------ #
+    # 5. Common-dependency consistency assertion (lines 614-621)           #
+    # ------------------------------------------------------------------ #
+
+    @pytest.mark.parametrize(
+        "dm_has,sm_has,dep,should_assert",
+        [
+            # Both have it -> consistent -> no assertion error
+            (True, True, "react", False),
+            # Neither has it -> consistent -> no assertion error
+            (False, False, "react", False),
+            # One has it, other doesn't -> inconsistent -> assertion error
+            (True, False, "react", True),
+            (False, True, "react", True),
+        ],
+    )
+    def test_dependency_consistency_condition(self, dm_has, sm_has, dep, should_assert):
+        """dm_has == sm_has assertion mirrors the changed code at line 619."""
+        if dm_has or sm_has:
+            if should_assert:
+                with pytest.raises(AssertionError) as exc_info:
+                    assert dm_has == sm_has, (
+                        f"Dependency '{dep}' inconsistently present: "
+                        f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    )
+                assert dep in str(exc_info.value)
+            else:
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: "
+                    f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
+
+    def test_dependency_consistency_skips_when_neither_document_has_dep(self):
+        """When neither dm_has nor sm_has is True the check is skipped entirely."""
+        dm_has = False
+        sm_has = False
+        # The guard 'if dm_has or sm_has' prevents the assert from running
+        assert not (dm_has or sm_has)
+
+    def test_dependency_consistency_error_message_format(self):
+        """Error message includes the dependency name and both document states."""
+        dep = "axios"
+        dm_has = True
+        sm_has = False
+        message = (
+            f"Dependency '{dep}' inconsistently present: "
+            f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
+        )
+        assert dep in message
+        assert "dependencyMatrix=True" in message
+        assert "systemManifest=False" in message
+
+    # ------------------------------------------------------------------ #
+    # 6. Regression: assert formatting produces correct error messages     #
+    # ------------------------------------------------------------------ #
+
+    def test_assertion_message_file_types_includes_unexpected_set(self):
+        """Regression: parenthesised assert message format correctly surfaces unexpected types."""
+        expected_types = {"py", "js", "ts", "tsx"}
+        found_types = {"py", "rs", "go"}
+        with pytest.raises(AssertionError) as exc_info:
+            assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
+                f"Unexpected file types: {found_types - expected_types}"
+            )
+        error_text = str(exc_info.value)
+        # Both unexpected types must appear in the message
+        unexpected = found_types - expected_types
+        for t in unexpected:
+            assert t in error_text, f"Expected '{t}' in error: {error_text}"
+
+    def test_assertion_message_project_structure_missing(self):
+        """Regression: parenthesised assert message for missing Project Structure section."""
+        content = "# System Manifest\n## Dependencies\n"
+        with pytest.raises(AssertionError) as exc_info:
+            assert "## Project Structure" in content, (
+                "## Project Structure section not found in system manifest"
+            )
+        assert "Project Structure" in str(exc_info.value)
+
+    def test_assertion_message_dependency_inconsistency(self):
+        """Regression: parenthesised assert message for inconsistent dependency presence."""
+        dep = "@testing-library/jest-dom"
+        dm_has = False
+        sm_has = True
+        with pytest.raises(AssertionError) as exc_info:
+            assert dm_has == sm_has, (
+                f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+            )
+        assert dep in str(exc_info.value)
+
+    def test_assertion_message_file_section_missing_dep_info(self):
+        """Regression: parenthesised assert message for section without dependency information."""
+        section = "some_text_without_deps"
+        has_deps = "Dependencies:" in section or "No dependencies found" in section
+        with pytest.raises(AssertionError) as exc_info:
+            assert has_deps or section.strip().startswith("\\"), (
+                "File section should have dependency information"
+            )
+        assert "File section should have dependency information" in str(exc_info.value)

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -425,7 +425,7 @@ class TestSystemManifest:
             system_manifest_content(str): Full markdown text of the system manifest to inspect.
         """
         # Look for file dependency entries like: ### \path\to\file.py
-        file_pattern = r"###\s+\\[\w\\/._-]+\.\w+"
+        file_pattern = r"###\s+\\[\w/._-]+\.\w+"
         matches = re.findall(file_pattern, system_manifest_content)
 
         # If there are file entries, they should be properly formatted

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -751,8 +751,7 @@ class TestChangedFunctionLogic:
             "## Project Directory Structure\n"
             "📂 src\n"
             "  📄 main.py\n"
-            "## PY Dependencies\n"
-            + extra_content
+            "## PY Dependencies\n" + extra_content
         )
 
     # ------------------------------------------------------------------ #
@@ -824,9 +823,7 @@ class TestChangedFunctionLogic:
     )
     def test_file_header_regex_matches_valid_paths(self, header):
         """Updated regex matches valid file headers with common path characters."""
-        assert re.search(self.FILE_HEADER_REGEX, header) is not None, (
-            f"Regex should match: {header!r}"
-        )
+        assert re.search(self.FILE_HEADER_REGEX, header) is not None, f"Regex should match: {header!r}"
 
     @pytest.mark.parametrize(
         "header",
@@ -838,9 +835,7 @@ class TestChangedFunctionLogic:
     )
     def test_file_header_regex_matches_paths_with_underscores(self, header):
         """Underscore in filenames matches via \\w even though it was removed from the explicit set."""
-        assert re.search(self.FILE_HEADER_REGEX, header) is not None, (
-            f"Regex should match underscore path: {header!r}"
-        )
+        assert re.search(self.FILE_HEADER_REGEX, header) is not None, f"Regex should match underscore path: {header!r}"
 
     @pytest.mark.parametrize(
         "non_header",
@@ -854,23 +849,15 @@ class TestChangedFunctionLogic:
     )
     def test_file_header_regex_does_not_match_non_paths(self, non_header):
         """Updated regex should not match non-file-path headers."""
-        assert re.search(self.FILE_HEADER_REGEX, non_header) is None, (
-            f"Regex should NOT match: {non_header!r}"
-        )
+        assert re.search(self.FILE_HEADER_REGEX, non_header) is None, f"Regex should NOT match: {non_header!r}"
 
     def test_file_header_regex_result_contains_path_separator(self):
         """Each matched file header must contain a path separator (backslash or slash)."""
-        content = (
-            r"### \src\main.py" + "\n"
-            r"### \frontend\app\page.tsx" + "\n"
-            "### Plain heading\n"
-        )
+        content = r"### \src\main.py" + "\n" r"### \frontend\app\page.tsx" + "\n### Plain heading\n"
         matches = re.findall(self.FILE_HEADER_REGEX, content)
         assert len(matches) == 2
         for match in matches:
-            assert "\\" in match or "/" in match, (
-                f"File path should have proper separators: {match}"
-            )
+            assert "\\" in match or "/" in match, f"File path should have proper separators: {match}"
 
     def test_old_and_new_regex_are_functionally_equivalent_for_underscore(self):
         """Confirm the regex change is non-breaking: both old and new match underscore paths."""
@@ -906,9 +893,7 @@ class TestChangedFunctionLogic:
             return
         has_deps = "Dependencies:" in section or "No dependencies found" in section
         condition = has_deps or section.strip().startswith("\\")
-        assert condition == expected_pass, (
-            f"Section {section!r}: expected condition={expected_pass}, got {condition}"
-        )
+        assert condition == expected_pass, f"Section {section!r}: expected condition={expected_pass}, got {condition}"
 
     def test_dependency_entry_section_starting_with_hash_is_skipped(self):
         """Sections starting with '#' are excluded from the dependency-content check."""
@@ -923,9 +908,7 @@ class TestChangedFunctionLogic:
     def test_project_structure_assertion_passes_when_section_present(self):
         """Assertion passes when '## Project Structure' is in the manifest content."""
         content = self._make_system_manifest()
-        assert "## Project Structure" in content, (
-            "## Project Structure section not found in system manifest"
-        )
+        assert "## Project Structure" in content, "## Project Structure section not found in system manifest"
 
     def test_project_structure_assertion_fails_when_section_absent(self):
         """Assertion fails when '## Project Structure' is not in the manifest content."""
@@ -934,13 +917,7 @@ class TestChangedFunctionLogic:
 
     def test_project_structure_section_extraction(self):
         """Content after '## Project Structure' up to the next '##' is extracted correctly."""
-        content = (
-            "# System Manifest\n"
-            "## Project Structure\n"
-            "- 5 py files\n"
-            "- 3 ts files\n"
-            "## Dependencies\n"
-        )
+        content = "# System Manifest\n## Project Structure\n- 5 py files\n- 3 ts files\n## Dependencies\n"
         sm_content = content.split("## Project Structure")[1].split("##")[0]
         dm_pattern = r"- (\d+) (\w+) files"
         counts = {ft: int(c) for c, ft in re.findall(dm_pattern, sm_content)}
@@ -968,14 +945,12 @@ class TestChangedFunctionLogic:
             if should_assert:
                 with pytest.raises(AssertionError) as exc_info:
                     assert dm_has == sm_has, (
-                        f"Dependency '{dep}' inconsistently present: "
-                        f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                        f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
                     )
                 assert dep in str(exc_info.value)
             else:
                 assert dm_has == sm_has, (
-                    f"Dependency '{dep}' inconsistently present: "
-                    f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
                 )
 
     def test_dependency_consistency_skips_when_neither_document_has_dep(self):
@@ -990,10 +965,7 @@ class TestChangedFunctionLogic:
         dep = "axios"
         dm_has = True
         sm_has = False
-        message = (
-            f"Dependency '{dep}' inconsistently present: "
-            f"dependencyMatrix={dm_has}, systemManifest={sm_has}"
-        )
+        message = f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
         assert dep in message
         assert "dependencyMatrix=True" in message
         assert "systemManifest=False" in message
@@ -1020,9 +992,7 @@ class TestChangedFunctionLogic:
         """Regression: parenthesised assert message for missing Project Structure section."""
         content = "# System Manifest\n## Dependencies\n"
         with pytest.raises(AssertionError) as exc_info:
-            assert "## Project Structure" in content, (
-                "## Project Structure section not found in system manifest"
-            )
+            assert "## Project Structure" in content, "## Project Structure section not found in system manifest"
         assert "Project Structure" in str(exc_info.value)
 
     def test_assertion_message_dependency_inconsistency(self):
@@ -1041,7 +1011,5 @@ class TestChangedFunctionLogic:
         section = "some_text_without_deps"
         has_deps = "Dependencies:" in section or "No dependencies found" in section
         with pytest.raises(AssertionError) as exc_info:
-            assert has_deps or section.strip().startswith("\\"), (
-                "File section should have dependency information"
-            )
+            assert has_deps or section.strip().startswith("\\"), "File section should have dependency information"
         assert "File section should have dependency information" in str(exc_info.value)

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -808,7 +808,7 @@ class TestChangedFunctionLogic:
     # ------------------------------------------------------------------ #
 
 
-FILE_HEADER_REGEX = r"###\s+\\[\w/._-]+\.\w+"
+    FILE_HEADER_REGEX = r"###\s+\\[\w\\/._-]+\.\w+"
 
   @pytest.mark.parametrize(
        "header",

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -451,9 +451,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith(
-                        "\\"
-                    ), "File section should have dependency information"
+                    assert has_deps or section.strip().startswith("\\"), (
+                        "File section should have dependency information"
+                    )
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -535,9 +535,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert (
-            "## Project Structure" in system_manifest_content
-        ), "## Project Structure section not found in system manifest"
+        assert "## Project Structure" in system_manifest_content, (
+            "## Project Structure section not found in system manifest"
+        )
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -615,9 +615,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert (
-                    dm_has == sm_has
-                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
 
 
 @pytest.mark.unit
@@ -775,9 +775,9 @@ class TestChangedFunctionLogic:
         allowed_extras = {"jsx", "json", "md"}
         found_types = set(file_types_str.split(", "))
         # Mirrors the assertion at line 128 exactly
-        assert found_types.issubset(
-            expected_types | allowed_extras
-        ), f"Unexpected file types: {found_types - expected_types}"
+        assert found_types.issubset(expected_types | allowed_extras), (
+            f"Unexpected file types: {found_types - expected_types}"
+        )
 
     @pytest.mark.parametrize(
         "file_types_str",
@@ -943,14 +943,14 @@ class TestChangedFunctionLogic:
         if dm_has or sm_has:
             if should_assert:
                 with pytest.raises(AssertionError) as exc_info:
-                    assert (
-                        dm_has == sm_has
-                    ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    assert dm_has == sm_has, (
+                        f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    )
                 assert dep in str(exc_info.value)
             else:
-                assert (
-                    dm_has == sm_has
-                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
 
     def test_dependency_consistency_skips_when_neither_document_has_dep(self):
         """When neither dm_has nor sm_has is True the check is skipped entirely."""
@@ -978,9 +978,9 @@ class TestChangedFunctionLogic:
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = {"py", "rs", "go"}
         with pytest.raises(AssertionError) as exc_info:
-            assert found_types.issubset(
-                expected_types | {"jsx", "json", "md"}
-            ), f"Unexpected file types: {found_types - expected_types}"
+            assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
+                f"Unexpected file types: {found_types - expected_types}"
+            )
         error_text = str(exc_info.value)
         # Both unexpected types must appear in the message
         unexpected = found_types - expected_types
@@ -1000,9 +1000,9 @@ class TestChangedFunctionLogic:
         dm_has = False
         sm_has = True
         with pytest.raises(AssertionError) as exc_info:
-            assert (
-                dm_has == sm_has
-            ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+            assert dm_has == sm_has, (
+                f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+            )
         assert dep in str(exc_info.value)
 
     def test_assertion_message_file_section_missing_dep_info(self):

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -808,7 +808,6 @@ class TestChangedFunctionLogic:
     # ------------------------------------------------------------------ #
 
     FILE_HEADER_REGEX = r"###\s+\\[\w\\/._-]+\.\w+"
-
   @pytest.mark.parametrize(
        "header",
         [

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -425,7 +425,7 @@ class TestSystemManifest:
             system_manifest_content(str): Full markdown text of the system manifest to inspect.
         """
         # Look for file dependency entries like: ### \path\to\file.py
-        file_pattern = r"###\s+\\[\w/._-]+\.\w+"
+        file_pattern = r"###\s+\\[\w\\/.-]+\.\w+"
         matches = re.findall(file_pattern, system_manifest_content)
 
         # If there are file entries, they should be properly formatted

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -807,7 +807,6 @@ class TestChangedFunctionLogic:
     # 2. Updated regex pattern (line 428)                                  #
     # ------------------------------------------------------------------ #
 
-
     FILE_HEADER_REGEX = r"###\s+\\[\w\\/._-]+\.\w+"
 
   @pytest.mark.parametrize(

--- a/tests/unit/test_documentation_validation.py
+++ b/tests/unit/test_documentation_validation.py
@@ -451,9 +451,9 @@ class TestSystemManifest:
                 has_deps = "Dependencies:" in section or "No dependencies found" in section
                 # Allow for section headers without file content
                 if not section.startswith("#"):
-                    assert has_deps or section.strip().startswith(
-                        "\\"
-                    ), "File section should have dependency information"
+                    assert has_deps or section.strip().startswith("\\"), (
+                        "File section should have dependency information"
+                    )
 
     def test_system_manifest_no_duplicate_sections(self, system_manifest_content):
         """Test that there are no duplicate major sections."""
@@ -535,9 +535,9 @@ class TestDocumentationConsistency:
 
         # Extract file counts from system manifest (first occurrence in Project Structure)
         # Extract file counts from system manifest (first occurrence in Project Structure)
-        assert (
-            "## Project Structure" in system_manifest_content
-        ), "## Project Structure section not found in system manifest"
+        assert "## Project Structure" in system_manifest_content, (
+            "## Project Structure section not found in system manifest"
+        )
         sm_content = system_manifest_content.split("## Project Structure")[1].split("##")[0]
         sm_counts = {file_type: int(count) for count, file_type in re.findall(dm_pattern, sm_content)}
 
@@ -615,9 +615,9 @@ class TestDocumentationConsistency:
             sm_has = any(dep in d for d in sm_deps)
             # If one has it, both should (or neither)
             if dm_has or sm_has:
-                assert (
-                    dm_has == sm_has
-                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
 
 
 @pytest.mark.unit
@@ -775,9 +775,9 @@ class TestChangedFunctionLogic:
         allowed_extras = {"jsx", "json", "md"}
         found_types = set(file_types_str.split(", "))
         # Mirrors the assertion at line 128 exactly
-        assert found_types.issubset(
-            expected_types | allowed_extras
-        ), f"Unexpected file types: {found_types - expected_types}"
+        assert found_types.issubset(expected_types | allowed_extras), (
+            f"Unexpected file types: {found_types - expected_types}"
+        )
 
     @pytest.mark.parametrize(
         "file_types_str",
@@ -941,14 +941,14 @@ class TestChangedFunctionLogic:
         if dm_has or sm_has:
             if should_assert:
                 with pytest.raises(AssertionError) as exc_info:
-                    assert (
-                        dm_has == sm_has
-                    ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    assert dm_has == sm_has, (
+                        f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                    )
                 assert dep in str(exc_info.value)
             else:
-                assert (
-                    dm_has == sm_has
-                ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                assert dm_has == sm_has, (
+                    f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+                )
 
     def test_dependency_consistency_skips_when_neither_document_has_dep(self):
         """When neither dm_has nor sm_has is True the check is skipped entirely."""
@@ -976,9 +976,9 @@ class TestChangedFunctionLogic:
         expected_types = {"py", "js", "ts", "tsx"}
         found_types = {"py", "rs", "go"}
         with pytest.raises(AssertionError) as exc_info:
-            assert found_types.issubset(
-                expected_types | {"jsx", "json", "md"}
-            ), f"Unexpected file types: {found_types - expected_types}"
+            assert found_types.issubset(expected_types | {"jsx", "json", "md"}), (
+                f"Unexpected file types: {found_types - expected_types}"
+            )
         error_text = str(exc_info.value)
         # Both unexpected types must appear in the message
         unexpected = found_types - expected_types
@@ -998,9 +998,9 @@ class TestChangedFunctionLogic:
         dm_has = False
         sm_has = True
         with pytest.raises(AssertionError) as exc_info:
-            assert (
-                dm_has == sm_has
-            ), f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+            assert dm_has == sm_has, (
+                f"Dependency '{dep}' inconsistently present: dependencyMatrix={dm_has}, systemManifest={sm_has}"
+            )
         assert dep in str(exc_info.value)
 
     def test_assertion_message_file_section_missing_dep_info(self):

--- a/tests/unit/test_real_data_fetcher.py
+++ b/tests/unit/test_real_data_fetcher.py
@@ -1449,9 +1449,9 @@ class TestDataFetcherConsistency:
 
         # At least some events should reference known symbols
         referenced_assets = {event.asset_id for event in events}
-        assert any(asset_id in known_symbols for asset_id in referenced_assets), (
-            "Events should reference known asset IDs"
-        )
+        assert any(
+            asset_id in known_symbols for asset_id in referenced_assets
+        ), "Events should reference known asset IDs"
 
 
 @pytest.mark.unit

--- a/tests/unit/test_real_data_fetcher.py
+++ b/tests/unit/test_real_data_fetcher.py
@@ -1449,9 +1449,9 @@ class TestDataFetcherConsistency:
 
         # At least some events should reference known symbols
         referenced_assets = {event.asset_id for event in events}
-        assert any(
-            asset_id in known_symbols for asset_id in referenced_assets
-        ), "Events should reference known asset IDs"
+        assert any(asset_id in known_symbols for asset_id in referenced_assets), (
+            "Events should reference known asset IDs"
+        )
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## **User description**
## Description

Character classes in regular expressions should not contain the same character twice. pyhton:S5869

Remove duplicates from character class.

Software qualities impacted:
- Maintainability (medium#0

Site:
- tests/unit/test_documentation_validation.py
- Line 428

Duplicate (current):
`file_pattern = r"###\s+\\[\w\\/._-]+\.\w+"'

De-duplicated (fix):
'file_pattern = r"###\s+\\[\w/._-]+\.\w+"'


## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test addition/update
- [ ] Dependency update

## Related Issues

<!-- Link to related issues using #issue_number -->

Closes #

## Changes Made

<!-- List the main changes made in this PR -->

- line 428 - file_pattern = r"###\s+\\[\w\\/._-]+\.\w+"
- line 428 + file_pattern = r"###\s+\\[\w/._-]+\.\w+"
-

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Unit tests pass locally
- [ ] Integration tests pass locally
- [ ] Manual testing completed
- [ ] New tests added for new functionality

### Test Commands

```bash
# Commands used to test
pytest
npm test
```

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Checklist

### Code Quality

- [X] My code follows the project's style guidelines
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

### Documentation

- [ ] I have updated the README.md (if needed)
- [ ] I have updated the CHANGELOG.md
- [ ] I have updated relevant documentation files
- [ ] I have added/updated docstrings

### Dependencies

- [X] I have checked for dependency conflicts
- [ ] I have updated requirements.txt (if needed)
- [ ] I have updated package.json (if needed)

### Branch Management

- [X] My branch is up to date with main
- [X] I will delete this branch after merge
- [X] This branch has a descriptive name
- [X] This PR has been open for less than 2 weeks

## Additional Notes

<!-- Add any additional notes or context about the PR -->

**For Reviewers**: Please ensure the branch is deleted after merging this PR to maintain repository hygiene.

**Related Documentation**:
- [Contributing Guidelines](../CONTRIBUTING.md)
- [Branch Cleanup Guidelines](../BRANCH_CLEANUP_QUICK_REFERENCE.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the file-dependency header regex and adds regression tests to make documentation validation more reliable. Keeps Windows and mixed-separator paths working and reduces false failures.

- **Bug Fixes**
  - Regex updated: r"###\s+\\[\w\\/._-]+\.\w+" → r"###\s+\\[\w\\/.-]+\.\w+"; underscores still match via \w; synced `FILE_HEADER_REGEX`.
  - Added focused tests for header matching (incl. underscores), ignoring non-path headings, dependency-entry content, Project Structure presence, cross-doc dependency consistency, and clearer assertion messages.

- **Refactors**
  - Formatted `tests/unit/test_documentation_validation.py` with `black`, `isort`, `ruff`, `prettier`, and `standard`; no functional changes.

<sup>Written for commit d2221af6831b500dd5275c4864c15eee7d00dfc7. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/981">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Fix file-dependency matching in documentation checks and add regression coverage**

### What Changed
- The file-path check now matches dependency headers without relying on a duplicate underscore pattern, while still accepting valid paths.
- Added regression tests for the updated file-header matching, dependency-entry checks, project-structure presence, and dependency consistency between documents.
- Expanded test coverage to verify the expected failure messages when documentation content is missing or inconsistent.

### Impact
`✅ Fewer false failures in documentation validation`
`✅ Clearer checks for file dependency entries`
`✅ Safer regression coverage for manifest consistency`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
