### PR TITLE
Centralize DATABASE_URL access via Settings (remove env reads from api/database.py)

### DIFF
--- a/api/database.py
+++ b/api/database.py
@@ -26,8 +26,7 @@ def _get_database_url() -> str:
     database_url = get_settings().effective_database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database. "
-            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+            "Database URL must be configured before using the database. Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
         )
     return database_url
 

--- a/api/database.py
+++ b/api/database.py
@@ -23,7 +23,7 @@ def _get_database_url() -> str:
     Raises:
         ValueError: If the configured `DATABASE_URL` is missing or empty.
     """
-    database_url = load_settings().database_url
+    database_url = get_settings().database_url
     if not database_url:
         raise ValueError("DATABASE_URL environment variable must be set before using the database")
     return database_url

--- a/api/database.py
+++ b/api/database.py
@@ -15,18 +15,18 @@ from src.config.settings import get_settings
 
 def _get_database_url() -> str:
     """
-    Read the effective database URL from centralized runtime settings.
+    Read the API SQLite database URL from centralized runtime settings.
 
     Returns:
-        The configured database URL exposed by settings.
+        The configured DATABASE_URL value exposed by settings.
 
     Raises:
-        ValueError: If no effective database URL is configured.
+        ValueError: If DATABASE_URL is missing or empty.
     """
-    database_url = get_settings().effective_database_url
+    database_url = get_settings().database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database. Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+            "DATABASE_URL must be configured before using the API database helpers."
         )
     return database_url
 

--- a/api/database.py
+++ b/api/database.py
@@ -25,9 +25,7 @@ def _get_database_url() -> str:
     """
     database_url = get_settings().database_url
     if not database_url:
-        raise ValueError(
-            "Database URL must be configured before using the database. Set DATABASE_URL."
-        )
+        raise ValueError("Database URL must be configured before using the database. Set DATABASE_URL.")
     return database_url
 
 

--- a/api/database.py
+++ b/api/database.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import atexit
-import os
 import sqlite3
 import threading
 from collections.abc import Iterator
@@ -11,18 +10,20 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
+from src.config.settings import load_settings
+
 
 def _get_database_url() -> str:
     """
-    Read the DATABASE_URL environment variable and return its value.
+    Read the database URL from centralized runtime settings.
 
     Returns:
-        The value of the `DATABASE_URL` environment variable.
+        The configured `DATABASE_URL` value exposed by settings.
 
     Raises:
-        ValueError: If the `DATABASE_URL` environment variable is not set.
+        ValueError: If the configured `DATABASE_URL` is missing or empty.
     """
-    database_url = os.getenv("DATABASE_URL")
+    database_url = load_settings().database_url
     if not database_url:
         raise ValueError("DATABASE_URL environment variable must be set before using the database")
     return database_url

--- a/api/database.py
+++ b/api/database.py
@@ -25,9 +25,7 @@ def _get_database_url() -> str:
     """
     database_url = get_settings().database_url
     if not database_url:
-        raise ValueError(
-            "DATABASE_URL must be configured before using the API database helpers."
-        )
+        raise ValueError("DATABASE_URL must be configured before using the API database helpers.")
     return database_url
 
 

--- a/api/database.py
+++ b/api/database.py
@@ -15,17 +15,20 @@ from src.config.settings import get_settings
 
 def _get_database_url() -> str:
     """
-    Read the database URL from centralized runtime settings.
+    Read the effective database URL from centralized runtime settings.
 
     Returns:
-        The configured `DATABASE_URL` value exposed by settings.
+        The configured database URL exposed by settings.
 
     Raises:
-        ValueError: If the configured `DATABASE_URL` is missing or empty.
+        ValueError: If no effective database URL is configured.
     """
-    database_url = get_settings().database_url
+    database_url = get_settings().effective_database_url
     if not database_url:
-        raise ValueError("Database URL must be configured before using the database. Set DATABASE_URL.")
+        raise ValueError(
+            "Database URL must be configured before using the database. "
+            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+        )
     return database_url
 
 

--- a/api/database.py
+++ b/api/database.py
@@ -26,7 +26,8 @@ def _get_database_url() -> str:
     database_url = get_settings().effective_database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database. Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+            "Database URL must be configured before using the database. "
+            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
         )
     return database_url
 

--- a/api/database.py
+++ b/api/database.py
@@ -26,7 +26,7 @@ def _get_database_url() -> str:
     database_url = get_settings().database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database. "
+            "Database URL must be configured before using the database."
             "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
         )
     return database_url

--- a/api/database.py
+++ b/api/database.py
@@ -25,7 +25,10 @@ def _get_database_url() -> str:
     """
     database_url = get_settings().database_url
     if not database_url:
-        raise ValueError("DATABASE_URL environment variable must be set before using the database")
+        raise ValueError(
+            "Database URL must be configured before using the database. "
+            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+        )
     return database_url
 
 

--- a/api/database.py
+++ b/api/database.py
@@ -10,7 +10,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-from src.config.settings import load_settings
+from src.config.settings import get_settings
 
 
 def _get_database_url() -> str:

--- a/api/database.py
+++ b/api/database.py
@@ -26,7 +26,7 @@ def _get_database_url() -> str:
     database_url = get_settings().database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database.Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+            "Database URL must be configured before using the database. Set DATABASE_URL."
         )
     return database_url
 

--- a/api/database.py
+++ b/api/database.py
@@ -26,8 +26,7 @@ def _get_database_url() -> str:
     database_url = get_settings().database_url
     if not database_url:
         raise ValueError(
-            "Database URL must be configured before using the database."
-            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+            "Database URL must be configured before using the database.Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
         )
     return database_url
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -88,21 +88,6 @@ class Settings(BaseModel):
             return []
         return _parse_csv_env(self.allowed_origins_raw)
 
-    @property
-    def effective_database_url(self) -> Optional[str]:
-        """
-        Return the effective database URL for the API database helpers.
-
-        Prefers `asset_graph_database_url` when set, otherwise falls back to
-        `database_url`.
-
-        Returns:
-            Optional[str]: Effective database URL, or `None` when neither
-            source is configured.
-        """
-        return self.asset_graph_database_url or self.database_url
-
-
 def load_settings() -> Settings:
     """
     Load runtime settings from environment variables.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -483,8 +483,7 @@ def initialize_schema() -> None:
     - `hashed_password`: TEXT, not null
     - `disabled`: INTEGER, not null, defaults to 0
     """
-    execute(
-        """
+    execute("""
         CREATE TABLE IF NOT EXISTS user_credentials(
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             username TEXT UNIQUE NOT NULL,
@@ -493,6 +492,4 @@ def initialize_schema() -> None:
             hashed_password TEXT NOT NULL,
             disabled INTEGER NOT NULL DEFAULT 0
         )
-        """
-    )
-    
+        """)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -89,6 +89,19 @@ class Settings(BaseModel):
         return _parse_csv_env(self.allowed_origins_raw)
 
 
+    @property
+    def effective_database_url(self) -> Optional[str]:
+        """
+        Return the effective database URL for API database helpers.
+
+        `ASSET_GRAPH_DATABASE_URL` takes precedence when configured. `DATABASE_URL`
+        remains the fallback for compatibility with existing local and deployment
+        environments.
+
+        Returns:
+            Optional[str]: Effective database URL, or None when no database URL is configured.
+        """
+        return self.asset_graph_database_url or self.database_url
 
 def load_settings() -> Settings:
     """

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -88,7 +88,6 @@ class Settings(BaseModel):
             return []
         return _parse_csv_env(self.allowed_origins_raw)
 
-
     @property
     def effective_database_url(self) -> Optional[str]:
         """
@@ -102,6 +101,7 @@ class Settings(BaseModel):
             Optional[str]: Effective database URL, or None when no database URL is configured.
         """
         return self.asset_graph_database_url or self.database_url
+
 
 def load_settings() -> Settings:
     """

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -71,6 +71,7 @@ class Settings(BaseModel):
     use_real_data_fetcher: bool = Field(default=False)
 
     # Database configuration
+    database_url: Optional[str] = Field(default=None)
     asset_graph_database_url: Optional[str] = Field(default=None)
 
     @property
@@ -95,7 +96,7 @@ def load_settings() -> Settings:
     Creates a Settings instance populated from these environment variables:
     ENV (default "development", stripped and lowercased), ALLOWED_ORIGINS,
     GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, USE_REAL_DATA_FETCHER (parsed as a
-    boolean), and ASSET_GRAPH_DATABASE_URL.
+    boolean), DATABASE_URL, and ASSET_GRAPH_DATABASE_URL.
 
     Returns:
         settings (Settings): Constructed and validated Settings object.
@@ -106,6 +107,7 @@ def load_settings() -> Settings:
         graph_cache_path=os.getenv("GRAPH_CACHE_PATH"),
         real_data_cache_path=os.getenv("REAL_DATA_CACHE_PATH"),
         use_real_data_fetcher=_parse_bool_env(os.getenv("USE_REAL_DATA_FETCHER")),
+        database_url=os.getenv("DATABASE_URL"),
         asset_graph_database_url=os.getenv("ASSET_GRAPH_DATABASE_URL"),
     )
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -88,20 +88,6 @@ class Settings(BaseModel):
             return []
         return _parse_csv_env(self.allowed_origins_raw)
 
-    @property
-    def effective_database_url(self) -> Optional[str]:
-        """
-        Return the effective database URL for API database helpers.
-
-        `ASSET_GRAPH_DATABASE_URL` takes precedence when configured. `DATABASE_URL`
-        remains the fallback for compatibility with existing local and deployment
-        environments.
-
-        Returns:
-            Optional[str]: Effective database URL, or None when no database URL is configured.
-        """
-        return self.asset_graph_database_url or self.database_url
-
 
 def load_settings() -> Settings:
     """

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -89,6 +89,7 @@ class Settings(BaseModel):
         return _parse_csv_env(self.allowed_origins_raw)
 
 
+
 def load_settings() -> Settings:
     """
     Load runtime settings from environment variables.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -88,6 +88,7 @@ class Settings(BaseModel):
             return []
         return _parse_csv_env(self.allowed_origins_raw)
 
+
 def load_settings() -> Settings:
     """
     Load runtime settings from environment variables.

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,126 +1,498 @@
-"""Centralized typed settings layer for selected runtime configuration.
-
-This module provides a typed settings interface for the runtime configuration
-centralized by this PR, specifically environment mode, CORS allowlist input,
-graph cache settings, real-data fetcher settings, and database URL resolution.
-It does not yet replace all direct environment reads across the repository.
-"""
+"""Lightweight database helpers for the API layer."""
 
 from __future__ import annotations
 
-import os
-from functools import lru_cache
-from typing import Optional
+import atexit
+import sqlite3
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from urllib.parse import unquote, urlparse
 
-from pydantic import BaseModel, ConfigDict, Field
+from src.config.settings import get_settings
 
 
-def _parse_bool_env(value: Optional[str]) -> bool:
+def _get_database_url() -> str:
     """
-    Parse a boolean environment variable value.
-
-    Interprets the value case-insensitively; the values "1", "true", "yes",
-    or "on" (ignoring surrounding whitespace) are treated as true.
-
-    Parameters:
-        value (Optional[str]): Environment variable value to parse.
+    Return the effective database URL from centralized runtime settings.
 
     Returns:
-        bool: True if the value matches an accepted truthy value, False otherwise.
+        str: Effective database URL.
+
+    Raises:
+        ValueError: If no effective database URL is configured.
     """
-    if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "yes", "on"}
+    database_url = get_settings().effective_database_url
+    if not database_url:
+        raise ValueError(
+            "Database URL must be configured before using the database helpers. "
+            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
+        )
+    return database_url
 
 
-def _parse_csv_env(value: str) -> list[str]:
+def _normalize_sqlite_path(parsed_path: str) -> str:
     """
-    Parse a comma-separated environment variable value into a list of strings.
-
-    Splits on commas, trims whitespace, and excludes empty entries.
+    Decode percent-encoding in a SQLite URL path.
 
     Parameters:
-        value (str): Comma-separated string to parse.
+        parsed_path (str): The raw path component extracted from a parsed SQLite URL, possibly containing
+            percent-encoded characters.
 
     Returns:
-        list[str]: A list of trimmed non-empty strings.
+        str: The path with percent-encoded sequences decoded.
     """
-    return [item.strip() for item in value.split(",") if item.strip()]
+    return unquote(parsed_path)
 
 
-class Settings(BaseModel):
+def _is_standard_memory_path(parsed: object, normalized_path: str) -> bool:
     """
-    Runtime configuration settings centralized by this PR.
+    Determine whether a parsed SQLite URL refers to the standard SQLite in-memory database.
 
-    Settings are loaded from environment variables and exposed through a typed,
-    immutable model. The cached accessor provides consistent config for startup
-    and module-level initialization paths.
+    Parameters:
+        parsed (object): Result of urllib.parse.urlparse (or similar) whose `netloc` may be ":memory:".
+        normalized_path (str): Percent-decoded path component of the URL.
+
+    Returns:
+        bool: `True` if `parsed.netloc == ":memory:"` or `normalized_path` is `":memory:"` or
+            `"/:memory:"`, `False` otherwise.
+    """
+    parsed_netloc = getattr(parsed, "netloc", "")
+    return parsed_netloc == ":memory:" or normalized_path in {":memory:", "/:memory:"}
+
+
+def _resolve_uri_style_memory_path(
+    path: str,
+    query: str,
+) -> str | None:
+    """
+    Return a URI-style SQLite in-memory path extracted from a URL path component.
+
+    If `path` represents a URI-style in-memory database (after removing leading
+    slashes and beginning with `file:` and containing `:memory:`), return the
+    normalized URI string. If `query` is non-empty, append it prefixed with `?`.
+
+    Parameters:
+        path (str): URL path component that may include leading slashes and a
+            `file:` URI indicating an in-memory database.
+        query (str): Raw query string (without a leading '?') to append when
+            present.
+
+    Returns:
+        str | None: The normalized URI-style memory path with `?{query}` appended
+            if `query` is non-empty, or `None` if `path` is not a URI-style memory
+            database.
+    """
+    if not path.lstrip("/").startswith("file:") or ":memory:" not in path:
+        return None
+    result = path.lstrip("/")
+    if query:
+        result += f"?{query}"
+    return result
+
+
+def _resolve_file_path(path: str) -> str:
+    """
+    Convert a normalized SQLite file path component into an absolute filesystem path.
+
+    Handles three forms:
+    - Absolute paths starting with a single leading slash (e.g., "/foo") are resolved as-is.
+    - UNC-like paths starting with two leading slashes (e.g., "//server/path") drop the first slash and are resolved.
+    - Rootless or relative-looking paths have any leading slashes removed and are resolved
+      relative to the current working directory.
+
+    Parameters:
+        path (str): Normalized SQLite path component; may be absolute ("/..."), UNC-like ("//..."), or rootless.
+
+    Returns:
+        str: The resolved absolute filesystem path.
+    """
+    if path.startswith("/") and not path.startswith("//"):
+        return str(Path(path).resolve())
+    if path.startswith("//"):
+        return str(Path(path[1:]).resolve())
+    return str(Path(path.lstrip("/")).resolve())
+
+
+def _resolve_sqlite_path(url: str) -> str:
+    """
+    Resolve a SQLite URL to a filesystem path or in-memory indicator.
+
+    Accept SQLite URLs with schemes like `sqlite:///relative.db`,
+    `sqlite:////absolute/path.db`, and `sqlite:///:memory:`.
+    Percent-encodings in the URL path are decoded before resolution.
+    For in-memory URLs (`:memory:` or `/:memory:`), return the literal string
+    `":memory:"`. URI-style memory databases like
+    `sqlite:///file::memory:?cache=shared` are returned as-is.
+
+    Parameters:
+        url (str): SQLite URL to resolve.
+
+    Returns:
+        str: Filesystem path for file-based URLs, the literal string `":memory:"`
+            for standard in-memory databases, or the original URI-style memory path.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme != "sqlite":
+        raise ValueError(f"Not a valid sqlite URI: {url}")
+
+    normalized_path = parsed.path.rstrip("/")
+    if _is_standard_memory_path(parsed, normalized_path):
+        return ":memory:"
+
+    path = _normalize_sqlite_path(parsed.path)
+    uri_memory_path = _resolve_uri_style_memory_path(path, parsed.query)
+    if uri_memory_path is not None:
+        return uri_memory_path
+
+    return _resolve_file_path(path)
+
+
+def _get_database_path() -> str:
+    """
+    Return the resolved SQLite path for the effective database URL.
+
+    Returns:
+        str: Resolved SQLite path for the configured database URL.
+    """
+    return _resolve_sqlite_path(_get_database_url())
+
+
+# Module-level shared in-memory connection
+_MEMORY_CONNECTION: sqlite3.Connection | None = None
+_MEMORY_CONNECTION_MANAGER: _DatabaseConnectionManager | None = None
+_MEMORY_CONNECTION_LOCK = threading.Lock()
+
+
+def _is_memory_db(path: str | None = None) -> bool:
+    """
+    Determine whether a SQLite database path denotes an in-memory database.
+
+    If `path` is omitted, the current configured database path is evaluated. The function treats the
+    literal ":memory:" and file-style URIs whose path component is exactly ":memory:" (for
+    example, "file::memory:" or "file::memory:?cache=shared") as in-memory targets. It does not
+    treat file URIs where ":memory:" appears as part of a filesystem path or URIs that use
+    `mode=memory` as in-memory.
+
+    Parameters:
+        path (str | None): Database path or URI to evaluate. If omitted, the
+            current configured database path is used.
+
+    Returns:
+        bool: `True` if the evaluated target denotes an in-memory SQLite database, `False` otherwise.
+    """
+    target = _get_database_path() if path is None else path
+    if target == ":memory:":
+        return True
+
+    parsed = urlparse(target)
+    return parsed.scheme == "file" and (parsed.path == ":memory:" or ":memory:" in parsed.query)
+
+
+class _DatabaseConnectionManager:
+    """Manages SQLite connections to a configured database path.
+
+    Provides a persistent shared connection for in-memory databases and creates
+    new connections for file-backed databases. Thread-safe for in-memory usage.
     """
 
-    model_config = ConfigDict(frozen=True)
-
-    # Environment mode
-    env: str = Field(default="development")
-
-    # CORS configuration
-    allowed_origins_raw: str = Field(default="")
-
-    # Graph data source configuration
-    graph_cache_path: Optional[str] = Field(default=None)
-    real_data_cache_path: Optional[str] = Field(default=None)
-    use_real_data_fetcher: bool = Field(default=False)
-
-    # Database configuration
-    database_url: Optional[str] = Field(default=None)
-    asset_graph_database_url: Optional[str] = Field(default=None)
-
-    @property
-    def allowed_origins(self) -> list[str]:
+    def __init__(self, database_path: str):
         """
-        Return the configured CORS allowed origins as a list of trimmed, non-empty strings.
+        Create a connection manager for the given resolved SQLite database path.
 
-        If `allowed_origins_raw` is empty, returns an empty list; otherwise the raw value is parsed by splitting on commas, trimming whitespace, and excluding empty entries.
+        The manager owns connection creation and lifecycle for both in-memory
+        and file-backed databases.
+
+        Parameters:
+            database_path (str): Resolved SQLite path — a filesystem path, the
+                literal ":memory:", or a URI-style memory path (e.g.
+                "file::memory:?cache=shared").
+        """
+        self._database_path = database_path
+        self._memory_connection: sqlite3.Connection | None = None
+        self._memory_connection_lock = threading.Lock()
+
+    def connect(self) -> sqlite3.Connection:
+        """
+        Open a SQLite connection for the manager's configured database path.
+
+        In-memory databases return a single shared connection (created on the
+        first call and reused thereafter). File-backed databases return a new
+        connection on every call. The returned connection has its row factory
+        set to ``sqlite3.Row``.
 
         Returns:
-            list[str]: Parsed allowed origin strings.
+            sqlite3.Connection: The shared in-memory connection, or a new
+                connection for file-backed databases.
         """
-        if not self.allowed_origins_raw:
-            return []
-        return _parse_csv_env(self.allowed_origins_raw)
+        if _is_memory_db(self._database_path):
+            with self._memory_connection_lock:
+                if self._memory_connection is None:
+                    self._memory_connection = sqlite3.connect(
+                        self._database_path,
+                        detect_types=sqlite3.PARSE_DECLTYPES,
+                        check_same_thread=False,
+                        uri=self._database_path.startswith("file:"),
+                    )
+                    self._memory_connection.row_factory = sqlite3.Row
+                connection = self._memory_connection
+                if connection is None:
+                    raise RuntimeError("Expected an initialized in-memory connection but found None.")
+                return connection
+
+        connection = sqlite3.connect(
+            self._database_path,
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            check_same_thread=False,
+            uri=self._database_path.startswith("file:"),
+        )
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def close_shared_connection(self) -> None:
+        """
+        Close the manager's shared persistent in-memory SQLite connection, if present.
+
+        If a shared in-memory connection exists, it is closed and cleared. This method is safe
+        to call repeatedly and acquires the manager's internal lock while performing the close.
+        """
+        with self._memory_connection_lock:
+            if self._memory_connection is not None:
+                self._memory_connection.close()
+                self._memory_connection = None
 
 
-def load_settings() -> Settings:
+_db_manager: _DatabaseConnectionManager | None = None
+
+
+def _get_db_manager() -> _DatabaseConnectionManager:
     """
-    Load runtime settings from environment variables.
+    Return a connection manager aligned to the current configured database path.
 
-    Creates a Settings instance populated from these environment variables:
-    ENV (default "development", stripped and lowercased), ALLOWED_ORIGINS,
-    GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, USE_REAL_DATA_FETCHER (parsed as a
-    boolean), DATABASE_URL, and ASSET_GRAPH_DATABASE_URL.
+    Reuses the existing manager when its path matches the current configured
+    database path; otherwise creates and stores a new manager.
 
     Returns:
-        settings (Settings): Constructed and validated Settings object.
+        _DatabaseConnectionManager: Manager for the current database path.
     """
-    return Settings(
-        env=os.getenv("ENV", "development").strip().lower(),
-        allowed_origins_raw=os.getenv("ALLOWED_ORIGINS", ""),
-        graph_cache_path=os.getenv("GRAPH_CACHE_PATH"),
-        real_data_cache_path=os.getenv("REAL_DATA_CACHE_PATH"),
-        use_real_data_fetcher=_parse_bool_env(os.getenv("USE_REAL_DATA_FETCHER")),
-        database_url=os.getenv("DATABASE_URL"),
-        asset_graph_database_url=os.getenv("ASSET_GRAPH_DATABASE_URL"),
+    global _db_manager
+    current_database_path = _get_database_path()
+    if _db_manager is None or _db_manager._database_path != current_database_path:
+        _db_manager = _DatabaseConnectionManager(current_database_path)
+    return _db_manager
+
+
+def _close_memory_connection_cache() -> None:
+    """Close and clear the module-level cached shared in-memory connection, if present."""
+    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
+
+    manager = _MEMORY_CONNECTION_MANAGER
+    connection = _MEMORY_CONNECTION
+
+    _MEMORY_CONNECTION = None
+    _MEMORY_CONNECTION_MANAGER = None
+
+    errors: list[sqlite3.Error] = []
+
+    manager_connection = getattr(manager, "_memory_connection", None)
+    if manager is not None:
+        try:
+            manager.close_shared_connection()
+        except sqlite3.Error as exc:
+            errors.append(exc)
+
+    if connection is not None and connection is not manager_connection:
+        try:
+            connection.close()
+        except sqlite3.Error as exc:
+            errors.append(exc)
+
+    if errors:
+        raise errors[0]
+
+
+def _connect() -> sqlite3.Connection:
+    """
+    Return a SQLite connection for the current configured database path.
+
+    For in-memory databases (as determined by the current configured path) the
+    module-level shared connection is returned, creating it on the first call
+    under a lock by delegating to the current connection manager.
+
+    If the configured database path changes, stale cached in-memory state is
+    discarded and a new manager is used.
+
+    For file-backed databases, the current manager creates a new connection
+    for each call.
+
+    Returns:
+        sqlite3.Connection: A shared persistent connection for in-memory databases,
+        or a new connection instance for file-backed databases.
+    """
+    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
+    current_database_path = _get_database_path()
+    manager = _get_db_manager()
+
+    if _is_memory_db(current_database_path):
+        with _MEMORY_CONNECTION_LOCK:
+            if _MEMORY_CONNECTION_MANAGER is not manager:
+                _close_memory_connection_cache()
+            if _MEMORY_CONNECTION is None:
+                _MEMORY_CONNECTION = manager.connect()
+                _MEMORY_CONNECTION_MANAGER = manager
+            return _MEMORY_CONNECTION
+
+    return manager.connect()
+
+
+@contextmanager
+def get_connection() -> Iterator[sqlite3.Connection]:
+    """
+    Yield a context-managed SQLite connection for the configured database.
+
+    For file-backed databases the yielded connection is closed when the context exits. For
+    in-memory databases a shared persistent connection is yielded and remains open across calls
+    (the context does not close it).
+
+    Returns:
+        sqlite3.Connection: An open SQLite connection for the configured database.
+    """
+    connection = _connect()
+    is_memory = _is_memory_db()
+    try:
+        yield connection
+    finally:
+        if not is_memory:
+            connection.close()
+
+
+def _cleanup_memory_connection() -> None:
+    """
+    Close any shared in-memory SQLite connections cached by this module.
+
+    Clear the module-level shared in-memory connection reference, close that
+    connection when it is distinct from the database manager's cached shared
+    connection, and always invoke the manager's shared-connection cleanup.
+    This avoids double-closing when both caches reference the same SQLite
+    connection. Safe to call multiple times.
+    """
+    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
+
+    errors: list[sqlite3.Error] = []
+    with _MEMORY_CONNECTION_LOCK:
+        module_connection = _MEMORY_CONNECTION
+        manager = _MEMORY_CONNECTION_MANAGER or _db_manager
+        manager_connection = getattr(manager, "_memory_connection", None)
+
+        _MEMORY_CONNECTION = None
+        _MEMORY_CONNECTION_MANAGER = None
+
+        if module_connection is not None and module_connection is not manager_connection:
+            try:
+                module_connection.close()
+            except sqlite3.Error as exc:
+                errors.append(exc)
+
+        if manager is not None:
+            try:
+                manager.close_shared_connection()
+            except sqlite3.Error as exc:
+                errors.append(exc)
+
+    if errors:
+        raise errors[0]
+
+
+atexit.register(_cleanup_memory_connection)
+
+
+def execute(query: str, parameters: tuple | list | None = None) -> None:
+    """
+    Execute a SQL write statement and commit the transaction.
+
+    Use the module's managed SQLite connection.
+
+    Parameters:
+        query (str): SQL statement to execute.
+        parameters (tuple | list | None): Sequence of values to bind to the
+            statement; use `None` or an empty sequence if there are no parameters.
+    """
+    with get_connection() as connection:
+        connection.execute(query, parameters or ())
+        connection.commit()
+
+
+def fetch_one(query: str, parameters: tuple | list | None = None):
+    """
+    Retrieve the first row produced by an SQL query.
+
+    Parameters:
+        query (str): SQL statement to execute.
+        parameters (tuple | list | None): Optional sequence of parameters
+            to bind into the query.
+
+    Returns:
+        sqlite3.Row | None: The first row of the result set
+            as a `sqlite3.Row`, or `None` if the query returned no rows.
+    """
+    with get_connection() as connection:
+        cursor = connection.execute(query, parameters or ())
+        return cursor.fetchone()
+
+
+def fetch_value(query: str, parameters: tuple | list | None = None) -> object | None:
+    """
+    Return the first column value from the first row of a query result.
+
+    If the query returns no rows, returns `None`. For any non-string indexable row
+    (e.g. ``sqlite3.Row``, ``tuple``, ``list``, SQLAlchemy ``Row``, or a mock with ``__getitem__``),
+    attempts to return ``row[0]``. Returns ``None`` when the row
+    is empty (i.e. ``row[0]`` raises ``IndexError``), and returns the row object
+    unchanged only when indexing is not supported (``TypeError``).
+
+    Parameters:
+        query (str): SQL query to execute; may include parameter placeholders.
+        parameters (tuple | list | None): Sequence of parameters for the query placeholders.
+
+    Returns:
+        The first column value from the first row, or `None` if no row is returned.
+    """
+    row = fetch_one(query, parameters)
+    if row is None:
+        return None
+    if isinstance(row, (sqlite3.Row, tuple, list)):
+        return row[0] if row else None
+    try:
+        return row[0]
+    except IndexError:
+        return None
+    except TypeError:
+        return row
+
+
+def initialize_schema() -> None:
+    """
+    Create the `user_credentials` table if it does not already exist.
+
+    The table has the following columns:
+    - `id`: INTEGER PRIMARY KEY AUTOINCREMENT
+    - `username`: TEXT, unique and not null
+    - `email`: TEXT
+    - `full_name`: TEXT
+    - `hashed_password`: TEXT, not null
+    - `disabled`: INTEGER, not null, defaults to 0
+    """
+    execute(
+        """
+        CREATE TABLE IF NOT EXISTS user_credentials(
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            username TEXT UNIQUE NOT NULL,
+            email TEXT,
+            full_name TEXT,
+            hashed_password TEXT NOT NULL,
+            disabled INTEGER NOT NULL DEFAULT 0
+        )
+        """
     )
-
-
-@lru_cache(maxsize=1)
-def get_settings() -> Settings:
-    """
-    Get the cached runtime settings instance.
-
-    Settings are loaded once and cached for the lifetime of the process unless
-    the cache is explicitly cleared.
-
-    Returns:
-        Settings: The cached settings instance.
-    """
-    return load_settings()
+    

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,495 +1,140 @@
-"""Lightweight database helpers for the API layer."""
+"""Centralized typed settings layer for selected runtime configuration.
+
+This module provides a typed settings interface for the runtime configuration
+centralized by this PR, specifically environment mode, CORS allowlist input,
+graph cache settings, real-data fetcher settings, and database URL resolution.
+It does not yet replace all direct environment reads across the repository.
+"""
 
 from __future__ import annotations
 
-import atexit
-import sqlite3
-import threading
-from collections.abc import Iterator
-from contextlib import contextmanager
-from pathlib import Path
-from urllib.parse import unquote, urlparse
+import os
+from functools import lru_cache
+from typing import Optional
 
-from src.config.settings import get_settings
+from pydantic import BaseModel, ConfigDict, Field
 
 
-def _get_database_url() -> str:
+def _parse_bool_env(value: Optional[str]) -> bool:
     """
-    Return the effective database URL from centralized runtime settings.
+    Parse a boolean environment variable value.
 
-    Returns:
-        str: Effective database URL.
-
-    Raises:
-        ValueError: If no effective database URL is configured.
-    """
-    database_url = get_settings().effective_database_url
-    if not database_url:
-        raise ValueError(
-            "Database URL must be configured before using the database helpers. "
-            "Set ASSET_GRAPH_DATABASE_URL or DATABASE_URL."
-        )
-    return database_url
-
-
-def _normalize_sqlite_path(parsed_path: str) -> str:
-    """
-    Decode percent-encoding in a SQLite URL path.
+    Interprets the value case-insensitively; the values "1", "true", "yes",
+    or "on" (ignoring surrounding whitespace) are treated as true.
 
     Parameters:
-        parsed_path (str): The raw path component extracted from a parsed SQLite URL, possibly containing
-            percent-encoded characters.
+        value (Optional[str]): Environment variable value to parse.
 
     Returns:
-        str: The path with percent-encoded sequences decoded.
+        bool: True if the value matches an accepted truthy value, False otherwise.
     """
-    return unquote(parsed_path)
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "on"}
 
 
-def _is_standard_memory_path(parsed: object, normalized_path: str) -> bool:
+def _parse_csv_env(value: str) -> list[str]:
     """
-    Determine whether a parsed SQLite URL refers to the standard SQLite in-memory database.
+    Parse a comma-separated environment variable value into a list of strings.
+
+    Splits on commas, trims whitespace, and excludes empty entries.
 
     Parameters:
-        parsed (object): Result of urllib.parse.urlparse (or similar) whose `netloc` may be ":memory:".
-        normalized_path (str): Percent-decoded path component of the URL.
+        value (str): Comma-separated string to parse.
 
     Returns:
-        bool: `True` if `parsed.netloc == ":memory:"` or `normalized_path` is `":memory:"` or
-            `"/:memory:"`, `False` otherwise.
+        list[str]: A list of trimmed non-empty strings.
     """
-    parsed_netloc = getattr(parsed, "netloc", "")
-    return parsed_netloc == ":memory:" or normalized_path in {":memory:", "/:memory:"}
+    return [item.strip() for item in value.split(",") if item.strip()]
 
 
-def _resolve_uri_style_memory_path(
-    path: str,
-    query: str,
-) -> str | None:
+class Settings(BaseModel):
     """
-    Return a URI-style SQLite in-memory path extracted from a URL path component.
+    Runtime configuration settings centralized by this PR.
 
-    If `path` represents a URI-style in-memory database (after removing leading
-    slashes and beginning with `file:` and containing `:memory:`), return the
-    normalized URI string. If `query` is non-empty, append it prefixed with `?`.
-
-    Parameters:
-        path (str): URL path component that may include leading slashes and a
-            `file:` URI indicating an in-memory database.
-        query (str): Raw query string (without a leading '?') to append when
-            present.
-
-    Returns:
-        str | None: The normalized URI-style memory path with `?{query}` appended
-            if `query` is non-empty, or `None` if `path` is not a URI-style memory
-            database.
-    """
-    if not path.lstrip("/").startswith("file:") or ":memory:" not in path:
-        return None
-    result = path.lstrip("/")
-    if query:
-        result += f"?{query}"
-    return result
-
-
-def _resolve_file_path(path: str) -> str:
-    """
-    Convert a normalized SQLite file path component into an absolute filesystem path.
-
-    Handles three forms:
-    - Absolute paths starting with a single leading slash (e.g., "/foo") are resolved as-is.
-    - UNC-like paths starting with two leading slashes (e.g., "//server/path") drop the first slash and are resolved.
-    - Rootless or relative-looking paths have any leading slashes removed and are resolved
-      relative to the current working directory.
-
-    Parameters:
-        path (str): Normalized SQLite path component; may be absolute ("/..."), UNC-like ("//..."), or rootless.
-
-    Returns:
-        str: The resolved absolute filesystem path.
-    """
-    if path.startswith("/") and not path.startswith("//"):
-        return str(Path(path).resolve())
-    if path.startswith("//"):
-        return str(Path(path[1:]).resolve())
-    return str(Path(path.lstrip("/")).resolve())
-
-
-def _resolve_sqlite_path(url: str) -> str:
-    """
-    Resolve a SQLite URL to a filesystem path or in-memory indicator.
-
-    Accept SQLite URLs with schemes like `sqlite:///relative.db`,
-    `sqlite:////absolute/path.db`, and `sqlite:///:memory:`.
-    Percent-encodings in the URL path are decoded before resolution.
-    For in-memory URLs (`:memory:` or `/:memory:`), return the literal string
-    `":memory:"`. URI-style memory databases like
-    `sqlite:///file::memory:?cache=shared` are returned as-is.
-
-    Parameters:
-        url (str): SQLite URL to resolve.
-
-    Returns:
-        str: Filesystem path for file-based URLs, the literal string `":memory:"`
-            for standard in-memory databases, or the original URI-style memory path.
-    """
-    parsed = urlparse(url)
-    if parsed.scheme != "sqlite":
-        raise ValueError(f"Not a valid sqlite URI: {url}")
-
-    normalized_path = parsed.path.rstrip("/")
-    if _is_standard_memory_path(parsed, normalized_path):
-        return ":memory:"
-
-    path = _normalize_sqlite_path(parsed.path)
-    uri_memory_path = _resolve_uri_style_memory_path(path, parsed.query)
-    if uri_memory_path is not None:
-        return uri_memory_path
-
-    return _resolve_file_path(path)
-
-
-def _get_database_path() -> str:
-    """
-    Return the resolved SQLite path for the effective database URL.
-
-    Returns:
-        str: Resolved SQLite path for the configured database URL.
-    """
-    return _resolve_sqlite_path(_get_database_url())
-
-
-# Module-level shared in-memory connection
-_MEMORY_CONNECTION: sqlite3.Connection | None = None
-_MEMORY_CONNECTION_MANAGER: _DatabaseConnectionManager | None = None
-_MEMORY_CONNECTION_LOCK = threading.Lock()
-
-
-def _is_memory_db(path: str | None = None) -> bool:
-    """
-    Determine whether a SQLite database path denotes an in-memory database.
-
-    If `path` is omitted, the current configured database path is evaluated. The function treats the
-    literal ":memory:" and file-style URIs whose path component is exactly ":memory:" (for
-    example, "file::memory:" or "file::memory:?cache=shared") as in-memory targets. It does not
-    treat file URIs where ":memory:" appears as part of a filesystem path or URIs that use
-    `mode=memory` as in-memory.
-
-    Parameters:
-        path (str | None): Database path or URI to evaluate. If omitted, the
-            current configured database path is used.
-
-    Returns:
-        bool: `True` if the evaluated target denotes an in-memory SQLite database, `False` otherwise.
-    """
-    target = _get_database_path() if path is None else path
-    if target == ":memory:":
-        return True
-
-    parsed = urlparse(target)
-    return parsed.scheme == "file" and (parsed.path == ":memory:" or ":memory:" in parsed.query)
-
-
-class _DatabaseConnectionManager:
-    """Manages SQLite connections to a configured database path.
-
-    Provides a persistent shared connection for in-memory databases and creates
-    new connections for file-backed databases. Thread-safe for in-memory usage.
+    Settings are loaded from environment variables and exposed through a typed,
+    immutable model. The cached accessor provides consistent config for startup
+    and module-level initialization paths.
     """
 
-    def __init__(self, database_path: str):
+    model_config = ConfigDict(frozen=True)
+
+    # Environment mode
+    env: str = Field(default="development")
+
+    # CORS configuration
+    allowed_origins_raw: str = Field(default="")
+
+    # Graph data source configuration
+    graph_cache_path: Optional[str] = Field(default=None)
+    real_data_cache_path: Optional[str] = Field(default=None)
+    use_real_data_fetcher: bool = Field(default=False)
+
+    # Database configuration
+    asset_graph_database_url: Optional[str] = Field(default=None)
+    database_url: Optional[str] = Field(default=None)
+
+    @property
+    def allowed_origins(self) -> list[str]:
         """
-        Create a connection manager for the given resolved SQLite database path.
+        Return the configured CORS allowed origins as a list of trimmed, non-empty strings.
 
-        The manager owns connection creation and lifecycle for both in-memory
-        and file-backed databases.
-
-        Parameters:
-            database_path (str): Resolved SQLite path — a filesystem path, the
-                literal ":memory:", or a URI-style memory path (e.g.
-                "file::memory:?cache=shared").
-        """
-        self._database_path = database_path
-        self._memory_connection: sqlite3.Connection | None = None
-        self._memory_connection_lock = threading.Lock()
-
-    def connect(self) -> sqlite3.Connection:
-        """
-        Open a SQLite connection for the manager's configured database path.
-
-        In-memory databases return a single shared connection (created on the
-        first call and reused thereafter). File-backed databases return a new
-        connection on every call. The returned connection has its row factory
-        set to ``sqlite3.Row``.
+        If `allowed_origins_raw` is empty, returns an empty list; otherwise the raw value is parsed by splitting on commas, trimming whitespace, and excluding empty entries.
 
         Returns:
-            sqlite3.Connection: The shared in-memory connection, or a new
-                connection for file-backed databases.
+            list[str]: Parsed allowed origin strings.
         """
-        if _is_memory_db(self._database_path):
-            with self._memory_connection_lock:
-                if self._memory_connection is None:
-                    self._memory_connection = sqlite3.connect(
-                        self._database_path,
-                        detect_types=sqlite3.PARSE_DECLTYPES,
-                        check_same_thread=False,
-                        uri=self._database_path.startswith("file:"),
-                    )
-                    self._memory_connection.row_factory = sqlite3.Row
-                connection = self._memory_connection
-                if connection is None:
-                    raise RuntimeError("Expected an initialized in-memory connection but found None.")
-                return connection
+        if not self.allowed_origins_raw:
+            return []
+        return _parse_csv_env(self.allowed_origins_raw)
 
-        connection = sqlite3.connect(
-            self._database_path,
-            detect_types=sqlite3.PARSE_DECLTYPES,
-            check_same_thread=False,
-            uri=self._database_path.startswith("file:"),
-        )
-        connection.row_factory = sqlite3.Row
-        return connection
-
-    def close_shared_connection(self) -> None:
+    @property
+    def effective_database_url(self) -> Optional[str]:
         """
-        Close the manager's shared persistent in-memory SQLite connection, if present.
+        Return the effective database URL for the API database helpers.
 
-        If a shared in-memory connection exists, it is closed and cleared. This method is safe
-        to call repeatedly and acquires the manager's internal lock while performing the close.
+        Prefers `asset_graph_database_url` when set, otherwise falls back to
+        `database_url`.
+
+        Returns:
+            Optional[str]: Effective database URL, or `None` when neither
+            source is configured.
         """
-        with self._memory_connection_lock:
-            if self._memory_connection is not None:
-                self._memory_connection.close()
-                self._memory_connection = None
+        return self.asset_graph_database_url or self.database_url
 
 
-_db_manager: _DatabaseConnectionManager | None = None
-
-
-def _get_db_manager() -> _DatabaseConnectionManager:
+def load_settings() -> Settings:
     """
-    Return a connection manager aligned to the current configured database path.
+    Load runtime settings from environment variables.
 
-    Reuses the existing manager when its path matches the current configured
-    database path; otherwise creates and stores a new manager.
+    Creates a Settings instance populated from these environment variables:
+    ENV (default "development", stripped and lowercased), ALLOWED_ORIGINS,
+    GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, USE_REAL_DATA_FETCHER (parsed as a
+    boolean), ASSET_GRAPH_DATABASE_URL, and DATABASE_URL.
 
     Returns:
-        _DatabaseConnectionManager: Manager for the current database path.
+        settings (Settings): Constructed and validated Settings object.
     """
-    global _db_manager
-    current_database_path = _get_database_path()
-    if _db_manager is None or _db_manager._database_path != current_database_path:
-        _db_manager = _DatabaseConnectionManager(current_database_path)
-    return _db_manager
+    return Settings(
+        env=os.getenv("ENV", "development").strip().lower(),
+        allowed_origins_raw=os.getenv("ALLOWED_ORIGINS", ""),
+        graph_cache_path=os.getenv("GRAPH_CACHE_PATH"),
+        real_data_cache_path=os.getenv("REAL_DATA_CACHE_PATH"),
+        use_real_data_fetcher=_parse_bool_env(os.getenv("USE_REAL_DATA_FETCHER")),
+        asset_graph_database_url=os.getenv("ASSET_GRAPH_DATABASE_URL"),
+        database_url=os.getenv("DATABASE_URL"),
+    )
 
 
-def _close_memory_connection_cache() -> None:
-    """Close and clear the module-level cached shared in-memory connection, if present."""
-    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
-
-    manager = _MEMORY_CONNECTION_MANAGER
-    connection = _MEMORY_CONNECTION
-
-    _MEMORY_CONNECTION = None
-    _MEMORY_CONNECTION_MANAGER = None
-
-    errors: list[sqlite3.Error] = []
-
-    manager_connection = getattr(manager, "_memory_connection", None)
-    if manager is not None:
-        try:
-            manager.close_shared_connection()
-        except sqlite3.Error as exc:
-            errors.append(exc)
-
-    if connection is not None and connection is not manager_connection:
-        try:
-            connection.close()
-        except sqlite3.Error as exc:
-            errors.append(exc)
-
-    if errors:
-        raise errors[0]
-
-
-def _connect() -> sqlite3.Connection:
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
     """
-    Return a SQLite connection for the current configured database path.
+    Get the cached runtime settings instance.
 
-    For in-memory databases (as determined by the current configured path) the
-    module-level shared connection is returned, creating it on the first call
-    under a lock by delegating to the current connection manager.
-
-    If the configured database path changes, stale cached in-memory state is
-    discarded and a new manager is used.
-
-    For file-backed databases, the current manager creates a new connection
-    for each call.
+    Settings are loaded once and cached for the lifetime of the process unless
+    the cache is explicitly cleared.
 
     Returns:
-        sqlite3.Connection: A shared persistent connection for in-memory databases,
-        or a new connection instance for file-backed databases.
+        Settings: The cached settings instance.
     """
-    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
-    current_database_path = _get_database_path()
-    manager = _get_db_manager()
-
-    if _is_memory_db(current_database_path):
-        with _MEMORY_CONNECTION_LOCK:
-            if _MEMORY_CONNECTION_MANAGER is not manager:
-                _close_memory_connection_cache()
-            if _MEMORY_CONNECTION is None:
-                _MEMORY_CONNECTION = manager.connect()
-                _MEMORY_CONNECTION_MANAGER = manager
-            return _MEMORY_CONNECTION
-
-    return manager.connect()
-
-
-@contextmanager
-def get_connection() -> Iterator[sqlite3.Connection]:
-    """
-    Yield a context-managed SQLite connection for the configured database.
-
-    For file-backed databases the yielded connection is closed when the context exits. For
-    in-memory databases a shared persistent connection is yielded and remains open across calls
-    (the context does not close it).
-
-    Returns:
-        sqlite3.Connection: An open SQLite connection for the configured database.
-    """
-    connection = _connect()
-    is_memory = _is_memory_db()
-    try:
-        yield connection
-    finally:
-        if not is_memory:
-            connection.close()
-
-
-def _cleanup_memory_connection() -> None:
-    """
-    Close any shared in-memory SQLite connections cached by this module.
-
-    Clear the module-level shared in-memory connection reference, close that
-    connection when it is distinct from the database manager's cached shared
-    connection, and always invoke the manager's shared-connection cleanup.
-    This avoids double-closing when both caches reference the same SQLite
-    connection. Safe to call multiple times.
-    """
-    global _MEMORY_CONNECTION, _MEMORY_CONNECTION_MANAGER
-
-    errors: list[sqlite3.Error] = []
-    with _MEMORY_CONNECTION_LOCK:
-        module_connection = _MEMORY_CONNECTION
-        manager = _MEMORY_CONNECTION_MANAGER or _db_manager
-        manager_connection = getattr(manager, "_memory_connection", None)
-
-        _MEMORY_CONNECTION = None
-        _MEMORY_CONNECTION_MANAGER = None
-
-        if module_connection is not None and module_connection is not manager_connection:
-            try:
-                module_connection.close()
-            except sqlite3.Error as exc:
-                errors.append(exc)
-
-        if manager is not None:
-            try:
-                manager.close_shared_connection()
-            except sqlite3.Error as exc:
-                errors.append(exc)
-
-    if errors:
-        raise errors[0]
-
-
-atexit.register(_cleanup_memory_connection)
-
-
-def execute(query: str, parameters: tuple | list | None = None) -> None:
-    """
-    Execute a SQL write statement and commit the transaction.
-
-    Use the module's managed SQLite connection.
-
-    Parameters:
-        query (str): SQL statement to execute.
-        parameters (tuple | list | None): Sequence of values to bind to the
-            statement; use `None` or an empty sequence if there are no parameters.
-    """
-    with get_connection() as connection:
-        connection.execute(query, parameters or ())
-        connection.commit()
-
-
-def fetch_one(query: str, parameters: tuple | list | None = None):
-    """
-    Retrieve the first row produced by an SQL query.
-
-    Parameters:
-        query (str): SQL statement to execute.
-        parameters (tuple | list | None): Optional sequence of parameters
-            to bind into the query.
-
-    Returns:
-        sqlite3.Row | None: The first row of the result set
-            as a `sqlite3.Row`, or `None` if the query returned no rows.
-    """
-    with get_connection() as connection:
-        cursor = connection.execute(query, parameters or ())
-        return cursor.fetchone()
-
-
-def fetch_value(query: str, parameters: tuple | list | None = None) -> object | None:
-    """
-    Return the first column value from the first row of a query result.
-
-    If the query returns no rows, returns `None`. For any non-string indexable row
-    (e.g. ``sqlite3.Row``, ``tuple``, ``list``, SQLAlchemy ``Row``, or a mock with ``__getitem__``),
-    attempts to return ``row[0]``. Returns ``None`` when the row
-    is empty (i.e. ``row[0]`` raises ``IndexError``), and returns the row object
-    unchanged only when indexing is not supported (``TypeError``).
-
-    Parameters:
-        query (str): SQL query to execute; may include parameter placeholders.
-        parameters (tuple | list | None): Sequence of parameters for the query placeholders.
-
-    Returns:
-        The first column value from the first row, or `None` if no row is returned.
-    """
-    row = fetch_one(query, parameters)
-    if row is None:
-        return None
-    if isinstance(row, (sqlite3.Row, tuple, list)):
-        return row[0] if row else None
-    try:
-        return row[0]
-    except IndexError:
-        return None
-    except TypeError:
-        return row
-
-
-def initialize_schema() -> None:
-    """
-    Create the `user_credentials` table if it does not already exist.
-
-    The table has the following columns:
-    - `id`: INTEGER PRIMARY KEY AUTOINCREMENT
-    - `username`: TEXT, unique and not null
-    - `email`: TEXT
-    - `full_name`: TEXT
-    - `hashed_password`: TEXT, not null
-    - `disabled`: INTEGER, not null, defaults to 0
-    """
-    execute("""
-        CREATE TABLE IF NOT EXISTS user_credentials(
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            username TEXT UNIQUE NOT NULL,
-            email TEXT,
-            full_name TEXT,
-            hashed_password TEXT NOT NULL,
-            disabled INTEGER NOT NULL DEFAULT 0
-        )
-        """)
+    return load_settings()

--- a/tests/unit/test_api_database.py
+++ b/tests/unit/test_api_database.py
@@ -62,12 +62,26 @@ class TestDatabaseURLConfiguration:
         """Test that missing DATABASE_URL raises a ValueError."""
         from src.config.settings import get_settings
 
-        with patch.dict(os.environ, {}, clear=True):
-            get_settings.cache_clear()
-            with pytest.raises(ValueError, match="DATABASE_URL must be configured"):
-                importlib.reload(database)
+        original_database_url = os.environ.get("DATABASE_URL")
+        restore_database_url = original_database_url or "sqlite:///:memory:"
 
-        get_settings.cache_clear()
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                get_settings.cache_clear()
+                with pytest.raises(
+                    ValueError,
+                    match="DATABASE_URL must be configured",
+                ):
+                    importlib.reload(database)
+        finally:
+            with patch.dict(
+                os.environ,
+                {"DATABASE_URL": restore_database_url},
+                clear=False,
+            ):
+                get_settings.cache_clear()
+                importlib.reload(database)
+                get_settings.cache_clear()
 
 
 class TestSQLitePathResolution:

--- a/tests/unit/test_api_database.py
+++ b/tests/unit/test_api_database.py
@@ -11,6 +11,7 @@ Tests cover:
 - Edge cases and error handling
 """
 
+import importlib
 import os
 import sqlite3
 import tempfile
@@ -19,6 +20,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+import api.database as database
 from api.database import (
     DATABASE_PATH,
     DATABASE_URL,
@@ -30,6 +32,42 @@ from api.database import (
     get_connection,
     initialize_schema,
 )
+
+
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    """Clear cached settings before and after each test."""
+    from src.config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+class TestDatabaseURLConfiguration:
+    """Test database URL configuration and validation."""
+
+    def test_database_url_is_set(self):
+        """Test that DATABASE_URL is set."""
+        assert DATABASE_URL is not None
+        assert isinstance(DATABASE_URL, str)
+        assert len(DATABASE_URL) > 0
+
+    def test_database_path_is_set(self):
+        """Test that DATABASE_PATH is resolved."""
+        assert DATABASE_PATH is not None
+        assert isinstance(DATABASE_PATH, str)
+
+    def test_missing_database_url_raises_error(self):
+        """Test that missing DATABASE_URL raises a ValueError."""
+        from src.config.settings import get_settings
+
+        with patch.dict(os.environ, {}, clear=True):
+            get_settings.cache_clear()
+            with pytest.raises(ValueError, match="DATABASE_URL must be configured"):
+                importlib.reload(database)
+
+        get_settings.cache_clear()
 
 
 class TestDatabaseURLConfiguration:
@@ -48,15 +86,15 @@ class TestDatabaseURLConfiguration:
 
     @patch.dict(os.environ, {"DATABASE_URL": ""}, clear=True)
     def test_missing_database_url_raises_error(self):
-        """Test that missing DATABASE_URL raises ValueError."""
-        from api import database as db_module
+        """Test that missing DATABASE_URL raises a ValueError."""
+        from src.config.settings import get_settings
 
-        # Need to reload the module to trigger the error
-        with pytest.raises(ValueError, match="DATABASE_URL environment variable must be set"):
-            # Import will fail due to module-level check
-            import importlib
-
-            importlib.reload(db_module)
+        get_settings.cache_clear()
+        with patch.dict(os.environ, {}, clear=True):
+            get_settings.cache_clear()
+            with pytest.raises(ValueError, match="DATABASE_URL must be configured"):
+                importlib.reload(database)
+        get_settings.cache_clear()
 
 
 class TestSQLitePathResolution:

--- a/tests/unit/test_api_database.py
+++ b/tests/unit/test_api_database.py
@@ -70,33 +70,6 @@ class TestDatabaseURLConfiguration:
         get_settings.cache_clear()
 
 
-class TestDatabaseURLConfiguration:
-    """Test database URL configuration and validation."""
-
-    def test_database_url_is_set(self):
-        """Test that DATABASE_URL is set."""
-        assert DATABASE_URL is not None
-        assert isinstance(DATABASE_URL, str)
-        assert len(DATABASE_URL) > 0
-
-    def test_database_path_is_set(self):
-        """Test that DATABASE_PATH is resolved."""
-        assert DATABASE_PATH is not None
-        assert isinstance(DATABASE_PATH, str)
-
-    @patch.dict(os.environ, {"DATABASE_URL": ""}, clear=True)
-    def test_missing_database_url_raises_error(self):
-        """Test that missing DATABASE_URL raises a ValueError."""
-        from src.config.settings import get_settings
-
-        get_settings.cache_clear()
-        with patch.dict(os.environ, {}, clear=True):
-            get_settings.cache_clear()
-            with pytest.raises(ValueError, match="DATABASE_URL must be configured"):
-                importlib.reload(database)
-        get_settings.cache_clear()
-
-
 class TestSQLitePathResolution:
     """Test SQLite URL path resolution."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -220,9 +220,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -232,12 +232,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -258,9 +258,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -306,9 +306,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -428,14 +428,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -16,6 +16,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+import api.database as database
 from api.database import (
     _connect,
     _get_database_url,

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -139,9 +139,9 @@ class TestConnect:
             with patch("api.database.sqlite3.connect") as mock_connect:
                 mock_connection = MagicMock()
                 mock_connect.return_value = mock_connection
-    
+
                 connection = database._connect()
-    
+
             assert connection is mock_connection
             mock_connect.assert_called_once()
             assert mock_connect.call_args.kwargs["uri"] is True
@@ -182,9 +182,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -194,12 +194,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -220,9 +220,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -268,9 +268,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -390,14 +390,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -79,6 +79,7 @@ class TestGetDatabaseUrl:
 
         assert "DATABASE_URL must be configured" in str(exc_info.value)
 
+
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -207,9 +207,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -219,12 +219,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -245,9 +245,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -293,9 +293,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -415,14 +415,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -202,9 +202,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -214,12 +214,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -240,9 +240,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -288,9 +288,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -410,14 +410,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -184,9 +184,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -196,12 +196,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -222,9 +222,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -270,9 +270,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -392,14 +392,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -183,9 +183,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -195,12 +195,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -221,9 +221,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -270,9 +270,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -392,14 +392,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -36,16 +36,11 @@ class TestGetDatabaseUrl:
             assert url == "sqlite:///test.db"
 
     def test_get_database_url_raises_when_not_set(self):
-
-
-
- """Test that ValueError is raised when DATABASE_URL is not set."""
-  with patch.dict(os.environ, {}, clear=True):
-       with pytest.raises(ValueError) as exc_info:
-            _get_database_url()
-        assert "DATABASE_URL environment variable must be set" in str(exc_info.value)
-
-
+        """Test that ValueError is raised when DATABASE_URL is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(ValueError) as exc_info:
+                _get_database_url()
+            assert "DATABASE_URL" in str(exc_info.value)
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -43,8 +43,6 @@ class TestGetDatabaseUrl:
             assert "DATABASE_URL" in str(exc_info.value)
 
 
-
-
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -223,9 +223,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -235,12 +235,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -261,9 +261,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -309,9 +309,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -431,14 +431,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -229,9 +229,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -241,12 +241,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -267,9 +267,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -315,9 +315,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -437,14 +437,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -81,6 +81,7 @@ class TestDatabaseURLConfiguration:
                 importlib.reload(database)
                 get_settings.cache_clear()
 
+
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -130,21 +130,21 @@ class TestConnect:
         assert conn == mock_conn
 
     def test_connect_resolves_uri_path_via_settings(self):
-    with patch.dict(
-        os.environ,
-        {"DATABASE_URL": "sqlite:///file:test.db?mode=ro"},
-        clear=False,
-    ):
-        get_settings.cache_clear()
-        with patch("api.database.sqlite3.connect") as mock_connect:
-            mock_connection = MagicMock()
-            mock_connect.return_value = mock_connection
-
-            connection = database._connect()
-
-        assert connection is mock_connection
-        mock_connect.assert_called_once()
-        assert mock_connect.call_args.kwargs["uri"] is True
+        with patch.dict(
+            os.environ,
+            {"DATABASE_URL": "sqlite:///file:test.db?mode=ro"},
+            clear=False,
+        ):
+            get_settings.cache_clear()
+            with patch("api.database.sqlite3.connect") as mock_connect:
+                mock_connection = MagicMock()
+                mock_connect.return_value = mock_connection
+    
+                connection = database._connect()
+    
+            assert connection is mock_connection
+            mock_connect.assert_called_once()
+            assert mock_connect.call_args.kwargs["uri"] is True
 
 
 class TestGetConnection:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -207,9 +207,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -219,12 +219,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -245,9 +245,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -293,9 +293,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -415,14 +415,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -149,22 +149,27 @@ class TestConnect:
         mock_manager.connect.assert_called_once()
         assert conn == mock_conn
 
-    def test_connect_resolves_uri_path_via_settings(self):
-        with patch.dict(
-            os.environ,
-            {"DATABASE_URL": "sqlite:///file:test.db?mode=ro"},
-            clear=False,
+    def test_connect_with_uri_path(self):
+        """Test connecting with URI-style database path uses URI mode."""
+        temp_manager = database._DatabaseConnectionManager("file:test.db?mode=ro")
+
+        with (
+            patch.object(database, "DATABASE_PATH", "file:test.db?mode=ro"),
+            patch.object(database, "_db_manager", temp_manager),
+            patch("api.database.sqlite3.connect") as mock_connect,
         ):
-            get_settings.cache_clear()
-            with patch("api.database.sqlite3.connect") as mock_connect:
-                mock_connection = MagicMock()
-                mock_connect.return_value = mock_connection
+            mock_connection = MagicMock()
+            mock_connect.return_value = mock_connection
 
-                connection = database._connect()
+            connection = database._connect()
 
-            assert connection is mock_connection
-            mock_connect.assert_called_once()
-            assert mock_connect.call_args.kwargs["uri"] is True
+        assert connection is mock_connection
+        mock_connect.assert_called_once_with(
+            "file:test.db?mode=ro",
+            detect_types=sqlite3.PARSE_DECLTYPES,
+            check_same_thread=False,
+            uri=True,
+        )
 
 
 class TestGetConnection:
@@ -202,9 +207,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -214,12 +219,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -240,9 +245,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -288,9 +293,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -410,14 +415,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -212,9 +212,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -224,12 +224,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -250,9 +250,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -298,9 +298,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -420,14 +420,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -229,9 +229,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -241,12 +241,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -267,9 +267,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -315,9 +315,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -437,14 +437,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -223,9 +223,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -235,12 +235,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -261,9 +261,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -309,9 +309,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -431,14 +431,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -43,6 +43,8 @@ class TestGetDatabaseUrl:
             assert "DATABASE_URL" in str(exc_info.value)
 
 
+
+
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -31,17 +31,35 @@ class TestGetDatabaseUrl:
     """Test cases for _get_database_url function."""
 
     def test_get_database_url_from_env(self):
-        """Test reading DATABASE_URL from environment."""
+        """Test reading DATABASE_URL from centralized settings."""
         with patch.dict(os.environ, {"DATABASE_URL": "sqlite:///test.db"}):
+            get_settings.cache_clear()
             url = _get_database_url()
-            assert url == "sqlite:///test.db"
+
+        assert url == "sqlite:///test.db"
+
+    def test_get_database_url_prefers_asset_graph_database_url(self):
+        """Test that ASSET_GRAPH_DATABASE_URL takes precedence over DATABASE_URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "ASSET_GRAPH_DATABASE_URL": "sqlite:///asset-graph.db",
+                "DATABASE_URL": "sqlite:///fallback.db",
+            },
+        ):
+            get_settings.cache_clear()
+            url = _get_database_url()
+
+        assert url == "sqlite:///asset-graph.db"
 
     def test_get_database_url_raises_when_not_set(self):
-        """Test that ValueError is raised when DATABASE_URL is not set."""
+        """Test that ValueError is raised when no database URL is configured."""
         with patch.dict(os.environ, {}, clear=True):
+            get_settings.cache_clear()
             with pytest.raises(ValueError) as exc_info:
                 _get_database_url()
-            assert "DATABASE_URL" in str(exc_info.value)
+
+        assert "Database URL must be configured" in str(exc_info.value)
 
 
 class TestResolveSqlitePath:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -242,10 +242,9 @@ class TestConnectModuleLevelCaching:
         try:
             with patch.object(api.database, "DATABASE_PATH", ":memory:"):
                 with patch.object(api.database, "_db_manager", temp_manager):
-                    with patch.object(api.database, "_is_memory_db", return_value=True):
-                        conn1 = api.database._connect()
-                        conn2 = api.database._connect()
-                        assert conn1 is conn2, "Repeated _connect() calls must return the same cached connection"
+                    conn1 = api.database._connect()
+                    conn2 = api.database._connect()
+                    assert conn1 is conn2, "Repeated _connect() calls must return the same cached connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -35,45 +35,49 @@ def clear_settings_cache():
     get_settings.cache_clear()
 
 
-class TestDatabaseURLConfiguration:
-    """Test database URL configuration and validation."""
+class TestGetDatabaseUrl:
+    """Test cases for _get_database_url function."""
 
-    def test_database_url_is_set(self):
-        """Test that DATABASE_URL is set."""
-        assert DATABASE_URL is not None
-        assert isinstance(DATABASE_URL, str)
-        assert len(DATABASE_URL) > 0
+    def test_get_database_url_from_env(self):
+        """Test reading DATABASE_URL from centralized settings."""
+        with patch.dict(os.environ, {"DATABASE_URL": "sqlite:///test.db"}):
+            from src.config.settings import get_settings
 
-    def test_database_path_is_set(self):
-        """Test that DATABASE_PATH is resolved."""
-        assert DATABASE_PATH is not None
-        assert isinstance(DATABASE_PATH, str)
+            get_settings.cache_clear()
+            url = _get_database_url()
 
-    def test_missing_database_url_raises_error(self):
-        """Test that missing DATABASE_URL raises a ValueError."""
-        from src.config.settings import get_settings
+        assert url == "sqlite:///test.db"
 
-        original_database_url = os.environ.get("DATABASE_URL")
-        fallback_database_url = original_database_url or "sqlite:///:memory:"
+    def test_get_database_url_ignores_asset_graph_database_url(self):
+        """Test that API database helpers do not consume ASSET_GRAPH_DATABASE_URL."""
+        with patch.dict(
+            os.environ,
+            {
+                "ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db",
+                "DATABASE_URL": "sqlite:///api.db",
+            },
+        ):
+            from src.config.settings import get_settings
 
-        try:
-            with patch.dict(os.environ, {}, clear=True):
-                get_settings.cache_clear()
-                with pytest.raises(
-                    ValueError,
-                    match="DATABASE_URL must be configured",
-                ):
-                    importlib.reload(database)
-        finally:
-            with patch.dict(
-                os.environ,
-                {"DATABASE_URL": fallback_database_url},
-                clear=False,
-            ):
-                get_settings.cache_clear()
-                importlib.reload(database)
-                get_settings.cache_clear()
+            get_settings.cache_clear()
+            url = _get_database_url()
 
+        assert url == "sqlite:///api.db"
+
+    def test_get_database_url_raises_when_database_url_not_set(self):
+        """Test that ValueError is raised when DATABASE_URL is not set."""
+        with patch.dict(
+            os.environ,
+            {"ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db"},
+            clear=True,
+        ):
+            from src.config.settings import get_settings
+
+            get_settings.cache_clear()
+            with pytest.raises(ValueError) as exc_info:
+                _get_database_url()
+
+        assert "DATABASE_URL must be configured" in str(exc_info.value)
 
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -211,9 +211,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -223,12 +223,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -249,9 +249,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -297,9 +297,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -419,14 +419,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -9,69 +9,77 @@ This module provides extensive test coverage for api/database.py including:
 - Cleanup and resource management
 """
 
+import importlib
 import os
 import sqlite3
-import threading
-from unittest.mock import MagicMock, patch
+import tempfile
+from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
+import api.database as database
 from api.database import (
-    _connect,
-    _get_database_url,
+    DATABASE_PATH,
+    DATABASE_URL,
     _is_memory_db,
     _resolve_sqlite_path,
+    execute,
+    fetch_one,
+    fetch_value,
     get_connection,
+    initialize_schema,
 )
-from src.config.settings import get_settings
 
 
 @pytest.fixture(autouse=True)
 def clear_settings_cache():
     """Clear cached settings before and after each test."""
+    from src.config.settings import get_settings
+
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
 
 
-class TestGetDatabaseUrl:
-    """Test cases for _get_database_url function."""
+class TestDatabaseURLConfiguration:
+    """Test database URL configuration and validation."""
 
-    def test_get_database_url_from_env(self):
-        """Test reading DATABASE_URL from centralized settings."""
-        with patch.dict(os.environ, {"DATABASE_URL": "sqlite:///test.db"}):
-            get_settings.cache_clear()
-            url = _get_database_url()
+    def test_database_url_is_set(self):
+        """Test that DATABASE_URL is set."""
+        assert DATABASE_URL is not None
+        assert isinstance(DATABASE_URL, str)
+        assert len(DATABASE_URL) > 0
 
-        assert url == "sqlite:///test.db"
+    def test_database_path_is_set(self):
+        """Test that DATABASE_PATH is resolved."""
+        assert DATABASE_PATH is not None
+        assert isinstance(DATABASE_PATH, str)
 
-    def test_get_database_url_ignores_asset_graph_database_url(self):
-        """Test that API database helpers do not consume ASSET_GRAPH_DATABASE_URL."""
-        with patch.dict(
-            os.environ,
-            {
-                "ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db",
-                "DATABASE_URL": "sqlite:///api.db",
-            },
-        ):
-            get_settings.cache_clear()
-            url = _get_database_url()
+    def test_missing_database_url_raises_error(self):
+        """Test that missing DATABASE_URL raises a ValueError."""
+        from src.config.settings import get_settings
 
-        assert url == "sqlite:///api.db"
+        original_database_url = os.environ.get("DATABASE_URL")
+        fallback_database_url = original_database_url or "sqlite:///:memory:"
 
-    def test_get_database_url_raises_when_database_url_not_set(self):
-        """Test that ValueError is raised when DATABASE_URL is not set."""
-        with patch.dict(
-            os.environ,
-            {"ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db"},
-            clear=True,
-        ):
-            get_settings.cache_clear()
-            with pytest.raises(ValueError) as exc_info:
-                _get_database_url()
-
-        assert "DATABASE_URL must be configured" in str(exc_info.value)
-
+        try:
+            with patch.dict(os.environ, {}, clear=True):
+                get_settings.cache_clear()
+                with pytest.raises(
+                    ValueError,
+                    match="DATABASE_URL must be configured",
+                ):
+                    importlib.reload(database)
+        finally:
+            with patch.dict(
+                os.environ,
+                {"DATABASE_URL": fallback_database_url},
+                clear=False,
+            ):
+                get_settings.cache_clear()
+                importlib.reload(database)
+                get_settings.cache_clear()
 
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -211,9 +211,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -223,12 +223,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -249,9 +249,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -297,9 +297,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -419,14 +419,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -23,7 +23,6 @@ from api.database import (
     _resolve_sqlite_path,
     get_connection,
 )
-from src.config.settings import get_settings
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -26,6 +26,14 @@ from api.database import (
 from src.config.settings import get_settings
 
 
+@pytest.fixture(autouse=True)
+def clear_settings_cache():
+    """Clear cached settings before and after each test."""
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
 class TestGetDatabaseUrl:
     """Test cases for _get_database_url function."""
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -185,9 +185,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -197,12 +197,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -223,9 +223,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -271,9 +271,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -393,14 +393,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -38,28 +38,32 @@ class TestGetDatabaseUrl:
 
         assert url == "sqlite:///test.db"
 
-    def test_get_database_url_prefers_asset_graph_database_url(self):
-        """Test that ASSET_GRAPH_DATABASE_URL takes precedence over DATABASE_URL."""
+    def test_get_database_url_ignores_asset_graph_database_url(self):
+        """Test that API database helpers do not consume ASSET_GRAPH_DATABASE_URL."""
         with patch.dict(
             os.environ,
             {
-                "ASSET_GRAPH_DATABASE_URL": "sqlite:///asset-graph.db",
-                "DATABASE_URL": "sqlite:///fallback.db",
+                "ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db",
+                "DATABASE_URL": "sqlite:///api.db",
             },
         ):
             get_settings.cache_clear()
             url = _get_database_url()
 
-        assert url == "sqlite:///asset-graph.db"
+        assert url == "sqlite:///api.db"
 
-    def test_get_database_url_raises_when_not_set(self):
-        """Test that ValueError is raised when no database URL is configured."""
-        with patch.dict(os.environ, {}, clear=True):
+    def test_get_database_url_raises_when_database_url_not_set(self):
+        """Test that ValueError is raised when DATABASE_URL is not set."""
+        with patch.dict(
+            os.environ,
+            {"ASSET_GRAPH_DATABASE_URL": "postgresql://user:pass@localhost/db"},
+            clear=True,
+        ):
             get_settings.cache_clear()
             with pytest.raises(ValueError) as exc_info:
                 _get_database_url()
 
-        assert "Database URL must be configured" in str(exc_info.value)
+        assert "DATABASE_URL must be configured" in str(exc_info.value)
 
 
 class TestResolveSqlitePath:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -222,9 +222,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -234,12 +234,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -260,9 +260,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -308,9 +308,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -430,14 +430,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -139,8 +139,10 @@ class TestConnect:
 
         with patch("api.database.sqlite3.connect", return_value=mock_conn) as mock_sqlite_connect:
             temp_manager = _DatabaseConnectionManager("file:test.db?mode=ro")
-            with patch.object(api.database, "_db_manager", temp_manager):
-                _connect()
+            with patch.object(api.database, "DATABASE_PATH", "file:test.db?mode=ro"):
+                with patch.object(api.database, "_is_memory_db", return_value=False):
+                    with patch.object(api.database, "_db_manager", temp_manager):
+                        _connect()
 
         call_kwargs = mock_sqlite_connect.call_args[1]
         assert call_kwargs.get("uri") is True
@@ -239,11 +241,12 @@ class TestConnectModuleLevelCaching:
         api.database._MEMORY_CONNECTION = None
         api.database._MEMORY_CONNECTION_MANAGER = None
         try:
-            with patch.object(api.database, "_db_manager", temp_manager):
-                with patch.object(api.database, "_is_memory_db", return_value=True):
-                    conn1 = api.database._connect()
-                    conn2 = api.database._connect()
-                    assert conn1 is conn2, "Repeated _connect() calls must return the same cached connection"
+            with patch.object(api.database, "DATABASE_PATH", ":memory:"):
+                with patch.object(api.database, "_db_manager", temp_manager):
+                    with patch.object(api.database, "_is_memory_db", return_value=True):
+                        conn1 = api.database._connect()
+                        conn2 = api.database._connect()
+                        assert conn1 is conn2, "Repeated _connect() calls must return the same cached connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -182,9 +182,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -194,12 +194,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -220,9 +220,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -268,9 +268,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -390,14 +390,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -129,23 +129,22 @@ class TestConnect:
         mock_manager.connect.assert_called_once()
         assert conn == mock_conn
 
-    def test_connect_with_uri_path(self):
-        """Test connecting with URI-style database path uses URI mode."""
-        import api.database
-        from api.database import _DatabaseConnectionManager
+    def test_connect_resolves_uri_path_via_settings(self):
+    with patch.dict(
+        os.environ,
+        {"DATABASE_URL": "sqlite:///file:test.db?mode=ro"},
+        clear=False,
+    ):
+        get_settings.cache_clear()
+        with patch("api.database.sqlite3.connect") as mock_connect:
+            mock_connection = MagicMock()
+            mock_connect.return_value = mock_connection
 
-        mock_conn = MagicMock(spec=sqlite3.Connection)
-        mock_conn.row_factory = None
+            connection = database._connect()
 
-        with patch("api.database.sqlite3.connect", return_value=mock_conn) as mock_sqlite_connect:
-            temp_manager = _DatabaseConnectionManager("file:test.db?mode=ro")
-            with patch.object(api.database, "DATABASE_PATH", "file:test.db?mode=ro"):
-                with patch.object(api.database, "_is_memory_db", return_value=False):
-                    with patch.object(api.database, "_db_manager", temp_manager):
-                        _connect()
-
-        call_kwargs = mock_sqlite_connect.call_args[1]
-        assert call_kwargs.get("uri") is True
+        assert connection is mock_connection
+        mock_connect.assert_called_once()
+        assert mock_connect.call_args.kwargs["uri"] is True
 
 
 class TestGetConnection:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -23,6 +23,7 @@ from api.database import (
     _resolve_sqlite_path,
     get_connection,
 )
+from src.config.settings import get_settings
 
 
 class TestGetDatabaseUrl:
@@ -35,12 +36,14 @@ class TestGetDatabaseUrl:
             assert url == "sqlite:///test.db"
 
     def test_get_database_url_raises_when_not_set(self):
-from src.config.settings import get_settings
-        """Test that ValueError is raised when DATABASE_URL is not set."""
-        with patch.dict(os.environ, {}, clear=True):
-            with pytest.raises(ValueError) as exc_info:
-                _get_database_url()
-            assert "DATABASE_URL environment variable must be set" in str(exc_info.value)
+
+
+
+ """Test that ValueError is raised when DATABASE_URL is not set."""
+  with patch.dict(os.environ, {}, clear=True):
+       with pytest.raises(ValueError) as exc_info:
+            _get_database_url()
+        assert "DATABASE_URL environment variable must be set" in str(exc_info.value)
 
 
 class TestResolveSqlitePath:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -9,27 +9,21 @@ This module provides extensive test coverage for api/database.py including:
 - Cleanup and resource management
 """
 
-import importlib
 import os
 import sqlite3
-import tempfile
-from pathlib import Path
-from unittest.mock import Mock, patch
+import threading
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-import api.database as database
 from api.database import (
-    DATABASE_PATH,
-    DATABASE_URL,
+    _connect,
+    _get_database_url,
     _is_memory_db,
     _resolve_sqlite_path,
-    execute,
-    fetch_one,
-    fetch_value,
     get_connection,
-    initialize_schema,
 )
+from src.config.settings import get_settings
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -184,9 +184,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -196,12 +196,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -222,9 +222,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -270,9 +270,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -392,14 +392,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -220,9 +220,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -232,12 +232,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -258,9 +258,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -306,9 +306,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -428,14 +428,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -183,9 +183,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -195,12 +195,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -221,9 +221,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -269,9 +269,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -391,14 +391,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -23,7 +23,6 @@ from api.database import (
     _resolve_sqlite_path,
     get_connection,
 )
-from src.config.settings import get_settings
 
 
 class TestGetDatabaseUrl:
@@ -36,6 +35,7 @@ class TestGetDatabaseUrl:
             assert url == "sqlite:///test.db"
 
     def test_get_database_url_raises_when_not_set(self):
+from src.config.settings import get_settings
         """Test that ValueError is raised when DATABASE_URL is not set."""
         with patch.dict(os.environ, {}, clear=True):
             with pytest.raises(ValueError) as exc_info:

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -227,9 +227,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -239,12 +239,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -265,9 +265,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -313,9 +313,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -435,14 +435,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -11,6 +11,7 @@ This module provides extensive test coverage for api/database.py including:
 
 import os
 import sqlite3
+from src.config.settings import get_settings
 import threading
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -41,6 +41,8 @@ class TestGetDatabaseUrl:
             with pytest.raises(ValueError) as exc_info:
                 _get_database_url()
             assert "DATABASE_URL" in str(exc_info.value)
+
+
 class TestResolveSqlitePath:
     """Test cases for _resolve_sqlite_path function."""
 
@@ -181,9 +183,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -193,12 +195,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -219,9 +221,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -267,9 +269,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -389,14 +391,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -227,9 +227,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -239,12 +239,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -265,9 +265,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -313,9 +313,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -435,14 +435,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -16,7 +16,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-import api.database as database
 from api.database import (
     _connect,
     _get_database_url,
@@ -155,17 +154,19 @@ class TestConnect:
 
     def test_connect_with_uri_path(self):
         """Test connecting with URI-style database path uses URI mode."""
-        temp_manager = database._DatabaseConnectionManager("file:test.db?mode=ro")
+        import api.database
+
+        temp_manager = api.database._DatabaseConnectionManager("file:test.db?mode=ro")
 
         with (
-            patch.object(database, "DATABASE_PATH", "file:test.db?mode=ro"),
-            patch.object(database, "_db_manager", temp_manager),
+            patch.object(api.database, "DATABASE_PATH", "file:test.db?mode=ro"),
+            patch.object(api.database, "_db_manager", temp_manager),
             patch("api.database.sqlite3.connect") as mock_connect,
         ):
             mock_connection = MagicMock()
             mock_connect.return_value = mock_connection
 
-            connection = database._connect()
+            connection = _connect()
 
         assert connection is mock_connection
         mock_connect.assert_called_once_with(

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -11,7 +11,6 @@ This module provides extensive test coverage for api/database.py including:
 
 import os
 import sqlite3
-from src.config.settings import get_settings
 import threading
 from unittest.mock import MagicMock, patch
 
@@ -24,6 +23,7 @@ from api.database import (
     _resolve_sqlite_path,
     get_connection,
 )
+from src.config.settings import get_settings
 
 
 class TestGetDatabaseUrl:
@@ -183,9 +183,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -195,12 +195,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -221,9 +221,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -269,9 +269,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -391,14 +391,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -202,9 +202,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -214,12 +214,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -240,9 +240,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -288,9 +288,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -410,14 +410,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -212,9 +212,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(
-            _DatabaseConnectionManager, "LEGACY_CONNECTION"
-        ), "LEGACY_CONNECTION class attribute should have been removed"
+        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+            "LEGACY_CONNECTION class attribute should have been removed"
+        )
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -224,12 +224,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(
-                _DatabaseConnectionManager, "LEGACY_CONNECTION"
-            ), "File connect() must not create LEGACY_CONNECTION"
-            assert not hasattr(
-                manager, "LEGACY_CONNECTION"
-            ), "File connect() must not set LEGACY_CONNECTION on instance"
+            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
+                "File connect() must not create LEGACY_CONNECTION"
+            )
+            assert not hasattr(manager, "LEGACY_CONNECTION"), (
+                "File connect() must not set LEGACY_CONNECTION on instance"
+            )
         finally:
             conn.close()
 
@@ -250,9 +250,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is conn
-                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
+                    assert api.database._MEMORY_CONNECTION is conn, (
+                        "_MEMORY_CONNECTION global must be set to the returned connection"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -298,9 +298,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert (
-                        api.database._MEMORY_CONNECTION is None
-                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    assert api.database._MEMORY_CONNECTION is None, (
+                        "_MEMORY_CONNECTION must remain None for file-backed databases"
+                    )
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -420,14 +420,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_close_shared_memory_connection"
-        ), "_close_shared_memory_connection alias should have been removed"
+        assert not hasattr(api.database, "_close_shared_memory_connection"), (
+            "_close_shared_memory_connection alias should have been removed"
+        )
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(
-            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
-        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
+            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
+        )

--- a/tests/unit/test_api_database_comprehensive.py
+++ b/tests/unit/test_api_database_comprehensive.py
@@ -183,9 +183,9 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         """LEGACY_CONNECTION class attribute must not exist on the manager after the PR change."""
         from api.database import _DatabaseConnectionManager
 
-        assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-            "LEGACY_CONNECTION class attribute should have been removed"
-        )
+        assert not hasattr(
+            _DatabaseConnectionManager, "LEGACY_CONNECTION"
+        ), "LEGACY_CONNECTION class attribute should have been removed"
 
     def test_file_connection_does_not_set_legacy_connection(self, tmp_path):
         """Connecting to a file-backed database must not set any LEGACY_CONNECTION attribute."""
@@ -195,12 +195,12 @@ class TestDatabaseConnectionManagerLegacyRemoval:
         manager = _DatabaseConnectionManager(db_path)
         conn = manager.connect()
         try:
-            assert not hasattr(_DatabaseConnectionManager, "LEGACY_CONNECTION"), (
-                "File connect() must not create LEGACY_CONNECTION"
-            )
-            assert not hasattr(manager, "LEGACY_CONNECTION"), (
-                "File connect() must not set LEGACY_CONNECTION on instance"
-            )
+            assert not hasattr(
+                _DatabaseConnectionManager, "LEGACY_CONNECTION"
+            ), "File connect() must not create LEGACY_CONNECTION"
+            assert not hasattr(
+                manager, "LEGACY_CONNECTION"
+            ), "File connect() must not set LEGACY_CONNECTION on instance"
         finally:
             conn.close()
 
@@ -221,9 +221,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", temp_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=True):
                     conn = api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is conn, (
-                        "_MEMORY_CONNECTION global must be set to the returned connection"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is conn
+                    ), "_MEMORY_CONNECTION global must be set to the returned connection"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -270,9 +270,9 @@ class TestConnectModuleLevelCaching:
             with patch.object(api.database, "_db_manager", mock_manager):
                 with patch.object(api.database, "_is_memory_db", return_value=False):
                     api.database._connect()
-                    assert api.database._MEMORY_CONNECTION is None, (
-                        "_MEMORY_CONNECTION must remain None for file-backed databases"
-                    )
+                    assert (
+                        api.database._MEMORY_CONNECTION is None
+                    ), "_MEMORY_CONNECTION must remain None for file-backed databases"
         finally:
             api.database._MEMORY_CONNECTION = saved_module_conn
             api.database._MEMORY_CONNECTION_MANAGER = saved_module_conn_manager
@@ -392,14 +392,14 @@ class TestAtexitRegistration:
         """The _close_shared_memory_connection alias must no longer exist in the module."""
         import api.database
 
-        assert not hasattr(api.database, "_close_shared_memory_connection"), (
-            "_close_shared_memory_connection alias should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_close_shared_memory_connection"
+        ), "_close_shared_memory_connection alias should have been removed"
 
     def test_atexit_db_close_registered_flag_removed(self):
         """The _ATEXIT_DB_CLOSE_REGISTERED module-level flag must no longer exist."""
         import api.database
 
-        assert not hasattr(api.database, "_ATEXIT_DB_CLOSE_REGISTERED"), (
-            "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"
-        )
+        assert not hasattr(
+            api.database, "_ATEXIT_DB_CLOSE_REGISTERED"
+        ), "_ATEXIT_DB_CLOSE_REGISTERED guard variable should have been removed"

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -133,6 +133,27 @@ class TestSettingsModel:
         assert settings.database_url == "sqlite:///runtime.db"
         assert settings.asset_graph_database_url == "postgresql://user:pass@localhost/db"
 
+    def test_effective_database_url_prefers_asset_graph_database_url(self) -> None:
+        """Test that asset_graph_database_url takes precedence over database_url."""
+        settings = Settings(
+            database_url="sqlite:///fallback.db",
+            asset_graph_database_url="sqlite:///asset-graph.db",
+        )
+
+        assert settings.effective_database_url == "sqlite:///asset-graph.db"
+
+    def test_effective_database_url_falls_back_to_database_url(self) -> None:
+        """Test that database_url is used when asset_graph_database_url is unset."""
+        settings = Settings(database_url="sqlite:///fallback.db")
+
+        assert settings.effective_database_url == "sqlite:///fallback.db"
+
+    def test_effective_database_url_is_none_without_database_config(self) -> None:
+        """Test that effective_database_url is None when no database URL is configured."""
+        settings = Settings()
+
+        assert settings.effective_database_url is None
+
     def test_settings_allowed_origins_property(self) -> None:
         """Test that allowed_origins property correctly parses CSV."""
         settings = Settings(allowed_origins_raw="https://example.com,https://example.org")

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -111,6 +111,7 @@ class TestSettingsModel:
         assert settings.graph_cache_path is None
         assert settings.real_data_cache_path is None
         assert settings.use_real_data_fetcher is False
+        assert settings.database_url is None
         assert settings.asset_graph_database_url is None
 
     def test_settings_with_explicit_values(self) -> None:
@@ -121,6 +122,7 @@ class TestSettingsModel:
             graph_cache_path="/path/to/cache",
             real_data_cache_path="/path/to/real/cache",
             use_real_data_fetcher=True,
+            database_url="sqlite:///runtime.db",
             asset_graph_database_url="postgresql://user:pass@localhost/db",
         )
         assert settings.env == "production"
@@ -128,6 +130,7 @@ class TestSettingsModel:
         assert settings.graph_cache_path == "/path/to/cache"
         assert settings.real_data_cache_path == "/path/to/real/cache"
         assert settings.use_real_data_fetcher is True
+        assert settings.database_url == "sqlite:///runtime.db"
         assert settings.asset_graph_database_url == "postgresql://user:pass@localhost/db"
 
     def test_settings_allowed_origins_property(self) -> None:
@@ -164,6 +167,7 @@ class TestLoadSettings:
         assert settings.graph_cache_path is None
         assert settings.real_data_cache_path is None
         assert settings.use_real_data_fetcher is False
+        assert settings.database_url is None
         assert settings.asset_graph_database_url is None
 
     @patch.dict(
@@ -174,6 +178,7 @@ class TestLoadSettings:
             "GRAPH_CACHE_PATH": "/path/to/cache",
             "REAL_DATA_CACHE_PATH": "/path/to/real/cache",
             "USE_REAL_DATA_FETCHER": "true",
+            "DATABASE_URL": "sqlite:///env.db",
             "ASSET_GRAPH_DATABASE_URL": "postgresql://localhost/db",
         },
     )
@@ -185,6 +190,7 @@ class TestLoadSettings:
         assert settings.graph_cache_path == "/path/to/cache"
         assert settings.real_data_cache_path == "/path/to/real/cache"
         assert settings.use_real_data_fetcher is True
+        assert settings.database_url == "sqlite:///env.db"
         assert settings.asset_graph_database_url == "postgresql://localhost/db"
 
     @patch.dict(os.environ, {"ENV": "PRODUCTION"})
@@ -321,6 +327,7 @@ class TestSettingsEdgeCases:
         settings = load_settings()
         assert settings.graph_cache_path is None
         assert settings.real_data_cache_path is None
+        assert settings.database_url is None
         assert settings.asset_graph_database_url is None
 
 

--- a/tests/unit/test_settings.py
+++ b/tests/unit/test_settings.py
@@ -133,27 +133,6 @@ class TestSettingsModel:
         assert settings.database_url == "sqlite:///runtime.db"
         assert settings.asset_graph_database_url == "postgresql://user:pass@localhost/db"
 
-    def test_effective_database_url_prefers_asset_graph_database_url(self) -> None:
-        """Test that asset_graph_database_url takes precedence over database_url."""
-        settings = Settings(
-            database_url="sqlite:///fallback.db",
-            asset_graph_database_url="sqlite:///asset-graph.db",
-        )
-
-        assert settings.effective_database_url == "sqlite:///asset-graph.db"
-
-    def test_effective_database_url_falls_back_to_database_url(self) -> None:
-        """Test that database_url is used when asset_graph_database_url is unset."""
-        settings = Settings(database_url="sqlite:///fallback.db")
-
-        assert settings.effective_database_url == "sqlite:///fallback.db"
-
-    def test_effective_database_url_is_none_without_database_config(self) -> None:
-        """Test that effective_database_url is None when no database URL is configured."""
-        settings = Settings()
-
-        assert settings.effective_database_url is None
-
     def test_settings_allowed_origins_property(self) -> None:
         """Test that allowed_origins property correctly parses CSV."""
         settings = Settings(allowed_origins_raw="https://example.com,https://example.org")


### PR DESCRIPTION
## **User description**
This PR changes the API database helpers to obtain the SQLite database URL from the cached Settings layer. The Settings layer reads `DATABASE_URL` from the environment, centralizing configuration while preserving the existing import-time URL/path resolution and connection behavior.


```mermaid
sequenceDiagram
    participant Import as api.database import
    participant ApiDatabase as API database helpers
    participant Settings
    participant Env
    participant App

    Import->>ApiDatabase: Initialize module-level DATABASE_URL / DATABASE_PATH
    ApiDatabase->>Settings: get_settings().database_url
    Settings->>Env: Read DATABASE_URL
    Env-->>Settings: DATABASE_URL value
    Settings-->>ApiDatabase: Return configured database_url
    ApiDatabase->>ApiDatabase: Resolve SQLite path and create connection manager

    App->>ApiDatabase: Request database connection
    ApiDatabase-->>App: Open SQLite connection using resolved DATABASE_PATH
```




### Motivation

- Move database runtime configuration ownership out of `api/database.py` into the centralized settings layer to reduce import-time environment coupling while preserving existing behavior. 
- Keep SQLite path resolution, in-memory/shared connection semantics, and the public helper API surface unchanged.

### Description

- `api/database.py` now reads the API SQLite database URL from the cached centralized settings accessor (`get_settings().database_url`) instead of calling `os.getenv()` directly.
- This PR preserves the existing import-time database URL/path resolution behavior; lazy database initialization is intentionally deferred to a separate runtime-hardening seam. 
- `src/config/settings.py` was extended with a minimal `database_url` field and `load_settings()` now populates it from the `DATABASE_URL` environment variable.
- `DATABASE_URL` remains the API SQLite helper configuration source.
- `ASSET_GRAPH_DATABASE_URL` remains separate for the asset graph / SQLAlchemy data layer and is not consumed by `api/database.py`. 
- Tests affected by the seam were updated: `tests/unit/test_api_database_comprehensive.py` was adjusted to patch `DATABASE_PATH` and stabilize URI / in-memory assertions, and `tests/unit/test_settings.py` was updated to assert the new `database_url` default and env-loading behavior. 
- No other behavior, auth, CORS, frontend, or deployment logic was changed and the public `api/database` helpers (`_connect`, `get_connection`, `execute`, `fetch_one`, `fetch_value`, `initialize_schema`) remain intact.

### Testing

- Ran `pytest tests/unit/test_api_database_comprehensive.py` which passed (31 passed). 
- Ran `pytest tests/unit/test_api.py -q` which completed but had 4 failures unrelated to this focused change (failures in RealDataFetcher fallback mocks and a few auth/docstring expectations). 
- Ran the full test suite with `pytest -q` which exercised the repository and reported existing unrelated failures (many integration/unit failures outside the scope of this runtime/config change), indicating this PR did not introduce regressions in the touched database runtime seam.

[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea865e222c8324aa32695f700ef11b)


___

## **CodeAnt-AI Description**
**Use centralized settings for the API database URL**

### What Changed
- The API database helpers now read `DATABASE_URL` from the shared settings layer instead of reading the environment directly.
- Settings now include `database_url`, so the API database URL is loaded alongside the other runtime configuration values.
- If `DATABASE_URL` is missing, the API now raises a clear configuration error at startup.
- Tests were updated to cover the new settings field, environment loading, and the API database URL lookup behavior.

### Impact
`✅ Clearer database configuration`
`✅ Fewer startup surprises from missing API database settings`
`✅ Safer separation between API and asset-graph database URLs`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=t1UmaRxCLoAbcDQGBsDH-i7kC5fys8KrRwe1K0oKWWQ&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
