### PR TITLE
Define paginated assets response contract

### DIFF
--- a/api/api_models.py
+++ b/api/api_models.py
@@ -19,6 +19,15 @@ class AssetResponse(BaseModel):
     additional_fields: dict[str, Any] = Field(default_factory=dict)
 
 
+class AssetPageResponse(BaseModel):
+    """Response model for paginated asset data."""
+
+    items: list[AssetResponse]
+    total: int
+    page: int
+    page_size: int
+
+
 class RelationshipResponse(BaseModel):
     """Response model for relationship data."""
 

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -25,7 +25,7 @@ class AssetPageResponse(BaseModel):
     items: list[AssetResponse]
     total: int
     page: int
-    page_size: int
+    per_page: int
 
 
 class RelationshipResponse(BaseModel):

--- a/api/routers/assets.py
+++ b/api/routers/assets.py
@@ -1,5 +1,7 @@
 """Asset API routes."""
 
+from typing import Annotated
+
 from fastapi import APIRouter, HTTPException, Query
 
 from ..api_models import AssetPageResponse, AssetResponse
@@ -13,12 +15,12 @@ from ..router_helpers import (
 router = APIRouter()
 
 
-@router.get("/api/assets")
+@router.get("/api/assets", response_model=AssetPageResponse)
 async def get_assets(
     asset_class: str | None = None,
     sector: str | None = None,
-    page: int = Query(default=1, ge=1),
-    page_size: int = Query(default=50, ge=1),
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=1000)] = 50,
 ) -> AssetPageResponse:
     """Return a paginated page of assets filtered by asset class and sector."""
     try:
@@ -29,10 +31,12 @@ async def get_assets(
                 continue
             if sector and asset.sector != sector:
                 continue
-            assets.append(AssetResponse(**serialize_asset(asset)))
+            assets.append(asset)
+        assets.sort(key=lambda asset: asset.id)
         total = len(assets)
-        start = (page - 1) * page_size
-        end = start + page_size
+        start = (page - 1) * per_page
+        end = start + per_page
+        page_assets = assets[start:end]
     except HTTPException:
         raise
     except Exception as e:
@@ -41,7 +45,12 @@ async def get_assets(
             status_code=500,
             detail="An internal error occurred. Please try again later.",
         ) from e
-    return AssetPageResponse(items=assets[start:end], total=total, page=page, page_size=page_size)
+    return AssetPageResponse(
+        items=[AssetResponse(**serialize_asset(asset)) for asset in page_assets],
+        total=total,
+        page=page,
+        per_page=per_page,
+    )
 
 
 @router.get("/api/assets/{asset_id}")

--- a/api/routers/assets.py
+++ b/api/routers/assets.py
@@ -15,7 +15,7 @@ from ..router_helpers import (
 router = APIRouter()
 
 
-@router.get("/api/assets", response_model=AssetPageResponse)
+@router.get("/api/assets")
 async def get_assets(
     asset_class: str | None = None,
     sector: str | None = None,

--- a/api/routers/assets.py
+++ b/api/routers/assets.py
@@ -53,7 +53,7 @@ async def get_assets(
     )
 
 
-@router.get("/api/assets/{asset_id}")
+@router.get("/api/assets")
 async def get_asset_detail(asset_id: str) -> AssetResponse:
     """Return detailed data for a single asset."""
     try:

--- a/api/routers/assets.py
+++ b/api/routers/assets.py
@@ -53,7 +53,7 @@ async def get_assets(
     )
 
 
-@router.get("/api/assets")
+@router.get("/api/assets/{asset_id}")
 async def get_asset_detail(asset_id: str) -> AssetResponse:
     """Return detailed data for a single asset."""
     try:

--- a/api/routers/assets.py
+++ b/api/routers/assets.py
@@ -1,8 +1,8 @@
 """Asset API routes."""
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 
-from ..api_models import AssetResponse
+from ..api_models import AssetPageResponse, AssetResponse
 from ..router_helpers import (
     get_graph,
     logger,
@@ -17,8 +17,10 @@ router = APIRouter()
 async def get_assets(
     asset_class: str | None = None,
     sector: str | None = None,
-) -> list[AssetResponse]:
-    """Return assets filtered by asset class and sector."""
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=50, ge=1),
+) -> AssetPageResponse:
+    """Return a paginated page of assets filtered by asset class and sector."""
     try:
         g = get_graph()
         assets = []
@@ -28,6 +30,9 @@ async def get_assets(
             if sector and asset.sector != sector:
                 continue
             assets.append(AssetResponse(**serialize_asset(asset)))
+        total = len(assets)
+        start = (page - 1) * page_size
+        end = start + page_size
     except HTTPException:
         raise
     except Exception as e:
@@ -36,7 +41,7 @@ async def get_assets(
             status_code=500,
             detail="An internal error occurred. Please try again later.",
         ) from e
-    return assets
+    return AssetPageResponse(items=assets[start:end], total=total, page=page, page_size=page_size)
 
 
 @router.get("/api/assets/{asset_id}")

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -31,6 +31,25 @@ def asset_items(page: dict) -> list[dict]:
     return page["items"]
 
 
+def all_asset_items(client: TestClient) -> list[dict]:
+    """Return all asset items across paginated assets responses."""
+    first_response = client.get("/api/assets")
+    assert first_response.status_code == 200
+    first_payload = first_response.json()
+    assets = asset_items(first_payload)
+
+    total = first_payload["total"]
+    per_page = first_payload["per_page"]
+
+    for page in range(2, (total + per_page - 1) // per_page + 1):
+        response = client.get(f"/api/assets?page={page}&per_page={per_page}")
+        assert response.status_code == 200
+        assets.extend(asset_items(response.json()))
+
+    assert len(assets) == total
+    return assets
+
+
 class TestCompleteAPIFlow:
     """Test complete API workflows."""
 
@@ -69,11 +88,10 @@ class TestCompleteAPIFlow:
         metrics = metrics_response.json()
 
         # Get all assets
-        assets_response = client.get("/api/assets")
-        assets = asset_items(assets_response.json())
+        assets = all_asset_items(client)
 
         # Verify metrics match actual counts
-        assert metrics["total_assets"] == assets_response.json()["total"]
+        assert metrics["total_assets"] == len(assets)
 
         # Verify asset class counts
         asset_class_counts = {}
@@ -87,8 +105,7 @@ class TestCompleteAPIFlow:
     def test_visualization_data_consistency(client):
         """Test visualization data consistency with assets."""
         # Get assets
-        assets_response = client.get("/api/assets")
-        assets = asset_items(assets_response.json())
+        assets = all_asset_items(client)
         asset_ids = {asset["id"] for asset in assets}
 
         # Get visualization data

--- a/tests/integration/test_api_integration.py
+++ b/tests/integration/test_api_integration.py
@@ -21,6 +21,16 @@ def client():
     return TestClient(app)
 
 
+def asset_items(page: dict) -> list[dict]:
+    """Return asset items from a paginated assets response."""
+    assert set(page) == {"items", "total", "page", "per_page"}
+    assert isinstance(page["items"], list)
+    assert isinstance(page["total"], int)
+    assert isinstance(page["page"], int)
+    assert isinstance(page["per_page"], int)
+    return page["items"]
+
+
 class TestCompleteAPIFlow:
     """Test complete API workflows."""
 
@@ -34,7 +44,7 @@ class TestCompleteAPIFlow:
         # Step 2: Get all assets
         assets_response = client.get("/api/assets")
         assert assets_response.status_code == 200
-        assets = assets_response.json()
+        assets = asset_items(assets_response.json())
         assert len(assets) > 0
 
         # Step 3: Get detail for first asset
@@ -60,10 +70,10 @@ class TestCompleteAPIFlow:
 
         # Get all assets
         assets_response = client.get("/api/assets")
-        assets = assets_response.json()
+        assets = asset_items(assets_response.json())
 
         # Verify metrics match actual counts
-        assert metrics["total_assets"] == len(assets)
+        assert metrics["total_assets"] == assets_response.json()["total"]
 
         # Verify asset class counts
         asset_class_counts = {}
@@ -78,7 +88,7 @@ class TestCompleteAPIFlow:
         """Test visualization data consistency with assets."""
         # Get assets
         assets_response = client.get("/api/assets")
-        assets = assets_response.json()
+        assets = asset_items(assets_response.json())
         asset_ids = {asset["id"] for asset in assets}
 
         # Get visualization data
@@ -98,7 +108,7 @@ class TestCompleteAPIFlow:
     def test_filter_combinations(client):
         """Test various filter combinations return consistent results."""
         # Get all assets
-        all_assets = client.get("/api/assets").json()
+        all_assets = asset_items(client.get("/api/assets").json())
 
         # Get unique asset classes and sectors
         asset_classes = {a["asset_class"] for a in all_assets}
@@ -106,13 +116,13 @@ class TestCompleteAPIFlow:
 
         # Test each asset class filter
         for ac in asset_classes:
-            filtered = client.get(f"/api/assets?asset_class={ac}").json()
+            filtered = asset_items(client.get(f"/api/assets?asset_class={ac}").json())
             assert all(a["asset_class"] == ac for a in filtered)
             assert len(filtered) <= len(all_assets)
 
         # Test each sector filter
         for sector in sectors:
-            filtered = client.get(f"/api/assets?sector={sector}").json()
+            filtered = asset_items(client.get(f"/api/assets?sector={sector}").json())
             assert all(a["sector"] == sector for a in filtered)
             assert len(filtered) <= len(all_assets)
 
@@ -123,7 +133,7 @@ class TestDataIntegrity:
     @staticmethod
     def test_asset_detail_matches_list(client):
         """Test that asset details match what is in the list."""
-        assets = client.get("/api/assets").json()
+        assets = asset_items(client.get("/api/assets").json())
 
         for asset in assets[:3]:  # Test first 3 assets
             detail = client.get(f"/api/assets/{asset['id']}").json()
@@ -257,4 +267,4 @@ class TestErrorRecovery:
         # Test with invalid query parameters
         response = client.get("/api/assets?asset_class=INVALID")
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert len(asset_items(response.json())) == 0

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -32,6 +32,16 @@ TEST_ORIGIN_HTTPS_LOOPBACK = "https://127.0.0.1:8000"
 TEST_ORIGIN_FTP_LOCALHOST = "ftp://localhost:3000"  # Invalid protocol test case
 
 
+def asset_items(page: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return asset items from a paginated assets response."""
+    assert set(page) == {"items", "total", "page", "page_size"}
+    assert isinstance(page["items"], list)
+    assert isinstance(page["total"], int)
+    assert isinstance(page["page"], int)
+    assert isinstance(page["page_size"], int)
+    return page["items"]
+
+
 @pytest.fixture
 def client():
     """Create a test client for the FastAPI app.
@@ -252,7 +262,7 @@ class TestAssetsEndpoint:
 
         response = client.get("/api/assets")
         assert response.status_code == 200
-        data = response.json()
+        data = asset_items(response.json())
         assert len(data) == 4  # equity, bond, commodity, currency
 
         # Verify structure
@@ -272,7 +282,7 @@ class TestAssetsEndpoint:
 
         response = client.get("/api/assets?asset_class=Equity")
         assert response.status_code == 200
-        data = response.json()
+        data = asset_items(response.json())
         assert len(data) == 1
         assert data[0]["asset_class"] == "Equity"
         assert data[0]["symbol"] == "AAPL"
@@ -284,7 +294,7 @@ class TestAssetsEndpoint:
 
         response = client.get("/api/assets?sector=Technology")
         assert response.status_code == 200
-        data = response.json()
+        data = asset_items(response.json())
         assert len(data) == 1
         assert data[0]["sector"] == "Technology"
 
@@ -295,7 +305,7 @@ class TestAssetsEndpoint:
 
         response = client.get("/api/assets?asset_class=Equity&sector=Technology")
         assert response.status_code == 200
-        data = response.json()
+        data = asset_items(response.json())
         assert len(data) == 1
         assert data[0]["asset_class"] == "Equity"
         assert data[0]["sector"] == "Technology"
@@ -307,7 +317,7 @@ class TestAssetsEndpoint:
 
         response = client.get("/api/assets?asset_class=Equity")
         assert response.status_code == 200
-        data = response.json()
+        data = asset_items(response.json())
 
         equity = data[0]
         assert "additional_fields" in equity
@@ -565,7 +575,7 @@ class TestEdgeCases:
 
         response = client.get("/api/assets")
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert len(asset_items(response.json())) == 0
 
         response = client.get("/api/metrics")
         assert response.status_code == 200
@@ -589,7 +599,7 @@ class TestEdgeCases:
 
         response = client.get("/api/assets?sector=NonExistent")
         assert response.status_code == 200
-        assert len(response.json()) == 0
+        assert len(asset_items(response.json())) == 0
 
 
 @pytest.mark.unit
@@ -610,7 +620,7 @@ class TestConcurrency:
         # All should succeed
         for response in responses:
             assert response.status_code == 200
-            assert len(response.json()) == 4
+            assert len(asset_items(response.json())) == 4
 
 
 @pytest.mark.unit
@@ -627,7 +637,7 @@ class TestResponseValidation:
         apply_mock_graph(mock_graph_instance, mock_graph)
 
         response = client.get("/api/assets")
-        data = response.json()
+        data = asset_items(response.json())
 
         for asset in data:
             # Required fields
@@ -955,7 +965,9 @@ class TestAPIBoundaryConditions:
         # Should not timeout or error
         response = client.get("/api/assets")
         assert response.status_code == 200
-        assert len(response.json()) == 1000
+        data = response.json()
+        assert data["total"] == 1000
+        assert len(data["items"]) == 50
 
     @staticmethod
     @patch("api.main.graph")

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -966,6 +966,8 @@ class TestAPIBoundaryConditions:
         response = client.get("/api/assets")
         assert response.status_code == 200
         data = response.json()
+        assert data["page"] == 1
+        assert data["per_page"] == 50
         assert data["total"] == 1000
         assert len(data["items"]) == 50
 

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -34,11 +34,11 @@ TEST_ORIGIN_FTP_LOCALHOST = "ftp://localhost:3000"  # Invalid protocol test case
 
 def asset_items(page: dict[str, Any]) -> list[dict[str, Any]]:
     """Return asset items from a paginated assets response."""
-    assert set(page) == {"items", "total", "page", "page_size"}
+    assert set(page) == {"items", "total", "page", "per_page"}
     assert isinstance(page["items"], list)
     assert isinstance(page["total"], int)
     assert isinstance(page["page"], int)
-    assert isinstance(page["page_size"], int)
+    assert isinstance(page["per_page"], int)
     return page["items"]
 
 

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -48,13 +48,13 @@ from src.models.financial_models import AssetClass, Equity
 CORS_DEV_ORIGIN = "http://localhost:3000"
 
 
-def _assert_asset_page(data: dict[str, Any], *, page: int = 1, page_size: int = 50) -> list[dict[str, Any]]:
+def _assert_asset_page(data: dict[str, Any], *, page: int = 1, per_page: int = 50) -> list[dict[str, Any]]:
     """Assert that an assets response follows the paginated contract."""
-    assert set(data) == {"items", "total", "page", "page_size"}
+    assert set(data) == {"items", "total", "page", "per_page"}
     assert isinstance(data["items"], list)
     assert isinstance(data["total"], int)
     assert data["page"] == page
-    assert data["page_size"] == page_size
+    assert data["per_page"] == per_page
     assert data["total"] >= len(data["items"])
     return data["items"]
 
@@ -367,27 +367,47 @@ class TestAPIEndpoints:
         assert "price" in asset
 
     def test_get_assets_explicit_pagination(self, client: TestClient) -> None:
-        """Assets endpoint supports explicit page and page_size parameters."""
-        first_response = client.get("/api/assets?page=1&page_size=2")
-        second_response = client.get("/api/assets?page=2&page_size=2")
+        """Assets endpoint supports explicit page and per_page parameters."""
+        first_response = client.get("/api/assets?page=1&per_page=2")
+        second_response = client.get("/api/assets?page=2&per_page=2")
 
         assert first_response.status_code == 200
         assert second_response.status_code == 200
 
-        first_page = _assert_asset_page(first_response.json(), page=1, page_size=2)
-        second_page = _assert_asset_page(second_response.json(), page=2, page_size=2)
+        first_payload = first_response.json()
+        second_payload = second_response.json()
+        first_page = _assert_asset_page(first_payload, page=1, per_page=2)
+        second_page = _assert_asset_page(second_payload, page=2, per_page=2)
 
         assert len(first_page) == 2
         assert len(second_page) == 2
+        assert first_payload["total"] == second_payload["total"]
+        assert first_payload["total"] >= len(first_page) + len(second_page)
         assert {asset["id"] for asset in first_page}.isdisjoint({asset["id"] for asset in second_page})
+
+    def test_get_assets_rejects_invalid_pagination(self, client: TestClient) -> None:
+        """Assets endpoint rejects invalid page and per_page values."""
+        assert client.get("/api/assets?page=0").status_code == 422
+        assert client.get("/api/assets?per_page=0").status_code == 422
+        assert client.get("/api/assets?per_page=1001").status_code == 422
+
+    def test_get_assets_out_of_range_page_returns_empty_items(self, client: TestClient) -> None:
+        """Assets endpoint returns an empty page for out-of-range page requests."""
+        response = client.get("/api/assets?page=999999&per_page=50")
+        assert response.status_code == 200
+        payload = response.json()
+        assets = _assert_asset_page(payload, page=999999, per_page=50)
+        assert assets == []
+        assert payload["total"] >= 0
 
     def test_get_assets_filter_by_class(self, client):
         """Test filtering assets by asset class."""
-        response = client.get("/api/assets?asset_class=EQUITY")
+        response = client.get("/api/assets?asset_class=Equity")
         assert response.status_code == 200
         assets = _assert_asset_page(response.json())
+        assert assets
         for asset in assets:
-            assert asset["asset_class"] == "EQUITY"
+            assert asset["asset_class"] == "Equity"
 
     def test_get_assets_filter_by_sector(self, client: TestClient) -> None:
         """Assets endpoint supports filtering by sector."""
@@ -400,11 +420,12 @@ class TestAPIEndpoints:
     def test_get_assets_filter_by_class_and_sector(self, client: TestClient) -> None:
         """Assets endpoint supports combined asset_class and sector filters."""
         # IMPORTANT: use '&' not '&amp;' (HTML entity should not appear in test URLs)
-        response = client.get("/api/assets?asset_class=EQUITY&sector=Technology")
+        response = client.get("/api/assets?asset_class=Equity&sector=Technology")
         assert response.status_code == 200
         assets = _assert_asset_page(response.json())
+        assert assets
         for asset in assets:
-            assert asset["asset_class"] == "EQUITY"
+            assert asset["asset_class"] == "Equity"
             assert asset["sector"] == "Technology"
 
     def test_get_metrics_enriched_statistics(self, client: TestClient) -> None:
@@ -731,37 +752,37 @@ class TestAdditionalFields:
 
     def test_equity_additional_fields(self, client: TestClient) -> None:
         """Equity assets include expected equity-specific fields in additional_fields."""
-        response = client.get("/api/assets?asset_class=EQUITY")
+        response = client.get("/api/assets?asset_class=Equity")
         assets = _assert_asset_page(response.json())
 
-        if assets:
-            asset = assets[0]
-            additional = asset.get("additional_fields", {})
-            possible_fields = {
-                "pe_ratio",
-                "dividend_yield",
-                "earnings_per_share",
-                "book_value",
-            }
-            has_equity_field = any(field in additional for field in possible_fields)
-            assert has_equity_field or additional == {}
+        assert assets
+        asset = assets[0]
+        additional = asset.get("additional_fields", {})
+        possible_fields = {
+            "pe_ratio",
+            "dividend_yield",
+            "earnings_per_share",
+            "book_value",
+        }
+        has_equity_field = any(field in additional for field in possible_fields)
+        assert has_equity_field or additional == {}
 
     def test_bond_additional_fields(self, client: TestClient) -> None:
         """Bond assets include expected bond-specific fields in additional_fields."""
-        response = client.get("/api/assets?asset_class=BOND")
+        response = client.get("/api/assets?asset_class=Fixed Income")
         assets = _assert_asset_page(response.json())
 
-        if assets:
-            asset = assets[0]
-            additional = asset.get("additional_fields", {})
-            possible_fields = {
-                "yield_to_maturity",
-                "coupon_rate",
-                "maturity_date",
-                "credit_rating",
-            }
-            has_bond_field = any(field in additional for field in possible_fields)
-            assert has_bond_field or additional == {}
+        assert assets
+        asset = assets[0]
+        additional = asset.get("additional_fields", {})
+        possible_fields = {
+            "yield_to_maturity",
+            "coupon_rate",
+            "maturity_date",
+            "credit_rating",
+        }
+        has_bond_field = any(field in additional for field in possible_fields)
+        assert has_bond_field or additional == {}
 
 
 @pytest.mark.unit
@@ -839,11 +860,11 @@ class TestIntegrationScenarios:
         response = client.get("/api/assets")
         all_assets = _assert_asset_page(response.json())
 
-        response = client.get("/api/assets?asset_class=EQUITY")
+        response = client.get("/api/assets?asset_class=Equity")
         equity_assets = _assert_asset_page(response.json())
         assert len(equity_assets) <= len(all_assets)
 
-        response = client.get("/api/assets?asset_class=EQUITY&sector=Technology")
+        response = client.get("/api/assets?asset_class=Equity&sector=Technology")
         tech_equity_assets = _assert_asset_page(response.json())
         assert len(tech_equity_assets) <= len(equity_assets)
 

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -27,6 +27,7 @@ from fastapi.testclient import TestClient
 
 import api.main as api_main
 from api.api_models import (
+    AssetPageResponse,
     AssetResponse,
     MetricsResponse,
     RelationshipResponse,
@@ -45,6 +46,17 @@ from src.logic.asset_graph import AssetRelationshipGraph
 from src.models.financial_models import AssetClass, Equity
 
 CORS_DEV_ORIGIN = "http://localhost:3000"
+
+
+def _assert_asset_page(data: dict[str, Any], *, page: int = 1, page_size: int = 50) -> list[dict[str, Any]]:
+    """Assert that an assets response follows the paginated contract."""
+    assert set(data) == {"items", "total", "page", "page_size"}
+    assert isinstance(data["items"], list)
+    assert isinstance(data["total"], int)
+    assert data["page"] == page
+    assert data["page_size"] == page_size
+    assert data["total"] >= len(data["items"])
+    return data["items"]
 
 
 # -----------------------
@@ -343,8 +355,7 @@ class TestAPIEndpoints:
         """Test getting all assets without filters."""
         response = client.get("/api/assets")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         assert len(assets) > 0
 
         asset = assets[0]
@@ -355,12 +366,26 @@ class TestAPIEndpoints:
         assert "sector" in asset
         assert "price" in asset
 
+    def test_get_assets_explicit_pagination(self, client: TestClient) -> None:
+        """Assets endpoint supports explicit page and page_size parameters."""
+        first_response = client.get("/api/assets?page=1&page_size=2")
+        second_response = client.get("/api/assets?page=2&page_size=2")
+
+        assert first_response.status_code == 200
+        assert second_response.status_code == 200
+
+        first_page = _assert_asset_page(first_response.json(), page=1, page_size=2)
+        second_page = _assert_asset_page(second_response.json(), page=2, page_size=2)
+
+        assert len(first_page) == 2
+        assert len(second_page) == 2
+        assert {asset["id"] for asset in first_page}.isdisjoint({asset["id"] for asset in second_page})
+
     def test_get_assets_filter_by_class(self, client):
         """Test filtering assets by asset class."""
         response = client.get("/api/assets?asset_class=EQUITY")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         for asset in assets:
             assert asset["asset_class"] == "EQUITY"
 
@@ -368,8 +393,7 @@ class TestAPIEndpoints:
         """Assets endpoint supports filtering by sector."""
         response = client.get("/api/assets?sector=Technology")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         for asset in assets:
             assert asset["sector"] == "Technology"
 
@@ -378,8 +402,7 @@ class TestAPIEndpoints:
         # IMPORTANT: use '&' not '&amp;' (HTML entity should not appear in test URLs)
         response = client.get("/api/assets?asset_class=EQUITY&sector=Technology")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         for asset in assets:
             assert asset["asset_class"] == "EQUITY"
             assert asset["sector"] == "Technology"
@@ -498,7 +521,7 @@ class TestAPIEndpoints:
     def test_get_asset_detail_valid(self, client: TestClient) -> None:
         """Asset detail endpoint returns the requested asset when it exists."""
         response = client.get("/api/assets")
-        assets = response.json()
+        assets = _assert_asset_page(response.json())
         asset_id = assets[0]["id"]
 
         response = client.get(f"/api/assets/{asset_id}")
@@ -515,7 +538,7 @@ class TestAPIEndpoints:
     def test_get_asset_relationships_valid(self, client: TestClient) -> None:
         """Asset relationships endpoint returns relationships for a valid asset."""
         response = client.get("/api/assets")
-        assets = response.json()
+        assets = _assert_asset_page(response.json())
         asset_id = assets[0]["id"]
 
         response = client.get(f"/api/assets/{asset_id}/relationships")
@@ -709,7 +732,7 @@ class TestAdditionalFields:
     def test_equity_additional_fields(self, client: TestClient) -> None:
         """Equity assets include expected equity-specific fields in additional_fields."""
         response = client.get("/api/assets?asset_class=EQUITY")
-        assets = response.json()
+        assets = _assert_asset_page(response.json())
 
         if assets:
             asset = assets[0]
@@ -726,7 +749,7 @@ class TestAdditionalFields:
     def test_bond_additional_fields(self, client: TestClient) -> None:
         """Bond assets include expected bond-specific fields in additional_fields."""
         response = client.get("/api/assets?asset_class=BOND")
-        assets = response.json()
+        assets = _assert_asset_page(response.json())
 
         if assets:
             asset = assets[0]
@@ -785,7 +808,7 @@ class TestIntegrationScenarios:
         """Exercise the core browse flow: list assets, fetch detail, fetch relationships."""
         response = client.get("/api/assets")
         assert response.status_code == 200
-        assets = response.json()
+        assets = _assert_asset_page(response.json())
         assert assets
 
         asset_id = assets[0]["id"]
@@ -814,14 +837,14 @@ class TestIntegrationScenarios:
     def test_filter_refinement_workflow(self, client: TestClient) -> None:
         """Confirm progressive filters reduce (or keep) result sets, never increase them."""
         response = client.get("/api/assets")
-        all_assets = response.json()
+        all_assets = _assert_asset_page(response.json())
 
         response = client.get("/api/assets?asset_class=EQUITY")
-        equity_assets = response.json()
+        equity_assets = _assert_asset_page(response.json())
         assert len(equity_assets) <= len(all_assets)
 
         response = client.get("/api/assets?asset_class=EQUITY&sector=Technology")
-        tech_equity_assets = response.json()
+        tech_equity_assets = _assert_asset_page(response.json())
         assert len(tech_equity_assets) <= len(equity_assets)
 
 
@@ -1647,16 +1670,14 @@ class TestEndpointRegressionCases:
         """Assets endpoint should return empty list for nonexistent asset class."""
         response = client.get("/api/assets?asset_class=NONEXISTENT")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         assert len(assets) == 0
 
     def test_assets_endpoint_with_nonexistent_sector(self, client: TestClient):
         """Assets endpoint should return empty list for nonexistent sector."""
         response = client.get("/api/assets?sector=NonexistentSector")
         assert response.status_code == 200
-        assets = response.json()
-        assert isinstance(assets, list)
+        assets = _assert_asset_page(response.json())
         assert len(assets) == 0
 
     def test_asset_relationships_empty_list(self, bare_client: TestClient):


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI production path response contract is changed.
- Frontend: no changes.
- Gradio: no changes.

This PR chooses Option A: `/api/assets` is an explicit paginated resource.

## Primary Objective

Define the `/api/assets` contract as a paginated response with `items`, `total`, `page`, and `per_page`.

## Scope

### In Scope

- Add `AssetPageResponse` with `items`, `total`, `page`, and `per_page`.
- Update `GET /api/assets` to accept `page` and bounded `per_page` query parameters.
- Use `Annotated` FastAPI query parameters and an explicit `AssetPageResponse` return annotation.
- Preserve existing in-memory filtering behavior and apply deterministic sorting by asset id before page slicing.
- Defer asset serialization until after slicing the selected page.
- Keep out-of-range pages as `200` with empty `items`, requested `page`, requested `per_page`, and filtered `total`.
- Update backend unit and integration API tests to assert and consume the new paginated envelope.
- Add an integration helper for tests that need full-dataset comparisons across all asset pages.

### Out of Scope

- Database optimization.
- Query/data-layer refactors.
- Frontend work.
- Visualization changes.
- Metrics changes.
- Changing out-of-range pages to 404 or clamping.
- Scanner/tooling configuration and style-only findings unrelated to this contract.

### Files Expected to Change

- `api/api_models.py` — adds the explicit asset page response model.
- `api/routers/assets.py` — returns the paginated assets response contract.
- `tests/unit/test_api_main.py` — updates production API tests for the envelope and pagination policy.
- `tests/unit/test_api.py` — updates legacy API tests for the envelope.
- `tests/integration/test_api_integration.py` — updates integration consumers for the envelope and full-dataset comparisons.

## Validation Commands

```bash
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_api_main.py -v
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_api.py -v
PATH="/workspace/.venv/bin:$PATH" pytest tests/integration/test_api_integration.py -v
git diff --check -- "api/api_models.py" "api/routers/assets.py" "tests/unit/test_api_main.py" "tests/unit/test_api.py" "tests/integration/test_api_integration.py"
PATH="/workspace/.venv/bin:$PATH" pre-commit run --files "api/api_models.py" "api/routers/assets.py" "tests/unit/test_api_main.py" "tests/unit/test_api.py" "tests/integration/test_api_integration.py"
```

Pytest and `git diff --check` passed. `pre-commit` ran; formatting/import hooks passed, while existing flake8-docstrings in broad test files and unrelated mypy errors in `src/data/sample_data.py` remain outside this scoped contract change.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Required pytest validation passes locally
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Runtime behavior changes are limited to the `/api/assets` response contract
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

---

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

## Additional Notes

Codacy MCP tools were not available in this workspace, so Codacy analysis could not be run for the edited files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defines `GET /api/assets` as a paginated endpoint returning { items, total, page, per_page }. Preserves filtering, sorts by id before slicing, validates `page`/`per_page`, and updates tests; asset detail and relationships endpoints are unchanged.

- **New Features**
  - Added `AssetPageResponse` with items, total, page, per_page; `GET /api/assets` accepts `page` and `per_page` (defaults: 1 and 50; 1 <= per_page <= 1000; invalid values return 422).
  - Results are sorted by id, then sliced; out-of-range pages return 200 with empty items; assets are serialized after slicing.
  - Updated unit/integration tests and added helpers to read all pages.

- **Migration**
  - Clients should read assets from `items` and handle pagination (`page`/`per_page`).

<sup>Written for commit 7664773e2081405a705ff48de97400d1a9a35c2f. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1081?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Return assets in paginated pages with a fixed response shape**

### What Changed
- `/api/assets` now returns a paginated response with `items`, `total`, `page`, and `per_page` instead of a plain list
- Users can request a specific page and page size; invalid values are rejected, and pages past the end return an empty `items` list with the requested pagination values
- Asset filtering still works, and results are now returned in a stable order
- Tests were updated to read the paginated response and verify full-data checks across all pages

### Impact
`✅ Clearer asset list responses`
`✅ Safer page-by-page browsing`
`✅ Fewer broken data checks in integration tests`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=JPZmAR6QdfcJDDzM4EPZSyBxzFDVE_UB4t0hcwvihHo&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
