### PR TITLE
Add graph persistence repository helpers

### DIFF
--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -149,9 +149,11 @@ class AssetGraphRepository:
             graph.add_asset(asset)
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
-        persisted_ = self.list_()
-        explicit_relationship_keys = {(rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_}
-        for relationship in persisted_:
+        persisted_relationships = self.list_relationships()
+        explicit_relationship_keys = {
+            (rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_relationships
+        }
+        for relationship in persisted_relationships:
             expand_reverse = (
                 relationship.bidirectional
                 and (
@@ -219,7 +221,7 @@ class AssetGraphRepository:
 
         self.upsert_assets(incoming_assets)
 
-    def replace__from_graph(
+    def replace_relationships_from_graph(
         self,
         relationships: GraphRelationshipRows,
     ) -> None:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -120,12 +120,12 @@ class AssetGraphRepository:
     def load_graph(self) -> AssetRelationshipGraph:
         """
         Reconstruct an in-memory asset relationship graph from persisted rows.
-        
+
         Loads only durable persisted data; does not derive relationships from other
         sources or restore visualization/layout metadata. Persisted relationship rows
         are loaded one-for-one as directed edges, so a stored bidirectional flag is not
         expanded into an additional reverse edge during graph reconstruction.
-        
+
         Returns:
             AssetRelationshipGraph: The reconstructed graph containing persisted assets,
             relationship rows, and regulatory events.

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -85,7 +85,9 @@ class _BaseAssetKwargs(TypedDict):
     market_cap: float | None
     currency: str
 
+
 GraphRelationshipRows = Dict[str, List[Tuple[str, str, float]]]
+
 
 class AssetGraphRepository:
     """Data access layer for the asset relationship graph."""
@@ -153,7 +155,7 @@ class AssetGraphRepository:
     def replace_relationships_from_graph(
         self,
         relationships: GraphRelationshipRows,
-     ) -> None:
+    ) -> None:
         """
         Replace persisted relationships with the supplied graph relationships.
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator
+from collections.abc import Callable, Generator, Iterable
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, TypedDict
@@ -10,6 +10,7 @@ from typing import Any, TypedDict
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from src.logic.asset_graph import AssetRelationshipGraph
 from src.models.financial_models import (
     Asset,
     AssetClass,
@@ -92,13 +93,93 @@ class AssetGraphRepository:
         self.session = session
 
     # ------------------------------------------------------------------
+    # Graph persistence helpers
+    # ------------------------------------------------------------------
+    def save_graph(self, graph: AssetRelationshipGraph) -> None:
+        """
+        Persist the current graph truth using the existing schema contract.
+
+        This method stores assets, directed relationships, and regulatory events
+        through the current ORM models. It intentionally does not persist layout
+        coordinates or visualization metadata.
+        """
+        self.upsert_assets(graph.assets.values())
+        self.replace_relationships_from_graph(graph.relationships)
+        self.replace_regulatory_events(graph.regulatory_events)
+
+    def load_graph(self) -> AssetRelationshipGraph:
+        """
+        Reconstruct an in-memory graph from persisted assets and relationships.
+
+        The returned graph is loaded from durable graph truth only. The method
+        does not derive new relationships, rebuild from sample data, or assign
+        visualization coordinates.
+        """
+        graph = AssetRelationshipGraph()
+        for asset in self.list_assets():
+            graph.add_asset(asset)
+        for event in self.list_regulatory_events():
+            graph.add_regulatory_event(event)
+        for relationship in self.list_relationships():
+            graph.add_relationship(
+                relationship.source_id,
+                relationship.target_id,
+                relationship.relationship_type,
+                relationship.strength,
+                bidirectional=False,
+            )
+        return graph
+
+    def upsert_assets(self, assets: Iterable[Asset]) -> None:
+        """Create or update multiple assets in a single repository session."""
+        for asset in assets:
+            self.upsert_asset(asset)
+
+    def replace_relationships_from_graph(
+        self,
+        relationships: dict[str, list[tuple[str, str, float]]],
+    ) -> None:
+        """
+        Replace persisted relationships with the supplied graph relationships.
+
+        This is the schema-compatible bulk publish primitive for the first graph
+        persistence implementation. It preserves directed edges exactly as stored
+        in the in-memory graph instead of collapsing reciprocal relationships.
+        """
+        self.session.query(AssetRelationshipORM).delete()
+        for source_id, outgoing_relationships in relationships.items():
+            for target_id, relationship_type, strength in outgoing_relationships:
+                self.add_or_update_relationship(
+                    source_id,
+                    target_id,
+                    relationship_type,
+                    strength,
+                    bidirectional=False,
+                )
+
+    def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
+        """
+        Replace persisted regulatory events with the supplied event collection.
+
+        The current compatibility mode uses event IDs as the idempotency key.
+        Stable event-key semantics for a normalized shared-event model remain a
+        later schema/repository migration concern.
+        """
+        self.session.query(RegulatoryEventAssetORM).delete()
+        self.session.query(RegulatoryEventORM).delete()
+        for event in events:
+            self.upsert_regulatory_event(event)
+
+    # ------------------------------------------------------------------
     # Asset helpers
     # ------------------------------------------------------------------
     def upsert_asset(self, asset: Asset) -> None:
         """
         Create or update the persistent record for a domain Asset.
 
-        Maps fields from the given domain `Asset` onto an `AssetORM` (creating one if needed) and stages the ORM instance on the repository session for persistence.
+        Maps fields from the given domain `Asset` onto an `AssetORM` (creating
+        one if needed) and stages the ORM instance on the repository session for
+        persistence.
 
         Parameters:
             asset (Asset): Domain asset to persist or update.
@@ -163,13 +244,16 @@ class AssetGraphRepository:
         """
         Create or update an asset relationship and stage it on the repository session.
 
-        Accepts either a single _RelationshipUpsertSpec or explicit fields (source_id, target_id, rel_type, strength[, bidirectional=False]).
-        Strength must be a numeric value between -1.0 and 1.0 inclusive; boolean values are rejected.
+        Accepts either a single _RelationshipUpsertSpec or explicit fields
+        (source_id, target_id, rel_type, strength[, bidirectional=False]).
+        Strength must be a numeric value between -1.0 and 1.0 inclusive; boolean
+        values are rejected.
 
         Parameters:
             *args: Either a single `_RelationshipUpsertSpec` or positional fields:
                 (source_id, target_id, rel_type, strength[, bidirectional]).
-            **kwargs: When not passing a `_RelationshipUpsertSpec`, may include `bidirectional` as a keyword.
+            **kwargs: When not passing a `_RelationshipUpsertSpec`, may include
+                `bidirectional` as a keyword.
         """
         relationship_spec = self._build_relationship_upsert_spec(
             *args,
@@ -309,7 +393,9 @@ class AssetGraphRepository:
         List all asset relationships stored in the repository.
 
         Returns:
-            List[RelationshipRecord]: A list of RelationshipRecord objects, each containing source_id, target_id, relationship_type, strength (float), and bidirectional (bool).
+            List[RelationshipRecord]: A list of RelationshipRecord objects, each
+                containing source_id, target_id, relationship_type, strength
+                (float), and bidirectional (bool).
         """
         result = self.session.execute(select(AssetRelationshipORM)).scalars().all()
         return [

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -196,12 +196,7 @@ class AssetGraphRepository:
                     delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
-                self.session.execute(
-                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
-                    execution_options={"synchronize_session": "fetch"},
-                )
-            self.session.flush()
-        self.upsert_assets(incoming_assets)
+                self.session.flush()
 
     def replace_relationships_from_graph(
         self,

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -95,7 +95,7 @@ class AssetGraphRepository:
     def __init__(self, session: Session):
         """
         Initialize the repository with a SQLAlchemy session for database operations.
-        
+
         Parameters:
             session (Session): SQLAlchemy Session used for all database access by this repository.
         """
@@ -107,9 +107,9 @@ class AssetGraphRepository:
     def save_graph(self, graph: AssetRelationshipGraph) -> None:
         """
         Persist an AssetRelationshipGraph snapshot to the database.
-        
+
         Stores the graph's assets, directed relationships, and regulatory events using snapshot semantics and does not persist any layout or visualization metadata.
-        
+
         Parameters:
             graph (AssetRelationshipGraph): In-memory graph whose assets, relationships, and regulatory_events will replace the persisted state.
         """
@@ -120,9 +120,9 @@ class AssetGraphRepository:
     def load_graph(self) -> AssetRelationshipGraph:
         """
         Reconstruct an in-memory asset relationship graph from persisted assets, relationships, and regulatory events.
-        
+
         Loads only durable persisted data; does not derive relationships from other sources or restore visualization/layout metadata. Relationship `bidirectional` flags are preserved as stored.
-        
+
         Returns:
             graph (AssetRelationshipGraph): The reconstructed graph containing persisted assets, relationships (with `bidirectional` forwarded), and regulatory events.
         """
@@ -166,9 +166,9 @@ class AssetGraphRepository:
     ) -> None:
         """
         Replace all persisted relationships with the provided directed adjacency data.
-        
+
         Deletes all existing relationship rows and inserts a new row for each outgoing edge in `relationships`. Each outgoing tuple is interpreted as (target_id, relationship_type, strength); `strength` is validated to be a number between -1.0 and 1.0 inclusive and stored as the relationship strength. Inserted rows are stored as directed edges with `bidirectional=False`.
-        
+
         Parameters:
             relationships (dict[str, list[tuple[str, str, float]]]): Mapping from source asset id to a list of outgoing edges; each edge is a tuple of (target_id, relationship_type, strength).
         """
@@ -193,9 +193,9 @@ class AssetGraphRepository:
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
         """
         Replace all persisted regulatory events with the supplied collection.
-        
+
         Performs a snapshot-style replacement: deletes all existing regulatory events and their event-asset link rows, flushes the deletion, then inserts ORM rows for each provided event including their related asset associations. The provided events' IDs are used as the idempotency key for this operation.
-         
+
         Parameters:
             events (Iterable[RegulatoryEvent]): Iterable of regulatory events to persist as the complete set.
         """
@@ -537,9 +537,9 @@ class AssetGraphRepository:
     def list_regulatory_events(self) -> list[RegulatoryEvent]:
         """
         Retrieve all persisted regulatory events ordered by date then id.
-        
+
         Each returned event includes its associated related_assets (eagerly loaded).
-        
+
         Returns:
             events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`, then `id`, with `related_assets` populated.
         """
@@ -560,7 +560,7 @@ class AssetGraphRepository:
     def delete_regulatory_event(self, event_id: str) -> None:
         """
         Delete the persisted regulatory event with the given id.
-        
+
         Parameters:
             event_id (str): Primary key of the regulatory event to delete. If no matching record exists, no action is taken.
         """

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -172,12 +172,18 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
+        persisted_ids = set(
+            self.session.execute(select(AssetORM.id)).scalars().all()
+        )
         stale_ids = persisted_ids - incoming_ids
 
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
+                self.session.execute(
+                    select(RegulatoryEventORM.id).where(
+                        RegulatoryEventORM.asset_id.in_(stale_ids)
+                    )
+                )
                 .scalars()
                 .all()
             )
@@ -190,17 +196,23 @@ class AssetGraphRepository:
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
+                delete(RegulatoryEventAssetORM).where(
+                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
+                ),
                 execution_options={"synchronize_session": "fetch"},
             )
 
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
+                    delete(RegulatoryEventAssetORM).where(
+                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
+                    ),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
+                    delete(RegulatoryEventORM).where(
+                        RegulatoryEventORM.id.in_(stale_event_ids)
+                    ),
                     execution_options={"synchronize_session": "fetch"},
                 )
 
@@ -291,7 +303,9 @@ class AssetGraphRepository:
                 impact_score=event.impact_score,
             )
             for related_id in dict.fromkeys(event.related_assets):
-                event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
+                event_orm.related_assets.append(
+                    RegulatoryEventAssetORM(asset_id=related_id)
+                )
             self.session.add(event_orm)
 
     # ------------------------------------------------------------------
@@ -337,7 +351,11 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
         }
 
         for asset in incoming_assets:
@@ -357,7 +375,11 @@ class AssetGraphRepository:
                 representing all assets in the database,
                 ordered by asset id.
         """
-        result = self.session.execute(select(AssetORM).order_by(AssetORM.id)).scalars().all()
+        result = (
+            self.session.execute(select(AssetORM).order_by(AssetORM.id))
+            .scalars()
+            .all()
+        )
         return [self._to_asset_model(record) for record in result]
 
     def get_assets_map(self) -> dict[str, Asset]:
@@ -417,7 +439,9 @@ class AssetGraphRepository:
             *args,
             **kwargs,
         )
-        relationship = self._get_or_create_relationship_orm(relationship_spec)
+        relationship = self._get_or_create_relationship_orm(
+            relationship_spec
+        )
         self.session.add(relationship)
 
     def _build_relationship_upsert_spec(
@@ -461,7 +485,9 @@ class AssetGraphRepository:
             )
 
         if len(args) < 4:
-            raise TypeError("Expected (source_id, target_id, rel_type, strength[, bidirectional])")
+            raise TypeError(
+                "Expected (source_id, target_id, rel_type, strength[, bidirectional])"
+            )
 
         source_id = args[0]
         target_id = args[1]
@@ -638,7 +664,9 @@ class AssetGraphRepository:
         existing.impact_score = event.impact_score
         existing.related_assets.clear()
         for related_id in dict.fromkeys(event.related_assets):
-            existing.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
+            existing.related_assets.append(
+                RegulatoryEventAssetORM(asset_id=related_id)
+            )
 
         self.session.add(existing)
 
@@ -695,7 +723,9 @@ class AssetGraphRepository:
         orm.asset_class = asset.asset_class.value
         orm.sector = asset.sector
         orm.price = float(asset.price)
-        orm.market_cap = float(asset.market_cap) if asset.market_cap is not None else None
+        orm.market_cap = (
+            float(asset.market_cap) if asset.market_cap is not None else None
+        )
         orm.currency = asset.currency
 
         orm.pe_ratio = getattr(asset, "pe_ratio", None)

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -172,48 +172,32 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(
-            self.session.execute(select(AssetORM.id)).scalars().all()
-        )
+        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
         stale_ids = persisted_ids - incoming_ids
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(
-                    select(RegulatoryEventORM.id).where(
-                        RegulatoryEventORM.asset_id.in_(stale_ids)
-                    )
-                )
+                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
                 .scalars()
                 .all()
             )
             self.session.execute(
                 delete(AssetRelationshipORM).where(
-                    (
-                        AssetRelationshipORM.source_asset_id.in_(stale_ids)
-                    )
-                    | (
-                        AssetRelationshipORM.target_asset_id.in_(stale_ids)
-                    )
+                    (AssetRelationshipORM.source_asset_id.in_(stale_ids))
+                    | (AssetRelationshipORM.target_asset_id.in_(stale_ids))
                 ),
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(
-                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
-                ),
+                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(
-                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(
-                        RegulatoryEventORM.id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
             self.session.flush()
@@ -344,11 +328,7 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, TypedDict
+from typing import Any, Iterable, TypedDict
 
-from sqlalchemy import select
+from sqlalchemy import delete, select
 from sqlalchemy.orm import Session
 
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -103,7 +103,7 @@ class AssetGraphRepository:
         through the current ORM models. It intentionally does not persist layout
         coordinates or visualization metadata.
         """
-        self.upsert_assets(graph.assets.values())
+        self.replace_assets(graph.assets.values())
         self.replace_relationships_from_graph(graph.relationships)
         self.replace_regulatory_events(graph.regulatory_events)
 
@@ -126,7 +126,7 @@ class AssetGraphRepository:
                 relationship.target_id,
                 relationship.relationship_type,
                 relationship.strength,
-                bidirectional=False,
+                bidirectional=relationship.bidirectional,
             )
         return graph
 
@@ -134,6 +134,20 @@ class AssetGraphRepository:
         """Create or update multiple assets in a single repository session."""
         for asset in assets:
             self.upsert_asset(asset)
+
+    def replace_assets(self, assets: Iterable[Asset]) -> None:
+        """
+        Replace persisted assets with the supplied graph asset collection.
+
+        Rows absent from the incoming graph are deleted so save/load behaves as
+        a graph snapshot operation rather than a partial upsert.
+        """
+        incoming_assets = list(assets)
+        incoming_ids = {asset.id for asset in incoming_assets}
+        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
+        for stale_id in sorted(persisted_ids - incoming_ids):
+            self.delete_asset(stale_id)
+        self.upsert_assets(incoming_assets)
 
     def replace_relationships_from_graph(
         self,
@@ -146,15 +160,21 @@ class AssetGraphRepository:
         persistence implementation. It preserves directed edges exactly as stored
         in the in-memory graph instead of collapsing reciprocal relationships.
         """
-        self.session.query(AssetRelationshipORM).delete()
+        self.session.execute(
+            delete(AssetRelationshipORM),
+            execution_options={"synchronize_session": False},
+        )
         for source_id, outgoing_relationships in relationships.items():
             for target_id, relationship_type, strength in outgoing_relationships:
-                self.add_or_update_relationship(
-                    source_id,
-                    target_id,
-                    relationship_type,
-                    strength,
-                    bidirectional=False,
+                normalized_strength = self._validate_relationship_strength(strength)
+                self.session.add(
+                    AssetRelationshipORM(
+                        source_asset_id=source_id,
+                        target_asset_id=target_id,
+                        relationship_type=relationship_type,
+                        strength=normalized_strength,
+                        bidirectional=False,
+                    )
                 )
 
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
@@ -165,10 +185,26 @@ class AssetGraphRepository:
         Stable event-key semantics for a normalized shared-event model remain a
         later schema/repository migration concern.
         """
-        self.session.query(RegulatoryEventAssetORM).delete()
-        self.session.query(RegulatoryEventORM).delete()
+        self.session.execute(
+            delete(RegulatoryEventAssetORM),
+            execution_options={"synchronize_session": False},
+        )
+        self.session.execute(
+            delete(RegulatoryEventORM),
+            execution_options={"synchronize_session": False},
+        )
         for event in events:
-            self.upsert_regulatory_event(event)
+            event_orm = RegulatoryEventORM(
+                id=event.id,
+                asset_id=event.asset_id,
+                event_type=event.event_type.value,
+                date=event.date,
+                description=event.description,
+                impact_score=event.impact_score,
+            )
+            for related_id in event.related_assets:
+                event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
+            self.session.add(event_orm)
 
     # ------------------------------------------------------------------
     # Asset helpers
@@ -397,7 +433,17 @@ class AssetGraphRepository:
                 containing source_id, target_id, relationship_type, strength
                 (float), and bidirectional (bool).
         """
-        result = self.session.execute(select(AssetRelationshipORM)).scalars().all()
+        result = (
+            self.session.execute(
+                select(AssetRelationshipORM).order_by(
+                    AssetRelationshipORM.source_asset_id,
+                    AssetRelationshipORM.target_asset_id,
+                    AssetRelationshipORM.relationship_type,
+                )
+            )
+            .scalars()
+            .all()
+        )
         return [
             RelationshipRecord(
                 source_id=rel.source_asset_id,
@@ -475,7 +521,16 @@ class AssetGraphRepository:
 
     def list_regulatory_events(self) -> list[RegulatoryEvent]:
         """Return all regulatory events."""
-        result = self.session.execute(select(RegulatoryEventORM)).scalars().all()
+        result = (
+            self.session.execute(
+                select(RegulatoryEventORM).order_by(
+                    RegulatoryEventORM.date,
+                    RegulatoryEventORM.id,
+                )
+            )
+            .scalars()
+            .all()
+        )
         return [self._to_regulatory_event_model(record) for record in result]
 
     def delete_regulatory_event(self, event_id: str) -> None:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Tuple, TypedDict
 
 from sqlalchemy import delete, select
-from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -157,11 +156,6 @@ class AssetGraphRepository:
             )
         return graph
 
-    def upsert_assets(self, assets: Iterable[Asset]) -> None:
-        """Create or update multiple assets in a single repository session."""
-        for asset in assets:
-            self.upsert_asset(asset)
-
     def replace_assets(self, assets: Iterable[Asset]) -> None:
         """
         Replace persisted assets with the supplied graph asset collection.
@@ -266,6 +260,25 @@ class AssetGraphRepository:
     # ------------------------------------------------------------------
     # Asset helpers
     # ------------------------------------------------------------------
+    def upsert_asset(self, asset: Asset) -> None:
+        """
+        Create or update the persistent record for a domain Asset.
+
+        Maps fields from the given domain `Asset` onto an `AssetORM`, creating
+        one if needed, and stages the ORM instance on the repository session.
+
+        Args:
+            asset: Domain asset to persist or update.
+
+        Returns:
+            None.
+        """
+        existing = self.session.get(AssetORM, asset.id)
+        if existing is None:
+            existing = AssetORM(id=asset.id)
+        self._update_asset_orm(existing, asset)
+        self.session.add(existing)
+
     def upsert_assets(self, assets: Iterable[Asset]) -> None:
         """
         Create or update multiple assets in a single repository session.

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -162,8 +162,9 @@ class AssetGraphRepository:
         """
         self.session.execute(
             delete(AssetRelationshipORM),
-            execution_options={"synchronize_session": False},
+            execution_options={"synchronize_session": "fetch"},
         )
+        self.session.flush()
         for source_id, outgoing_relationships in relationships.items():
             for target_id, relationship_type, strength in outgoing_relationships:
                 normalized_strength = self._validate_relationship_strength(strength)
@@ -187,12 +188,13 @@ class AssetGraphRepository:
         """
         self.session.execute(
             delete(RegulatoryEventAssetORM),
-            execution_options={"synchronize_session": False},
+            execution_options={"synchronize_session": "fetch"},
         )
         self.session.execute(
             delete(RegulatoryEventORM),
-            execution_options={"synchronize_session": False},
+            execution_options={"synchronize_session": "fetch"},
         )
+        self.session.flush()
         for event in events:
             event_orm = RegulatoryEventORM(
                 id=event.id,

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -172,14 +172,22 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
+        persisted_ids = set(
+            self.session.execute(select(AssetORM.id)).scalars().all()
+        )
         stale_ids = persisted_ids - incoming_ids
+
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
+                self.session.execute(
+                    select(RegulatoryEventORM.id).where(
+                        RegulatoryEventORM.asset_id.in_(stale_ids)
+                    )
+                )
                 .scalars()
                 .all()
             )
+
             self.session.execute(
                 delete(AssetRelationshipORM).where(
                     (AssetRelationshipORM.source_asset_id.in_(stale_ids))
@@ -188,15 +196,33 @@ class AssetGraphRepository:
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
+                delete(RegulatoryEventAssetORM).where(
+                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
+                ),
                 execution_options={"synchronize_session": "fetch"},
             )
+
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
+                    delete(RegulatoryEventAssetORM).where(
+                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
+                    ),
                     execution_options={"synchronize_session": "fetch"},
                 )
-                self.session.flush()
+                self.session.execute(
+                    delete(RegulatoryEventORM).where(
+                        RegulatoryEventORM.id.in_(stale_event_ids)
+                    ),
+                    execution_options={"synchronize_session": "fetch"},
+                )
+
+            self.session.execute(
+                delete(AssetORM).where(AssetORM.id.in_(stale_ids)),
+                execution_options={"synchronize_session": "fetch"},
+            )
+            self.session.flush()
+
+        self.upsert_assets(incoming_assets)
 
     def replace_relationships_from_graph(
         self,
@@ -323,7 +349,11 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -165,9 +165,51 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
+        persisted_ids = set(
+            self.session.execute(select(AssetORM.id)).scalars().all()
+        )
         stale_ids = persisted_ids - incoming_ids
         if stale_ids:
+            stale_event_ids = set(
+                self.session.execute(
+                    select(RegulatoryEventORM.id).where(
+                        RegulatoryEventORM.asset_id.in_(stale_ids)
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            self.session.execute(
+                delete(AssetRelationshipORM).where(
+                    AssetRelationshipORM.source_asset_id.in_(stale_ids)
+                ),
+                execution_options={"synchronize_session": "fetch"},
+            )
+            self.session.execute(
+                delete(AssetRelationshipORM).where(
+                    AssetRelationshipORM.target_asset_id.in_(stale_ids)
+                ),
+                execution_options={"synchronize_session": "fetch"},
+            )
+            self.session.execute(
+                delete(RegulatoryEventAssetORM).where(
+                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
+                ),
+                execution_options={"synchronize_session": "fetch"},
+            )
+            if stale_event_ids:
+                self.session.execute(
+                    delete(RegulatoryEventAssetORM).where(
+                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
+                    ),
+                    execution_options={"synchronize_session": "fetch"},
+                )
+                self.session.execute(
+                    delete(RegulatoryEventORM).where(
+                        RegulatoryEventORM.id.in_(stale_event_ids)
+                    ),
+                    execution_options={"synchronize_session": "fetch"},
+                )
             self.session.execute(
                 delete(AssetORM).where(AssetORM.id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
@@ -253,8 +295,10 @@ class AssetGraphRepository:
                 description=event.description,
                 impact_score=event.impact_score,
             )
-            for related_id in event.related_assets:
-                event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
+            for related_id in dict.fromkeys(event.related_assets):
+                event_orm.related_assets.append(
+                    RegulatoryEventAssetORM(asset_id=related_id)
+                )
             self.session.add(event_orm)
 
     # ------------------------------------------------------------------
@@ -297,10 +341,14 @@ class AssetGraphRepository:
         if not incoming_assets:
             return
 
-        incoming_ids = [asset.id for asset in incoming_assets]
+        incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
         }
 
         for asset in incoming_assets:
@@ -308,6 +356,7 @@ class AssetGraphRepository:
             if orm is None:
                 orm = AssetORM(id=asset.id)
                 self.session.add(orm)
+                existing_assets[asset.id] = orm
             self._update_asset_orm(orm, asset)
 
     def list_assets(self) -> list[Asset]:
@@ -599,8 +648,10 @@ class AssetGraphRepository:
         existing.description = event.description
         existing.impact_score = event.impact_score
         existing.related_assets.clear()
-        for related_id in event.related_assets:
-            existing.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
+        for related_id in dict.fromkeys(event.related_assets):
+            existing.related_assets.append(
+                RegulatoryEventAssetORM(asset_id=related_id)
+            )
 
         self.session.add(existing)
 
@@ -747,7 +798,7 @@ class AssetGraphRepository:
         Returns:
             RegulatoryEvent: Domain model built from the ORM row.
         """
-        related_assets = [assoc.asset_id for assoc in orm.related_assets]
+        related_assets = sorted(assoc.asset_id for assoc in orm.related_assets)
         return RegulatoryEvent(
             id=orm.id,
             asset_id=orm.asset_id,

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Tuple, TypedDict
+from typing import Any, Dict, Iterable, List, Tuple, TypeAlias, TypedDict
 
 from sqlalchemy import delete, select
 from sqlalchemy.orm import Session, selectinload
@@ -86,7 +86,7 @@ class _BaseAssetKwargs(TypedDict):
     currency: str
 
 
-GRAPH_RELATIONSHIP_ROWS = Dict[str, List[Tuple[str, str, float]]]
+GraphRelationshipRows: TypeAlias = Dict[str, List[Tuple[str, str, float]]]
 
 
 class AssetGraphRepository:
@@ -149,11 +149,11 @@ class AssetGraphRepository:
             graph.add_asset(asset)
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
-        persisted_relationships = self.list_relationships()
+        persisted_ = self.list_()
         explicit_relationship_keys = {
-            (rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_relationships
+            (rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_
         }
-        for relationship in persisted_relationships:
+        for relationship in persisted_:
             expand_reverse = (
                 relationship.bidirectional
                 and (
@@ -221,9 +221,9 @@ class AssetGraphRepository:
 
         self.upsert_assets(incoming_assets)
 
-    def replace_relationships_from_graph(
+    def replace__from_graph(
         self,
-        relationships: GRAPH_RELATIONSHIP_ROWS,
+        relationships: GraphRelationshipRows,
     ) -> None:
         """
         Replace all persisted relationships with directed adjacency data.
@@ -282,6 +282,20 @@ class AssetGraphRepository:
             SQLAlchemyError: If the active database session fails while deleting or
                 staging event rows.
         """
+        incoming_events = list(events)
+        seen_event_ids: set[str] = set()
+        duplicate_event_ids: set[str] = set()
+        for event in incoming_events:
+            if event.id in seen_event_ids:
+                duplicate_event_ids.add(event.id)
+            seen_event_ids.add(event.id)
+        if duplicate_event_ids:
+            duplicate_ids = ", ".join(sorted(duplicate_event_ids))
+            raise ValueError(
+                "replace_regulatory_events() received duplicate event IDs: "
+                f"{duplicate_ids}"
+            )
+
         self.session.execute(
             delete(RegulatoryEventAssetORM),
             execution_options={"synchronize_session": "fetch"},
@@ -291,7 +305,7 @@ class AssetGraphRepository:
             execution_options={"synchronize_session": "fetch"},
         )
         self.session.flush()
-        for event in events:
+        for event in incoming_events:
             event_orm = RegulatoryEventORM(
                 id=event.id,
                 asset_id=event.asset_id,

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -147,6 +147,13 @@ class AssetGraphRepository:
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
         for relationship in self.list_relationships():
+            if relationship.bidirectional:
+                raise ValueError(
+                    "load_graph() requires persisted relationship rows to be directed; "
+                    f"found bidirectional relationship row for "
+                    f"{relationship.source_id}->{relationship.target_id} "
+                    f"({relationship.relationship_type})"
+                )
             graph.add_relationship(
                 relationship.source_id,
                 relationship.target_id,
@@ -165,39 +172,50 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
+        persisted_ids = set(
+            self.session.execute(select(AssetORM.id)).scalars().all()
+        )
         stale_ids = persisted_ids - incoming_ids
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
+                self.session.execute(
+                    select(RegulatoryEventORM.id).where(
+                        RegulatoryEventORM.asset_id.in_(stale_ids)
+                    )
+                )
                 .scalars()
                 .all()
             )
             self.session.execute(
-                delete(AssetRelationshipORM).where(AssetRelationshipORM.source_asset_id.in_(stale_ids)),
+                delete(AssetRelationshipORM).where(
+                    (
+                        AssetRelationshipORM.source_asset_id.in_(stale_ids)
+                    )
+                    | (
+                        AssetRelationshipORM.target_asset_id.in_(stale_ids)
+                    )
+                ),
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(AssetRelationshipORM).where(AssetRelationshipORM.target_asset_id.in_(stale_ids)),
-                execution_options={"synchronize_session": "fetch"},
-            )
-            self.session.execute(
-                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
+                delete(RegulatoryEventAssetORM).where(
+                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
+                ),
                 execution_options={"synchronize_session": "fetch"},
             )
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
+                    delete(RegulatoryEventAssetORM).where(
+                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
+                    ),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
+                    delete(RegulatoryEventORM).where(
+                        RegulatoryEventORM.id.in_(stale_event_ids)
+                    ),
                     execution_options={"synchronize_session": "fetch"},
                 )
-            self.session.execute(
-                delete(AssetORM).where(AssetORM.id.in_(stale_ids)),
-                execution_options={"synchronize_session": "fetch"},
-            )
             self.session.flush()
         self.upsert_assets(incoming_assets)
 
@@ -326,7 +344,11 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -133,9 +133,9 @@ class AssetGraphRepository:
         Reconstruct an in-memory asset relationship graph from persisted rows.
 
         Loads only durable persisted data; does not derive relationships from other
-        sources or restore visualization/layout metadata. Persisted relationship rows
-        are loaded one-for-one as directed edges, so a stored bidirectional flag is not
-        expanded into an additional reverse edge during graph reconstruction.
+        sources or restore visualization/layout metadata. Legacy persisted rows with
+        bidirectional=True are expanded through AssetRelationshipGraph semantics for
+        compatibility; save_graph() persists the resulting graph as directed rows.
 
         Returns:
             AssetRelationshipGraph: The reconstructed graph containing persisted assets,
@@ -147,19 +147,12 @@ class AssetGraphRepository:
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
         for relationship in self.list_relationships():
-            if relationship.bidirectional:
-                raise ValueError(
-                    "load_graph() requires persisted relationship rows to be directed; "
-                    f"found bidirectional relationship row for "
-                    f"{relationship.source_id}->{relationship.target_id} "
-                    f"({relationship.relationship_type})"
-                )
             graph.add_relationship(
                 relationship.source_id,
                 relationship.target_id,
                 relationship.relationship_type,
                 relationship.strength,
-                bidirectional=False,
+                bidirectional=relationship.bidirectional,
             )
         return graph
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -165,49 +165,33 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(
-            self.session.execute(select(AssetORM.id)).scalars().all()
-        )
+        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
         stale_ids = persisted_ids - incoming_ids
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(
-                    select(RegulatoryEventORM.id).where(
-                        RegulatoryEventORM.asset_id.in_(stale_ids)
-                    )
-                )
+                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
                 .scalars()
                 .all()
             )
             self.session.execute(
-                delete(AssetRelationshipORM).where(
-                    AssetRelationshipORM.source_asset_id.in_(stale_ids)
-                ),
+                delete(AssetRelationshipORM).where(AssetRelationshipORM.source_asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(AssetRelationshipORM).where(
-                    AssetRelationshipORM.target_asset_id.in_(stale_ids)
-                ),
+                delete(AssetRelationshipORM).where(AssetRelationshipORM.target_asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(
-                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
-                ),
+                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(
-                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(
-                        RegulatoryEventORM.id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
             self.session.execute(
@@ -296,9 +280,7 @@ class AssetGraphRepository:
                 impact_score=event.impact_score,
             )
             for related_id in dict.fromkeys(event.related_assets):
-                event_orm.related_assets.append(
-                    RegulatoryEventAssetORM(asset_id=related_id)
-                )
+                event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
             self.session.add(event_orm)
 
     # ------------------------------------------------------------------
@@ -344,11 +326,7 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
 
         for asset in incoming_assets:
@@ -649,9 +627,7 @@ class AssetGraphRepository:
         existing.impact_score = event.impact_score
         existing.related_assets.clear()
         for related_id in dict.fromkeys(event.related_assets):
-            existing.related_assets.append(
-                RegulatoryEventAssetORM(asset_id=related_id)
-            )
+            existing.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
 
         self.session.add(existing)
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -87,7 +87,7 @@ class _BaseAssetKwargs(TypedDict):
     currency: str
 
 
-GraphRelationshipRows = Dict[str, List[Tuple[str, str, float]]]
+GRAPH_RELATIONSHIP_ROWS = Dict[str, List[Tuple[str, str, float]]]
 
 
 class AssetGraphRepository:
@@ -183,7 +183,7 @@ class AssetGraphRepository:
 
     def replace_relationships_from_graph(
         self,
-        relationships: GraphRelationshipRows,
+        relationships: GRAPH_RELATIONSHIP_ROWS,
     ) -> None:
         """
         Replace all persisted relationships with directed adjacency data.

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -172,18 +172,12 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(
-            self.session.execute(select(AssetORM.id)).scalars().all()
-        )
+        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
         stale_ids = persisted_ids - incoming_ids
 
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(
-                    select(RegulatoryEventORM.id).where(
-                        RegulatoryEventORM.asset_id.in_(stale_ids)
-                    )
-                )
+                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
                 .scalars()
                 .all()
             )
@@ -196,23 +190,17 @@ class AssetGraphRepository:
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(
-                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
-                ),
+                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
 
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(
-                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(
-                        RegulatoryEventORM.id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
 
@@ -349,11 +337,7 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -134,8 +134,11 @@ class AssetGraphRepository:
 
         Loads only durable persisted data; does not derive relationships from other
         sources or restore visualization/layout metadata. Legacy persisted rows with
-        bidirectional=True are expanded through AssetRelationshipGraph semantics for
-        compatibility; save_graph() persists the resulting graph as directed rows.
+        bidirectional=True are expanded through AssetRelationshipGraph semantics only
+        when no explicit reverse row of the same (target, source, relationship_type) is
+        also persisted; an explicit reverse row always wins and is loaded as a directed
+        edge so its strength is preserved. save_graph() persists the resulting graph
+        back as directed rows.
 
         Returns:
             AssetRelationshipGraph: The reconstructed graph containing persisted assets,
@@ -146,13 +149,23 @@ class AssetGraphRepository:
             graph.add_asset(asset)
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
-        for relationship in self.list_relationships():
+        persisted_relationships = self.list_relationships()
+        explicit_relationship_keys = {
+            (rel.source_id, rel.target_id, rel.relationship_type)
+            for rel in persisted_relationships
+        }
+        for relationship in persisted_relationships:
+            expand_reverse = relationship.bidirectional and (
+                relationship.target_id,
+                relationship.source_id,
+                relationship.relationship_type,
+            ) not in explicit_relationship_keys
             graph.add_relationship(
                 relationship.source_id,
                 relationship.target_id,
                 relationship.relationship_type,
                 relationship.strength,
-                bidirectional=relationship.bidirectional,
+                bidirectional=expand_reverse,
             )
         return graph
 
@@ -233,18 +246,19 @@ class AssetGraphRepository:
             execution_options={"synchronize_session": "fetch"},
         )
         self.session.flush()
-        for source_id, outgoing_relationships in relationships.items():
-            for target_id, relationship_type, strength in outgoing_relationships:
-                normalized_strength = self._validate_relationship_strength(strength)
-                self.session.add(
-                    AssetRelationshipORM(
-                        source_asset_id=source_id,
-                        target_asset_id=target_id,
-                        relationship_type=relationship_type,
-                        strength=normalized_strength,
-                        bidirectional=False,
-                    )
-                )
+        relationship_rows = [
+            AssetRelationshipORM(
+                source_asset_id=source_id,
+                target_asset_id=target_id,
+                relationship_type=relationship_type,
+                strength=self._validate_relationship_strength(strength),
+                bidirectional=False,
+            )
+            for source_id, outgoing_relationships in relationships.items()
+            for target_id, relationship_type, strength in outgoing_relationships
+        ]
+        if relationship_rows:
+            self.session.add_all(relationship_rows)
 
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
         """

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -525,7 +525,9 @@ class AssetGraphRepository:
         """Return all regulatory events."""
         result = (
             self.session.execute(
-                select(RegulatoryEventORM).order_by(
+                select(RegulatoryEventORM)
+                .options(selectinload(RegulatoryEventORM.related_assets))
+                .order_by(
                     RegulatoryEventORM.date,
                     RegulatoryEventORM.id,
                 )

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable, Generator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Iterable, TypedDict
+from typing import Any, Dict, Iterable, List, Tuple, TypedDict
 
 from sqlalchemy import delete, select
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, selectinload
 
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.models.financial_models import (
@@ -85,6 +85,7 @@ class _BaseAssetKwargs(TypedDict):
     market_cap: float | None
     currency: str
 
+GraphRelationshipRows = Dict[str, List[Tuple[str, str, float]]]
 
 class AssetGraphRepository:
     """Data access layer for the asset relationship graph."""
@@ -151,8 +152,8 @@ class AssetGraphRepository:
 
     def replace_relationships_from_graph(
         self,
-        relationships: dict[str, list[tuple[str, str, float]]],
-    ) -> None:
+        relationships: GraphRelationshipRows,
+     ) -> None:
         """
         Replace persisted relationships with the supplied graph relationships.
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -108,18 +108,18 @@ class AssetGraphRepository:
     def save_graph(self, graph: AssetRelationshipGraph) -> None:
         """
         Persist an AssetRelationshipGraph snapshot to the database.
-        
+
         Stores the graph's assets, directed relationships, and regulatory events using
         snapshot semantics. Layout and visualization metadata are intentionally not
         persisted.
-        
+
         Args:
             graph: In-memory graph whose assets, relationships, and regulatory events
                 replace the persisted state.
-        
+
         Returns:
             None.
-        
+
         Raises:
             SQLAlchemyError: If the active database session fails while staging
                 replacement rows.
@@ -187,18 +187,18 @@ class AssetGraphRepository:
     ) -> None:
         """
         Replace all persisted relationships with directed adjacency data.
-        
+
         Deletes existing relationship rows and inserts one new row for each outgoing
         edge in `relationships`. Each outgoing tuple is interpreted as
         `(target_id, relationship_type, strength)`. Inserted rows are stored as directed
         edges with `bidirectional=False`.
-        
+
         Args:
             relationships: Mapping from source asset ID to outgoing edge tuples.
-        
+
         Returns:
             None.
-        
+
         Raises:
             SQLAlchemyError: If the active database session fails while deleting or
                 staging relationship rows.
@@ -225,18 +225,18 @@ class AssetGraphRepository:
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
         """
         Replace all persisted regulatory events with the supplied collection.
-        
+
         Deletes existing regulatory events and event-asset link rows, flushes the
         deletion, then inserts ORM rows for each provided event and related asset
         association. Event IDs are used as the idempotency key for this compatibility
         mode.
-        
+
         Args:
             events: Regulatory events to persist as the complete event set.
-        
+
         Returns:
             None.
-        
+
         Raises:
             SQLAlchemyError: If the active database session fails while deleting or
                 staging event rows.
@@ -269,13 +269,13 @@ class AssetGraphRepository:
     def upsert_assets(self, assets: Iterable[Asset]) -> None:
         """
         Create or update multiple assets in a single repository session.
-    
+
         Args:
             assets: Domain assets to create or update.
-    
+
         Returns:
             None.
-    
+
         Raises:
             SQLAlchemyError: If the active database session fails while loading or
                 staging asset rows.
@@ -283,17 +283,13 @@ class AssetGraphRepository:
         incoming_assets = list(assets)
         if not incoming_assets:
             return
-    
+
         incoming_ids = [asset.id for asset in incoming_assets]
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
-    
+
         for asset in incoming_assets:
             orm = existing_assets.get(asset.id)
             if orm is None:
@@ -540,7 +536,7 @@ class AssetGraphRepository:
         Return the relationship between two assets for the given relationship type.
 
         Returns:
-            `RelationshipRecord` if a matching relationship exists 
+            `RelationshipRecord` if a matching relationship exists
             (with `strength` converted to a `float`), `None` otherwise.
         """
         stmt = select(AssetRelationshipORM).where(
@@ -602,7 +598,7 @@ class AssetGraphRepository:
         Each returned event includes its associated related_assets (eagerly loaded).
 
         Returns:
-            events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`, 
+            events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`,
             then `id`, with `related_assets` populated.
         """
         result = (
@@ -624,7 +620,7 @@ class AssetGraphRepository:
         Delete the persisted regulatory event with the given id.
 
         Parameters:
-            event_id (str): Primary key of the regulatory event to delete. 
+            event_id (str): Primary key of the regulatory event to delete.
             If no matching record exists, no action is taken.
         """
         record = self.session.get(RegulatoryEventORM, event_id)
@@ -679,7 +675,7 @@ class AssetGraphRepository:
             orm (AssetORM): The persisted ORM row to convert.
 
         Returns:
-            Asset: A domain Asset. Returns an Equity, Bond, Commodity, or Currency instance when 
+            Asset: A domain Asset. Returns an Equity, Bond, Commodity, or Currency instance when
             `orm.asset_class` indicates that class; otherwise returns a generic `Asset`.
         """
         asset_class = AssetClass(orm.asset_class)

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Dict, Iterable, List, Tuple, TypedDict
 
 from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, selectinload
 
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -107,11 +108,22 @@ class AssetGraphRepository:
     def save_graph(self, graph: AssetRelationshipGraph) -> None:
         """
         Persist an AssetRelationshipGraph snapshot to the database.
-
-        Stores the graph's assets, directed relationships, and regulatory events using snapshot semantics and does not persist any layout or visualization metadata.
-
-        Parameters:
-            graph (AssetRelationshipGraph): In-memory graph whose assets, relationships, and regulatory_events will replace the persisted state.
+        
+        Stores the graph's assets, directed relationships, and regulatory events using
+        snapshot semantics. Layout and visualization metadata are intentionally not
+        persisted.
+        
+        Args:
+            graph: In-memory graph whose assets, relationships, and regulatory events
+                replace the persisted state.
+        
+        Returns:
+            None.
+        
+        Raises:
+            SQLAlchemyError: If the active database session fails while staging
+                replacement rows.
+            ValueError: If a relationship strength is invalid.
         """
         self.replace_assets(graph.assets.values())
         self.replace_relationships_from_graph(graph.relationships)
@@ -160,8 +172,13 @@ class AssetGraphRepository:
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
         persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
-        for stale_id in sorted(persisted_ids - incoming_ids):
-            self.delete_asset(stale_id)
+        stale_ids = persisted_ids - incoming_ids
+        if stale_ids:
+            self.session.execute(
+                delete(AssetORM).where(AssetORM.id.in_(stale_ids)),
+                execution_options={"synchronize_session": "fetch"},
+            )
+            self.session.flush()
         self.upsert_assets(incoming_assets)
 
     def replace_relationships_from_graph(
@@ -169,12 +186,23 @@ class AssetGraphRepository:
         relationships: GraphRelationshipRows,
     ) -> None:
         """
-        Replace all persisted relationships with the provided directed adjacency data.
-
-        Deletes all existing relationship rows and inserts a new row for each outgoing edge in `relationships`. Each outgoing tuple is interpreted as (target_id, relationship_type, strength); `strength` is validated to be a number between -1.0 and 1.0 inclusive and stored as the relationship strength. Inserted rows are stored as directed edges with `bidirectional=False`.
-
-        Parameters:
-            relationships (dict[str, list[tuple[str, str, float]]]): Mapping from source asset id to a list of outgoing edges; each edge is a tuple of (target_id, relationship_type, strength).
+        Replace all persisted relationships with directed adjacency data.
+        
+        Deletes existing relationship rows and inserts one new row for each outgoing
+        edge in `relationships`. Each outgoing tuple is interpreted as
+        `(target_id, relationship_type, strength)`. Inserted rows are stored as directed
+        edges with `bidirectional=False`.
+        
+        Args:
+            relationships: Mapping from source asset ID to outgoing edge tuples.
+        
+        Returns:
+            None.
+        
+        Raises:
+            SQLAlchemyError: If the active database session fails while deleting or
+                staging relationship rows.
+            ValueError: If any relationship strength is invalid.
         """
         self.session.execute(
             delete(AssetRelationshipORM),
@@ -197,11 +225,21 @@ class AssetGraphRepository:
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
         """
         Replace all persisted regulatory events with the supplied collection.
-
-        Performs a snapshot-style replacement: deletes all existing regulatory events and their event-asset link rows, flushes the deletion, then inserts ORM rows for each provided event including their related asset associations. The provided events' IDs are used as the idempotency key for this operation.
-
-        Parameters:
-            events (Iterable[RegulatoryEvent]): Iterable of regulatory events to persist as the complete set.
+        
+        Deletes existing regulatory events and event-asset link rows, flushes the
+        deletion, then inserts ORM rows for each provided event and related asset
+        association. Event IDs are used as the idempotency key for this compatibility
+        mode.
+        
+        Args:
+            events: Regulatory events to persist as the complete event set.
+        
+        Returns:
+            None.
+        
+        Raises:
+            SQLAlchemyError: If the active database session fails while deleting or
+                staging event rows.
         """
         self.session.execute(
             delete(RegulatoryEventAssetORM),
@@ -228,22 +266,40 @@ class AssetGraphRepository:
     # ------------------------------------------------------------------
     # Asset helpers
     # ------------------------------------------------------------------
-    def upsert_asset(self, asset: Asset) -> None:
+    def upsert_assets(self, assets: Iterable[Asset]) -> None:
         """
-        Create or update the persistent record for a domain Asset.
-
-        Maps fields from the given domain `Asset` onto an `AssetORM` (creating
-        one if needed) and stages the ORM instance on the repository session for
-        persistence.
-
-        Parameters:
-            asset (Asset): Domain asset to persist or update.
+        Create or update multiple assets in a single repository session.
+    
+        Args:
+            assets: Domain assets to create or update.
+    
+        Returns:
+            None.
+    
+        Raises:
+            SQLAlchemyError: If the active database session fails while loading or
+                staging asset rows.
         """
-        existing = self.session.get(AssetORM, asset.id)
-        if existing is None:
-            existing = AssetORM(id=asset.id)
-        self._update_asset_orm(existing, asset)
-        self.session.add(existing)
+        incoming_assets = list(assets)
+        if not incoming_assets:
+            return
+    
+        incoming_ids = [asset.id for asset in incoming_assets]
+        existing_assets = {
+            orm.id: orm
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
+        }
+    
+        for asset in incoming_assets:
+            orm = existing_assets.get(asset.id)
+            if orm is None:
+                orm = AssetORM(id=asset.id)
+                self.session.add(orm)
+            self._update_asset_orm(orm, asset)
 
     def list_assets(self) -> list[Asset]:
         """
@@ -484,7 +540,8 @@ class AssetGraphRepository:
         Return the relationship between two assets for the given relationship type.
 
         Returns:
-            `RelationshipRecord` if a matching relationship exists (with `strength` converted to a `float`), `None` otherwise.
+            `RelationshipRecord` if a matching relationship exists 
+            (with `strength` converted to a `float`), `None` otherwise.
         """
         stmt = select(AssetRelationshipORM).where(
             AssetRelationshipORM.source_asset_id == source_id,
@@ -545,7 +602,8 @@ class AssetGraphRepository:
         Each returned event includes its associated related_assets (eagerly loaded).
 
         Returns:
-            events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`, then `id`, with `related_assets` populated.
+            events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`, 
+            then `id`, with `related_assets` populated.
         """
         result = (
             self.session.execute(
@@ -566,7 +624,8 @@ class AssetGraphRepository:
         Delete the persisted regulatory event with the given id.
 
         Parameters:
-            event_id (str): Primary key of the regulatory event to delete. If no matching record exists, no action is taken.
+            event_id (str): Primary key of the regulatory event to delete. 
+            If no matching record exists, no action is taken.
         """
         record = self.session.get(RegulatoryEventORM, event_id)
         if record is not None:
@@ -620,7 +679,8 @@ class AssetGraphRepository:
             orm (AssetORM): The persisted ORM row to convert.
 
         Returns:
-            Asset: A domain Asset. Returns an Equity, Bond, Commodity, or Currency instance when `orm.asset_class` indicates that class; otherwise returns a generic `Asset`.
+            Asset: A domain Asset. Returns an Equity, Bond, Commodity, or Currency instance when 
+            `orm.asset_class` indicates that class; otherwise returns a generic `Asset`.
         """
         asset_class = AssetClass(orm.asset_class)
         base_kwargs: _BaseAssetKwargs = {

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -87,6 +87,24 @@ class _BaseAssetKwargs(TypedDict):
 
 
 GraphRelationshipRows: TypeAlias = Dict[str, List[Tuple[str, str, float]]]
+_IN_CLAUSE_CHUNK_SIZE = 400
+
+
+def _iter_id_chunks(values: Iterable[str]) -> Generator[tuple[str, ...], None, None]:
+    """
+    Yield stable-size chunks for SQL IN predicates.
+
+    The chunk size stays below common SQLite variable limits even when a query
+    uses the same chunk in more than one IN predicate.
+    """
+    batch: list[str] = []
+    for value in values:
+        batch.append(value)
+        if len(batch) == _IN_CLAUSE_CHUNK_SIZE:
+            yield tuple(batch)
+            batch = []
+    if batch:
+        yield tuple(batch)
 
 
 class AssetGraphRepository:
@@ -185,38 +203,46 @@ class AssetGraphRepository:
         stale_ids = persisted_ids - incoming_ids
 
         if stale_ids:
-            stale_event_ids = set(
-                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
-                .scalars()
-                .all()
-            )
+            stale_event_ids: set[str] = set()
+            for stale_id_chunk in _iter_id_chunks(stale_ids):
+                stale_event_ids.update(
+                    self.session.execute(
+                        select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_id_chunk))
+                    )
+                    .scalars()
+                    .all()
+                )
 
-            self.session.execute(
-                delete(AssetRelationshipORM).where(
-                    (AssetRelationshipORM.source_asset_id.in_(stale_ids))
-                    | (AssetRelationshipORM.target_asset_id.in_(stale_ids))
-                ),
-                execution_options={"synchronize_session": "fetch"},
-            )
-            self.session.execute(
-                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
-                execution_options={"synchronize_session": "fetch"},
-            )
+                self.session.execute(
+                    delete(AssetRelationshipORM).where(
+                        (AssetRelationshipORM.source_asset_id.in_(stale_id_chunk))
+                        | (AssetRelationshipORM.target_asset_id.in_(stale_id_chunk))
+                    ),
+                    execution_options={"synchronize_session": "fetch"},
+                )
+                self.session.execute(
+                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_id_chunk)),
+                    execution_options={"synchronize_session": "fetch"},
+                )
 
             if stale_event_ids:
-                self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
-                    execution_options={"synchronize_session": "fetch"},
-                )
-                self.session.execute(
-                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
-                    execution_options={"synchronize_session": "fetch"},
-                )
+                for stale_event_id_chunk in _iter_id_chunks(stale_event_ids):
+                    self.session.execute(
+                        delete(RegulatoryEventAssetORM).where(
+                            RegulatoryEventAssetORM.event_id.in_(stale_event_id_chunk)
+                        ),
+                        execution_options={"synchronize_session": "fetch"},
+                    )
+                    self.session.execute(
+                        delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_id_chunk)),
+                        execution_options={"synchronize_session": "fetch"},
+                    )
 
-            self.session.execute(
-                delete(AssetORM).where(AssetORM.id.in_(stale_ids)),
-                execution_options={"synchronize_session": "fetch"},
-            )
+            for stale_id_chunk in _iter_id_chunks(stale_ids):
+                self.session.execute(
+                    delete(AssetORM).where(AssetORM.id.in_(stale_id_chunk)),
+                    execution_options={"synchronize_session": "fetch"},
+                )
             self.session.flush()
 
         self.upsert_assets(incoming_assets)
@@ -302,6 +328,7 @@ class AssetGraphRepository:
             execution_options={"synchronize_session": "fetch"},
         )
         self.session.flush()
+        event_rows: list[RegulatoryEventORM] = []
         for event in incoming_events:
             event_orm = RegulatoryEventORM(
                 id=event.id,
@@ -313,7 +340,9 @@ class AssetGraphRepository:
             )
             for related_id in dict.fromkeys(event.related_assets):
                 event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
-            self.session.add(event_orm)
+            event_rows.append(event_orm)
+        if event_rows:
+            self.session.add_all(event_rows)
 
     # ------------------------------------------------------------------
     # Asset helpers
@@ -356,10 +385,16 @@ class AssetGraphRepository:
             return
 
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
-        existing_assets = {
-            orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
-        }
+        existing_assets: dict[str, AssetORM] = {}
+        for incoming_id_chunk in _iter_id_chunks(incoming_ids):
+            existing_assets.update(
+                {
+                    orm.id: orm
+                    for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_id_chunk)))
+                    .scalars()
+                    .all()
+                }
+            )
 
         for asset in incoming_assets:
             orm = existing_assets.get(asset.id)
@@ -741,7 +776,7 @@ class AssetGraphRepository:
     @staticmethod
     def _to_asset_model(orm: AssetORM) -> Asset:
         """
-        Constructs a domain Asset instance (specific subclass when applicable) from an AssetORM row.
+        Construct a domain Asset instance (specific subclass when applicable) from an AssetORM row.
 
         Parameters:
             orm (AssetORM): The persisted ORM row to convert.

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -119,12 +119,16 @@ class AssetGraphRepository:
 
     def load_graph(self) -> AssetRelationshipGraph:
         """
-        Reconstruct an in-memory asset relationship graph from persisted assets, relationships, and regulatory events.
-
-        Loads only durable persisted data; does not derive relationships from other sources or restore visualization/layout metadata. Relationship `bidirectional` flags are preserved as stored.
-
+        Reconstruct an in-memory asset relationship graph from persisted rows.
+        
+        Loads only durable persisted data; does not derive relationships from other
+        sources or restore visualization/layout metadata. Persisted relationship rows
+        are loaded one-for-one as directed edges, so a stored bidirectional flag is not
+        expanded into an additional reverse edge during graph reconstruction.
+        
         Returns:
-            graph (AssetRelationshipGraph): The reconstructed graph containing persisted assets, relationships (with `bidirectional` forwarded), and regulatory events.
+            AssetRelationshipGraph: The reconstructed graph containing persisted assets,
+            relationship rows, and regulatory events.
         """
         graph = AssetRelationshipGraph()
         for asset in self.list_assets():
@@ -137,7 +141,7 @@ class AssetGraphRepository:
                 relationship.target_id,
                 relationship.relationship_type,
                 relationship.strength,
-                bidirectional=relationship.bidirectional,
+                bidirectional=False,
             )
         return graph
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -150,9 +150,7 @@ class AssetGraphRepository:
         for event in self.list_regulatory_events():
             graph.add_regulatory_event(event)
         persisted_ = self.list_()
-        explicit_relationship_keys = {
-            (rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_
-        }
+        explicit_relationship_keys = {(rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_}
         for relationship in persisted_:
             expand_reverse = (
                 relationship.bidirectional
@@ -291,10 +289,7 @@ class AssetGraphRepository:
             seen_event_ids.add(event.id)
         if duplicate_event_ids:
             duplicate_ids = ", ".join(sorted(duplicate_event_ids))
-            raise ValueError(
-                "replace_regulatory_events() received duplicate event IDs: "
-                f"{duplicate_ids}"
-            )
+            raise ValueError(f"replace_regulatory_events() received duplicate event IDs: {duplicate_ids}")
 
         self.session.execute(
             delete(RegulatoryEventAssetORM),

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -300,11 +300,7 @@ class AssetGraphRepository:
         incoming_ids = [asset.id for asset in incoming_assets]
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -172,18 +172,12 @@ class AssetGraphRepository:
         """
         incoming_assets = list(assets)
         incoming_ids = {asset.id for asset in incoming_assets}
-        persisted_ids = set(
-            self.session.execute(select(AssetORM.id)).scalars().all()
-        )
+        persisted_ids = set(self.session.execute(select(AssetORM.id)).scalars().all())
         stale_ids = persisted_ids - incoming_ids
 
         if stale_ids:
             stale_event_ids = set(
-                self.session.execute(
-                    select(RegulatoryEventORM.id).where(
-                        RegulatoryEventORM.asset_id.in_(stale_ids)
-                    )
-                )
+                self.session.execute(select(RegulatoryEventORM.id).where(RegulatoryEventORM.asset_id.in_(stale_ids)))
                 .scalars()
                 .all()
             )
@@ -196,23 +190,17 @@ class AssetGraphRepository:
                 execution_options={"synchronize_session": "fetch"},
             )
             self.session.execute(
-                delete(RegulatoryEventAssetORM).where(
-                    RegulatoryEventAssetORM.asset_id.in_(stale_ids)
-                ),
+                delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.asset_id.in_(stale_ids)),
                 execution_options={"synchronize_session": "fetch"},
             )
 
             if stale_event_ids:
                 self.session.execute(
-                    delete(RegulatoryEventAssetORM).where(
-                        RegulatoryEventAssetORM.event_id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventAssetORM).where(RegulatoryEventAssetORM.event_id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
                 self.session.execute(
-                    delete(RegulatoryEventORM).where(
-                        RegulatoryEventORM.id.in_(stale_event_ids)
-                    ),
+                    delete(RegulatoryEventORM).where(RegulatoryEventORM.id.in_(stale_event_ids)),
                     execution_options={"synchronize_session": "fetch"},
                 )
 
@@ -303,9 +291,7 @@ class AssetGraphRepository:
                 impact_score=event.impact_score,
             )
             for related_id in dict.fromkeys(event.related_assets):
-                event_orm.related_assets.append(
-                    RegulatoryEventAssetORM(asset_id=related_id)
-                )
+                event_orm.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
             self.session.add(event_orm)
 
     # ------------------------------------------------------------------
@@ -351,11 +337,7 @@ class AssetGraphRepository:
         incoming_ids = list(dict.fromkeys(asset.id for asset in incoming_assets))
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(
-                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
-            )
-            .scalars()
-            .all()
+            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
         }
 
         for asset in incoming_assets:
@@ -375,11 +357,7 @@ class AssetGraphRepository:
                 representing all assets in the database,
                 ordered by asset id.
         """
-        result = (
-            self.session.execute(select(AssetORM).order_by(AssetORM.id))
-            .scalars()
-            .all()
-        )
+        result = self.session.execute(select(AssetORM).order_by(AssetORM.id)).scalars().all()
         return [self._to_asset_model(record) for record in result]
 
     def get_assets_map(self) -> dict[str, Asset]:
@@ -439,9 +417,7 @@ class AssetGraphRepository:
             *args,
             **kwargs,
         )
-        relationship = self._get_or_create_relationship_orm(
-            relationship_spec
-        )
+        relationship = self._get_or_create_relationship_orm(relationship_spec)
         self.session.add(relationship)
 
     def _build_relationship_upsert_spec(
@@ -485,9 +461,7 @@ class AssetGraphRepository:
             )
 
         if len(args) < 4:
-            raise TypeError(
-                "Expected (source_id, target_id, rel_type, strength[, bidirectional])"
-            )
+            raise TypeError("Expected (source_id, target_id, rel_type, strength[, bidirectional])")
 
         source_id = args[0]
         target_id = args[1]
@@ -664,9 +638,7 @@ class AssetGraphRepository:
         existing.impact_score = event.impact_score
         existing.related_assets.clear()
         for related_id in dict.fromkeys(event.related_assets):
-            existing.related_assets.append(
-                RegulatoryEventAssetORM(asset_id=related_id)
-            )
+            existing.related_assets.append(RegulatoryEventAssetORM(asset_id=related_id))
 
         self.session.add(existing)
 
@@ -723,9 +695,7 @@ class AssetGraphRepository:
         orm.asset_class = asset.asset_class.value
         orm.sector = asset.sector
         orm.price = float(asset.price)
-        orm.market_cap = (
-            float(asset.market_cap) if asset.market_cap is not None else None
-        )
+        orm.market_cap = float(asset.market_cap) if asset.market_cap is not None else None
         orm.currency = asset.currency
 
         orm.pe_ratio = getattr(asset, "pe_ratio", None)

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -93,6 +93,12 @@ class AssetGraphRepository:
     """Data access layer for the asset relationship graph."""
 
     def __init__(self, session: Session):
+        """
+        Initialize the repository with a SQLAlchemy session for database operations.
+        
+        Parameters:
+            session (Session): SQLAlchemy Session used for all database access by this repository.
+        """
         self.session = session
 
     # ------------------------------------------------------------------
@@ -100,11 +106,12 @@ class AssetGraphRepository:
     # ------------------------------------------------------------------
     def save_graph(self, graph: AssetRelationshipGraph) -> None:
         """
-        Persist the current graph truth using the existing schema contract.
-
-        This method stores assets, directed relationships, and regulatory events
-        through the current ORM models. It intentionally does not persist layout
-        coordinates or visualization metadata.
+        Persist an AssetRelationshipGraph snapshot to the database.
+        
+        Stores the graph's assets, directed relationships, and regulatory events using snapshot semantics and does not persist any layout or visualization metadata.
+        
+        Parameters:
+            graph (AssetRelationshipGraph): In-memory graph whose assets, relationships, and regulatory_events will replace the persisted state.
         """
         self.replace_assets(graph.assets.values())
         self.replace_relationships_from_graph(graph.relationships)
@@ -112,11 +119,12 @@ class AssetGraphRepository:
 
     def load_graph(self) -> AssetRelationshipGraph:
         """
-        Reconstruct an in-memory graph from persisted assets and relationships.
-
-        The returned graph is loaded from durable graph truth only. The method
-        does not derive new relationships, rebuild from sample data, or assign
-        visualization coordinates.
+        Reconstruct an in-memory asset relationship graph from persisted assets, relationships, and regulatory events.
+        
+        Loads only durable persisted data; does not derive relationships from other sources or restore visualization/layout metadata. Relationship `bidirectional` flags are preserved as stored.
+        
+        Returns:
+            graph (AssetRelationshipGraph): The reconstructed graph containing persisted assets, relationships (with `bidirectional` forwarded), and regulatory events.
         """
         graph = AssetRelationshipGraph()
         for asset in self.list_assets():
@@ -157,11 +165,12 @@ class AssetGraphRepository:
         relationships: GraphRelationshipRows,
     ) -> None:
         """
-        Replace persisted relationships with the supplied graph relationships.
-
-        This is the schema-compatible bulk publish primitive for the first graph
-        persistence implementation. It preserves directed edges exactly as stored
-        in the in-memory graph instead of collapsing reciprocal relationships.
+        Replace all persisted relationships with the provided directed adjacency data.
+        
+        Deletes all existing relationship rows and inserts a new row for each outgoing edge in `relationships`. Each outgoing tuple is interpreted as (target_id, relationship_type, strength); `strength` is validated to be a number between -1.0 and 1.0 inclusive and stored as the relationship strength. Inserted rows are stored as directed edges with `bidirectional=False`.
+        
+        Parameters:
+            relationships (dict[str, list[tuple[str, str, float]]]): Mapping from source asset id to a list of outgoing edges; each edge is a tuple of (target_id, relationship_type, strength).
         """
         self.session.execute(
             delete(AssetRelationshipORM),
@@ -183,11 +192,12 @@ class AssetGraphRepository:
 
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
         """
-        Replace persisted regulatory events with the supplied event collection.
-
-        The current compatibility mode uses event IDs as the idempotency key.
-        Stable event-key semantics for a normalized shared-event model remain a
-        later schema/repository migration concern.
+        Replace all persisted regulatory events with the supplied collection.
+        
+        Performs a snapshot-style replacement: deletes all existing regulatory events and their event-asset link rows, flushes the deletion, then inserts ORM rows for each provided event including their related asset associations. The provided events' IDs are used as the idempotency key for this operation.
+         
+        Parameters:
+            events (Iterable[RegulatoryEvent]): Iterable of regulatory events to persist as the complete set.
         """
         self.session.execute(
             delete(RegulatoryEventAssetORM),
@@ -525,7 +535,14 @@ class AssetGraphRepository:
         self.session.add(existing)
 
     def list_regulatory_events(self) -> list[RegulatoryEvent]:
-        """Return all regulatory events."""
+        """
+        Retrieve all persisted regulatory events ordered by date then id.
+        
+        Each returned event includes its associated related_assets (eagerly loaded).
+        
+        Returns:
+            events (list[RegulatoryEvent]): RegulatoryEvent models ordered by `date`, then `id`, with `related_assets` populated.
+        """
         result = (
             self.session.execute(
                 select(RegulatoryEventORM)
@@ -541,7 +558,12 @@ class AssetGraphRepository:
         return [self._to_regulatory_event_model(record) for record in result]
 
     def delete_regulatory_event(self, event_id: str) -> None:
-        """Delete a regulatory event."""
+        """
+        Delete the persisted regulatory event with the given id.
+        
+        Parameters:
+            event_id (str): Primary key of the regulatory event to delete. If no matching record exists, no action is taken.
+        """
         record = self.session.get(RegulatoryEventORM, event_id)
         if record is not None:
             self.session.delete(record)

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -300,7 +300,11 @@ class AssetGraphRepository:
         incoming_ids = [asset.id for asset in incoming_assets]
         existing_assets = {
             orm.id: orm
-            for orm in self.session.execute(select(AssetORM).where(AssetORM.id.in_(incoming_ids))).scalars().all()
+            for orm in self.session.execute(
+                select(AssetORM).where(AssetORM.id.in_(incoming_ids))
+            )
+            .scalars()
+            .all()
         }
 
         for asset in incoming_assets:

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -151,15 +151,18 @@ class AssetGraphRepository:
             graph.add_regulatory_event(event)
         persisted_relationships = self.list_relationships()
         explicit_relationship_keys = {
-            (rel.source_id, rel.target_id, rel.relationship_type)
-            for rel in persisted_relationships
+            (rel.source_id, rel.target_id, rel.relationship_type) for rel in persisted_relationships
         }
         for relationship in persisted_relationships:
-            expand_reverse = relationship.bidirectional and (
-                relationship.target_id,
-                relationship.source_id,
-                relationship.relationship_type,
-            ) not in explicit_relationship_keys
+            expand_reverse = (
+                relationship.bidirectional
+                and (
+                    relationship.target_id,
+                    relationship.source_id,
+                    relationship.relationship_type,
+                )
+                not in explicit_relationship_keys
+            )
             graph.add_relationship(
                 relationship.source_id,
                 relationship.target_id,

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -548,7 +548,7 @@ class TestConcurrentDatabaseAccess:
 
     def test_concurrent_reads_safe(self, isolated_base) -> None:
         """Concurrent reads should not interfere with each other.
-    
+
         Uses a temporary file-based SQLite database with NullPool so each reader
         thread opens its own database connection. This validates concurrent
         read-session behavior without relying on a shared in-memory SQLite
@@ -557,20 +557,20 @@ class TestConcurrentDatabaseAccess:
         import os
         import tempfile
         import threading
-    
+
         from sqlalchemy import create_engine as _create_engine
         from sqlalchemy.pool import NullPool
-    
+
         class TestModel(isolated_base):  # type: ignore[misc]  # pylint: disable=redefined-outer-name
             """Test model for concurrent read validation."""
-    
+
             __tablename__ = "test_concurrent_reads"
             id = Column(Integer, primary_key=True)
             value = Column(String)
-    
+
         results: list[int] = []
         errors: list[Exception] = []
-    
+
         with tempfile.TemporaryDirectory() as tmpdir:
             db_url = f"sqlite:///{os.path.join(tmpdir, 'concurrent_reads.db')}"
             # NullPool: each session opens its own SQLite connection, so concurrent
@@ -583,15 +583,15 @@ class TestConcurrentDatabaseAccess:
             )
             init_db(file_engine)
             factory = create_session_factory(file_engine)
-    
+
             with session_scope(factory) as session:
                 for i in range(100):
                     session.add(TestModel(id=i, value=f"value_{i}"))
-    
+
             def read_data() -> None:
                 """
                 Worker executed by a thread to perform a read-only count query.
-    
+
                 Appends the number of rows in `TestModel` to the shared `results`
                 list. If an exception occurs, appends the exception instance to the
                 shared `errors` list.
@@ -602,15 +602,15 @@ class TestConcurrentDatabaseAccess:
                         results.append(count)
                 except Exception as exc:  # noqa: BLE001
                     errors.append(exc)
-    
+
             threads = [threading.Thread(target=read_data) for _ in range(10)]
             for thread in threads:
                 thread.start()
             for thread in threads:
                 thread.join()
-    
+
             file_engine.dispose()
-    
+
         assert len(errors) == 0, f"Unexpected errors under concurrent reads: {errors}"
         assert len(results) == 10
         assert all(count == 100 for count in results)

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -619,6 +619,7 @@ class TestConcurrentDatabaseAccess:
         complete successfully, validating the DB/session stack under concurrency
         without relying on any Python-level locking.
         """
+
         class TestModel(isolated_base):  # type: ignore[misc]  # pylint: disable=redefined-outer-name
             """Test model for concurrent write validation."""
 
@@ -633,10 +634,10 @@ class TestConcurrentDatabaseAccess:
             # so concurrent access is exercised at the database level, not masked
             # by a shared in-memory connection.
             file_engine = create_engine(
-                 db_url,
-                 poolclass=NullPool,
-                 connect_args={"timeout": 30},  # wait up to 30 s for the DB lock
-             )
+                db_url,
+                poolclass=NullPool,
+                connect_args={"timeout": 30},  # wait up to 30 s for the DB lock
+            )
             init_db(file_engine)
             factory = create_session_factory(file_engine)
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -520,8 +520,6 @@ class TestConcurrentDatabaseAccess:
 
     def test_concurrent_session_creation(self, engine: Engine) -> None:
         """Multiple concurrent sessions should be safe."""
-        import threading
-
         factory = create_session_factory(engine)
         sessions: list[Any] = []
         errors: list[Exception] = []
@@ -621,13 +619,6 @@ class TestConcurrentDatabaseAccess:
         complete successfully, validating the DB/session stack under concurrency
         without relying on any Python-level locking.
         """
-        import os
-        import tempfile
-        import threading
-
-        from sqlalchemy import create_engine as _create_engine
-        from sqlalchemy.pool import NullPool
-
         class TestModel(isolated_base):  # type: ignore[misc]  # pylint: disable=redefined-outer-name
             """Test model for concurrent write validation."""
 
@@ -641,11 +632,11 @@ class TestConcurrentDatabaseAccess:
             # NullPool: each call to session_scope opens its own SQLite connection
             # so concurrent access is exercised at the database level, not masked
             # by a shared in-memory connection.
-            file_engine = _create_engine(
-                db_url,
-                poolclass=NullPool,
-                connect_args={"timeout": 30},  # wait up to 30 s for the DB lock
-            )
+            file_engine = create_engine(
+                 db_url,
+                 poolclass=NullPool,
+                 connect_args={"timeout": 30},  # wait up to 30 s for the DB lock
+             )
             init_db(file_engine)
             factory = create_session_factory(file_engine)
 

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 import os
 import sqlite3
+import tempfile
+import threading
 from collections.abc import Iterator
 from typing import Any
 from unittest.mock import Mock, patch
@@ -22,7 +24,7 @@ import pytest
 from sqlalchemy import Column, Integer, String, create_engine
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import NullPool, StaticPool
 
 from api.database import (
     _cleanup_memory_connection,
@@ -546,6 +548,7 @@ class TestConcurrentDatabaseAccess:
         assert len(errors) == 0
         assert len(sessions) == 10
 
+    # pylint: disable=too-many-locals
     def test_concurrent_reads_safe(self, isolated_base) -> None:
         """Concurrent reads should not interfere with each other.
 
@@ -554,12 +557,6 @@ class TestConcurrentDatabaseAccess:
         read-session behavior without relying on a shared in-memory SQLite
         connection from StaticPool.
         """
-        import os
-        import tempfile
-        import threading
-
-        from sqlalchemy import create_engine as _create_engine
-        from sqlalchemy.pool import NullPool
 
         class TestModel(isolated_base):  # type: ignore[misc]  # pylint: disable=redefined-outer-name
             """Test model for concurrent read validation."""
@@ -576,7 +573,7 @@ class TestConcurrentDatabaseAccess:
             # NullPool: each session opens its own SQLite connection, so concurrent
             # reads are exercised at the database level rather than through a single
             # shared in-memory connection.
-            file_engine = _create_engine(
+            file_engine = create_engine(
                 db_url,
                 poolclass=NullPool,
                 connect_args={"timeout": 30},

--- a/tests/unit/test_database.py
+++ b/tests/unit/test_database.py
@@ -546,50 +546,73 @@ class TestConcurrentDatabaseAccess:
         assert len(errors) == 0
         assert len(sessions) == 10
 
-    def test_concurrent_reads_safe(self, engine: Engine, isolated_base) -> None:
-        """Concurrent reads should not interfere with each other."""
+    def test_concurrent_reads_safe(self, isolated_base) -> None:
+        """Concurrent reads should not interfere with each other.
+    
+        Uses a temporary file-based SQLite database with NullPool so each reader
+        thread opens its own database connection. This validates concurrent
+        read-session behavior without relying on a shared in-memory SQLite
+        connection from StaticPool.
+        """
+        import os
+        import tempfile
         import threading
-
+    
+        from sqlalchemy import create_engine as _create_engine
+        from sqlalchemy.pool import NullPool
+    
         class TestModel(isolated_base):  # type: ignore[misc]  # pylint: disable=redefined-outer-name
             """Test model for concurrent read validation."""
-
+    
             __tablename__ = "test_concurrent_reads"
             id = Column(Integer, primary_key=True)
             value = Column(String)
-
-        init_db(engine)
-        factory = create_session_factory(engine)
-
-        with session_scope(factory) as session:
-            for i in range(100):
-                session.add(TestModel(id=i, value=f"value_{i}"))
-
+    
         results: list[int] = []
         errors: list[Exception] = []
-
-        def read_data() -> None:
-            """
-            Worker executed by a thread to perform a read-only count query and record results.
-
-            Appends the number of rows in `TestModel` to the shared `results`
-            list. If an exception occurs, appends the exception instance to the
-            shared `errors` list. Obtains a session from the module-level
-            session factory and does not return a value.
-            """
-            try:
-                with session_scope(factory) as session:
-                    count = session.query(TestModel).count()
-                    results.append(count)
-            except Exception as exc:  # noqa: BLE001
-                errors.append(exc)
-
-        threads = [threading.Thread(target=read_data) for _ in range(10)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-
-        assert len(errors) == 0
+    
+        with tempfile.TemporaryDirectory() as tmpdir:
+            db_url = f"sqlite:///{os.path.join(tmpdir, 'concurrent_reads.db')}"
+            # NullPool: each session opens its own SQLite connection, so concurrent
+            # reads are exercised at the database level rather than through a single
+            # shared in-memory connection.
+            file_engine = _create_engine(
+                db_url,
+                poolclass=NullPool,
+                connect_args={"timeout": 30},
+            )
+            init_db(file_engine)
+            factory = create_session_factory(file_engine)
+    
+            with session_scope(factory) as session:
+                for i in range(100):
+                    session.add(TestModel(id=i, value=f"value_{i}"))
+    
+            def read_data() -> None:
+                """
+                Worker executed by a thread to perform a read-only count query.
+    
+                Appends the number of rows in `TestModel` to the shared `results`
+                list. If an exception occurs, appends the exception instance to the
+                shared `errors` list.
+                """
+                try:
+                    with session_scope(factory) as session:
+                        count = session.query(TestModel).count()
+                        results.append(count)
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+    
+            threads = [threading.Thread(target=read_data) for _ in range(10)]
+            for thread in threads:
+                thread.start()
+            for thread in threads:
+                thread.join()
+    
+            file_engine.dispose()
+    
+        assert len(errors) == 0, f"Unexpected errors under concurrent reads: {errors}"
+        assert len(results) == 10
         assert all(count == 100 for count in results)
 
     def test_concurrent_writes(self, isolated_base) -> None:


### PR DESCRIPTION
## **User description**
## Summary

- Adds graph-level persistence helpers to the existing `AssetGraphRepository`.
- Provides `save_graph()` and `load_graph()` primitives for persisting and reconstructing graph truth through the current ORM/schema contract.
- Adds bulk repository helpers for assets, relationships, and regulatory events without changing API startup behavior.

## Scope

This is the first narrow implementation PR after #1109's graph persistence design.

This PR intentionally does **not** introduce new schema, migrations, or startup integration. It validates that the current schema can represent graph truth and provides repository primitives for subsequent integration PRs.

In scope:

- repository-level graph save/load helpers;
- directed relationship replacement from the in-memory graph relationship map;
- regulatory-event replacement using the current asset-scoped compatibility model;
- explicit preservation of graph truth / layout separation.

Out of scope:

- no Alembic setup;
- no ORM model changes;
- no `migrations/001_initial.sql` changes;
- no API route changes;
- no application startup/load integration;
- no hosted-readiness behavior changes;
- no layout or visualization persistence.

## Design alignment

- Builds directly on `docs/graph-persistence-design.md` from #1109.
- Preserves the current `AssetORM`, `AssetRelationshipORM`, `RegulatoryEventORM`, and `RegulatoryEventAssetORM` shape.
- Keeps asset-scoped regulatory-event compatibility mode: event IDs remain the idempotency key for this PR. Stable `event_key` semantics for a normalized shared-event model remain a later schema/repository migration concern.
- Persists directed relationships exactly as stored in `AssetRelationshipGraph.relationships`; reciprocal directed edges are not collapsed.
- Does not persist layout coordinates or visualization metadata.

## Reviewer checklist

Please review only the repository contract introduced here:

- `save_graph()` persists assets, relationships, and regulatory events from the in-memory graph;
- `load_graph()` reconstructs an `AssetRelationshipGraph` from persisted graph truth without deriving new relationships;
- relationship replacement is explicit and does not silently merge bidirectional edge pairs;
- regulatory-event replacement remains compatible with the current ORM/migration contract;
- no runtime/API behavior changes are introduced.

## Validation

Recommended local validation:

```bash
python -m pytest tests/unit/test_database.py
python -m pytest tests/unit -q
```

Focused follow-up PR:

- Add repository round-trip tests for graph -> DB -> graph once this contract is accepted.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds full graph snapshot save/load for assets, directed edges, and regulatory events in `AssetGraphRepository`; layout is not persisted. Bulk operations are hardened for large datasets and stable reads.

- **New Features**
  - `save_graph(graph)` and `load_graph()` to snapshot and rebuild assets, directed relationships, and events; edges saved with `bidirectional=False`, and on load legacy `bidirectional` rows expand only if no explicit reverse exists.
  - Bulk helpers: `replace_assets(...)`, `upsert_assets(...)`, `replace_relationships_from_graph(...)`, `replace_regulatory_events(...)`; accepts an adjacency map `(target_id, type, strength)`; validates `strength` in [-1.0, 1.0]; rejects duplicate event IDs.
  - Stable reads: relationships ordered by source/target/type; regulatory events eager-load related assets and order by date/id; event `related_assets` deduped on write and sorted on read.

- **Bug Fixes**
  - Snapshot semantics: prune stale assets; clean relationship rows and event-asset links; delete events tied to removed assets; deletes use `synchronize_session='fetch'` with a flush and chunked IN predicates to avoid SQL variable limit errors.
  - Concurrency tests: concurrent reads use a temp file-based SQLite DB with `NullPool` so each thread opens its own connection; direct `create_engine` usage and import cleanups.
  - Repository contract: corrected helper method names to match the API used by tests and callers.

<sup>Written for commit f4dbd9d103374374c200c62ed7981b5e45c93d98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Save and reload the full asset relationship graph as a snapshot**

### What Changed
- Added repository support to save an entire graph at once and load it back into memory, including assets, relationships, and regulatory events
- Saving now replaces removed items instead of leaving stale records behind
- Relationships are stored and loaded as directed edges, preserving explicit reverse links and relationship strength
- Regulatory event links are deduplicated, and loaded data is returned in a stable order
- Concurrent read tests now use a file-based SQLite database so they exercise separate connections more realistically

### Impact
`✅ Graph saves reflect the current state`
`✅ Fewer stale assets, relationships, and events`
`✅ More reliable concurrent read checks`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=UmvE0cta1Iu4n2-5ZPhEHyyuLBXIZ7mV1CAvvkDF_T0&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
