### PR TITLE
Add issue #1021 bond YTM regression coverage

### DIFF
--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/unit/test_formulaic_regressions.py
+++ b/tests/unit/test_formulaic_regressions.py
@@ -7,7 +7,7 @@ import pytest
 from src.analysis.formulaic_analysis import FormulaicAnalyzer
 from src.analysis.formulaic_examples import calculate_dividend_examples, calculate_pb_examples
 from src.logic.asset_graph import AssetRelationshipGraph
-from src.models.financial_models import AssetClass
+from src.models.financial_models import AssetClass, Bond
 
 
 @pytest.mark.unit
@@ -70,3 +70,32 @@ def test_calculate_pb_examples_skips_assets_without_price() -> None:
     graph.assets = {"MISS": malformed_asset}
 
     assert calculate_pb_examples(graph).startswith("Example:")
+
+
+@pytest.mark.unit
+def test_issue_1021_bond_heavy_portfolio_includes_ytm_formula() -> None:
+    """Fixed-income portfolios should expose YTM in formulaic analysis."""
+    graph = AssetRelationshipGraph()
+    for bond_id, symbol, ytm in (
+        ("BOND_A", "BNDA", 0.045),
+        ("BOND_B", "BNDB", 0.0375),
+        ("BOND_C", "BNDC", 0.052),
+    ):
+        graph.add_asset(
+            Bond(
+                id=bond_id,
+                symbol=symbol,
+                name=f"{symbol} Corporate Bond",
+                asset_class=AssetClass.FIXED_INCOME,
+                sector="Corporate",
+                price=100.0,
+                yield_to_maturity=ytm,
+            )
+        )
+
+    result = FormulaicAnalyzer().analyze_graph(graph)
+    ytm_formula = next(formula for formula in result["formulas"] if formula.name == "Yield-to-Maturity")
+
+    assert ytm_formula.category == "Income"
+    assert ytm_formula.example_calculation == "BNDA: YTM ≈ 4.50%; BNDB: YTM ≈ 3.75%"
+    assert result["categories"]["Income"] >= 1


### PR DESCRIPTION
## **User description**
## Primary Objective

Add a clean, issue-scoped regression guard for the Bond Yield-to-Maturity behavior requested in issue #1021.

## Issue Review

Issue #1021 asks for fixed-income graphs to display Yield-to-Maturity (YTM) relationship data again after the YTM handling in `src/analysis/formulaic_analysis.py` had regressed to a TODO.

Current `main` already contains the runtime YTM restoration:

- `FormulaicAnalyzer._extract_fundamental_formulas()` adds `Yield-to-Maturity` when `has_bonds(graph)` is true.
- `_yield_to_maturity_formula()` builds the YTM formula metadata.
- `calculate_ytm_examples(graph)` provides bond-symbol examples and percentage formatting.

This PR is therefore intentionally limited to a regression test that locks the issue #1021 behavior through the public analyzer path.

## In Scope

- Add one regression test in `tests/unit/test_formulaic_regressions.py`.
- Build a bond-heavy fixed-income graph.
- Assert `FormulaicAnalyzer().analyze_graph(graph)` includes `Yield-to-Maturity`.
- Assert the formula is categorized as `Income`.
- Assert the example calculation includes the first two bond YTM examples with deterministic percentage formatting.

## Out of Scope

- No production logic changes.
- No changes to `src/analysis/formulaic_analysis.py`.
- No changes to `src/analysis/formulaic_examples.py`.
- No API, frontend, persistence, deployment, dependency, or documentation changes.
- No hosted-readiness workflow changes.
- No broad mypy/type cleanup in existing formulaic example helpers.

## Files Expected to Change

- `tests/unit/test_formulaic_regressions.py`

## Validation Commands

```bash
python -m pytest tests/unit/test_formulaic_regressions.py -q
python -m pytest tests/unit/test_formulaic_analysis.py tests/unit/test_formulaic_regressions.py -q
python -m pre_commit run --files tests/unit/test_formulaic_regressions.py
```

Validation result:

- `python -m pytest tests/unit/test_formulaic_regressions.py -q` passed: 5 passed.
- `python -m pytest tests/unit/test_formulaic_analysis.py tests/unit/test_formulaic_regressions.py -q` passed: 86 passed.
- `python -m pre_commit run --files tests/unit/test_formulaic_regressions.py` passed trim/end-of-file/checks, Black, Ruff, and flake8. It fails at the existing mypy hook due to pre-existing typing errors in `src/analysis/formulaic_examples.py`, which this test-only PR does not change.

## Merge Criteria

- The changed-file diff remains limited to `tests/unit/test_formulaic_regressions.py`.
- The targeted pytest commands pass.
- Reviewers agree existing `src/analysis/formulaic_examples.py` mypy findings remain out of scope for this issue #1021 regression-test PR.

Refs #1021.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test to lock Yield-to-Maturity for bond-heavy portfolios via the public `FormulaicAnalyzer`, ensuring the formula appears under Income with deterministic examples (refs #1021). Also applies automated style formatting; no production code changes.

<sup>Written for commit cbef2b2fbc28bb94106bfb30ada310128ede0c16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add regression coverage for bond yield-to-maturity in formula analysis**

### What Changed
- Added a regression test that verifies bond-heavy portfolios include the Yield-to-Maturity formula again.
- The test checks that YTM appears under Income and that bond examples are shown with percentage formatting.
- Updated existing workflow tests only for formatting; no user-facing behavior changed there.

### Impact
`✅ Fewer bond analysis regressions`
`✅ Clearer fixed-income formula results`
`✅ Safer YTM coverage for future changes`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=ensAgA8KvKNO3YR6ygx-Gntaqtk-bPYU3_wxTjqA81Y&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
