### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -309,7 +309,7 @@ cd frontend && npm run dev
 ### Gotchas
 
 - The `python3-venv` system package must be installed for `python3 -m venv` to produce a working virtualenv (with pip/activate). The update script handles this.
-- The backend seeds the admin user on first startup when the DB is empty. If `dev.db` already exists with users, the `ADMIN_*` env vars are not re-applied.
+- The backend seeds or updates the admin user on startup if `ADMIN_USERNAME` and `ADMIN_PASSWORD` are provided. If the user already exists, their credentials and profile are updated to match the environment variables.
 - `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///./test.db` for tests).
 - 4 pre-existing test failures exist on `main` (as of this writing): 2 in `test_schema_report_cli_integration.py`, 1 in `test_database.py`, 1 in `test_workflow_validator.py`.
 - Frontend has ~65 pre-existing Jest test failures (480 of 545 pass). These are in the existing codebase, not caused by environment setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,4 +313,4 @@ cd frontend && npm run dev
 - `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///:memory:` for tests).
 - Pre-existing test failures may exist on `main` (e.g. in `test_schema_report_cli_integration.py`, `test_database.py`, `test_workflow_validator.py`).
 - Frontend may have pre-existing Jest test failures. These are in the existing codebase, not caused by environment setup.
-- The `DATABASE_URL` format the backend expects is `sqlite:///./dev.db` (3 slashes + relative path), not `sqlite:dev.db` as shown in `.env.example`.
+- The `DATABASE_URL` format recommended for relative paths is `sqlite:///./dev.db` (3 slashes + relative path).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -273,3 +273,44 @@ CircleCI (`.circleci/config.yml`) runs:
 
 - Python: flake8 (critical errors), pytest with coverage, safety + bandit
 - Frontend: `npm run lint`, `npm run build`
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+
+- **Python 3.12** via system python; venv at `/workspace/.venv`
+- **Node.js 20** installed via NodeSource apt repo
+- **npm** is the frontend package manager (lockfile: `frontend/package-lock.json`)
+- No Docker needed for local dev — SQLite is embedded
+
+### Starting services
+
+The FastAPI backend requires these env vars before startup: `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`. A minimal dev `.env` example:
+
+```sh
+export DATABASE_URL=sqlite:///./dev.db
+export SECRET_KEY=dev-secret-key-for-local-development-only
+export ADMIN_USERNAME=admin
+export ADMIN_PASSWORD=AdminPass123!
+export ENV=development
+```
+
+Then start services (see "Common commands" above for full details):
+
+```sh
+# Backend (port 8000)
+source .venv/bin/activate
+python -m uvicorn api.main:app --reload --host 127.0.0.1 --port 8000
+
+# Frontend (port 3000, in a separate terminal)
+cd frontend && npm run dev
+```
+
+### Gotchas
+
+- The `python3-venv` system package must be installed for `python3 -m venv` to produce a working virtualenv (with pip/activate). The update script handles this.
+- The backend seeds the admin user on first startup when the DB is empty. If `dev.db` already exists with users, the `ADMIN_*` env vars are not re-applied.
+- `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///./test.db` for tests).
+- 4 pre-existing test failures exist on `main` (as of this writing): 2 in `test_schema_report_cli_integration.py`, 1 in `test_database.py`, 1 in `test_workflow_validator.py`.
+- Frontend has ~65 pre-existing Jest test failures (480 of 545 pass). These are in the existing codebase, not caused by environment setup.
+- The `DATABASE_URL` format the backend expects is `sqlite:///./dev.db` (3 slashes + relative path), not `sqlite:dev.db` as shown in `.env.example`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -311,6 +311,6 @@ cd frontend && npm run dev
 - The `python3-venv` system package must be installed for `python3 -m venv` to produce a working virtualenv (with pip/activate). The update script handles this.
 - The backend seeds or updates the admin user on startup if `ADMIN_USERNAME` and `ADMIN_PASSWORD` are provided. If the user already exists, their credentials and profile are updated to match the environment variables.
 - `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///:memory:` for tests).
-- 4 pre-existing test failures exist on `main` (as of this writing): 2 in `test_schema_report_cli_integration.py`, 1 in `test_database.py`, 1 in `test_workflow_validator.py`.
-- Frontend has ~65 pre-existing Jest test failures (480 of 545 pass). These are in the existing codebase, not caused by environment setup.
+- Pre-existing test failures may exist on `main` (e.g. in `test_schema_report_cli_integration.py`, `test_database.py`, `test_workflow_validator.py`).
+- Frontend may have pre-existing Jest test failures. These are in the existing codebase, not caused by environment setup.
 - The `DATABASE_URL` format the backend expects is `sqlite:///./dev.db` (3 slashes + relative path), not `sqlite:dev.db` as shown in `.env.example`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -310,7 +310,7 @@ cd frontend && npm run dev
 
 - The `python3-venv` system package must be installed for `python3 -m venv` to produce a working virtualenv (with pip/activate). The update script handles this.
 - The backend seeds or updates the admin user on startup if `ADMIN_USERNAME` and `ADMIN_PASSWORD` are provided. If the user already exists, their credentials and profile are updated to match the environment variables.
-- `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///./test.db` for tests).
+- `pytest` needs `DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD` set in the environment (use in-memory SQLite `sqlite:///:memory:` for tests).
 - 4 pre-existing test failures exist on `main` (as of this writing): 2 in `test_schema_report_cli_integration.py`, 1 in `test_database.py`, 1 in `test_workflow_validator.py`.
 - Frontend has ~65 pre-existing Jest test failures (480 of 545 pass). These are in the existing codebase, not caused by environment setup.
 - The `DATABASE_URL` format the backend expects is `sqlite:///./dev.db` (3 slashes + relative path), not `sqlite:dev.db` as shown in `.env.example`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# Pull Request Template

## Architectural Alignment

- Backend: FastAPI (production path) — not modified
- Frontend: Next.js (production path) — not modified
- Gradio: non-production (demo/testing only) — not modified

This PR only updates documentation (`AGENTS.md`), no code changes.

## Primary Objective

Add a `## Cursor Cloud specific instructions` section to `AGENTS.md` so future cloud agents have durable, non-obvious guidance for setting up and running the development environment.

## Scope

### In Scope

- Add cloud-specific environment setup notes to `AGENTS.md`
- Document required env vars for backend startup
- Document known gotchas (python3-venv, DATABASE_URL format, pre-existing test failures)

### Out of Scope

- Code changes
- CI/CD changes
- Production architecture changes
- Fixing pre-existing test failures

### Files Expected to Change

- `AGENTS.md` — append cloud-specific instructions section

## Validation Commands

```bash
# Verify AGENTS.md is valid markdown
cat AGENTS.md
```

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Validation commands pass locally or in CI
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] If this is a docs/policy/architecture-only PR, I have not mixed those changes with unrelated code changes
- [x] If this is a docs/policy/architecture-only PR, no runtime behavior changes are included
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

---

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6b31866c-651e-4216-ae73-fe7d39b33cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b31866c-651e-4216-ae73-fe7d39b33cb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Cursor Cloud setup section to `AGENTS.md` with local env steps, a sample `.env` (includes `ENV=development`), and start commands (backend 8000 on 127.0.0.1, frontend 3000).

It covers required backend vars (`DATABASE_URL`, `SECRET_KEY`, `ADMIN_USERNAME`, `ADMIN_PASSWORD`), Python 3.12/Node 20 (NodeSource), venv at `/workspace/.venv`, `npm` with lockfile at `frontend/package-lock.json`, no Docker (SQLite), the `python3-venv` requirement, admin seeding/update behavior on startup, pytest env needs with in-memory SQLite `sqlite:///:memory:`, the correct `DATABASE_URL` format, and notes on existing backend and frontend test failures.

<sup>Written for commit 10580708edba7c94ae51f86900d06d723fd5ae2a. Summary will update on new commits. <a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1094?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

