### PR TITLE
Centralize public metrics in graph contract

### DIFF
--- a/api/api_models.py
+++ b/api/api_models.py
@@ -29,7 +29,7 @@ class RelationshipResponse(BaseModel):
 
 
 class MetricsResponse(BaseModel):
-    """Response model for network metrics."""
+    """Response model for graph-owned public network metrics."""
 
     total_assets: int
     total_relationships: int

--- a/api/routers/metrics.py
+++ b/api/routers/metrics.py
@@ -15,23 +15,14 @@ async def get_metrics() -> MetricsResponse:
         g = get_graph()
         metrics = g.calculate_metrics()
 
-        asset_classes = {}
-        for asset in g.assets.values():
-            key = asset.asset_class.value
-            asset_classes[key] = asset_classes.get(key, 0) + 1
-
-        degrees = [len(rels) for rels in g.relationships.values()]
-        avg_degree = sum(degrees) / len(degrees) if degrees else 0.0
-        max_degree = max(degrees) if degrees else 0
-
         return MetricsResponse(
             total_assets=metrics["total_assets"],
             total_relationships=metrics["total_relationships"],
-            asset_classes=asset_classes,
-            avg_degree=avg_degree,
-            max_degree=max_degree,
-            network_density=metrics.get("relationship_density", 0.0),
-            relationship_density=metrics.get("relationship_density", 0.0),
+            asset_classes=metrics["asset_classes"],
+            avg_degree=metrics["avg_degree"],
+            max_degree=metrics["max_degree"],
+            network_density=metrics["network_density"],
+            relationship_density=metrics["relationship_density"],
         )
     except Exception as e:
         logger.exception("Error getting metrics:")

--- a/api/routers/metrics.py
+++ b/api/routers/metrics.py
@@ -15,15 +15,7 @@ async def get_metrics() -> MetricsResponse:
         g = get_graph()
         metrics = g.calculate_metrics()
 
-        return MetricsResponse(
-            total_assets=metrics["total_assets"],
-            total_relationships=metrics["total_relationships"],
-            asset_classes=metrics["asset_classes"],
-            avg_degree=metrics["avg_degree"],
-            max_degree=metrics["max_degree"],
-            network_density=metrics["network_density"],
-            relationship_density=metrics["relationship_density"],
-        )
+        return MetricsResponse.model_validate(metrics)
     except Exception as e:
         logger.exception("Error getting metrics:")
         raise HTTPException(

--- a/src/logic/asset_graph.py
+++ b/src/logic/asset_graph.py
@@ -345,7 +345,9 @@ class AssetRelationshipGraph:
                 - asset_class_distribution (dict[str, int]): Counts of assets grouped by asset class value.
                 - asset_classes (dict[str, int]): Public API alias for asset_class_distribution.
                 - avg_degree (float): Mean outgoing relationship count for sources in the relationship map.
+                  Zero-degree assets (those absent from ``relationships``) are excluded from this average.
                 - max_degree (int): Maximum outgoing relationship count for sources in the relationship map.
+                  Zero-degree assets (those absent from ``relationships``) are excluded from this maximum.
                 - top_relationships (list[tuple[str, str, str, float]]): Up to 10 relationships sorted by strength as (source_id, target_id, rel_type, strength).
                 - regulatory_event_count (int): Number of stored regulatory events.
                 - regulatory_event_norm (float): Normalized regulatory event count in [0.0, 1.0) using a saturating mapping.
@@ -376,6 +378,8 @@ class AssetRelationshipGraph:
             "relationship_distribution": rel_dist,
             "asset_class_distribution": asset_class_dist,
             "asset_classes": asset_class_dist,
+            # avg_degree and max_degree are computed across sources present in
+            # `relationships`, not all assets; zero-degree assets are excluded.
             "avg_degree": avg_degree,
             "max_degree": max_degree,
             "top_relationships": top_relationships,

--- a/src/logic/asset_graph.py
+++ b/src/logic/asset_graph.py
@@ -377,7 +377,7 @@ class AssetRelationshipGraph:
             "network_density": density,
             "relationship_distribution": rel_dist,
             "asset_class_distribution": asset_class_dist,
-            "asset_classes": asset_class_dist,
+            "asset_classes": dict(asset_class_dist),
             # avg_degree and max_degree are computed across sources present in
             # `relationships`, not all assets; zero-degree assets are excluded.
             "avg_degree": avg_degree,

--- a/src/logic/asset_graph.py
+++ b/src/logic/asset_graph.py
@@ -340,8 +340,12 @@ class AssetRelationshipGraph:
                 - total_relationships (int): Total number of relationships stored.
                 - average_relationship_strength (float): Mean strength across all relationships (0.0 if none).
                 - relationship_density (float): Percentage of possible directed links present (0.0–100.0).
+                - network_density (float): Public API alias for relationship_density.
                 - relationship_distribution (dict[str, int]): Counts of relationships grouped by relationship type.
                 - asset_class_distribution (dict[str, int]): Counts of assets grouped by asset class value.
+                - asset_classes (dict[str, int]): Public API alias for asset_class_distribution.
+                - avg_degree (float): Mean outgoing relationship count for sources in the relationship map.
+                - max_degree (int): Maximum outgoing relationship count for sources in the relationship map.
                 - top_relationships (list[tuple[str, str, str, float]]): Up to 10 relationships sorted by strength as (source_id, target_id, rel_type, strength).
                 - regulatory_event_count (int): Number of stored regulatory events.
                 - regulatory_event_norm (float): Normalized regulatory event count in [0.0, 1.0) using a saturating mapping.
@@ -359,6 +363,7 @@ class AssetRelationshipGraph:
             total_relationships,
         )
         asset_class_dist = self._asset_class_distribution()
+        avg_degree, max_degree = self._degree_metrics()
         reg_events = len(self.regulatory_events)
         reg_events_norm, quality_score = self._quality_metrics(avg_strength, reg_events)
 
@@ -367,8 +372,12 @@ class AssetRelationshipGraph:
             "total_relationships": total_relationships,
             "average_relationship_strength": avg_strength,
             "relationship_density": density,
+            "network_density": density,
             "relationship_distribution": rel_dist,
             "asset_class_distribution": asset_class_dist,
+            "asset_classes": asset_class_dist,
+            "avg_degree": avg_degree,
+            "max_degree": max_degree,
             "top_relationships": top_relationships,
             "regulatory_event_count": reg_events,
             "regulatory_event_norm": reg_events_norm,
@@ -583,6 +592,19 @@ class AssetRelationshipGraph:
             key = asset.asset_class.value
             dist[key] = dist.get(key, 0) + 1
         return dist
+
+    def _degree_metrics(self) -> tuple[float, int]:
+        """
+        Compute public outgoing-degree metrics from the relationship map.
+
+        Returns:
+            tuple[float, int]: Average and maximum outgoing relationship counts
+                across sources present in `relationships`.
+        """
+        degrees = [len(rels) for rels in self.relationships.values()]
+        if not degrees:
+            return 0.0, 0
+        return sum(degrees) / len(degrees), max(degrees)
 
     @staticmethod
     def _relationship_density(asset_count: int, rel_count: int) -> float:

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -139,7 +139,7 @@ def _apply_mock_graph_configuration(mock_graph_instance: Any, graph: AssetRelati
     mock_graph_instance.assets = graph.assets
     mock_graph_instance.relationships = graph.relationships
     mock_graph_instance.calculate_metrics.return_value = {
-        "total_assets": 4,
+        "total_assets": metrics["total_assets"],
         "total_relationships": metrics["total_relationships"],
         "asset_classes": metrics["asset_classes"],
         "avg_degree": metrics["avg_degree"],

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -11,6 +11,7 @@ This module tests all API endpoints including:
 """
 
 from collections.abc import Callable
+from typing import Any
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -122,7 +123,7 @@ def mock_graph():
     return graph
 
 
-def _apply_mock_graph_configuration(mock_graph_instance: object, graph: AssetRelationshipGraph) -> None:
+def _apply_mock_graph_configuration(mock_graph_instance: Any, graph: AssetRelationshipGraph) -> None:
     """
     Copy core attributes from a concrete AssetRelationshipGraph onto a mocked graph used in tests.
 
@@ -132,10 +133,20 @@ def _apply_mock_graph_configuration(mock_graph_instance: object, graph: AssetRel
         mock_graph_instance (object): The mocked graph object (typically a unittest.mock.Mock) to configure.
         graph (AssetRelationshipGraph): The concrete AssetRelationshipGraph whose attributes will be copied.
     """
+    metrics = graph.calculate_metrics()
+
     # The patched object is a Mock from unittest.mock; we set attributes dynamically.
     mock_graph_instance.assets = graph.assets
     mock_graph_instance.relationships = graph.relationships
-    mock_graph_instance.calculate_metrics = graph.calculate_metrics
+    mock_graph_instance.calculate_metrics.return_value = {
+        "total_assets": 4,
+        "total_relationships": metrics["total_relationships"],
+        "asset_classes": metrics["asset_classes"],
+        "avg_degree": metrics["avg_degree"],
+        "max_degree": metrics["max_degree"],
+        "network_density": metrics["network_density"],
+        "relationship_density": metrics["relationship_density"],
+    }
     mock_graph_instance.get_3d_visualization_data = graph.get_3d_visualization_data_enhanced
 
 

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -381,6 +381,37 @@ class TestAPIEndpoints:
         if "relationship_density" in data:
             assert 0 <= data["relationship_density"] <= 100
 
+    def test_get_metrics_projects_graph_owned_contract(self, bare_client: TestClient) -> None:
+        """Metrics endpoint should only project public metrics from the graph layer."""
+        graph = Mock(spec=AssetRelationshipGraph)
+        graph.calculate_metrics.return_value = {
+            "total_assets": 9,
+            "total_relationships": 12,
+            "asset_classes": {"Graph Owned": 9},
+            "avg_degree": 2.5,
+            "max_degree": 7,
+            "network_density": 42.0,
+            "relationship_density": 42.0,
+        }
+        graph.assets = {
+            "IGNORED": Equity(
+                id="IGNORED",
+                symbol="IGN",
+                name="Should Not Be Counted",
+                asset_class=AssetClass.EQUITY,
+                sector="Technology",
+                price=1.0,
+            )
+        }
+        graph.relationships = {"IGNORED": [("ALSO_IGNORED", "same_sector", 0.7)]}
+
+        with patch("api.routers.metrics.get_graph", return_value=graph):
+            response = bare_client.get("/api/metrics")
+
+        assert response.status_code == 200
+        assert response.json() == graph.calculate_metrics.return_value
+        graph.calculate_metrics.assert_called_once_with()
+
     def test_get_metrics_no_assets(self, bare_client: TestClient) -> None:
         """Metrics endpoint returns zeros for an empty graph."""
         api_main.reset_graph()

--- a/tests/unit/test_asset_graph.py
+++ b/tests/unit/test_asset_graph.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from src.logic.asset_graph import AssetRelationshipGraph
+from src.models.financial_models import AssetClass, Equity
 
 
 @pytest.mark.unit
@@ -32,6 +33,48 @@ class TestAssetRelationshipGraphInit:
 
         assert hasattr(graph, "relationships")
         assert isinstance(graph.relationships, dict)
+
+
+@pytest.mark.unit
+class TestCalculateMetricsContract:
+    """Test graph-owned public metrics exposed by the API."""
+
+    @staticmethod
+    def test_calculate_metrics_includes_public_api_metrics():
+        """Graph metrics own the public API metric contract."""
+        graph = AssetRelationshipGraph()
+        graph.add_asset(
+            Equity(
+                id="AAPL",
+                symbol="AAPL",
+                name="Apple Inc.",
+                asset_class=AssetClass.EQUITY,
+                sector="Technology",
+                price=150.0,
+            )
+        )
+        graph.add_asset(
+            Equity(
+                id="MSFT",
+                symbol="MSFT",
+                name="Microsoft Corporation",
+                asset_class=AssetClass.EQUITY,
+                sector="Technology",
+                price=300.0,
+            )
+        )
+        graph.relationships = {
+            "AAPL": [("MSFT", "same_sector", 0.7), ("GOOG", "same_sector", 0.5)],
+            "MSFT": [("AAPL", "same_sector", 0.7)],
+        }
+
+        metrics = graph.calculate_metrics()
+
+        assert metrics["asset_classes"] == metrics["asset_class_distribution"]
+        assert metrics["asset_classes"] == {"Equity": 2}
+        assert metrics["avg_degree"] == pytest.approx(1.5)
+        assert metrics["max_degree"] == 2
+        assert metrics["network_density"] == metrics["relationship_density"]
 
 
 @pytest.mark.unit

--- a/tests/unit/test_asset_graph.py
+++ b/tests/unit/test_asset_graph.py
@@ -71,6 +71,7 @@ class TestCalculateMetricsContract:
         metrics = graph.calculate_metrics()
 
         assert metrics["asset_classes"] == metrics["asset_class_distribution"]
+        assert metrics["asset_classes"] is not metrics["asset_class_distribution"]
         assert metrics["asset_classes"] == {"Equity": 2}
         assert metrics["avg_degree"] == pytest.approx(1.5)
         assert metrics["max_degree"] == 2

--- a/tests/unit/test_asset_graph.py
+++ b/tests/unit/test_asset_graph.py
@@ -63,6 +63,8 @@ class TestCalculateMetricsContract:
                 price=300.0,
             )
         )
+        # Direct assignment intentionally exercises the current relationship-map contract
+        # used by calculate_metrics() without invoking relationship-building logic.
         graph.relationships = {
             "AAPL": [("MSFT", "same_sector", 0.7), ("GOOG", "same_sector", 0.5)],
             "MSFT": [("AAPL", "same_sector", 0.7)],


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI production path remains the only runtime surface changed.
- Frontend: no changes.
- Gradio: no changes.

This PR chooses Option A: all public metrics returned by `GET /api/metrics` originate from `AssetRelationshipGraph.calculate_metrics()`.

## Primary Objective

Centralize and clarify metric ownership so the API metrics endpoint is a validated projection of graph-owned public metrics.

## Scope

### In Scope

- Add public API metrics (`asset_classes`, `avg_degree`, `max_degree`, `network_density`) to `AssetRelationshipGraph.calculate_metrics()` without changing their meaning.
- Return `asset_classes` as a shallow copy of `asset_class_distribution` to avoid shared mutable aliasing.
- Remove router-side recomputation from `api/routers/metrics.py`.
- Project graph metrics through `MetricsResponse.model_validate(metrics)`.
- Clarify `MetricsResponse` as graph-owned public network metrics.
- Add/update unit tests enforcing graph ownership, API projection behavior, alias independence, legacy API mock compatibility, and direct relationship-map contract setup.

### Out of Scope

- Density unit changes.
- Visualization schema changes.
- Pagination changes.
- CORS, auth, or settings changes.
- Broad refactors or unrelated cleanup.

### Files Expected to Change

- `src/logic/asset_graph.py` — owns the complete public metrics contract.
- `api/routers/metrics.py` — validates/projects graph metrics without recomputation.
- `api/api_models.py` — clarifies response model ownership.
- `tests/unit/test_asset_graph.py` — enforces graph-owned public metric fields, alias independence, and documents direct relationship-map setup.
- `tests/unit/test_api_main.py` — enforces API projection from `calculate_metrics()`.
- `tests/unit/test_api.py` — keeps legacy mocked graph tests compatible with the graph-owned metrics contract.

## Validation Commands

```bash
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_api_main.py -v
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_api.py -v
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_asset_graph.py -v
git diff --check -- "tests/unit/test_asset_graph.py"
PATH="/workspace/.venv/bin:$PATH" pre-commit run --files "tests/unit/test_asset_graph.py"
```

Pytest, `git diff --check`, and pre-commit passed for the final comment-only update. Earlier full file-scoped pre-commit ran after installing dev dependencies; formatting/import hooks and mypy passed for scoped files, while flake8-docstrings reported existing `src/logic/asset_graph.py` docstring issues outside this scoped change.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Required pytest validation passes locally
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Runtime behavior changes are limited to metric ownership/projection
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

## Additional Notes

Codacy MCP tools were not available in this workspace, so Codacy analysis could not be run for the edited files or dependency installation security scan.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Centralized all public metrics in the graph contract and made `GET /api/metrics` return them directly from `AssetRelationshipGraph.calculate_metrics()` via `MetricsResponse.model_validate(...)`. This removes router recomputation and ensures the response mirrors graph-owned fields.

- **Refactors**
  - Added `asset_classes` (shallow copy), `avg_degree`, `max_degree`, and `network_density` to `calculate_metrics()`; degree stats exclude zero-degree assets.
  - Replaced router logic with `MetricsResponse.model_validate(metrics)`; tests verify exact passthrough of graph-owned fields.
  - Clarified `MetricsResponse` docstring; updated tests/mocks to return only public fields, use dynamic totals, and document direct relationship-map setup.

<sup>Written for commit e7231fafe12dabdebbb46cd7a5a4d178ebf6416a. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1075?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make the metrics endpoint return graph-owned public metrics**

### What Changed
- The metrics endpoint now returns the graph’s public metrics directly, instead of rebuilding values in the API layer.
- Public metrics now include asset class counts, average degree, max degree, and network density from the graph contract.
- Asset class data is returned as its own copy, so callers cannot affect the graph’s stored counts.
- The metrics response now clearly documents that it represents graph-owned public network metrics.

### Impact
`✅ Consistent metrics from /api/metrics`
`✅ Fewer mismatches between graph and API totals`
`✅ Safer asset class counts in responses`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Tdbn1UB-6_YjVrKmx36Fdj10STXmTyHlOKd4R123pX4&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
