### PR TITLE
Add graph persistence round-trip contract tests

### DIFF
--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,7 +1,9 @@
 """Unit tests for repository graph persistence helpers."""
 
 import pytest
-from sqlalchemy import create_engine
+
+_sqlalchemy = pytest.importorskip("sqlalchemy")
+create_engine = _sqlalchemy.create_engine
 
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -2,9 +2,6 @@
 
 import pytest
 
-_sqlalchemy = pytest.importorskip("sqlalchemy")
-create_engine = _sqlalchemy.create_engine
-
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -14,6 +11,10 @@ from src.models.financial_models import (
     RegulatoryActivity,
     RegulatoryEvent,
 )
+
+_sqlalchemy = pytest.importorskip("sqlalchemy")
+create_engine = _sqlalchemy.create_engine
+
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,0 +1,260 @@
+"""Unit tests for repository graph persistence helpers."""
+
+import pytest
+from sqlalchemy import create_engine
+
+from src.data.database import create_session_factory, init_db
+from src.data.repository import AssetGraphRepository
+from src.logic.asset_graph import AssetRelationshipGraph
+from src.models.financial_models import (
+    AssetClass,
+    Equity,
+    RegulatoryActivity,
+    RegulatoryEvent,
+)
+
+pytest.importorskip("sqlalchemy")
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def repository(tmp_path):
+    """Create an AssetGraphRepository backed by a temporary SQLite database."""
+    db_path = tmp_path / "graph_persistence.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    init_db(engine)
+    factory = create_session_factory(engine)
+    session = factory()
+    repo = AssetGraphRepository(session)
+    yield repo
+    session.close()
+    engine.dispose()
+
+
+def _equity(asset_id: str, symbol: str, sector: str = "Technology") -> Equity:
+    """Build a minimal equity asset for graph persistence tests."""
+    return Equity(
+        id=asset_id,
+        symbol=symbol,
+        name=f"{symbol} Equity",
+        asset_class=AssetClass.EQUITY,
+        sector=sector,
+        price=100.0,
+    )
+
+
+def _event(
+    event_id: str,
+    asset_id: str,
+    related_assets: list[str] | None = None,
+) -> RegulatoryEvent:
+    """Build a regulatory event for graph persistence tests."""
+    return RegulatoryEvent(
+        id=event_id,
+        asset_id=asset_id,
+        event_type=RegulatoryActivity.SEC_FILING,
+        date="2024-01-15",
+        description=f"{event_id} filing",
+        impact_score=0.5,
+        related_assets=related_assets or [],
+    )
+
+
+def _relationship_strength(
+    graph: AssetRelationshipGraph,
+    source_id: str,
+    target_id: str,
+    relationship_type: str,
+) -> float:
+    """Return the strength for one graph relationship."""
+    for target, rel_type, strength in graph.relationships.get(source_id, []):
+        if target == target_id and rel_type == relationship_type:
+            return strength
+    raise AssertionError(f"Missing relationship {source_id}->{target_id} ({relationship_type})")
+
+
+@pytest.mark.unit
+class TestGraphPersistenceRoundTrip:
+    """Test graph snapshot persistence and reconstruction."""
+
+    @staticmethod
+    def test_save_load_graph_round_trip_preserves_assets_relationships_and_events(
+        repository,
+    ) -> None:
+        """Save and load graph truth without deriving extra relationships."""
+        graph = AssetRelationshipGraph()
+        for asset in (
+            _equity("ASSET_A", "A"),
+            _equity("ASSET_B", "B"),
+            _equity("ASSET_C", "C"),
+        ):
+            graph.add_asset(asset)
+
+        graph.add_relationship("ASSET_A", "ASSET_B", "directed_alpha", 0.4)
+        graph.add_relationship("ASSET_B", "ASSET_A", "directed_alpha", 0.9)
+        graph.add_relationship("ASSET_A", "ASSET_C", "directed_beta", -0.2)
+        graph.add_regulatory_event(_event("EVENT_A", "ASSET_A", ["ASSET_C", "ASSET_B", "ASSET_B"]))
+
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        loaded = repository.load_graph()
+
+        assert set(loaded.assets) == {"ASSET_A", "ASSET_B", "ASSET_C"}
+        assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == 0.4
+        assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == 0.9
+        assert _relationship_strength(loaded, "ASSET_A", "ASSET_C", "directed_beta") == -0.2
+        assert "ASSET_C" not in loaded.relationships
+
+        assert len(loaded.regulatory_events) == 1
+        loaded_event = loaded.regulatory_events[0]
+        assert loaded_event.id == "EVENT_A"
+        assert loaded_event.related_assets == ["ASSET_B", "ASSET_C"]
+
+    @staticmethod
+    def test_save_graph_replaces_previous_snapshot_and_removes_stale_rows(
+        repository,
+    ) -> None:
+        """Save a smaller graph and remove rows absent from the new snapshot."""
+        first_graph = AssetRelationshipGraph()
+        for asset in (
+            _equity("KEEP", "KEEP"),
+            _equity("REMOVE", "REMOVE"),
+            _equity("RELATED", "RELATED"),
+        ):
+            first_graph.add_asset(asset)
+        first_graph.add_relationship("KEEP", "REMOVE", "old_edge", 0.6)
+        first_graph.add_regulatory_event(_event("OLD_EVENT", "REMOVE", ["KEEP"]))
+
+        repository.save_graph(first_graph)
+        repository.session.commit()
+
+        second_graph = AssetRelationshipGraph()
+        for asset in (_equity("KEEP", "KEEP"), _equity("RELATED", "RELATED")):
+            second_graph.add_asset(asset)
+        second_graph.add_relationship("KEEP", "RELATED", "new_edge", 0.7)
+        second_graph.add_regulatory_event(_event("NEW_EVENT", "KEEP", ["RELATED"]))
+
+        repository.save_graph(second_graph)
+        repository.session.commit()
+
+        loaded = repository.load_graph()
+        relationships = repository.list_relationships()
+        events = repository.list_regulatory_events()
+
+        assert set(loaded.assets) == {"KEEP", "RELATED"}
+        assert "REMOVE" not in loaded.assets
+        assert [(rel.source_id, rel.target_id, rel.relationship_type) for rel in relationships] == [
+            ("KEEP", "RELATED", "new_edge")
+        ]
+        assert all("REMOVE" not in {rel.source_id, rel.target_id} for rel in relationships)
+        assert [event.id for event in events] == ["NEW_EVENT"]
+        assert all(event.asset_id != "REMOVE" for event in events)
+
+    @staticmethod
+    def test_load_graph_expands_legacy_bidirectional_row_without_explicit_reverse(
+        repository,
+    ) -> None:
+        """Expand one legacy bidirectional row when no explicit reverse exists."""
+        repository.upsert_asset(_equity("LEGACY_A", "LA"))
+        repository.upsert_asset(_equity("LEGACY_B", "LB"))
+        repository.add_or_update_relationship(
+            "LEGACY_A",
+            "LEGACY_B",
+            "same_sector",
+            0.7,
+            bidirectional=True,
+        )
+        repository.session.commit()
+
+        loaded = repository.load_graph()
+
+        assert _relationship_strength(loaded, "LEGACY_A", "LEGACY_B", "same_sector") == 0.7
+        assert _relationship_strength(loaded, "LEGACY_B", "LEGACY_A", "same_sector") == 0.7
+
+    @staticmethod
+    def test_load_graph_preserves_explicit_reverse_strength_over_legacy_expansion(
+        repository,
+    ) -> None:
+        """Keep an explicit reverse row instead of synthesizing a duplicate."""
+        repository.upsert_asset(_equity("PAIR_A", "PA"))
+        repository.upsert_asset(_equity("PAIR_B", "PB"))
+        repository.add_or_update_relationship(
+            "PAIR_A",
+            "PAIR_B",
+            "same_sector",
+            0.7,
+            bidirectional=True,
+        )
+        repository.add_or_update_relationship(
+            "PAIR_B",
+            "PAIR_A",
+            "same_sector",
+            0.2,
+            bidirectional=False,
+        )
+        repository.session.commit()
+
+        loaded = repository.load_graph()
+
+        assert _relationship_strength(loaded, "PAIR_A", "PAIR_B", "same_sector") == 0.7
+        assert _relationship_strength(loaded, "PAIR_B", "PAIR_A", "same_sector") == 0.2
+        assert loaded.relationships["PAIR_A"].count(("PAIR_B", "same_sector", 0.7)) == 1
+        assert loaded.relationships["PAIR_B"].count(("PAIR_A", "same_sector", 0.2)) == 1
+
+        repository.save_graph(loaded)
+        repository.session.commit()
+
+        relationship_records = repository.list_relationships()
+        assert len(relationship_records) == 2
+        assert all(not record.bidirectional for record in relationship_records)
+        assert {
+            (record.source_id, record.target_id, record.relationship_type, record.strength)
+            for record in relationship_records
+        } == {
+            ("PAIR_A", "PAIR_B", "same_sector", 0.7),
+            ("PAIR_B", "PAIR_A", "same_sector", 0.2),
+        }
+
+    @staticmethod
+    def test_replace_regulatory_events_rejects_duplicate_ids_before_deleting_existing_rows(
+        repository,
+    ) -> None:
+        """Reject duplicate incoming event IDs before destructive replacement."""
+        repository.upsert_asset(_equity("EVENT_ASSET", "EA"))
+        repository.upsert_regulatory_event(_event("EXISTING_EVENT", "EVENT_ASSET"))
+        repository.session.commit()
+
+        with pytest.raises(ValueError, match="duplicate event IDs"):
+            repository.replace_regulatory_events(
+                [
+                    _event("DUP_EVENT", "EVENT_ASSET"),
+                    _event("DUP_EVENT", "EVENT_ASSET"),
+                ]
+            )
+
+        events = repository.list_regulatory_events()
+        assert [event.id for event in events] == ["EXISTING_EVENT"]
+        assert all(event.id != "DUP_EVENT" for event in events)
+
+    @staticmethod
+    def test_upsert_assets_reuses_created_orm_for_duplicate_incoming_ids(
+        repository,
+    ) -> None:
+        """Use one ORM row for duplicate incoming IDs and keep last value."""
+        first_asset = _equity("DUP_ASSET", "FIRST")
+        second_asset = _equity("DUP_ASSET", "SECOND", sector="Finance")
+        second_asset.price = 250.0
+        second_asset.name = "Second Equity"
+
+        repository.upsert_assets([first_asset, second_asset])
+        repository.session.commit()
+
+        assets = repository.list_assets()
+        assert len(assets) == 1
+        assert assets[0].id == "DUP_ASSET"
+        assert assets[0].symbol == "SECOND"
+        assert assets[0].name == "Second Equity"
+        assert assets[0].sector == "Finance"
+        assert assets[0].price == 250.0

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -12,9 +12,6 @@ from src.models.financial_models import (
     RegulatoryEvent,
 )
 
-_sqlalchemy = pytest.importorskip("sqlalchemy")
-create_engine = _sqlalchemy.create_engine
-
 
 pytestmark = pytest.mark.unit
 
@@ -25,6 +22,10 @@ def repository_factory(tmp_path):
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)
+_sqlalchemy = pytest.importorskip("sqlalchemy")
+create_engine = _sqlalchemy.create_engine
+
+
     factory = create_session_factory(engine)
     sessions = []
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -13,22 +13,28 @@ from src.models.financial_models import (
     RegulatoryEvent,
 )
 
-pytest.importorskip("sqlalchemy")
-
 pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
-def repository(tmp_path):
-    """Create an AssetGraphRepository backed by a temporary SQLite database."""
+def repository_factory(tmp_path):
+    """Create fresh repositories backed by one temporary SQLite database."""
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)
     factory = create_session_factory(engine)
-    session = factory()
-    repo = AssetGraphRepository(session)
-    yield repo
-    session.close()
+    sessions = []
+
+    def make_repository() -> AssetGraphRepository:
+        """Create a repository with a fresh SQLAlchemy session."""
+        session = factory()
+        sessions.append(session)
+        return AssetGraphRepository(session)
+
+    yield make_repository
+
+    for session in sessions:
+        session.close()
     engine.dispose()
 
 
@@ -74,15 +80,30 @@ def _relationship_strength(
     raise AssertionError(f"Missing relationship {source_id}->{target_id} ({relationship_type})")
 
 
+def _relationship_count(
+    graph: AssetRelationshipGraph,
+    source_id: str,
+    target_id: str,
+    relationship_type: str,
+) -> int:
+    """Return the number of matching graph relationships."""
+    return sum(
+        1
+        for target, rel_type, _ in graph.relationships.get(source_id, [])
+        if target == target_id and rel_type == relationship_type
+    )
+
+
 @pytest.mark.unit
 class TestGraphPersistenceRoundTrip:
     """Test graph snapshot persistence and reconstruction."""
 
     @staticmethod
     def test_save_load_graph_round_trip_preserves_assets_relationships_and_events(
-        repository,
+        repository_factory,
     ) -> None:
         """Save and load graph truth without deriving extra relationships."""
+        repository = repository_factory()
         graph = AssetRelationshipGraph()
         for asset in (
             _equity("ASSET_A", "A"),
@@ -99,24 +120,31 @@ class TestGraphPersistenceRoundTrip:
         repository.save_graph(graph)
         repository.session.commit()
 
-        loaded = repository.load_graph()
+        reader = repository_factory()
+        loaded = reader.load_graph()
 
         assert set(loaded.assets) == {"ASSET_A", "ASSET_B", "ASSET_C"}
-        assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == 0.4
-        assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == 0.9
-        assert _relationship_strength(loaded, "ASSET_A", "ASSET_C", "directed_beta") == -0.2
+        assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
+        assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == pytest.approx(0.9)
+        assert _relationship_strength(loaded, "ASSET_A", "ASSET_C", "directed_beta") == pytest.approx(-0.2)
         assert "ASSET_C" not in loaded.relationships
 
         assert len(loaded.regulatory_events) == 1
         loaded_event = loaded.regulatory_events[0]
         assert loaded_event.id == "EVENT_A"
+        assert loaded_event.asset_id == "ASSET_A"
+        assert loaded_event.event_type == RegulatoryActivity.SEC_FILING
+        assert loaded_event.date == "2024-01-15"
+        assert loaded_event.description == "EVENT_A filing"
+        assert loaded_event.impact_score == pytest.approx(0.5)
         assert loaded_event.related_assets == ["ASSET_B", "ASSET_C"]
 
     @staticmethod
     def test_save_graph_replaces_previous_snapshot_and_removes_stale_rows(
-        repository,
+        repository_factory,
     ) -> None:
         """Save a smaller graph and remove rows absent from the new snapshot."""
+        repository = repository_factory()
         first_graph = AssetRelationshipGraph()
         for asset in (
             _equity("KEEP", "KEEP"),
@@ -139,9 +167,10 @@ class TestGraphPersistenceRoundTrip:
         repository.save_graph(second_graph)
         repository.session.commit()
 
-        loaded = repository.load_graph()
-        relationships = repository.list_relationships()
-        events = repository.list_regulatory_events()
+        reader = repository_factory()
+        loaded = reader.load_graph()
+        relationships = reader.list_relationships()
+        events = reader.list_regulatory_events()
 
         assert set(loaded.assets) == {"KEEP", "RELATED"}
         assert "REMOVE" not in loaded.assets
@@ -154,9 +183,10 @@ class TestGraphPersistenceRoundTrip:
 
     @staticmethod
     def test_load_graph_expands_legacy_bidirectional_row_without_explicit_reverse(
-        repository,
+        repository_factory,
     ) -> None:
         """Expand one legacy bidirectional row when no explicit reverse exists."""
+        repository = repository_factory()
         repository.upsert_asset(_equity("LEGACY_A", "LA"))
         repository.upsert_asset(_equity("LEGACY_B", "LB"))
         repository.add_or_update_relationship(
@@ -168,16 +198,18 @@ class TestGraphPersistenceRoundTrip:
         )
         repository.session.commit()
 
-        loaded = repository.load_graph()
+        reader = repository_factory()
+        loaded = reader.load_graph()
 
-        assert _relationship_strength(loaded, "LEGACY_A", "LEGACY_B", "same_sector") == 0.7
-        assert _relationship_strength(loaded, "LEGACY_B", "LEGACY_A", "same_sector") == 0.7
+        assert _relationship_strength(loaded, "LEGACY_A", "LEGACY_B", "same_sector") == pytest.approx(0.7)
+        assert _relationship_strength(loaded, "LEGACY_B", "LEGACY_A", "same_sector") == pytest.approx(0.7)
 
     @staticmethod
     def test_load_graph_preserves_explicit_reverse_strength_over_legacy_expansion(
-        repository,
+        repository_factory,
     ) -> None:
         """Keep an explicit reverse row instead of synthesizing a duplicate."""
+        repository = repository_factory()
         repository.upsert_asset(_equity("PAIR_A", "PA"))
         repository.upsert_asset(_equity("PAIR_B", "PB"))
         repository.add_or_update_relationship(
@@ -196,32 +228,45 @@ class TestGraphPersistenceRoundTrip:
         )
         repository.session.commit()
 
-        loaded = repository.load_graph()
+        reader = repository_factory()
+        loaded = reader.load_graph()
 
-        assert _relationship_strength(loaded, "PAIR_A", "PAIR_B", "same_sector") == 0.7
-        assert _relationship_strength(loaded, "PAIR_B", "PAIR_A", "same_sector") == 0.2
-        assert loaded.relationships["PAIR_A"].count(("PAIR_B", "same_sector", 0.7)) == 1
-        assert loaded.relationships["PAIR_B"].count(("PAIR_A", "same_sector", 0.2)) == 1
+        assert _relationship_count(loaded, "PAIR_A", "PAIR_B", "same_sector") == 1
+        assert _relationship_count(loaded, "PAIR_B", "PAIR_A", "same_sector") == 1
+        assert _relationship_strength(loaded, "PAIR_A", "PAIR_B", "same_sector") == pytest.approx(0.7)
+        assert _relationship_strength(loaded, "PAIR_B", "PAIR_A", "same_sector") == pytest.approx(0.2)
 
-        repository.save_graph(loaded)
-        repository.session.commit()
+        normalizer = repository_factory()
+        normalizer.save_graph(loaded)
+        normalizer.session.commit()
 
-        relationship_records = repository.list_relationships()
+        verifier = repository_factory()
+        relationship_records = verifier.list_relationships()
         assert len(relationship_records) == 2
         assert all(not record.bidirectional for record in relationship_records)
-        assert {
-            (record.source_id, record.target_id, record.relationship_type, record.strength)
+        persisted_strengths = {
+            (record.source_id, record.target_id, record.relationship_type): record.strength
             for record in relationship_records
-        } == {
-            ("PAIR_A", "PAIR_B", "same_sector", 0.7),
-            ("PAIR_B", "PAIR_A", "same_sector", 0.2),
         }
+        assert persisted_strengths.keys() == {
+            ("PAIR_A", "PAIR_B", "same_sector"),
+            ("PAIR_B", "PAIR_A", "same_sector"),
+        }
+        assert persisted_strengths[("PAIR_A", "PAIR_B", "same_sector")] == pytest.approx(0.7)
+        assert persisted_strengths[("PAIR_B", "PAIR_A", "same_sector")] == pytest.approx(0.2)
+
+        reloaded = verifier.load_graph()
+        assert _relationship_count(reloaded, "PAIR_A", "PAIR_B", "same_sector") == 1
+        assert _relationship_count(reloaded, "PAIR_B", "PAIR_A", "same_sector") == 1
+        assert _relationship_strength(reloaded, "PAIR_A", "PAIR_B", "same_sector") == pytest.approx(0.7)
+        assert _relationship_strength(reloaded, "PAIR_B", "PAIR_A", "same_sector") == pytest.approx(0.2)
 
     @staticmethod
     def test_replace_regulatory_events_rejects_duplicate_ids_before_deleting_existing_rows(
-        repository,
+        repository_factory,
     ) -> None:
         """Reject duplicate incoming event IDs before destructive replacement."""
+        repository = repository_factory()
         repository.upsert_asset(_equity("EVENT_ASSET", "EA"))
         repository.upsert_regulatory_event(_event("EXISTING_EVENT", "EVENT_ASSET"))
         repository.session.commit()
@@ -230,6 +275,7 @@ class TestGraphPersistenceRoundTrip:
             repository.replace_regulatory_events(
                 [
                     _event("DUP_EVENT", "EVENT_ASSET"),
+                    _event("OTHER_EVENT", "EVENT_ASSET"),
                     _event("DUP_EVENT", "EVENT_ASSET"),
                 ]
             )
@@ -240,9 +286,10 @@ class TestGraphPersistenceRoundTrip:
 
     @staticmethod
     def test_upsert_assets_reuses_created_orm_for_duplicate_incoming_ids(
-        repository,
+        repository_factory,
     ) -> None:
         """Use one ORM row for duplicate incoming IDs and keep last value."""
+        repository = repository_factory()
         first_asset = _equity("DUP_ASSET", "FIRST")
         second_asset = _equity("DUP_ASSET", "SECOND", sector="Finance")
         second_asset.price = 250.0
@@ -257,4 +304,4 @@ class TestGraphPersistenceRoundTrip:
         assert assets[0].symbol == "SECOND"
         assert assets[0].name == "Second Equity"
         assert assets[0].sector == "Finance"
-        assert assets[0].price == 250.0
+        assert assets[0].price == pytest.approx(250.0)


### PR DESCRIPTION
## **User description**
## Summary
- Adds focused unit coverage for the graph persistence repository contract merged in #1114.
- Verifies graph -> DB -> graph round-trip behavior for assets, directed relationships, and regulatory events.
- Locks snapshot replacement behavior so stale assets, relationships, and regulatory events do not reappear after reload.
- Covers legacy bidirectional row handling and explicit reverse-row strength preservation.

## Scope
This is a tests-only follow-up to #1114.

In scope:
- repository-level graph persistence round-trip tests;
- snapshot stale-row removal tests;
- legacy bidirectional relationship reconstruction tests;
- regulatory-event duplicate-ID validation coverage;
- duplicate incoming asset ID coverage for `upsert_assets()`.

Out of scope:
- no repository logic changes;
- no schema or migration changes;
- no API/startup integration;
- no hosted deployment changes;
- no layout/visualization persistence;
- no Issue #1028 tracker changes.

## Validation
```bash
python -m pytest tests/unit/test_repository_graph_persistence.py -q
python -m pytest tests/unit/test_repository.py tests/unit/test_repository_comprehensive.py tests/unit/test_repository_graph_persistence.py -q
python -m pre_commit run --files tests/unit/test_repository_graph_persistence.py
```

Attempted but inconclusive:

```bash
python -m pytest tests/unit -q
```

The full unit command collected 2119 tests and then stopped producing output in this environment; no pytest/python process was visible afterward, so I did not treat it as passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add unit tests for graph -> DB -> graph round trips covering assets, relationships, and regulatory events.

Tests enforce snapshot stale-row removal, normalize legacy bidirectional rows without duplicating explicit reverse strengths, dedupe regulatory-event related_assets on reload, reject duplicate regulatory-event IDs before replace, apply last-write-wins for duplicate asset IDs in `upsert_assets()`, auto-skip when `sqlalchemy` is unavailable, and include formatting fixes.

<sup>Written for commit 24a1dd1ac7e17c629ca13f56a00a20993b29fd20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Strengthen graph persistence contract coverage

### What Changed
- Adds tests that save and reload a graph to confirm assets, relationships, and regulatory events come back intact.
- Verifies saving a new snapshot removes stale assets, relationships, and events instead of keeping removed data.
- Checks legacy two-way relationships load correctly, while preserving a real reverse relationship when both directions exist.
- Confirms duplicate regulatory event IDs are rejected before replacing existing records, and duplicate asset IDs keep the latest values.

### Impact
`✅ Safer graph reloads`
`✅ Fewer stale records after snapshot updates`
`✅ Clearer duplicate-data handling` 


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=1KA8d9z58fLFxc7zyoNQrP96pkoe0fcySLqmpEkPBVs&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
