### PR TITLE
Regenerate frontend package-lock.json to lock updated ESLint/Next and transitive deps

### DIFF
--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -103,9 +103,7 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
     });
 
     it("eslint-config-next range should be ^15.0.0", () => {
-      expect(packageJson.devDependencies["eslint-config-next"]).toBe(
-        "^15.0.0",
-      );
+      expect(packageJson.devDependencies["eslint-config-next"]).toBe("^15.0.0");
     });
 
     it("eslint-config-next should no longer be on version 14", () => {
@@ -143,9 +141,9 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
     });
 
     it("eslint entry should have a SHA-512 integrity hash", () => {
-      expect(
-        packageLock.packages["node_modules/eslint"]?.integrity,
-      ).toMatch(/^sha512-/);
+      expect(packageLock.packages["node_modules/eslint"]?.integrity).toMatch(
+        /^sha512-/,
+      );
     });
   });
 
@@ -228,8 +226,7 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
 
     it("eslint-plugin-react-hooks should resolve to 5.1.0", () => {
       expect(
-        packageLock.packages["node_modules/eslint-plugin-react-hooks"]
-          ?.version,
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"]?.version,
       ).toBe("5.1.0");
     });
 
@@ -289,20 +286,18 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
     });
 
     it("fast-glob should have a SHA-512 integrity hash", () => {
-      expect(
-        packageLock.packages["node_modules/fast-glob"]?.integrity,
-      ).toMatch(/^sha512-/);
+      expect(packageLock.packages["node_modules/fast-glob"]?.integrity).toMatch(
+        /^sha512-/,
+      );
     });
 
     it("fast-glob should list merge2 as a direct dependency", () => {
-      const deps =
-        packageLock.packages["node_modules/fast-glob"]?.dependencies;
+      const deps = packageLock.packages["node_modules/fast-glob"]?.dependencies;
       expect(deps?.["merge2"]).toBeDefined();
     });
 
     it("fast-glob should list micromatch as a direct dependency", () => {
-      const deps =
-        packageLock.packages["node_modules/fast-glob"]?.dependencies;
+      const deps = packageLock.packages["node_modules/fast-glob"]?.dependencies;
       expect(deps?.["micromatch"]).toBeDefined();
     });
   });
@@ -333,7 +328,11 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
       const [major, minor, patch] = (entry?.version ?? "0.0.0")
         .split(".")
         .map(Number);
-      expect(major > 1 || (major === 1 && minor > 10) || (major === 1 && minor === 10 && patch >= 3)).toBe(true);
+      expect(
+        major > 1 ||
+          (major === 1 && minor > 10) ||
+          (major === 1 && minor === 10 && patch >= 3),
+      ).toBe(true);
     });
 
     it("eslint-plugin-import should be present and at least 2.31.0", () => {
@@ -344,8 +343,7 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
     });
 
     it("eslint-plugin-jsx-a11y should be present and at least 6.10.0", () => {
-      const entry =
-        packageLock.packages["node_modules/eslint-plugin-jsx-a11y"];
+      const entry = packageLock.packages["node_modules/eslint-plugin-jsx-a11y"];
       expect(entry).toBeDefined();
       const [major, minor] = (entry?.version ?? "0.0.0").split(".").map(Number);
       expect(major > 6 || (major === 6 && minor >= 10)).toBe(true);
@@ -364,8 +362,7 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
   describe("integration – package.json and lockfile in sync for changed deps", () => {
     it("eslint range in package.json should be satisfied by locked version", () => {
       const range = packageJson.devDependencies.eslint; // e.g. "^8.57.1"
-      const locked =
-        packageLock.packages["node_modules/eslint"]?.version ?? "";
+      const locked = packageLock.packages["node_modules/eslint"]?.version ?? "";
       const [rangeMajor, rangeMinor, rangePatch] = range
         .replace(/^\^/, "")
         .split(".")
@@ -430,9 +427,7 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
 
     it("glob 10.x should not appear anywhere in the dependency tree", () => {
       const globPaths = Object.keys(packageLock.packages).filter(
-        (p) =>
-          p === "node_modules/glob" ||
-          p.endsWith("/node_modules/glob"),
+        (p) => p === "node_modules/glob" || p.endsWith("/node_modules/glob"),
       );
       globPaths.forEach((p) => {
         const version = packageLock.packages[p]?.version ?? "";

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -250,9 +250,15 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
 
   // ─── Lockfile – removed packages ──────────────────────────────────────────
 
-  describe("lockfile – glob removed (replaced by fast-glob)", () => {
-    it("the top-level glob package should not be present in the lockfile", () => {
-      expect(packageLock.packages["node_modules/glob"]).toBeUndefined();
+  describe("lockfile – glob replaced (fast-glob for @next/eslint-plugin-next, non-deprecated glob for jest)", () => {
+    it("if glob is present at the top level, it must not be the deprecated glob@10.x", () => {
+      const globEntry = packageLock.packages["node_modules/glob"];
+      if (globEntry) {
+        const major = parseInt((globEntry.version ?? "0").split(".")[0], 10);
+        expect(major).not.toBe(10);
+        // Should be the non-deprecated version (13+)
+        expect(major).toBeGreaterThanOrEqual(13);
+      }
     });
 
     it("@next/eslint-plugin-next should not indirectly require glob", () => {

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -50,8 +50,9 @@ type PackageLock = {
 };
 
 describe("ESLint and eslint-config-next Upgrade Validation", () => {
-  const packageJsonPath = join(process.cwd(), "package.json");
-  const packageLockPath = join(process.cwd(), "package-lock.json");
+  const projectRoot = join(__dirname, "..", "..", "..");
+  const packageJsonPath = join(projectRoot, "package.json");
+  const packageLockPath = join(projectRoot, "package-lock.json");
   let packageJson: PackageJson;
   let packageLock: PackageLock;
 

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -1,0 +1,445 @@
+/**
+ * Tests for the ESLint and eslint-config-next upgrade in this PR.
+ *
+ * PR changes validated:
+ * - eslint: ^8.57.0 → ^8.57.1
+ * - eslint-config-next: ^14.2.0 → ^15.0.0
+ *
+ * Lockfile changes validated:
+ * - eslint-config-next resolves to 15.0.0 (was 14.2.35)
+ * - @next/eslint-plugin-next resolves to 15.0.0 (was 14.2.35)
+ * - @next/eslint-plugin-next now depends on fast-glob instead of glob
+ * - eslint-plugin-react-hooks resolves to 5.1.0 (was 5.0.0-canary-…)
+ * - glob@10.3.10 removed from dependency tree
+ * - jackspeak removed (was a transitive dep of glob)
+ * - fast-glob@3.3.1 added
+ * - merge2@1.4.1 added (transitive dep of fast-glob)
+ * - eslint-config-next peerDependencies now accept eslint ^9.0.0
+ * - eslint-plugin-react-hooks peerDependencies now accept eslint ^9.0.0
+ */
+
+import { readFileSync, existsSync } from "fs";
+import { join } from "path";
+
+type PackageJson = {
+  devDependencies: Record<string, string>;
+  dependencies?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+type LockfilePackage = {
+  version?: string;
+  dev?: boolean;
+  resolved?: string;
+  integrity?: string;
+  license?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+  link?: boolean;
+  inBundle?: boolean;
+  optional?: boolean;
+};
+
+type PackageLock = {
+  name: string;
+  version: string;
+  lockfileVersion: number;
+  packages: Record<string, LockfilePackage>;
+};
+
+describe("ESLint and eslint-config-next Upgrade Validation", () => {
+  const packageJsonPath = join(process.cwd(), "package.json");
+  const packageLockPath = join(process.cwd(), "package-lock.json");
+  let packageJson: PackageJson;
+  let packageLock: PackageLock;
+
+  beforeAll(() => {
+    if (!existsSync(packageJsonPath)) throw new Error("package.json not found");
+    if (!existsSync(packageLockPath))
+      throw new Error("package-lock.json not found");
+    packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+    packageLock = JSON.parse(readFileSync(packageLockPath, "utf-8"));
+  });
+
+  // ─── package.json changes ──────────────────────────────────────────────────
+
+  describe("package.json – eslint version bump (^8.57.0 → ^8.57.1)", () => {
+    it("eslint should be present as a devDependency", () => {
+      expect(packageJson.devDependencies.eslint).toBeDefined();
+    });
+
+    it("eslint range should be ^8.57.1", () => {
+      expect(packageJson.devDependencies.eslint).toBe("^8.57.1");
+    });
+
+    it("eslint range should use caret (minor/patch updates allowed)", () => {
+      expect(packageJson.devDependencies.eslint).toMatch(/^\^/);
+    });
+
+    it("eslint major version should stay on 8", () => {
+      const range = packageJson.devDependencies.eslint;
+      const major = parseInt(range.replace(/^\^/, "").split(".")[0]);
+      expect(major).toBe(8);
+    });
+
+    it("eslint should not be an older patch (< 8.57.1)", () => {
+      const range = packageJson.devDependencies.eslint;
+      const [major, minor, patch] = range
+        .replace(/^\^/, "")
+        .split(".")
+        .map(Number);
+      // Must be exactly 8.57.1 or higher within this range declaration
+      expect(major).toBe(8);
+      expect(minor).toBe(57);
+      expect(patch).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("package.json – eslint-config-next major upgrade (^14 → ^15)", () => {
+    it("eslint-config-next should be present as a devDependency", () => {
+      expect(packageJson.devDependencies["eslint-config-next"]).toBeDefined();
+    });
+
+    it("eslint-config-next range should be ^15.0.0", () => {
+      expect(packageJson.devDependencies["eslint-config-next"]).toBe(
+        "^15.0.0",
+      );
+    });
+
+    it("eslint-config-next should no longer be on version 14", () => {
+      const range = packageJson.devDependencies["eslint-config-next"];
+      const major = parseInt(range.replace(/^\^/, "").split(".")[0]);
+      expect(major).not.toBe(14);
+    });
+
+    it("eslint-config-next should be on major version 15", () => {
+      const range = packageJson.devDependencies["eslint-config-next"];
+      const major = parseInt(range.replace(/^\^/, "").split(".")[0]);
+      expect(major).toBe(15);
+    });
+
+    it("eslint-config-next range should use caret", () => {
+      expect(packageJson.devDependencies["eslint-config-next"]).toMatch(/^\^/);
+    });
+  });
+
+  // ─── Lockfile – resolved versions ─────────────────────────────────────────
+
+  describe("lockfile – eslint resolves to 8.57.1", () => {
+    it("eslint should be in the lockfile", () => {
+      expect(packageLock.packages["node_modules/eslint"]).toBeDefined();
+    });
+
+    it("eslint locked version should be 8.57.1", () => {
+      expect(packageLock.packages["node_modules/eslint"]?.version).toBe(
+        "8.57.1",
+      );
+    });
+
+    it("eslint entry should be marked as dev", () => {
+      expect(packageLock.packages["node_modules/eslint"]?.dev).toBe(true);
+    });
+
+    it("eslint entry should have a SHA-512 integrity hash", () => {
+      expect(
+        packageLock.packages["node_modules/eslint"]?.integrity,
+      ).toMatch(/^sha512-/);
+    });
+  });
+
+  describe("lockfile – eslint-config-next resolves to 15.0.0", () => {
+    it("eslint-config-next should be in the lockfile", () => {
+      expect(
+        packageLock.packages["node_modules/eslint-config-next"],
+      ).toBeDefined();
+    });
+
+    it("eslint-config-next locked version should be 15.0.0", () => {
+      expect(
+        packageLock.packages["node_modules/eslint-config-next"]?.version,
+      ).toBe("15.0.0");
+    });
+
+    it("eslint-config-next should no longer resolve to 14.x", () => {
+      const version =
+        packageLock.packages["node_modules/eslint-config-next"]?.version ?? "";
+      const major = parseInt(version.split(".")[0]);
+      expect(major).not.toBe(14);
+    });
+
+    it("eslint-config-next peerDependencies should accept eslint ^9.0.0", () => {
+      const peers =
+        packageLock.packages["node_modules/eslint-config-next"]
+          ?.peerDependencies;
+      expect(peers?.eslint).toBeDefined();
+      expect(peers?.eslint).toContain("^9.0.0");
+    });
+
+    it("eslint-config-next peerDependencies should still accept eslint ^8.0.0", () => {
+      const peers =
+        packageLock.packages["node_modules/eslint-config-next"]
+          ?.peerDependencies;
+      expect(peers?.eslint).toContain("^8.0.0");
+    });
+
+    it("eslint-config-next should list @next/eslint-plugin-next as a dependency", () => {
+      const deps =
+        packageLock.packages["node_modules/eslint-config-next"]?.dependencies;
+      expect(deps?.["@next/eslint-plugin-next"]).toBeDefined();
+    });
+
+    it("eslint-config-next should list eslint-plugin-react-hooks as a dependency", () => {
+      const deps =
+        packageLock.packages["node_modules/eslint-config-next"]?.dependencies;
+      expect(deps?.["eslint-plugin-react-hooks"]).toBeDefined();
+    });
+  });
+
+  describe("lockfile – @next/eslint-plugin-next resolves to 15.0.0", () => {
+    it("@next/eslint-plugin-next should be in the lockfile", () => {
+      expect(
+        packageLock.packages["node_modules/@next/eslint-plugin-next"],
+      ).toBeDefined();
+    });
+
+    it("@next/eslint-plugin-next locked version should be 15.0.0", () => {
+      expect(
+        packageLock.packages["node_modules/@next/eslint-plugin-next"]?.version,
+      ).toBe("15.0.0");
+    });
+
+    it("@next/eslint-plugin-next 15.0.0 should depend on fast-glob, not glob", () => {
+      const deps =
+        packageLock.packages["node_modules/@next/eslint-plugin-next"]
+          ?.dependencies;
+      expect(deps?.["fast-glob"]).toBeDefined();
+      expect(deps?.["glob"]).toBeUndefined();
+    });
+  });
+
+  describe("lockfile – eslint-plugin-react-hooks stable release (5.1.0)", () => {
+    it("eslint-plugin-react-hooks should be in the lockfile", () => {
+      expect(
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"],
+      ).toBeDefined();
+    });
+
+    it("eslint-plugin-react-hooks should resolve to 5.1.0", () => {
+      expect(
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"]
+          ?.version,
+      ).toBe("5.1.0");
+    });
+
+    it("eslint-plugin-react-hooks should no longer be on a canary version", () => {
+      const version =
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"]
+          ?.version ?? "";
+      expect(version).not.toContain("canary");
+      expect(version).not.toContain("-");
+    });
+
+    it("eslint-plugin-react-hooks peerDependencies should accept eslint ^9.0.0", () => {
+      const peers =
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"]
+          ?.peerDependencies;
+      expect(peers?.eslint).toBeDefined();
+      expect(peers?.eslint).toContain("^9.0.0");
+    });
+  });
+
+  // ─── Lockfile – removed packages ──────────────────────────────────────────
+
+  describe("lockfile – glob removed (replaced by fast-glob)", () => {
+    it("the top-level glob package should not be present in the lockfile", () => {
+      expect(packageLock.packages["node_modules/glob"]).toBeUndefined();
+    });
+
+    it("@next/eslint-plugin-next should not indirectly require glob", () => {
+      const nextPluginDeps =
+        packageLock.packages["node_modules/@next/eslint-plugin-next"]
+          ?.dependencies ?? {};
+      expect(Object.keys(nextPluginDeps)).not.toContain("glob");
+    });
+  });
+
+  describe("lockfile – jackspeak removed (was transitive dep of glob)", () => {
+    it("jackspeak should not be present in the lockfile", () => {
+      expect(packageLock.packages["node_modules/jackspeak"]).toBeUndefined();
+    });
+  });
+
+  // ─── Lockfile – added packages ─────────────────────────────────────────────
+
+  describe("lockfile – fast-glob added (replaces glob)", () => {
+    it("fast-glob should be present in the lockfile", () => {
+      expect(packageLock.packages["node_modules/fast-glob"]).toBeDefined();
+    });
+
+    it("fast-glob locked version should be 3.3.1", () => {
+      expect(packageLock.packages["node_modules/fast-glob"]?.version).toBe(
+        "3.3.1",
+      );
+    });
+
+    it("fast-glob should be marked as a dev dependency", () => {
+      expect(packageLock.packages["node_modules/fast-glob"]?.dev).toBe(true);
+    });
+
+    it("fast-glob should have a SHA-512 integrity hash", () => {
+      expect(
+        packageLock.packages["node_modules/fast-glob"]?.integrity,
+      ).toMatch(/^sha512-/);
+    });
+
+    it("fast-glob should list merge2 as a direct dependency", () => {
+      const deps =
+        packageLock.packages["node_modules/fast-glob"]?.dependencies;
+      expect(deps?.["merge2"]).toBeDefined();
+    });
+
+    it("fast-glob should list micromatch as a direct dependency", () => {
+      const deps =
+        packageLock.packages["node_modules/fast-glob"]?.dependencies;
+      expect(deps?.["micromatch"]).toBeDefined();
+    });
+  });
+
+  describe("lockfile – merge2 added (transitive dep of fast-glob)", () => {
+    it("merge2 should be present in the lockfile", () => {
+      expect(packageLock.packages["node_modules/merge2"]).toBeDefined();
+    });
+
+    it("merge2 locked version should be 1.4.1", () => {
+      expect(packageLock.packages["node_modules/merge2"]?.version).toBe(
+        "1.4.1",
+      );
+    });
+
+    it("merge2 should be marked as a dev dependency", () => {
+      expect(packageLock.packages["node_modules/merge2"]?.dev).toBe(true);
+    });
+  });
+
+  // ─── Lockfile – updated plugin versions ───────────────────────────────────
+
+  describe("lockfile – updated eslint plugin versions", () => {
+    it("@rushstack/eslint-patch should be present and at least 1.10.3", () => {
+      const entry =
+        packageLock.packages["node_modules/@rushstack/eslint-patch"];
+      expect(entry).toBeDefined();
+      const [major, minor, patch] = (entry?.version ?? "0.0.0")
+        .split(".")
+        .map(Number);
+      expect(major > 1 || (major === 1 && minor > 10) || (major === 1 && minor === 10 && patch >= 3)).toBe(true);
+    });
+
+    it("eslint-plugin-import should be present and at least 2.31.0", () => {
+      const entry = packageLock.packages["node_modules/eslint-plugin-import"];
+      expect(entry).toBeDefined();
+      const [major, minor] = (entry?.version ?? "0.0.0").split(".").map(Number);
+      expect(major > 2 || (major === 2 && minor >= 31)).toBe(true);
+    });
+
+    it("eslint-plugin-jsx-a11y should be present and at least 6.10.0", () => {
+      const entry =
+        packageLock.packages["node_modules/eslint-plugin-jsx-a11y"];
+      expect(entry).toBeDefined();
+      const [major, minor] = (entry?.version ?? "0.0.0").split(".").map(Number);
+      expect(major > 6 || (major === 6 && minor >= 10)).toBe(true);
+    });
+
+    it("eslint-plugin-react should be present and at least 7.35.0", () => {
+      const entry = packageLock.packages["node_modules/eslint-plugin-react"];
+      expect(entry).toBeDefined();
+      const [major, minor] = (entry?.version ?? "0.0.0").split(".").map(Number);
+      expect(major > 7 || (major === 7 && minor >= 35)).toBe(true);
+    });
+  });
+
+  // ─── Integration: package.json ↔ lockfile consistency ─────────────────────
+
+  describe("integration – package.json and lockfile in sync for changed deps", () => {
+    it("eslint range in package.json should be satisfied by locked version", () => {
+      const range = packageJson.devDependencies.eslint; // e.g. "^8.57.1"
+      const locked =
+        packageLock.packages["node_modules/eslint"]?.version ?? "";
+      const [rangeMajor, rangeMinor, rangePatch] = range
+        .replace(/^\^/, "")
+        .split(".")
+        .map(Number);
+      const [lockMajor, lockMinor, lockPatch] = locked.split(".").map(Number);
+
+      expect(lockMajor).toBe(rangeMajor);
+      if (lockMinor === rangeMinor) {
+        expect(lockPatch).toBeGreaterThanOrEqual(rangePatch);
+      } else {
+        expect(lockMinor).toBeGreaterThan(rangeMinor);
+      }
+    });
+
+    it("eslint-config-next range in package.json should be satisfied by locked version", () => {
+      const range = packageJson.devDependencies["eslint-config-next"]; // "^15.0.0"
+      const locked =
+        packageLock.packages["node_modules/eslint-config-next"]?.version ?? "";
+      const rangeMajor = parseInt(range.replace(/^\^/, "").split(".")[0]);
+      const lockMajor = parseInt(locked.split(".")[0]);
+
+      expect(lockMajor).toBe(rangeMajor);
+    });
+
+    it("eslint-config-next root entry should list eslint-plugin-react-hooks", () => {
+      const lockedDeps =
+        packageLock.packages["node_modules/eslint-config-next"]?.dependencies;
+      expect(lockedDeps?.["eslint-plugin-react-hooks"]).toBeDefined();
+    });
+  });
+
+  // ─── Regression: old versions must not appear ─────────────────────────────
+
+  describe("regression – old versions must not appear in lockfile", () => {
+    it("eslint-config-next 14.x must not be present in the lockfile", () => {
+      const version =
+        packageLock.packages["node_modules/eslint-config-next"]?.version ?? "";
+      const major = parseInt(version.split(".")[0]);
+      expect(major).toBeGreaterThanOrEqual(15);
+    });
+
+    it("@next/eslint-plugin-next 14.x must not be present in the lockfile", () => {
+      const version =
+        packageLock.packages["node_modules/@next/eslint-plugin-next"]
+          ?.version ?? "";
+      const major = parseInt(version.split(".")[0]);
+      expect(major).toBeGreaterThanOrEqual(15);
+    });
+
+    it("eslint-plugin-react-hooks canary version must not be present", () => {
+      const version =
+        packageLock.packages["node_modules/eslint-plugin-react-hooks"]
+          ?.version ?? "";
+      expect(version).not.toMatch(/canary/);
+    });
+
+    it("eslint 8.57.0 must not be the pinned version (must be at least 8.57.1)", () => {
+      const version =
+        packageLock.packages["node_modules/eslint"]?.version ?? "";
+      expect(version).not.toBe("8.57.0");
+    });
+
+    it("glob 10.x should not appear anywhere in the dependency tree", () => {
+      const globPaths = Object.keys(packageLock.packages).filter(
+        (p) =>
+          p === "node_modules/glob" ||
+          p.endsWith("/node_modules/glob"),
+      );
+      globPaths.forEach((p) => {
+        const version = packageLock.packages[p]?.version ?? "";
+        const major = parseInt(version.split(".")[0]);
+        // No glob 10.x should be present (that's what was removed)
+        expect(major).not.toBe(10);
+      });
+    });
+  });
+});

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -50,7 +50,7 @@ type PackageLock = {
 };
 
 describe("ESLint and eslint-config-next Upgrade Validation", () => {
-  const projectRoot = join(__dirname, "..", "..", "..");
+  const projectRoot = join(__dirname, "..", "..");
   const packageJsonPath = join(projectRoot, "package.json");
   const packageLockPath = join(projectRoot, "package-lock.json");
   let packageJson: PackageJson;
@@ -432,12 +432,15 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
       expect(version).not.toBe("8.57.0");
     });
 
-    it("glob should not appear anywhere in the dependency tree", () => {
+    it("deprecated glob@10.x should not appear anywhere in the dependency tree", () => {
       const globPaths = Object.keys(packageLock.packages).filter(
         (p) => p === "node_modules/glob" || p.endsWith("/node_modules/glob"),
       );
-      expect(globPaths).toHaveLength(0);
-    });
+      globPaths.forEach((p) => {
+        const version = packageLock.packages[p]?.version ?? "";
+        const major = parseInt(version.split(".")[0], 10);
+        expect(major).not.toBe(10);
+      });
     });
   });
 });

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -426,16 +426,12 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
       expect(version).not.toBe("8.57.0");
     });
 
-    it("glob 10.x should not appear anywhere in the dependency tree", () => {
+    it("glob should not appear anywhere in the dependency tree", () => {
       const globPaths = Object.keys(packageLock.packages).filter(
         (p) => p === "node_modules/glob" || p.endsWith("/node_modules/glob"),
       );
-      globPaths.forEach((p) => {
-        const version = packageLock.packages[p]?.version ?? "";
-        const major = parseInt(version.split(".")[0]);
-        // No glob 10.x should be present (that's what was removed)
-        expect(major).not.toBe(10);
-      });
+      expect(globPaths).toHaveLength(0);
+    });
     });
   });
 });

--- a/frontend/__tests__/config/eslint-upgrade-validation.test.ts
+++ b/frontend/__tests__/config/eslint-upgrade-validation.test.ts
@@ -441,6 +441,5 @@ describe("ESLint and eslint-config-next Upgrade Validation", () => {
         const major = parseInt(version.split(".")[0], 10);
         expect(major).not.toBe(10);
       });
-    });
   });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -962,6 +962,9 @@
       "cpu": [
         "arm"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -969,10 +972,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
@@ -981,6 +981,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -988,10 +991,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
@@ -1000,6 +1000,9 @@
       "cpu": [
         "ppc64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1007,10 +1010,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
@@ -1019,6 +1019,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1026,10 +1029,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
@@ -1038,6 +1038,9 @@
       "cpu": [
         "s390x"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1045,10 +1048,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
@@ -1057,6 +1057,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1064,10 +1067,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
@@ -1076,6 +1076,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1083,10 +1086,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
@@ -1095,6 +1095,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1102,10 +1105,7 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
@@ -1113,6 +1113,9 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1127,10 +1130,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
@@ -1138,6 +1138,9 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1152,10 +1155,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm64": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
@@ -1163,6 +1163,9 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1177,10 +1180,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
@@ -1188,6 +1188,9 @@
       "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
       "cpu": [
         "riscv64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1202,10 +1205,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
@@ -1213,6 +1213,9 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1227,10 +1230,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-s390x": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
@@ -1238,6 +1238,9 @@
       "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1252,10 +1255,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.2.4"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.34.5",
@@ -1263,6 +1263,9 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1277,10 +1280,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
@@ -1288,6 +1288,9 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1302,10 +1305,7 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
@@ -1381,53 +1381,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/@isaacs/cliui": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
-      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^5.1.2",
-        "string-width-cjs": "npm:string-width@^4.2.0",
-        "strip-ansi": "^7.0.1",
-        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
-        "wrap-ansi": "^8.1.0",
-        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2184,54 +2137,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/@jest/reporters/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/jest-message-util": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
@@ -2269,22 +2174,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/@jest/reporters/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@jest/reporters/node_modules/pretty-format": {
@@ -2677,6 +2566,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2684,10 +2576,7 @@
       ],
       "engines": {
         "node": ">= 10"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
       "version": "16.2.3",
@@ -2696,6 +2585,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2703,10 +2595,7 @@
       ],
       "engines": {
         "node": ">= 10"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "16.2.3",
@@ -2715,6 +2604,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2722,10 +2614,7 @@
       ],
       "engines": {
         "node": ">= 10"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "16.2.3",
@@ -2734,6 +2623,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2741,10 +2633,7 @@
       ],
       "engines": {
         "node": ">= 10"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "16.2.3",
@@ -2824,17 +2713,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
-      }
-    },
-    "node_modules/@pkgjs/parseargs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
-      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@pkgr/core": {
@@ -3113,6 +2991,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3120,10 +3001,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.2.2",
@@ -3133,6 +3011,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3140,10 +3021,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.2.2",
@@ -3153,6 +3031,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3160,10 +3041,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.2.2",
@@ -3173,6 +3051,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3180,10 +3061,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.2.2",
@@ -4284,13 +4162,13 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
@@ -4301,13 +4179,13 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
@@ -4318,13 +4196,13 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
@@ -4335,13 +4213,13 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
@@ -4352,13 +4230,13 @@
         "riscv64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
@@ -4369,13 +4247,13 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
@@ -4386,13 +4264,13 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
@@ -4403,13 +4281,13 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "libc": [
-        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
@@ -6521,13 +6399,6 @@
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "license": "ISC"
     },
-    "node_modules/eastasianwidth": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
-      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.335",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.335.tgz",
@@ -7722,23 +7593,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/foreground-child": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
-      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "cross-spawn": "^7.0.6",
-        "signal-exit": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
@@ -8025,6 +7879,24 @@
         "weak-map": "^1.0.5"
       }
     },
+    "node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -8044,6 +7916,72 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/global-prefix": {
       "version": "4.0.0",
@@ -9660,54 +9598,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-config/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-config/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jest-config/node_modules/jest-util": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
@@ -9724,22 +9614,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-config/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-config/node_modules/pretty-format": {
@@ -10513,54 +10387,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/jest-runtime/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/glob": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
-      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^3.1.2",
-        "minimatch": "^9.0.4",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^1.11.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/jackspeak": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
-      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
-      }
-    },
     "node_modules/jest-runtime/node_modules/jest-message-util": {
       "version": "30.3.0",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
@@ -10598,22 +10424,6 @@
       },
       "engines": {
         "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/jest-runtime/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/jest-runtime/node_modules/pretty-format": {
@@ -11404,6 +11214,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11415,10 +11228,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
@@ -11428,6 +11238,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11439,10 +11252,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
@@ -11452,6 +11262,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11463,10 +11276,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
@@ -11476,6 +11286,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11487,10 +11300,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
@@ -12466,13 +12276,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/package-json-from-dist": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
-      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -12580,30 +12383,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "license": "MIT"
-    },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/pbf": {
       "version": "3.3.0",
@@ -14105,76 +13884,6 @@
         "parenthesis": "^3.1.5"
       }
     },
-    "node_modules/string-width": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
-      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eastasianwidth": "^0.2.0",
-        "emoji-regex": "^9.2.2",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/string.prototype.includes": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
@@ -14289,20 +13998,6 @@
       }
     },
     "node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi-cjs": {
-      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -14643,28 +14338,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/test-exclude/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/text-table": {
@@ -15557,107 +15230,6 @@
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4.1.0"
-      }
-    },
-    "node_modules/wrap-ansi": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
-      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^6.1.0",
-        "string-width": "^5.0.1",
-        "strip-ansi": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs": {
-      "name": "wrap-ansi",
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/ansi-styles": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
-      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,8 +29,8 @@
         "@types/react-dom": "^19.2.3",
         "@types/react-plotly.js": "^2.6.4",
         "autoprefixer": "^10.4.23",
-        "eslint": "^8.57.0",
-        "eslint-config-next": "^14.2.0",
+        "eslint": "^8.57.1",
+        "eslint-config-next": "^15.0.0",
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
         "postcss": "^8.4.31",
@@ -962,9 +962,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -972,7 +969,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
       "version": "1.2.4",
@@ -981,9 +981,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -991,7 +988,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
       "version": "1.2.4",
@@ -1000,9 +1000,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1010,7 +1007,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
       "version": "1.2.4",
@@ -1019,9 +1019,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1029,7 +1026,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
       "version": "1.2.4",
@@ -1038,9 +1038,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1048,7 +1045,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
       "version": "1.2.4",
@@ -1057,9 +1057,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1067,7 +1064,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
       "version": "1.2.4",
@@ -1076,9 +1076,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1086,7 +1083,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
       "version": "1.2.4",
@@ -1095,9 +1095,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1105,7 +1102,10 @@
       ],
       "funding": {
         "url": "https://opencollective.com/libvips"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@img/sharp-linux-arm": {
       "version": "0.34.5",
@@ -1113,9 +1113,6 @@
       "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1130,7 +1127,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linux-arm64": {
       "version": "0.34.5",
@@ -1138,9 +1138,6 @@
       "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1155,7 +1152,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-arm64": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linux-ppc64": {
       "version": "0.34.5",
@@ -1163,9 +1163,6 @@
       "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1180,7 +1177,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-ppc64": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linux-riscv64": {
       "version": "0.34.5",
@@ -1188,9 +1188,6 @@
       "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1205,7 +1202,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-riscv64": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linux-s390x": {
       "version": "0.34.5",
@@ -1213,9 +1213,6 @@
       "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1230,7 +1227,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-s390x": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linux-x64": {
       "version": "0.34.5",
@@ -1238,9 +1238,6 @@
       "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1255,7 +1252,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.2.4"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
       "version": "0.34.5",
@@ -1263,9 +1263,6 @@
       "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1280,7 +1277,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
       "version": "0.34.5",
@@ -1288,9 +1288,6 @@
       "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1305,7 +1302,10 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@img/sharp-wasm32": {
       "version": "0.34.5",
@@ -2629,13 +2629,13 @@
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-14.2.35.tgz",
-      "integrity": "sha512-Jw9A3ICz2183qSsqwi7fgq4SBPiNfmOLmTPXKvlnzstUwyvBrtySiY+8RXJweNAs9KThb1+bYhZh9XWcNOr2zQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.0.0.tgz",
+      "integrity": "sha512-UG/Gnsq6Sc4wRhO9qk+vc/2v4OfRXH7GEH6/TGlNF5eU/vI9PIO7q+kgd65X2DxJ+qIpHWpzWwlPLmqMi1FE9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "glob": "10.3.10"
+        "fast-glob": "3.3.1"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -2677,9 +2677,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2687,7 +2684,10 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@next/swc-linux-arm64-musl": {
       "version": "16.2.3",
@@ -2696,9 +2696,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2706,7 +2703,10 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@next/swc-linux-x64-gnu": {
       "version": "16.2.3",
@@ -2715,9 +2715,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2725,7 +2722,10 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@next/swc-linux-x64-musl": {
       "version": "16.2.3",
@@ -2734,9 +2734,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2744,7 +2741,10 @@
       ],
       "engines": {
         "node": ">= 10"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
       "version": "16.2.3",
@@ -3113,9 +3113,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3123,7 +3120,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.2.2",
@@ -3133,9 +3133,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3143,7 +3140,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.2.2",
@@ -3153,9 +3153,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3163,7 +3160,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.2.2",
@@ -3173,9 +3173,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3183,7 +3180,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.2.2",
@@ -3214,6 +3214,70 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.1.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
+      "version": "2.8.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.2.2",
@@ -4220,13 +4284,13 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
@@ -4237,13 +4301,13 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
@@ -4254,13 +4318,13 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
@@ -4271,13 +4335,13 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
@@ -4288,13 +4352,13 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
@@ -4305,13 +4369,13 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
@@ -4322,13 +4386,13 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "glibc"
       ]
     },
     "node_modules/@unrs/resolver-binding-linux-x64-musl": {
@@ -4339,13 +4403,13 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
+      ],
+      "libc": [
+        "musl"
       ]
     },
     "node_modules/@unrs/resolver-binding-wasm32-wasi": {
@@ -6883,25 +6947,25 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "14.2.35",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-14.2.35.tgz",
-      "integrity": "sha512-BpLsv01UisH193WyT/1lpHqq5iJ/Orfz9h/NOOlAmTUq4GY349PextQ62K4XpnaM9supeiEn3TaOTeQO07gURg==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.0.0.tgz",
+      "integrity": "sha512-HFeTwCR2lFEUWmdB00WZrzaak2CvMvxici38gQknA6Bu2HPizSE4PNFGaFzr5GupjBt+SBJ/E0GIP57ZptOD3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "14.2.35",
-        "@rushstack/eslint-patch": "^1.3.3",
+        "@next/eslint-plugin-next": "15.0.0",
+        "@rushstack/eslint-patch": "^1.10.3",
         "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.28.1",
-        "eslint-plugin-jsx-a11y": "^6.7.1",
-        "eslint-plugin-react": "^7.33.2",
-        "eslint-plugin-react-hooks": "^4.5.0 || 5.0.0-canary-7118f5dd7-20230705"
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.35.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0",
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
@@ -7136,16 +7200,16 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.0.0-canary-7118f5dd7-20230705",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.0.0-canary-7118f5dd7-20230705.tgz",
-      "integrity": "sha512-AZYbMo/NW9chdL7vk6HQzQhT+PvTAEVqWk9ziruUoW2kAOcN5qNyelv70e0F1VNQAbvutOC9oc+xfWycI9FxDw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.1.0.tgz",
+      "integrity": "sha512-mpJRtPgHN2tNAvZ35AMfqeB3Xqeo273QxrHJsbBEPWODRM4r0yB6jfoROqKEYrOn27UtRPpcpHc2UqyBSuUNTw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
       }
     },
     "node_modules/eslint-plugin-react/node_modules/doctrine": {
@@ -7420,6 +7484,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/fast-isnumeric": {
@@ -7931,30 +8025,6 @@
         "weak-map": "^1.0.5"
       }
     },
-    "node_modules/glob": {
-      "version": "10.3.10",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
-      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "foreground-child": "^3.1.0",
-        "jackspeak": "^2.3.5",
-        "minimatch": "^9.0.1",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
-        "path-scurry": "^1.10.1"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -7974,32 +8044,6 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "license": "BSD-2-Clause",
       "peer": true
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/global-prefix": {
       "version": "4.0.0",
@@ -9301,25 +9345,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/jackspeak": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
-      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^8.0.2"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      },
-      "optionalDependencies": {
-        "@pkgjs/parseargs": "^0.11.0"
       }
     },
     "node_modules/jest": {
@@ -11379,9 +11404,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11393,7 +11415,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
@@ -11403,9 +11428,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11417,7 +11439,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
@@ -11427,9 +11452,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11441,7 +11463,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
@@ -11451,9 +11476,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -11465,7 +11487,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
@@ -11794,6 +11819,16 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/micromatch": {
       "version": "4.0.8",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -45,5 +45,16 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.3.0"
+  },
+  "overrides": {
+    "@jest/reporters": {
+      "glob": "^13.0.6"
+    },
+    "jest-config": {
+      "glob": "^13.0.6"
+    },
+    "jest-runtime": {
+      "glob": "^13.0.6"
+    }
   }
 }


### PR DESCRIPTION
## **User description**
### Motivation

- Ensure the frontend dependency tree is up to date after upgrading ESLint/Next related packages and their transitive dependencies. 

### Description

- Regenerated `frontend/package-lock.json` with version bumps including `eslint` (patch), `eslint-config-next` -> `15.0.0`, `@next/eslint-plugin-next` -> `15.0.0`, and `eslint-plugin-react-hooks` -> `5.1.0`. 
- Added and locked transitive dependencies such as `fast-glob`, `merge2` and several nested `@tailwindcss/oxide-wasm32-wasi` bundles and their inlined deps. 
- Normalized platform metadata (added/relocated `libc` entries) across many platform-specific packages and updated integrity/resolved fields for multiple packages. 
- Cleaned up and updated various transitive entries to reflect the new installable dependency tree.

### Testing

- Ran `npm ci` against the updated lockfile and the installation completed successfully. 
- Ran the frontend unit test suite with `npm test` (Jest) and tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db6dba6d208324a8b431207567fe34)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Regenerated `frontend/package-lock.json` for the ESLint/Next upgrade and expanded the validation test to assert resolved versions, `fast-glob` usage, and `glob` pinning. Added `package.json` overrides so Jest uses `glob@^13` and removed deprecated `glob@10`/`jackspeak` from the tree.

- **Dependencies**
  - Bump `eslint` to 8.57.1, `eslint-config-next`/`@next/eslint-plugin-next` to 15.0.0, and `eslint-plugin-react-hooks` to 5.1.0 (peers accept `eslint` ^9).
  - Switch `@next/eslint-plugin-next` from `glob` to `fast-glob` (adds `merge2`); add `overrides` for `@jest/reporters`, `jest-config`, and `jest-runtime` to pin `glob@^13.0.6`.

- **Bug Fixes**
  - Expand and fix the validation test: check `fast-glob`/`merge2` presence, ensure `glob@10` is gone, and verify peer ranges; corrected project root path and updated assertions.

<sup>Written for commit 311a97fc2f69bb8ab99018846b8a41c9331c3426. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1002">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Refresh frontend lint and build dependency lockfile

### What Changed
- Updated the locked frontend lint packages to newer versions, including Next.js ESLint support and React Hooks rules
- Replaced the older glob-based dependency used by the Next ESLint package with the newer fast-glob path
- Refreshed platform-specific package metadata so installs work cleanly across Linux, macOS, and Windows variants
- Added the missing bundled dependencies for Tailwind’s WASM package to keep the lockfile complete

### Impact
`✅ Safer frontend dependency installs`
`✅ Fewer lint-tool version conflicts`
`✅ Reduced risk of platform-specific install failures`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
