### PR TITLE
Clarify FastAPI backend deployment path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,26 @@
 # Frontend API Configuration
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
+# Backend runtime configuration
+# Required before importing/running api.main:app
+DATABASE_URL=sqlite:///./dev.db
+SECRET_KEY=replace-with-a-long-random-secret
+
+# Required when seeding a new local/dev API database
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=replace-with-a-strong-password
+# ADMIN_EMAIL=admin@example.com
+# ADMIN_FULL_NAME=Admin User
+# ADMIN_DISABLED=false
+
 # Backend CORS Configuration (optional)
 # Comma-separated list of additional allowed origins for CORS
 # ALLOWED_ORIGINS=https://your-frontend.vercel.app,https://your-custom-domain.com
+
+# Optional graph data-source configuration
+# GRAPH_CACHE_PATH=/path/to/graph-cache.json
+# REAL_DATA_CACHE_PATH=/path/to/real-data-cache.json
+# USE_REAL_DATA_FETCHER=false
 
 # For production deployment on Vercel
 # NEXT_PUBLIC_API_URL=https://your-api-domain.vercel.app

--- a/.env.example
+++ b/.env.example
@@ -4,7 +4,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 # Backend runtime configuration
 # Required before importing/running api.main:app
 # Local/dev SQLite file example for the current API database layer
-DATABASE_URL=sqlite:./dev.db
+DATABASE_URL=sqlite:///./dev.db
 SECRET_KEY=replace-with-a-long-random-secret
 
 # Required when seeding a new local/dev API database
@@ -22,6 +22,7 @@ ADMIN_PASSWORD=replace-with-a-strong-password
 # GRAPH_CACHE_PATH=/path/to/graph-cache.json
 # REAL_DATA_CACHE_PATH=/path/to/real-data-cache.json
 # USE_REAL_DATA_FETCHER=false
+# ASSET_GRAPH_DATABASE_URL=sqlite:///./graph.db
 
 # For production deployment on Vercel
 # NEXT_PUBLIC_API_URL=https://your-api-domain.vercel.app

--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@ DATABASE_URL=sqlite:///./dev.db
 SECRET_KEY=replace-with-a-long-random-secret
 
 # Required when seeding a new local/dev API database
-ADMIN_USERNAME=admin
 ADMIN_PASSWORD=replace-with-a-strong-password
+ADMIN_USERNAME=admin
 # ADMIN_EMAIL=admin@example.com
 # ADMIN_FULL_NAME=Admin User
 # ADMIN_DISABLED=false

--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,8 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Backend runtime configuration
 # Required before importing/running api.main:app
-DATABASE_URL=sqlite:///./dev.db
+# Local/dev SQLite file example for the current API database layer
+DATABASE_URL=sqlite:./dev.db
 SECRET_KEY=replace-with-a-long-random-secret
 
 # Required when seeding a new local/dev API database

--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Backend runtime configuration
 # Required before importing/running api.main:app
-# Local/dev SQLite file example for the current API database layer
-DATABASE_URL=sqlite:///./dev.db
+# Local/dev example for the current API resolver: sqlite:dev.db
+DATABASE_URL=sqlite:dev.db
 SECRET_KEY=replace-with-a-long-random-secret
 
 # Required to bootstrap the first user when the configured API database has no users
@@ -22,7 +22,7 @@ ADMIN_USERNAME=admin
 # GRAPH_CACHE_PATH=/path/to/graph-cache.json
 # REAL_DATA_CACHE_PATH=/path/to/real-data-cache.json
 # USE_REAL_DATA_FETCHER=false
-# ASSET_GRAPH_DATABASE_URL=sqlite:///./graph.db
+# ASSET_GRAPH_DATABASE_URL=sqlite:graph.db
 
 # For production deployment on Vercel
 # NEXT_PUBLIC_API_URL=https://your-api-domain.vercel.app

--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 DATABASE_URL=sqlite:///./dev.db
 SECRET_KEY=replace-with-a-long-random-secret
 
-# Required when seeding a new local/dev API database
+# Required to bootstrap the first user when the configured API database has no users
 ADMIN_PASSWORD=replace-with-a-strong-password
 ADMIN_USERNAME=admin
 # ADMIN_EMAIL=admin@example.com

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,7 +34,7 @@ For local production-like testing, the command defaults to port `8000` when `POR
 
 Minimum backend environment required before importing `api.main`:
 
-- `DATABASE_URL` — SQLite URI used by `api/database.py`; local/dev file example: `sqlite:./dev.db`
+- `DATABASE_URL` — SQLite URI used by `api/database.py`; local/dev file example: `sqlite:///./dev.db`
 - `SECRET_KEY` — JWT signing key used by `api/auth.py`
 - Existing user credentials in the configured database, or bootstrap credentials:
   - `ADMIN_USERNAME`
@@ -51,7 +51,7 @@ Optional backend runtime settings:
 - `ASSET_GRAPH_DATABASE_URL` — graph persistence URL when used by graph repository flows; this does not replace the API auth/database `DATABASE_URL` requirement
 
 The current API database layer expects a SQLite URI for `DATABASE_URL`. Local SQLite files such as
-`sqlite:./dev.db` are suitable for local/dev runs, but do not use local SQLite file storage for durable production
+`sqlite:///./dev.db` are suitable for local/dev runs, but do not use local SQLite file storage for durable production
 persistence on Vercel/serverless filesystems. Durable production persistence requires a separate storage decision
 after the API database layer explicitly supports it.
 
@@ -81,7 +81,7 @@ after the API database layer explicitly supports it.
 3. **Run the FastAPI backend:**
 
    ```bash
-   export DATABASE_URL="sqlite:./dev.db"
+   export DATABASE_URL="sqlite:///./dev.db"
    export SECRET_KEY="replace-me-for-local-dev"
    export ADMIN_USERNAME="admin"
    export ADMIN_PASSWORD="replace-me-for-local-dev"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -83,7 +83,7 @@ after the API database layer explicitly supports it.
    The following commands use Linux/macOS shell syntax. On Windows PowerShell, set the same variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
 
    ```bash
-   export DATABASE_URL="sqlite:///./dev.db"
+   export DATABASE_URL="sqlite:dev.db"
    export SECRET_KEY="replace-me-for-local-dev"
    export ADMIN_USERNAME="admin"
    export ADMIN_PASSWORD="replace-me-for-local-dev"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -80,6 +80,8 @@ after the API database layer explicitly supports it.
 
 3. **Run the FastAPI backend:**
 
+   The following commands use Linux/macOS shell syntax. On Windows PowerShell, set the same variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
+
    ```bash
    export DATABASE_URL="sqlite:///./dev.db"
    export SECRET_KEY="replace-me-for-local-dev"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -34,7 +34,7 @@ For local production-like testing, the command defaults to port `8000` when `POR
 
 Minimum backend environment required before importing `api.main`:
 
-- `DATABASE_URL` — SQLite URI used by `api/database.py`; local/dev file example: `sqlite:///./dev.db`
+- `DATABASE_URL` — SQLite URI used by `api/database.py`; local/dev file example: `sqlite:dev.db`
 - `SECRET_KEY` — JWT signing key used by `api/auth.py`
 - Existing user credentials in the configured database, or bootstrap credentials:
   - `ADMIN_USERNAME`
@@ -51,7 +51,7 @@ Optional backend runtime settings:
 - `ASSET_GRAPH_DATABASE_URL` — graph persistence URL when used by graph repository flows; this does not replace the API auth/database `DATABASE_URL` requirement
 
 The current API database layer expects a SQLite URI for `DATABASE_URL`. Local SQLite files such as
-`sqlite:///./dev.db` are suitable for local/dev runs, but do not use local SQLite file storage for durable production
+`sqlite:dev.db` are suitable for local/dev runs, but do not use local SQLite file storage for durable production
 persistence on Vercel/serverless filesystems. Durable production persistence requires a separate storage decision
 after the API database layer explicitly supports it.
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -24,17 +24,17 @@ api.main:app
 `api/main.py` is intentionally a thin public entrypoint and compatibility surface. FastAPI application
 construction, lifespan startup, middleware, and router registration live in `api/app_factory.py`.
 
-Use this production-style run command on hosts that provide a `$PORT` environment variable:
+Use this production-style run command on hosts that provide a `PORT` environment variable:
 
 ```bash
-uvicorn api.main:app --host 0.0.0.0 --port "$PORT"
+python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"
 ```
 
-For local production-like testing, replace `$PORT` with a concrete port such as `8000`.
+For local production-like testing, the command defaults to port `8000` when `PORT` is not set.
 
 Minimum backend environment required before importing `api.main`:
 
-- `DATABASE_URL` — SQLite URL used by `api/database.py`, for example `sqlite:///./dev.db`
+- `DATABASE_URL` — SQLite URI used by `api/database.py`; local/dev file example: `sqlite:./dev.db`
 - `SECRET_KEY` — JWT signing key used by `api/auth.py`
 - Existing user credentials in the configured database, or bootstrap credentials:
   - `ADMIN_USERNAME`
@@ -44,11 +44,16 @@ Minimum backend environment required before importing `api.main`:
 Optional backend runtime settings:
 
 - `ENV` — environment mode; defaults to `development`
-- `ALLOWED_ORIGINS` — comma-separated CORS allowlist; configured through `src/config/settings.py`
+- `ALLOWED_ORIGINS` — comma-separated CORS allowlist; read from the environment by the settings layer
 - `GRAPH_CACHE_PATH` — graph cache path
 - `REAL_DATA_CACHE_PATH` — real-data cache path
 - `USE_REAL_DATA_FETCHER` — truthy value enables real-data fetcher mode
-- `ASSET_GRAPH_DATABASE_URL` — graph persistence URL when used by graph repository flows
+- `ASSET_GRAPH_DATABASE_URL` — graph persistence URL when used by graph repository flows; this does not replace the API auth/database `DATABASE_URL` requirement
+
+The current API database layer expects a SQLite URI for `DATABASE_URL`. Local SQLite files such as
+`sqlite:./dev.db` are suitable for local/dev runs, but do not use local SQLite file storage for durable production
+persistence on Vercel/serverless filesystems. Durable production persistence requires a separate storage decision
+after the API database layer explicitly supports it.
 
 ## Local Development
 
@@ -76,7 +81,7 @@ Optional backend runtime settings:
 3. **Run the FastAPI backend:**
 
    ```bash
-   export DATABASE_URL="sqlite:///./dev.db"
+   export DATABASE_URL="sqlite:./dev.db"
    export SECRET_KEY="replace-me-for-local-dev"
    export ADMIN_USERNAME="admin"
    export ADMIN_PASSWORD="replace-me-for-local-dev"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,6 +13,43 @@ The production application consists of two main components:
 1. **Backend API** (`/api`): FastAPI server that provides REST endpoints for the asset relationship graph
 2. **Frontend** (`/frontend`): Next.js application with React components for visualization
 
+## Backend Production Contract
+
+The backend production entrypoint is:
+
+```text
+api.main:app
+```
+
+`api/main.py` is intentionally a thin public entrypoint and compatibility surface. FastAPI application
+construction, lifespan startup, middleware, and router registration live in `api/app_factory.py`.
+
+Use this production-style run command on hosts that provide a `$PORT` environment variable:
+
+```bash
+uvicorn api.main:app --host 0.0.0.0 --port "$PORT"
+```
+
+For local production-like testing, replace `$PORT` with a concrete port such as `8000`.
+
+Minimum backend environment required before importing `api.main`:
+
+- `DATABASE_URL` — SQLite URL used by `api/database.py`, for example `sqlite:///./dev.db`
+- `SECRET_KEY` — JWT signing key used by `api/auth.py`
+- Existing user credentials in the configured database, or bootstrap credentials:
+  - `ADMIN_USERNAME`
+  - `ADMIN_PASSWORD`
+  - Optional: `ADMIN_EMAIL`, `ADMIN_FULL_NAME`, `ADMIN_DISABLED`
+
+Optional backend runtime settings:
+
+- `ENV` — environment mode; defaults to `development`
+- `ALLOWED_ORIGINS` — comma-separated CORS allowlist; configured through `src/config/settings.py`
+- `GRAPH_CACHE_PATH` — graph cache path
+- `REAL_DATA_CACHE_PATH` — real-data cache path
+- `USE_REAL_DATA_FETCHER` — truthy value enables real-data fetcher mode
+- `ASSET_GRAPH_DATABASE_URL` — graph persistence URL when used by graph repository flows
+
 ## Local Development
 
 ### Prerequisites
@@ -39,7 +76,11 @@ The production application consists of two main components:
 3. **Run the FastAPI backend:**
 
    ```bash
-   python -m uvicorn api.main:app --reload --host 0.0.0.0 --port 8000
+   export DATABASE_URL="sqlite:///./dev.db"
+   export SECRET_KEY="replace-me-for-local-dev"
+   export ADMIN_USERNAME="admin"
+   export ADMIN_PASSWORD="replace-me-for-local-dev"
+   python -m uvicorn api.main:app --reload --host 127.0.0.1 --port 8000
    ```
 
    The API will be available at `http://localhost:8000`
@@ -225,15 +266,9 @@ NEXT_PUBLIC_API_URL=https://your-api-domain.vercel.app
 
 ### CORS Issues
 
-If you encounter CORS errors, ensure the FastAPI backend has the correct origins configured in `api/main.py`:
-
-```python
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["http://localhost:3000", "https://*.vercel.app"],
-    ...
-)
-```
+If you encounter CORS errors, configure `ALLOWED_ORIGINS` for explicit production origins. CORS settings
+are loaded through `src/config/settings.py` and applied by `api/cors_policy.py`; do not edit
+`api/main.py` middleware directly.
 
 ### API Connection Errors
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -1,16 +1,22 @@
-# Docker Deployment Guide
+# Docker Guide (Gradio Demo Path)
 
-This guide explains how to run the Financial Asset Relationship Database using Docker and Docker Compose.
+This guide explains how to run the Financial Asset Relationship Database's Gradio demo using Docker and Docker
+Compose.
+
+The declared production architecture is the FastAPI backend plus Next.js frontend. This Dockerfile and
+`docker-compose.yml` currently start `app.py` on port `7860`, so they are for demos and internal testing, not the
+canonical production backend deployment path. For the production backend entrypoint and runtime requirements, see
+`DEPLOYMENT.md`.
 
 ## Quick Start
 
-### Using Docker Compose (Recommended)
+### Using Docker Compose (Gradio demo)
 
 ```bash
 # Build and start the application
 docker-compose up --build
 
-# Access the application at http://localhost:7860
+# Access the Gradio demo at http://localhost:7860
 ```
 
 ### Using Docker Directly
@@ -19,10 +25,10 @@ docker-compose up --build
 # Build the image
 docker build -t financial-asset-db .
 
-# Run the container
+# Run the Gradio demo container
 docker run -p 7860:7860 financial-asset-db
 
-# Access the application at http://localhost:7860
+# Access the Gradio demo at http://localhost:7860
 ```
 
 ## Docker Compose Options
@@ -38,7 +44,7 @@ docker-compose up
 
 Changes to `src/` will be reflected immediately (may require app restart).
 
-### Production Mode
+### Detached Demo Mode
 
 Build and run in detached mode:
 
@@ -223,7 +229,7 @@ If using PostgreSQL:
    - Use `docker-compose` for easier management
    - Keep development and production configs separate
 
-4. **Production**
+4. **Demo Operations**
    - Use specific image tags (not `latest`)
    - Set resource limits (CPU, memory)
    - Configure proper logging and monitoring
@@ -231,7 +237,7 @@ If using PostgreSQL:
 
 ## Multi-Stage Build (Advanced)
 
-For smaller production images, create a multi-stage Dockerfile:
+For smaller Gradio demo images, create a multi-stage Dockerfile:
 
 ```dockerfile
 # Build stage
@@ -249,9 +255,9 @@ ENV PATH=/root/.local/bin:$PATH
 CMD ["python", "app.py"]
 ```
 
-## Kubernetes Deployment (Optional)
+## Kubernetes Demo Deployment (Optional)
 
-For Kubernetes deployment, create manifests:
+For Kubernetes demo deployment, create manifests:
 
 ```yaml
 # deployment.yaml

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    ```bash
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    pip install -r requirements.txt
-   export DATABASE_URL=sqlite:///./dev.db
+   export DATABASE_URL=sqlite:./dev.db
    export SECRET_KEY=replace-with-a-long-random-secret
    export ADMIN_USERNAME=admin
    export ADMIN_PASSWORD=replace-with-a-strong-password
    python -m uvicorn api.main:app --reload --port 8000
    ```
 
-   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
 
 2. **Start the Next.js frontend (in a new terminal):**
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    ```bash
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    pip install -r requirements.txt
+   export DATABASE_URL=sqlite:///./dev.db
+   export SECRET_KEY=replace-with-a-long-random-secret
+   export ADMIN_USERNAME=admin
+   export ADMIN_PASSWORD=replace-with-a-strong-password
    python -m uvicorn api.main:app --reload --port 8000
    ```
 
-   Depending on your local setup or deployment target, the backend may also require environment configuration. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime and deployment details.
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port ${PORT:-8000}`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
 
 2. **Start the Next.js frontend (in a new terminal):**
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,23 @@ For the modern web frontend with REST API:
 
 **Quick Start (Both Servers):**
 
-```bash
-# Linux/Mac
-./run-dev.sh
+Before using the convenience scripts, set the backend runtime environment required by `api.main:app`. The scripts do not currently load these values from `.env.example`.
 
-# Windows
+```bash
+# Linux/macOS
+export DATABASE_URL=sqlite:dev.db
+export SECRET_KEY=replace-with-a-long-random-secret
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=replace-with-a-strong-password
+./run-dev.sh
+```
+
+```cmd
+REM Windows CMD
+set DATABASE_URL=sqlite:dev.db
+set SECRET_KEY=replace-with-a-long-random-secret
+set ADMIN_USERNAME=admin
+set ADMIN_PASSWORD=replace-with-a-strong-password
 run-dev.bat
 ```
 
@@ -39,7 +51,7 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    ```bash
    source .venv/bin/activate
    pip install -r requirements.txt
-   export DATABASE_URL=sqlite:///./dev.db
+   export DATABASE_URL=sqlite:dev.db
    export SECRET_KEY=replace-with-a-long-random-secret
    export ADMIN_USERNAME=admin
    export ADMIN_PASSWORD=replace-with-a-strong-password

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    ```bash
    source .venv/bin/activate  # On Windows: .venv\Scripts\activate
    pip install -r requirements.txt
-   export DATABASE_URL=sqlite:./dev.db
+   export DATABASE_URL=sqlite:///./dev.db
    export SECRET_KEY=replace-with-a-long-random-secret
    export ADMIN_USERNAME=admin
    export ADMIN_PASSWORD=replace-with-a-strong-password

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
 
 1. **Start the FastAPI backend:**
 
+   Linux/macOS:
+
    ```bash
-   source .venv/bin/activate  # On Windows: .venv\Scripts\activate
+   source .venv/bin/activate
    pip install -r requirements.txt
    export DATABASE_URL=sqlite:///./dev.db
    export SECRET_KEY=replace-with-a-long-random-secret
@@ -43,6 +45,8 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    export ADMIN_PASSWORD=replace-with-a-strong-password
    python -m uvicorn api.main:app --reload --port 8000
    ```
+
+   Windows PowerShell users should activate `.venv\Scripts\Activate.ps1` and set the same environment variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
 
    The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
 

--- a/VERCEL_DEPLOYMENT_CHECKLIST.md
+++ b/VERCEL_DEPLOYMENT_CHECKLIST.md
@@ -84,6 +84,13 @@ In the Vercel dashboard, add:
 - [ ] `NEXT_PUBLIC_API_URL` = `https://your-project.vercel.app`
   - Note: Use your actual Vercel deployment URL
   - This will be available after first deployment
+- [ ] `DATABASE_URL` = your API SQLite URL or deployment database URL
+- [ ] `SECRET_KEY` = a long random JWT signing secret
+- [ ] Seed credentials via an existing database user, or set:
+  - [ ] `ADMIN_USERNAME`
+  - [ ] `ADMIN_PASSWORD`
+  - [ ] Optional: `ADMIN_EMAIL`, `ADMIN_FULL_NAME`, `ADMIN_DISABLED`
+- [ ] Optional backend settings as needed: `ENV`, `ALLOWED_ORIGINS`, `GRAPH_CACHE_PATH`, `REAL_DATA_CACHE_PATH`, `USE_REAL_DATA_FETCHER`
 
 #### Step 5: Deploy
 
@@ -133,6 +140,12 @@ vercel
 # Set production environment variable
 vercel env add NEXT_PUBLIC_API_URL production
 # Enter: https://your-project.vercel.app
+
+# Minimum backend runtime variables
+vercel env add DATABASE_URL production
+vercel env add SECRET_KEY production
+vercel env add ADMIN_USERNAME production
+vercel env add ADMIN_PASSWORD production
 ```
 
 #### Step 5: Deploy to Production
@@ -202,20 +215,9 @@ vercel --prod
 **Error**: CORS policy errors in browser
 **Solution**:
 
-- [ ] Check CORS configuration in `api/main.py`
-- [ ] Add Vercel domain to allowed origins
+- [ ] Check `ALLOWED_ORIGINS` in the deployment environment
+- [ ] Add Vercel domain to `ALLOWED_ORIGINS`
 - [ ] Verify `NEXT_PUBLIC_API_URL` is set correctly
-
-```python
-# In api/main.py
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["https://*.vercel.app", "https://your-domain.com"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
-```
 
 #### Issue 4: Environment Variables Not Working
 

--- a/VERCEL_DEPLOYMENT_CHECKLIST.md
+++ b/VERCEL_DEPLOYMENT_CHECKLIST.md
@@ -85,7 +85,7 @@ In the Vercel dashboard, add:
   - Note: Use your actual Vercel deployment URL
   - This will be available after first deployment
 - [ ] `DATABASE_URL` = SQLite URI required by the current API database layer
-  - Local/dev example: `sqlite:///./dev.db`
+  - Local/dev example for the current API resolver: `sqlite:dev.db`
   - Vercel/serverless demo-only examples must use ephemeral storage such as `sqlite:///:memory:` or an explicit `/tmp` SQLite path, and must not be treated as durable production persistence.
   - Do not use local SQLite file storage for durable production persistence on Vercel/serverless environments.
   - For durable production deployment, use a persistent external storage strategy only after the API database layer explicitly supports it.

--- a/VERCEL_DEPLOYMENT_CHECKLIST.md
+++ b/VERCEL_DEPLOYMENT_CHECKLIST.md
@@ -86,6 +86,7 @@ In the Vercel dashboard, add:
   - This will be available after first deployment
 - [ ] `DATABASE_URL` = SQLite URI required by the current API database layer
   - Local/dev example: `sqlite:///./dev.db`
+  - Vercel/serverless demo-only examples must use ephemeral storage such as `sqlite:///:memory:` or an explicit `/tmp` SQLite path, and must not be treated as durable production persistence.
   - Do not use local SQLite file storage for durable production persistence on Vercel/serverless environments.
   - For durable production deployment, use a persistent external storage strategy only after the API database layer explicitly supports it.
 - [ ] `SECRET_KEY` = a long random JWT signing secret

--- a/VERCEL_DEPLOYMENT_CHECKLIST.md
+++ b/VERCEL_DEPLOYMENT_CHECKLIST.md
@@ -85,7 +85,7 @@ In the Vercel dashboard, add:
   - Note: Use your actual Vercel deployment URL
   - This will be available after first deployment
 - [ ] `DATABASE_URL` = SQLite URI required by the current API database layer
-  - Local/dev example: `sqlite:./dev.db`
+  - Local/dev example: `sqlite:///./dev.db`
   - Do not use local SQLite file storage for durable production persistence on Vercel/serverless environments.
   - For durable production deployment, use a persistent external storage strategy only after the API database layer explicitly supports it.
 - [ ] `SECRET_KEY` = a long random JWT signing secret
@@ -148,6 +148,8 @@ vercel env add NEXT_PUBLIC_API_URL production
 # Minimum backend runtime variables
 vercel env add DATABASE_URL production
 vercel env add SECRET_KEY production
+
+# Bootstrap credentials, only if the configured database does not already contain a usable user
 vercel env add ADMIN_USERNAME production
 vercel env add ADMIN_PASSWORD production
 ```

--- a/VERCEL_DEPLOYMENT_CHECKLIST.md
+++ b/VERCEL_DEPLOYMENT_CHECKLIST.md
@@ -84,12 +84,16 @@ In the Vercel dashboard, add:
 - [ ] `NEXT_PUBLIC_API_URL` = `https://your-project.vercel.app`
   - Note: Use your actual Vercel deployment URL
   - This will be available after first deployment
-- [ ] `DATABASE_URL` = your API SQLite URL or deployment database URL
+- [ ] `DATABASE_URL` = SQLite URI required by the current API database layer
+  - Local/dev example: `sqlite:./dev.db`
+  - Do not use local SQLite file storage for durable production persistence on Vercel/serverless environments.
+  - For durable production deployment, use a persistent external storage strategy only after the API database layer explicitly supports it.
 - [ ] `SECRET_KEY` = a long random JWT signing secret
 - [ ] Seed credentials via an existing database user, or set:
   - [ ] `ADMIN_USERNAME`
   - [ ] `ADMIN_PASSWORD`
   - [ ] Optional: `ADMIN_EMAIL`, `ADMIN_FULL_NAME`, `ADMIN_DISABLED`
+- [ ] Optional: `ASSET_GRAPH_DATABASE_URL` if using graph repository persistence flows; this does not replace the API auth/database `DATABASE_URL` requirement.
 - [ ] Optional backend settings as needed: `ENV`, `ALLOWED_ORIGINS`, `GRAPH_CACHE_PATH`, `REAL_DATA_CACHE_PATH`, `USE_REAL_DATA_FETCHER`
 
 #### Step 5: Deploy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,8 @@
 # Docker Compose for Financial Asset Relationship Database
 #
 # This compose file runs the Gradio demo/internal-testing surface. The
-# production architecture is FastAPI backend + Next.js frontend; run the
-# production backend via `uvicorn api.main:app`.
+# production architecture is FastAPI backend + Next.js frontend; see
+# DEPLOYMENT.md for the canonical production backend run command.
 version: '3.8'
 
 services:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,8 @@
 # Docker Compose for Financial Asset Relationship Database
+#
+# This compose file runs the Gradio demo/internal-testing surface. The
+# production architecture is FastAPI backend + Next.js frontend; run the
+# production backend via `uvicorn api.main:app`.
 version: '3.8'
 
 services:


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: documents the FastAPI production backend path.
- Frontend: documents Next.js as the intended production frontend without changing frontend code.
- Gradio: documented as non-production demo/internal testing, especially for existing Docker artifacts.

Read-first findings:

- Actual backend entrypoint: `api.main:app`.
- App construction: `api/app_factory.py` creates the FastAPI app and registers middleware/routers.
- Startup/lifespan: `api/app_factory.py` initializes the graph through `api/graph_lifecycle.py`.
- Production-style run command: `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`.
- Minimum backend env before importing `api.main`: `DATABASE_URL`, `SECRET_KEY`, and either existing DB user credentials or `ADMIN_USERNAME`/`ADMIN_PASSWORD` bootstrap credentials.
- Current `DATABASE_URL` behavior: the API database layer expects a SQLite URI; `sqlite:dev.db` is documented as a local/dev file example, and durable Vercel/serverless persistence is explicitly deferred until a separate storage decision/runtime support exists.
- No runtime code change is required; this PR is docs/config-comment alignment only.

## Primary Objective

Clarify and reconcile the backend deployment path for the declared production architecture: FastAPI backend, Next.js frontend, Gradio non-production.

## Scope

### In Scope

- Clarify the FastAPI backend production entrypoint and run command.
- Document minimum backend runtime environment requirements.
- Align README and deployment docs with `api.main:app` and settings-layer env behavior.
- Document current SQLite-only `DATABASE_URL` behavior and Vercel/serverless local-file durability limitation.
- Mark existing Docker/Docker Compose artifacts as Gradio demo/internal-testing path, not canonical production backend deployment.
- Update `.env.example` and Vercel checklist to mention backend env requirements and CORS settings location.

### Out of Scope

- New deployment platform implementation.
- Frontend implementation or Next.js deployment changes.
- Gradio refactor.
- Docker rewrite.
- CI/CD redesign.
- Scanner/dependency hygiene.
- Runtime database URI normalization or new database backend support.
- Auth/CORS/settings refactor.
- Pagination, visualization, metrics, or graph-computation changes.
- Deployment secrets handling beyond documenting currently required env vars.

### Files Expected to Change

- `README.md` — production backend entrypoint and local env reminders.
- `DEPLOYMENT.md` — canonical backend production contract, env requirements, and CORS troubleshooting path.
- `.env.example` — backend runtime env variables needed for local/production startup.
- `VERCEL_DEPLOYMENT_CHECKLIST.md` — backend env and CORS deployment checklist alignment.
- `DOCKER.md` — mark Docker path as Gradio demo/non-production.
- `docker-compose.yml` — comment that current compose file runs the Gradio demo surface.

## Validation Commands

```bash
DATABASE_URL="sqlite:dev.db" SECRET_KEY="test-secret-for-import" ADMIN_USERNAME="admin" ADMIN_PASSWORD="adminpass" PATH="/workspace/.venv/bin:$PATH" python - <<'PY'
from api.main import app
print(app.title)
PY
git diff --check -- "README.md" "DEPLOYMENT.md" "DOCKER.md" "docker-compose.yml" ".env.example" "VERCEL_DEPLOYMENT_CHECKLIST.md"
PATH="/workspace/.venv/bin:$PATH" pre-commit run --files "README.md" "DEPLOYMENT.md" "DOCKER.md" "docker-compose.yml" ".env.example" "VERCEL_DEPLOYMENT_CHECKLIST.md"
PATH="/workspace/.venv/bin:$PATH" pytest tests/unit/test_dev_scripts.py -v
```

All validation commands passed locally.

## Merge Criteria

- [x] The documented backend startup path matches the actual importable app.
- [x] The docs no longer imply Gradio is the production backend path.
- [x] The docs no longer imply an unimplemented or stale backend entrypoint.
- [x] Current SQLite `DATABASE_URL` behavior and serverless durability limits are documented without changing runtime database behavior.
- [x] Affected documentation/script validation tests pass.
- [x] No unrelated code, scanner, dependency, or CI cleanup is included.

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Runtime code changes are not included
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

## Additional Notes

Codacy MCP tools were not available in this workspace, so Codacy analysis could not be run for the edited files.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91b717a0-9c33-4cd8-a348-3aae36ae1678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Clarifies the FastAPI production backend entrypoint as `api.main:app`, standardizes the `uvicorn` run command, and clearly separates the Gradio Docker path from production. Also tightens env/CORS guidance and fixes a SQLite `DATABASE_URL` example in `DEPLOYMENT.md`.

- **Migration**
  - Run production: `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`
  - Set required env: `DATABASE_URL` (current resolver example `sqlite:dev.db`), `SECRET_KEY`; seed via existing DB user or bootstrap with `ADMIN_USERNAME`/`ADMIN_PASSWORD`
  - Serverless: do not use local SQLite for durable production; use only ephemeral SQLite for demos until persistent storage is supported
  - Configure CORS via `ALLOWED_ORIGINS`; settings load via `src/config/settings.py` and apply via `api/cors_policy.py`—do not edit `api/main.py`
  - Docker/Compose runs the Gradio demo on port `7860` only

<sup>Written for commit 0dbdb9a3fc4b8c5856b38959823cf31f23e4eff8. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1082?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Clarify the FastAPI production backend path and required runtime settings**

### What Changed
- Documented `api.main:app` as the production backend entrypoint and added the run command expected in production.
- Added the minimum backend environment needed to start the API, including database, secret key, and first-user bootstrap credentials.
- Corrected the SQLite example format in setup and deployment docs so the database URL matches the format the API expects.
- Marked the Docker and Compose path as the Gradio demo/internal-testing route, not the main production backend deployment.
- Updated Vercel and local setup guidance to call out environment variables, storage limits, and where CORS settings should be configured.

### Impact
`✅ Fewer deployment setup errors`
`✅ Clearer backend startup instructions`
`✅ Less confusion between demo and production paths`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Yenea54nNvGEPltJqTwBBh7anNhvNG3S3DYBzDVmR54&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
