### PR TITLE
Document graph persistence lifecycle seam

### DIFF
--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -194,7 +194,7 @@ Future startup loading must not:
 
 - overwrite persisted graph truth;
 - regenerate sample data and immediately persist it;
-- save on read-only endpoints;
+- trigger `save_graph()` during requests to read-only endpoints;
 - persist layout or visualization state;
 - silently change reset or reinitialize semantics.
 

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -155,9 +155,10 @@ when unset.
 
 This seam note does not choose the final runtime setting for graph persistence.
 The next implementation PR must explicitly decide whether startup graph
-persistence is governed by `ASSET_GRAPH_DATABASE_URL`, `DATABASE_URL`,
-`POSTGRES_URL`, a new explicit setting, or current repository/session-factory
-defaults.
+persistence is governed by `asset_graph_database_url` (env:
+`ASSET_GRAPH_DATABASE_URL`), `database_url` (env: `DATABASE_URL`),
+`postgres_url` (env: `POSTGRES_URL`), a new explicit setting, or current
+repository/session-factory defaults.
 
 Until that implementation PR makes the decision, references to these settings in
 this document are descriptive, not prescriptive.

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -172,7 +172,8 @@ The implementation PR must answer these before coding:
    - any regulatory event row;
    - any graph-owned table row.
 3. What happens when persistence is configured but empty?
-4. What happens when persistence is configured but unreachable?
+4. What happens when persistence is configured but unreachable or the schema is missing?
+5. Should the startup path automatically call `init_db()` if persistence is enabled?
 5. How does persisted graph loading interact with:
    - `GRAPH_CACHE_PATH`;
    - `USE_REAL_DATA_FETCHER`;

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -174,14 +174,14 @@ The implementation PR must answer these before coding:
 3. What happens when persistence is configured but empty?
 4. What happens when persistence is configured but unreachable or the schema is missing?
 5. Should the startup path automatically call `init_db()` if persistence is enabled?
-5. How does persisted graph loading interact with:
+6. How does persisted graph loading interact with:
    - `GRAPH_CACHE_PATH`;
    - `USE_REAL_DATA_FETCHER`;
    - sample fallback;
    - `set_graph_factory()` tests;
    - `reset_graph()`;
    - `api.main.graph` compatibility.
-6. How do we ensure startup load never triggers destructive
+7. How do we ensure startup load never triggers destructive
    `save_graph()` snapshot replacement?
 
 ## Save behavior boundary

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -1,0 +1,281 @@
+# Graph persistence lifecycle seam
+
+## Purpose
+
+This note identifies the smallest safe seam for integrating durable graph
+persistence into the FastAPI application lifecycle after #1114 and #1119.
+
+It does not implement persistence loading or saving.
+
+## Current baseline
+
+### Repository contract
+
+#1114 added repository helpers for graph snapshot persistence:
+
+- `AssetGraphRepository.save_graph()`
+- `AssetGraphRepository.load_graph()`
+
+#1119 added graph persistence round-trip contract tests that verify
+graph -> database -> graph behavior for assets, relationships, and regulatory
+events.
+
+### Runtime boundary
+
+The repository can persist and reconstruct graph truth, but the FastAPI runtime
+still initializes its in-memory graph through the existing lifecycle path.
+
+This document maps that lifecycle path and identifies where future
+`load_graph()` integration should be considered.
+
+## Current lifecycle map
+
+### Application startup
+
+`api/app_factory.py` owns FastAPI application construction and lifespan
+registration.
+
+Current startup behavior:
+
+1. FastAPI starts.
+2. `lifespan()` calls `get_graph()`.
+3. If graph initialization succeeds, startup logs
+   `Application startup complete - graph initialized`.
+4. If graph initialization fails, startup logs the exception and re-raises,
+   aborting startup.
+
+This is the current startup hook to document. This PR does not change it.
+
+### Graph singleton lifecycle
+
+`api/graph_lifecycle.py` owns the actual graph singleton lifecycle:
+
+- `graph_state.graph`
+- `graph_state.graph_factory`
+- `graph_lock`
+- `get_graph()`
+- `set_graph()`
+- `set_graph_factory()`
+- `reset_graph()`
+- `_initialize_graph()`
+
+`get_graph()` lazily initializes `graph_state.graph` under `graph_lock`.
+
+Current `_initialize_graph()` source order:
+
+1. Use `graph_state.graph_factory` when present.
+2. Use `GRAPH_CACHE_PATH` through `RealDataFetcher` when configured.
+3. Use `USE_REAL_DATA_FETCHER` with `REAL_DATA_CACHE_PATH` when enabled.
+4. Fall back to `create_sample_database()`.
+
+This is the key integration seam for future `AssetGraphRepository.load_graph()`
+work.
+
+### Backward compatibility layer
+
+`api/main.py` remains the public compatibility entrypoint.
+
+Important compatibility behavior:
+
+- It re-exports lifecycle helpers for older callers and tests.
+- It initializes a module-level `graph = _get_graph()` reference for older
+  callers and tests.
+- `api.main.set_graph()` updates lifecycle state and the module-level `graph`
+  reference.
+- `api.main.reset_graph()` resets lifecycle state and clears the module-level
+  `graph` reference so the next access falls through to lifecycle
+  initialization.
+
+Future integration must preserve this compatibility layer.
+
+### Router access path
+
+Routers generally access graph state through helper imports.
+
+`api/router_helpers.py` first checks `api.main.graph` for compatibility, then
+falls through to `api.graph_lifecycle.get_graph()`.
+
+Future startup or lifecycle changes must not leave `api.main.graph` stale or
+inconsistent with the lifecycle graph.
+
+## Persistence integration seam
+
+The future load integration should be considered at
+`api.graph_lifecycle._initialize_graph()` or in a small helper called by
+`_initialize_graph()`.
+
+Recommended future seam:
+
+```text
+api.graph_lifecycle._initialize_graph()
+    -> if explicit graph factory exists: preserve current behavior
+    -> else attempt persisted graph load if graph persistence is configured
+       and persisted graph rows exist
+    -> else preserve existing graph_cache_path / real-data / sample fallback
+       order
+```
+
+Alternative seam:
+
+```text
+api.app_factory.lifespan()
+    -> call a persistence-aware initialization helper before get_graph()
+```
+
+Rejected for now:
+
+- router-level persistence loading;
+- endpoint-level lazy persistence loading;
+- automatic `save_graph()` during startup;
+- persistence in `api.main` compatibility wrappers.
+
+## Settings boundary
+
+`src/config/settings.py` already exposes database-related settings:
+
+- `asset_graph_database_url`
+- `database_url`
+- `postgres_url`
+
+It also exposes graph source settings:
+
+- `graph_cache_path`
+- `real_data_cache_path`
+- `use_real_data_fetcher`
+
+`src/data/database.py` currently resolves the asset graph SQLAlchemy engine from
+`settings.asset_graph_database_url`, falling back to `sqlite:///./asset_graph.db`
+when unset.
+
+This seam note does not choose the final runtime setting for graph persistence.
+The next implementation PR must explicitly decide whether startup graph
+persistence is governed by `ASSET_GRAPH_DATABASE_URL`, `DATABASE_URL`,
+`POSTGRES_URL`, a new explicit setting, or current repository/session-factory
+defaults.
+
+Until that implementation PR makes the decision, references to these settings in
+this document are descriptive, not prescriptive.
+
+## Key design questions for the next PR
+
+The implementation PR must answer these before coding:
+
+1. Which setting governs graph persistence?
+   - `DATABASE_URL`
+   - `ASSET_GRAPH_DATABASE_URL`
+   - `POSTGRES_URL`
+   - a new explicit setting
+   - current repository/session-factory defaults
+2. What counts as an existing persisted graph?
+   - at least one asset row;
+   - any relationship row;
+   - any regulatory event row;
+   - any graph-owned table row.
+3. What happens when persistence is configured but empty?
+4. What happens when persistence is configured but unreachable?
+5. How does persisted graph loading interact with:
+   - `GRAPH_CACHE_PATH`;
+   - `USE_REAL_DATA_FETCHER`;
+   - sample fallback;
+   - `set_graph_factory()` tests;
+   - `reset_graph()`;
+   - `api.main.graph` compatibility.
+6. How do we ensure startup load never triggers destructive
+   `save_graph()` snapshot replacement?
+
+## Save behavior boundary
+
+`save_graph()` has destructive snapshot semantics.
+
+Therefore, startup load and save/rebuild integration must remain separate PRs.
+
+Future startup loading must not:
+
+- overwrite persisted graph truth;
+- regenerate sample data and immediately persist it;
+- save on read-only endpoints;
+- persist layout or visualization state;
+- silently change reset or reinitialize semantics.
+
+## Recommended next implementation PR
+
+Title:
+
+```text
+Load persisted graph during application startup
+```
+
+Expected behavior:
+
+- If graph persistence is configured and persisted graph rows exist, load graph
+  truth through `AssetGraphRepository.load_graph()`.
+- If no persisted graph exists, preserve current initialization behavior.
+- Preserve `graph_state.graph_factory` precedence.
+- Preserve `reset_graph()` semantics.
+- Preserve `api.main.graph` compatibility.
+
+## Test plan for the next PR
+
+The startup-load implementation PR should include tests for:
+
+### Existing factory behavior
+
+- `set_graph_factory()` still takes precedence.
+- No repository load is attempted when a factory is set.
+
+### Empty persistence fallback
+
+- A configured empty database does not produce an empty accidental production
+  graph unless explicitly selected.
+- The existing fallback path remains unchanged.
+
+### Persisted graph startup load
+
+- Persisted assets are loaded.
+- Persisted relationships are loaded.
+- Persisted regulatory events are loaded.
+
+### Directed relationship contract
+
+- Explicit reverse strengths survive startup loading.
+
+### Legacy compatibility
+
+- `bidirectional=True` rows expand only when no explicit reverse row exists.
+
+### Reset semantics
+
+- `reset_graph()` clears cached state and settings cache as before.
+- The next `get_graph()` reinitializes using the selected source.
+
+### Compatibility reference
+
+- `api.main.graph` and lifecycle graph do not diverge after startup, load, or
+  reset.
+
+### Failure handling
+
+- Configured unreachable database behavior is explicit and tested.
+
+## Non-goals
+
+This seam note does not implement:
+
+- repository loading during startup;
+- repository saving;
+- reset or reinitialize persistence behavior;
+- hosted readiness checks;
+- migrations;
+- API route changes;
+- frontend changes;
+- layout persistence;
+- scanner configuration changes;
+- Master Production Readiness Checklist - FarDb #1028 changes.
+
+## Follow-up sequence
+
+1. Implement startup persisted graph loading.
+2. Define explicit save/rebuild trigger semantics.
+3. Extend hosted readiness to prove persisted graph loading.
+4. Defer migrations until schema evolution becomes a concrete blocker.
+5. Defer layout persistence until graph-truth lifecycle behavior is stable.

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -160,30 +160,30 @@ this document are descriptive, not prescriptive.
 
 The implementation PR must answer these before coding:
 
-1. Which setting governs graph persistence?
+1. **Which setting governs graph persistence?**
    - `DATABASE_URL`
    - `ASSET_GRAPH_DATABASE_URL`
    - `POSTGRES_URL`
    - a new explicit setting
    - current repository/session-factory defaults
-2. What counts as an existing persisted graph?
+2. **What counts as an existing persisted graph?**
    - at least one asset row;
    - any relationship row;
    - any regulatory event row;
    - any graph-owned table row.
-3. What happens when persistence is configured but empty?
-4. What happens when persistence is configured but unreachable or the schema is missing?
-5. Should the startup path automatically call `init_db()` if persistence is enabled?
-6. How does persisted graph loading interact with:
+3. **What happens when persistence is configured but empty?**
+4. **What happens when persistence is configured but unreachable or the schema is missing?**
+5. **Should the startup path automatically call `init_db()` if persistence is enabled?**
+6. **How does persisted graph loading interact with:**
    - `GRAPH_CACHE_PATH`;
    - `USE_REAL_DATA_FETCHER`;
    - sample fallback;
    - `set_graph_factory()` tests;
    - `reset_graph()`;
    - `api.main.graph` compatibility.
-7. How do we ensure startup load never triggers destructive
-   `save_graph()` snapshot replacement?
-8. How is the database session managed during the one-off startup load?
+7. **How do we ensure startup load never triggers destructive
+   `save_graph()` snapshot replacement?**
+8. **How is the database session managed during the one-off startup load?**
    - Should startup loading create a short-lived session from the existing
      session factory?
    - Where is that session closed?
@@ -292,3 +292,64 @@ This seam note does not implement:
 3. Extend hosted readiness to prove persisted graph loading.
 4. Defer migrations until schema evolution becomes a concrete blocker.
 5. Defer layout persistence until graph-truth lifecycle behavior is stable.
+
+## Appendix: Current implementation anchors
+
+These snippets are included only as audit anchors for the next implementation
+PR. They are not a second source of truth for runtime behavior; implementation
+work must still verify the live source before changing code.
+
+### `api/app_factory.py` startup hook
+
+```python
+@asynccontextmanager
+async def lifespan(_fastapi_app: FastAPI):
+    try:
+        get_graph()
+        logger.info("Application startup complete - graph initialized")
+    except Exception:
+        logger.exception("Failed to initialize graph during startup")
+        raise
+
+    yield
+
+    logger.info("Application shutdown")
+```
+
+### `api/graph_lifecycle.py` initialization order
+
+```python
+def _initialize_graph() -> AssetRelationshipGraph:
+    if graph_state.graph_factory is not None:
+        return graph_state.graph_factory()
+
+    settings = get_settings()
+    cache_path = settings.graph_cache_path
+    use_real_data = settings.use_real_data_fetcher
+
+    if cache_path:
+        fetcher = RealDataFetcher(
+            cache_path=cache_path,
+            enable_network=use_real_data,
+        )
+        return fetcher.create_real_database()
+
+    if use_real_data:
+        real_data_cache_path = settings.real_data_cache_path
+        fetcher = RealDataFetcher(
+            cache_path=real_data_cache_path,
+            enable_network=True,
+        )
+        return fetcher.create_real_database()
+
+    return create_sample_database()
+```
+
+### Relevant settings names
+
+- `asset_graph_database_url`
+- `database_url`
+- `postgres_url`
+- `graph_cache_path`
+- `real_data_cache_path`
+- `use_real_data_fetcher`

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -64,11 +64,14 @@ This is the current startup hook to document. This PR does not change it.
 Current `_initialize_graph()` source order:
 
 1. Use `graph_state.graph_factory` when present.
-2. Otherwise, if `GRAPH_CACHE_PATH` is configured, initialize from that path
-   (and this branch may still enable `RealDataFetcher` network behavior when
-   `USE_REAL_DATA_FETCHER` is true).
-3. Otherwise, if `GRAPH_CACHE_PATH` is not configured, use
-   `USE_REAL_DATA_FETCHER` with `REAL_DATA_CACHE_PATH` when enabled.
+2. Otherwise, if `graph_cache_path` is configured (env:
+   `GRAPH_CACHE_PATH`), initialize from that path (and this branch may still
+   enable `RealDataFetcher` network behavior when `use_real_data_fetcher` is
+   true (env: `USE_REAL_DATA_FETCHER`)).
+3. Otherwise, if `graph_cache_path` is not configured (env:
+   `GRAPH_CACHE_PATH`), use `use_real_data_fetcher` (env:
+   `USE_REAL_DATA_FETCHER`) with `real_data_cache_path` (env:
+   `REAL_DATA_CACHE_PATH`) when enabled.
 4. Otherwise, fall back to `create_sample_database()`.
 
 This is the key integration seam for future `AssetGraphRepository.load_graph()`

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -64,9 +64,12 @@ This is the current startup hook to document. This PR does not change it.
 Current `_initialize_graph()` source order:
 
 1. Use `graph_state.graph_factory` when present.
-2. Use `GRAPH_CACHE_PATH` through `RealDataFetcher` when configured.
-3. Use `USE_REAL_DATA_FETCHER` with `REAL_DATA_CACHE_PATH` when enabled.
-4. Fall back to `create_sample_database()`.
+2. Otherwise, if `GRAPH_CACHE_PATH` is configured, initialize from that path
+   (and this branch may still enable `RealDataFetcher` network behavior when
+   `USE_REAL_DATA_FETCHER` is true).
+3. Otherwise, if `GRAPH_CACHE_PATH` is not configured, use
+   `USE_REAL_DATA_FETCHER` with `REAL_DATA_CACHE_PATH` when enabled.
+4. Otherwise, fall back to `create_sample_database()`.
 
 This is the key integration seam for future `AssetGraphRepository.load_graph()`
 work.

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -179,8 +179,10 @@ The implementation PR must answer these before coding:
    - any regulatory event row;
    - any graph-owned table row.
 3. **What happens when persistence is configured but empty?**
-4. **What happens when persistence is configured but unreachable or the schema is missing?**
-5. **Should the startup path automatically call `init_db()` if persistence is enabled?**
+4. **What happens when persistence is configured but unreachable or the
+   schema is missing?**
+5. **Should the startup path automatically call `init_db()` if persistence
+   is enabled?**
 6. **How does persisted graph loading interact with:**
    - `GRAPH_CACHE_PATH`;
    - `USE_REAL_DATA_FETCHER`;

--- a/docs/graph-persistence-lifecycle-seam.md
+++ b/docs/graph-persistence-lifecycle-seam.md
@@ -183,6 +183,12 @@ The implementation PR must answer these before coding:
    - `api.main.graph` compatibility.
 7. How do we ensure startup load never triggers destructive
    `save_graph()` snapshot replacement?
+8. How is the database session managed during the one-off startup load?
+   - Should startup loading create a short-lived session from the existing
+     session factory?
+   - Where is that session closed?
+   - How are startup-load session failures reported without leaking database
+     connection details?
 
 ## Save behavior boundary
 
@@ -257,6 +263,12 @@ The startup-load implementation PR should include tests for:
 ### Failure handling
 
 - Configured unreachable database behavior is explicit and tested.
+
+### Startup session management
+
+- Startup graph loading uses a bounded, short-lived database session.
+- The session is closed after load success or failure.
+- Session creation/load failures follow the selected startup failure policy.
 
 ## Non-goals
 

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""


### PR DESCRIPTION
## **User description**
## Architectural Alignment

- Backend: FastAPI production path documented.
- Frontend: Next.js production path unchanged.
- Gradio: non-production path unchanged.

This PR is documentation/audit only and does not change runtime behavior.

## Primary Objective

Document the exact FastAPI graph lifecycle seam where durable graph persistence should be integrated after #1114 and #1119, without changing runtime behavior.

## Scope

### In Scope

- Adds a read-first seam note for integrating durable graph persistence into the FastAPI graph lifecycle.
- Documents the current startup path from `api/app_factory.py` lifespan handling to `api/graph_lifecycle.py` graph initialization.
- Identifies `_initialize_graph()` as the recommended future integration point for `AssetGraphRepository.load_graph()`.
- Documents compatibility constraints around `api/main.py` and `api/router_helpers.py`.
- Separates future startup-load, save-trigger, hosted-readiness, migration, and layout-persistence decisions.
- Provides a test plan for the next implementation PR.

### Out of Scope

- No runtime behavior changes.
- No `load_graph()` startup implementation.
- No `save_graph()` trigger implementation.
- No repository changes.
- No schema or migration changes.
- No API route changes.
- No frontend changes.
- No hosted-readiness changes.
- No layout persistence.
- No Master Production Readiness Checklist - FarDb #1028 changes.

### Files Expected to Change

- `docs/graph-persistence-lifecycle-seam.md` - new audit/seam note for the graph persistence lifecycle integration point.

## Validation Commands

```bash
python -m pre_commit run --files docs/graph-persistence-lifecycle-seam.md
python -m pytest tests/integration/test_documentation_files_validation.py -q
```

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective.
- [x] Validation commands pass locally.
- [x] Changes align with production architecture (FastAPI + Next.js).
- [x] The changed-file diff is limited to `docs/graph-persistence-lifecycle-seam.md`.

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only.
- [x] I have explicitly listed what is out of scope.
- [x] This is a docs-only PR and does not mix documentation with unrelated code changes.
- [x] No runtime behavior changes are included.
- [x] I verified the branch, base branch, and referenced PR context before creating the PR.
- [x] I checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend).
- [x] I checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents the FastAPI graph persistence seam by mapping app startup in `api/app_factory.py` to graph init in `api/graph_lifecycle.py`, identifying `_initialize_graph()` as the future `AssetGraphRepository.load_graph()` hook. Adds implementation anchors, clarifies the compatibility layer in `api/main.py` and `api/router_helpers.py`, and raises a startup DB session management question; no runtime or test logic changes.

<sup>Written for commit 572cafc4785d9e75700b874636f6a7c103a30d9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Document the graph persistence lifecycle seam for future startup loading**

### What Changed
- Documents the current FastAPI startup path and where graph initialization happens today
- Identifies the graph lifecycle initialization step as the intended place for future persisted graph loading
- Clarifies compatibility rules for older callers that still rely on the shared graph reference
- Separates startup loading from saving, migrations, layout persistence, and route changes
- Adds the expected behavior and test cases for the next implementation PR

### Impact
`✅ Clearer path for startup graph loading`
`✅ Fewer compatibility breaks for older graph callers`
`✅ Safer rollout of persisted graph startup`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=HeYoz_2EPVXQLQWx1duspJaZgsxDGtC1E2hBhS68Z5U&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
