### PR TITLE
Type visualization response contract

### DIFF
--- a/api/api_models.py
+++ b/api/api_models.py
@@ -2,7 +2,7 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class AssetResponse(BaseModel):
@@ -43,6 +43,8 @@ class MetricsResponse(BaseModel):
 class VisualizationNode(BaseModel):
     """Response model for a visualization node."""
 
+    model_config = ConfigDict(extra="forbid")
+
     id: str
     symbol: str
     name: str
@@ -51,11 +53,13 @@ class VisualizationNode(BaseModel):
     y: float
     z: float
     color: str
-    size: float
+    size: int
 
 
 class VisualizationEdge(BaseModel):
     """Response model for a visualization edge."""
+
+    model_config = ConfigDict(extra="forbid")
 
     source: str
     target: str

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -40,8 +40,31 @@ class MetricsResponse(BaseModel):
     relationship_density: float = 0.0
 
 
-class VisualizationDataResponse(BaseModel):
-    """Response model for visualization data."""
+class VisualizationNode(BaseModel):
+    """Response model for a visualization node."""
 
-    nodes: list[dict[str, Any]]
-    edges: list[dict[str, Any]]
+    id: str
+    symbol: str
+    name: str
+    asset_class: str
+    x: float
+    y: float
+    z: float
+    color: str
+    size: float
+
+
+class VisualizationEdge(BaseModel):
+    """Response model for a visualization edge."""
+
+    source: str
+    target: str
+    relationship_type: str
+    strength: float
+
+
+class VisualizationDataResponse(BaseModel):
+    """Response model for typed visualization data."""
+
+    nodes: list[VisualizationNode]
+    edges: list[VisualizationEdge]

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -70,5 +70,7 @@ class VisualizationEdge(BaseModel):
 class VisualizationDataResponse(BaseModel):
     """Response model for typed visualization data."""
 
+    model_config = ConfigDict(extra="forbid")
+
     nodes: list[VisualizationNode]
     edges: list[VisualizationEdge]

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -561,6 +561,8 @@ class TestAPIEndpoints:
         assert "edges" in viz_data
         assert isinstance(viz_data["nodes"], list)
         assert isinstance(viz_data["edges"], list)
+        assert len(viz_data["nodes"]) > 0
+        assert len(viz_data["edges"]) > 0
 
         if viz_data["nodes"]:
             node = viz_data["nodes"][0]

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -591,13 +591,13 @@ class TestAPIEndpoints:
         response = client.get("/api/visualization")
         assert response.status_code == 200
         viz_data = response.json()
+        node_keys = {"id", "symbol", "name", "asset_class", "x", "y", "z", "color", "size"}
+        edge_keys = {"source", "target", "relationship_type", "strength"}
 
         assert "nodes" in viz_data
         assert "edges" in viz_data
-        assert all("id" in node and "asset_class" in node for node in viz_data["nodes"])
-        assert all("symbol" in node for node in viz_data["nodes"])
-        assert all("source" in edge and "target" in edge for edge in viz_data["edges"])
-        assert all("relationship_type" in edge and "strength" in edge for edge in viz_data["edges"])
+        assert all(node_keys.issubset(node) for node in viz_data["nodes"])
+        assert all(edge_keys.issubset(edge) for edge in viz_data["edges"])
 
     def test_get_asset_classes(self, client: TestClient) -> None:
         """Asset classes endpoint returns all AssetClass enum values."""

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -260,8 +260,27 @@ class TestPydanticModels:
     def test_visualization_data_response_model(self) -> None:
         """VisualizationDataResponse accepts node/edge lists for graph rendering."""
         viz = VisualizationDataResponse(
-            nodes=[{"id": "AAPL", "x": 1.0, "y": 2.0, "z": 3.0}],
-            edges=[{"source": "AAPL", "target": "MSFT"}],
+            nodes=[
+                {
+                    "id": "AAPL",
+                    "symbol": "AAPL",
+                    "name": "Apple Inc.",
+                    "asset_class": "Equity",
+                    "x": 1.0,
+                    "y": 2.0,
+                    "z": 3.0,
+                    "color": "#1f77b4",
+                    "size": 5,
+                }
+            ],
+            edges=[
+                {
+                    "source": "AAPL",
+                    "target": "MSFT",
+                    "relationship_type": "same_sector",
+                    "strength": 0.7,
+                }
+            ],
         )
         assert len(viz.nodes) == 1
         assert len(viz.edges) == 1
@@ -566,6 +585,19 @@ class TestAPIEndpoints:
             for key in ("source", "target", "relationship_type", "strength"):
                 assert key in edge
             assert 0 <= edge["strength"] <= 1
+
+    def test_visualization_response_enforces_domain_and_presentation_shape(self, client: TestClient) -> None:
+        """Visualization payload should expose typed domain fields and presentation encodings."""
+        response = client.get("/api/visualization")
+        assert response.status_code == 200
+        viz_data = response.json()
+
+        assert "nodes" in viz_data
+        assert "edges" in viz_data
+        assert all("id" in node and "asset_class" in node for node in viz_data["nodes"])
+        assert all("symbol" in node for node in viz_data["nodes"])
+        assert all("source" in edge and "target" in edge for edge in viz_data["edges"])
+        assert all("relationship_type" in edge and "strength" in edge for edge in viz_data["edges"])
 
     def test_get_asset_classes(self, client: TestClient) -> None:
         """Asset classes endpoint returns all AssetClass enum values."""

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -560,7 +560,7 @@ class TestAPIEndpoints:
         assert "nodes" in viz_data
         assert "edges" in viz_data
         assert isinstance(viz_data["nodes"], list)
-        assert isinstance(viz_data["edges"], list) 
+        assert isinstance(viz_data["edges"], list)
 
         if viz_data["nodes"]:
             node = viz_data["nodes"][0]

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -598,8 +598,8 @@ class TestAPIEndpoints:
         assert "edges" in viz_data
         assert len(viz_data["nodes"]) > 0
         assert len(viz_data["edges"]) > 0
-        assert all(node_keys.issubset(node) for node in viz_data["nodes"])
-        assert all(edge_keys.issubset(edge) for edge in viz_data["edges"])
+        assert all(set(node.keys()) == node_keys for node in viz_data["nodes"])
+        assert all(set(edge.keys()) == edge_keys for edge in viz_data["edges"])
 
     def test_get_asset_classes(self, client: TestClient) -> None:
         """Asset classes endpoint returns all AssetClass enum values."""

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -560,9 +560,7 @@ class TestAPIEndpoints:
         assert "nodes" in viz_data
         assert "edges" in viz_data
         assert isinstance(viz_data["nodes"], list)
-        assert isinstance(viz_data["edges"], list)
-        assert len(viz_data["nodes"]) > 0
-        assert len(viz_data["edges"]) > 0
+        assert isinstance(viz_data["edges"], list) 
 
         if viz_data["nodes"]:
             node = viz_data["nodes"][0]
@@ -598,6 +596,8 @@ class TestAPIEndpoints:
 
         assert "nodes" in viz_data
         assert "edges" in viz_data
+        assert len(viz_data["nodes"]) > 0
+        assert len(viz_data["edges"]) > 0
         assert all(node_keys.issubset(node) for node in viz_data["nodes"])
         assert all(edge_keys.issubset(edge) for edge in viz_data["edges"])
 

--- a/tests/unit/test_asset_graph.py
+++ b/tests/unit/test_asset_graph.py
@@ -87,6 +87,18 @@ class TestGet3DVisualizationDataEnhanced:
     """Test suite for get_3d_visualization_data_enhanced method."""
 
     @staticmethod
+    def test_get_3d_visualization_data_does_not_mutate_metrics():
+        """Visualization helper should not mutate graph metric state."""
+        graph = AssetRelationshipGraph()
+        graph.relationships["asset1"] = [("asset2", "correlation", 0.8)]
+
+        before = graph.calculate_metrics()
+        _ = graph.get_3d_visualization_data_enhanced()
+        after = graph.calculate_metrics()
+
+        assert before == after
+
+    @staticmethod
     def test_empty_graph_returns_placeholder():
         """Test that empty graph returns a single placeholder node."""
         graph = AssetRelationshipGraph()


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI production path response typing is changed.
- Frontend: no changes.
- Gradio: no changes.

Mapped current shapes before editing:

- `get_3d_visualization_data_enhanced()` returns `(positions, asset_ids, colors, hover)`; sample: `position=[1.0, 0.0, 0.0]`, `asset_id='AAPL'`, `color='#4ECDC4'`, `hover='Asset: AAPL'`.
- `GET /api/visualization` returns `nodes` with `id`, `symbol`, `name`, `asset_class`, `x`, `y`, `z`, `color`, `size`; `edges` with `source`, `target`, `relationship_type`, `strength`.

Field classification:

- Domain: `id`, `symbol`, `asset_class`, `source`, `target`, `relationship_type`, `strength`.
- Presentation: `name`, `x`, `y`, `z`, `color`, `size`.

## Primary Objective

Make the visualization API response a typed contract so domain fields and presentation encodings are explicit and extra fields are rejected.

## Scope

### In Scope

- Add `VisualizationNode` and `VisualizationEdge` Pydantic response models matching the current API payload.
- Forbid extra node, edge, and root response fields via `ConfigDict(extra="forbid")`.
- Type `size` as `int` to match the actual payload.
- Change `VisualizationDataResponse` from `list[dict[str, Any]]` to typed node/edge lists.
- Update existing response-model tests to use the real current payload shape.
- Add an API shape enforcement test for exact node/edge key sets.
- Add a graph-helper test proving visualization generation does not mutate metrics.

### Out of Scope

- Graph algorithms.
- Layout logic.
- Density logic.
- Pagination.
- Frontend changes.
- Field renaming.

### Files Expected to Change

- `api/api_models.py` — defines typed visualization response models.
- `tests/unit/test_api_main.py` — enforces API visualization response shape.
- `tests/unit/test_asset_graph.py` — verifies visualization helper does not mutate graph metrics.

## Validation Commands

```bash
DATABASE_URL="sqlite:///:memory:" SECRET_KEY="test-secret" ADMIN_USERNAME="admin" ADMIN_PASSWORD="password" PATH="/workspace/.venv/bin:$PATH" python - <<'PY'
# shape inspection script used before edits
PY
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_api_main.py -v
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_asset_graph.py -v
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_api.py -v
git diff --check -- "api/api_models.py" "tests/unit/test_api_main.py" "tests/unit/test_asset_graph.py"
PATH="/workspace/.venv/bin:$PATH" pre-commit run --files "api/api_models.py" "tests/unit/test_api_main.py"
```

Shape inspection, pytest, and `git diff --check` passed. `pre-commit` ran; formatting/import hooks passed, while existing flake8-docstrings in `tests/unit/test_api_main.py` and unrelated mypy errors in `src/data/sample_data.py` remain outside this scoped change.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Required pytest validation passes locally
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Runtime behavior changes are limited to typed visualization response validation
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

## Additional Notes

Codacy MCP tools were not available in this workspace, so Codacy analysis could not be run for the edited files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Typed the visualization API response in `FastAPI` with `pydantic` models for nodes and edges, forbidding extra fields (including at the root) and enforcing exact field sets. Tests ensure non-empty nodes/edges, valid edge strength, and stable metrics; payload shape is unchanged and no frontend changes.

- **Refactors**
  - Added `VisualizationNode`/`VisualizationEdge` with `ConfigDict(extra="forbid")`; `VisualizationDataResponse` now uses them, forbids extra root fields, and `size` is `int`.
  - Expanded tests: enforce exact node/edge keys, require non-empty lists in `/api/visualization`, check edge strength range, and verify the visualization helper doesn’t mutate metrics.

<sup>Written for commit 491e0658ece3cb3f1992f9cc6617a5d6504117de. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1079?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Make visualization API responses follow a strict typed shape**

### What Changed
- Visualization responses now require the full set of node and edge fields used by the graph view, including asset details and visual values.
- Extra fields are rejected in visualization nodes, edges, and the top-level response, so the API returns only the expected payload.
- Tests now verify the live visualization response has non-empty nodes and edges with exact field sets.
- Added coverage to ensure generating visualization data does not change graph metrics.

### Impact
`✅ Clearer visualization API responses`
`✅ Fewer broken graph payloads`
`✅ Safer graph rendering for consumers`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=SPv1CyV85xbYHnxOowINV7Slm3wylOhkhfbd-kj4XsM&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
