### PR TITLE
Normalize public network density contract

### DIFF
--- a/src/logic/asset_graph.py
+++ b/src/logic/asset_graph.py
@@ -340,7 +340,7 @@ class AssetRelationshipGraph:
                 - total_relationships (int): Total number of relationships stored.
                 - average_relationship_strength (float): Mean strength across all relationships (0.0 if none).
                 - relationship_density (float): Percentage of possible directed links present (0.0–100.0).
-                - network_density (float): Public API alias for relationship_density.
+                - network_density (float): Normalized fraction of possible directed links present (0.0–1.0).
                 - relationship_distribution (dict[str, int]): Counts of relationships grouped by relationship type.
                 - asset_class_distribution (dict[str, int]): Counts of assets grouped by asset class value.
                 - asset_classes (dict[str, int]): Public API alias for asset_class_distribution.
@@ -374,7 +374,7 @@ class AssetRelationshipGraph:
             "total_relationships": total_relationships,
             "average_relationship_strength": avg_strength,
             "relationship_density": density,
-            "network_density": density,
+            "network_density": density / 100.0,
             "relationship_distribution": rel_dist,
             "asset_class_distribution": asset_class_dist,
             "asset_classes": dict(asset_class_dist),

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -375,11 +375,12 @@ class TestAPIEndpoints:
         assert data["total_relationships"] > 0
         assert data["avg_degree"] > 0
         assert data["max_degree"] >= data["avg_degree"]
-        assert 0 <= data["network_density"] <= 100
+        assert 0 <= data["network_density"] <= 1
 
         # If the API includes relationship_density separately, validate its bounds too.
         if "relationship_density" in data:
             assert 0 <= data["relationship_density"] <= 100
+            assert data["network_density"] == pytest.approx(data["relationship_density"] / 100.0)
 
     def test_get_metrics_projects_graph_owned_contract(self, bare_client: TestClient) -> None:
         """Metrics endpoint should only project public metrics from the graph layer."""
@@ -390,7 +391,7 @@ class TestAPIEndpoints:
             "asset_classes": {"Graph Owned": 9},
             "avg_degree": 2.5,
             "max_degree": 7,
-            "network_density": 42.0,
+            "network_density": 0.42,
             "relationship_density": 42.0,
         }
         graph.assets = {
@@ -1658,8 +1659,9 @@ class TestEndpointRegressionCases:
         assert "network_density" in data
         assert "relationship_density" in data
 
-        # They should have the same value (as per the implementation)
-        assert data["network_density"] == data["relationship_density"]
+        assert 0 <= data["network_density"] <= 1
+        assert 0 <= data["relationship_density"] <= 100
+        assert data["network_density"] == pytest.approx(data["relationship_density"] / 100.0)
 
     def test_visualization_coordinates_precision(self, client: TestClient):
         """Visualization coordinates should be rounded to 6 decimal places."""

--- a/tests/unit/test_asset_graph.py
+++ b/tests/unit/test_asset_graph.py
@@ -77,7 +77,9 @@ class TestCalculateMetricsContract:
         assert metrics["asset_classes"] == {"Equity": 2}
         assert metrics["avg_degree"] == pytest.approx(1.5)
         assert metrics["max_degree"] == 2
-        assert metrics["network_density"] == metrics["relationship_density"]
+        assert 0 <= metrics["relationship_density"] <= 100
+        assert 0 <= metrics["network_density"] <= 1
+        assert metrics["network_density"] == pytest.approx(metrics["relationship_density"] / 100.0)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI production path remains the only runtime surface changed.
- Frontend: no changes.
- Gradio: no changes.

This PR carries forward the metrics contract decision from PR #1075 and clarifies the two density fields:

- `relationship_density`: internal/diagnostic percentage, `0.0-100.0`
- `network_density`: public API/UI normalized fraction, `0.0-1.0`

## Primary Objective

Clarify and enforce the density metric contract without changing router projection behavior or unrelated schemas.

## Scope

### In Scope

- Normalize `network_density` in `AssetRelationshipGraph.calculate_metrics()` as `relationship_density / 100.0`.
- Document `relationship_density` and `network_density` units in the graph metric contract docstring.
- Update graph and API tests to assert the split units and conversion relationship.
- Keep `/api/metrics` as `MetricsResponse.model_validate(metrics)` with no router transformation.

### Out of Scope

- Visualization schema changes.
- Pagination changes.
- CORS, auth, or settings changes.
- Refactoring `_relationship_density`.
- Normalizing `relationship_density`.
- Adding `.get()` fallbacks for required contract fields.

### Files Expected to Change

- `src/logic/asset_graph.py` — single source for density values and metric unit documentation.
- `tests/unit/test_asset_graph.py` — graph-level density contract assertions.
- `tests/unit/test_api_main.py` — API-level density contract and projection assertions.

## Validation Commands

```bash
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_api_main.py -v
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_asset_graph.py -v
PATH="/workspace/.venv/bin:$PATH" python -m pytest tests/unit/test_api.py -v
git diff --check -- "src/logic/asset_graph.py" "tests/unit/test_api_main.py" "tests/unit/test_asset_graph.py"
PATH="/workspace/.venv/bin:$PATH" pre-commit run --files "src/logic/asset_graph.py" "tests/unit/test_asset_graph.py" "tests/unit/test_api_main.py"
```

Pytest and `git diff --check` passed. `pre-commit` ran; formatting/import hooks passed, while existing flake8-docstrings and unrelated mypy issues remain outside this scoped change.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Required pytest validation passes locally
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Runtime behavior changes are limited to density contract normalization
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

---

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

## Additional Notes

Codacy MCP tools were not available in this workspace, so Codacy analysis could not be run for the edited files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize the public `network_density` metric to a 0–1 fraction while keeping `relationship_density` as a 0–100 percentage. Clarifies the contract without changing router logic or the UI.

- **Refactors**
  - Compute `network_density` as `relationship_density / 100.0` in `AssetRelationshipGraph.calculate_metrics()`.
  - Document units for both fields in the metrics docstring.
  - Update tests to assert bounds and the conversion; API projection remains unchanged.

<sup>Written for commit d4c4040822489c89136a45534e4debdc21821036. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1077?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

