### PR TITLE
Add MERGIFY_TOKEN to Python CI workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
     - name: Python CI common (${{ matrix.python-version }})
       uses: ./.github/actions/ci-common
+      env:
+        MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
       with:
         language: python
         python-version: ${{ matrix.python-version }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -37,14 +37,21 @@ jobs:
       matrix:
         python-version: ["3.9", "3.10", "3.11"]
 
-    steps:
+steps:
     - name: Python CI common (${{ matrix.python-version }})
       uses: ./.github/actions/ci-common
-  env:
-    MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
-
-  steps:
-  - name: Python CI common (${{ matrix.python-version }})
+      env:
+        MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+      with:
+        language: python
+        python-version: ${{ matrix.python-version }}
+        dependency-paths: |
+          requirements.txt
+          requirements-dev.txt
+        install: |
+          python -m pip install --upgrade pip &&
+          python -m pip install flake8 pytest &&
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     uses: ./.github/actions/ci-common
       with:
         language: python

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,8 +40,12 @@ jobs:
     steps:
     - name: Python CI common (${{ matrix.python-version }})
       uses: ./.github/actions/ci-common
-      env:
-        MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+  env:
+    MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}
+
+  steps:
+  - name: Python CI common (${{ matrix.python-version }})
+    uses: ./.github/actions/ci-common
       with:
         language: python
         python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
## **User description**
## Summary

Enable Mergify flaky test prevention for the pytest-based CI workflow.

This change wires the repository's existing GitHub Actions test job into Mergify CI Insights flaky test prevention by:

- adding `pytest-mergify` to the dependencies installed by CI
- exposing `MERGIFY_TOKEN` to the test execution environment
- keeping the existing workflow structure intact with no new workflow added

This is a minimal integration intended to align with the repository's current CI behavior.

## Why this change

The repository already uses `pytest`, so it is compatible with Mergify flaky test prevention. The `pytest-mergify` plugin uploads test result data to Mergify when `MERGIFY_TOKEN` is present and automatically reruns flaky tests within the configured prevention budget.

The current workflow runs `pytest` from the existing `Python package` GitHub Actions workflow. However:

- CI currently installs from `requirements.txt`
- CI does not currently expose `MERGIFY_TOKEN` to the test run
- `pytest-mergify` is not currently installed in the workflow path used by CI

Without those changes, flaky test prevention cannot activate.

## Scope

This PR is intentionally narrow.

It does **not**:
- add a new workflow
- change the test command structure
- hard-code any secret values
- alter branch protection, Mergify rules, or merge strategy
- refactor dependency management beyond what is required for this integration

## Changes made

### 1. Add `pytest-mergify` to CI-installed dependencies

Added `pytest-mergify` to `requirements.txt` so the existing workflow installs it as part of the current dependency path.

Reason:
the current workflow explicitly installs `requirements.txt`, so adding the package there ensures CI receives the plugin without requiring broader packaging changes.

### 2. Expose `MERGIFY_TOKEN` to the CI test step

Updated `.github/workflows/python-package.yml` so the existing `Python CI common` step receives:

```yaml
env:
  MERGIFY_TOKEN: ${{ secrets.MERGIFY_TOKEN }}

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `MERGIFY_TOKEN` to the Python CI workflow to enable Mergify CI Insights flaky test prevention during `pytest` runs. Also configure the ci-common step with dependency paths (including `requirements-dev.txt`) and an explicit install script, without changing the test command.

<sup>Written for commit 29292b118fdaec06fd7727833dfcce8e115106d8. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1005">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Expose Mergify token to the Python CI test run**

### What Changed
- The Python CI workflow now passes the Mergify token into the test environment
- This lets the existing CI test run connect to Mergify without changing the workflow structure

### Impact
`✅ Flaky test detection in Python CI`
`✅ Fewer missed Mergify test reports`
`✅ Cleaner CI integration without new workflows`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
