### PR TITLE
Load persisted graph during application startup

### DIFF
--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -105,24 +105,20 @@ def reset_graph() -> None:
 
 def _initialize_graph() -> AssetRelationshipGraph:
     """
-    Initialize the global AssetRelationshipGraph using the configured factory or settings-driven data sources.
-
-    Initialization order:
-        - If `graph_state.graph_factory` is set, return the factory result.
-        - If `settings.asset_graph_database_url` is set and the configured
-          store has at least one persisted asset row, load and return the graph
-          through the lifecycle provider. Configured-persistence failures raise
-          ``RuntimeError`` and do not fall through to later steps.
-        - If `settings.graph_cache_path` is set, create a real-data graph
-          through the lifecycle provider. Network access is enabled when
-          `settings.use_real_data_fetcher` is enabled.
-        - If `settings.graph_cache_path` is not set, but
-          `settings.use_real_data_fetcher` is enabled, create a real-data graph
-          through the lifecycle provider with network access enabled.
-        - Otherwise, return the sample in-memory graph.
-
+    Constructs the global AssetRelationshipGraph according to the configured factory and lifecycle settings.
+    
+    Initialization precedence:
+    1. If a custom `graph_state.graph_factory` is configured, return its result.
+    2. If `settings.asset_graph_database_url` is configured, attempt to load a persisted graph via the lifecycle provider and return it if found; persistence loading failures propagate as errors.
+    3. If `settings.graph_cache_path` is configured, load and return a graph from that cache (network access enabled when `settings.use_real_data_fetcher` is true).
+    4. If no cache path but `settings.use_real_data_fetcher` is true, build and return a graph from the real-data fetcher (using `settings.real_data_cache_path`).
+    5. Otherwise, return the sample in-memory graph provided by the lifecycle provider.
+    
     Returns:
         AssetRelationshipGraph: The initialized graph instance.
+    
+    Raises:
+        RuntimeError: If configured persistence is enabled but loading the persisted graph fails.
     """
     if graph_state.graph_factory is not None:
         return graph_state.graph_factory()

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -9,6 +9,7 @@ import threading
 from collections.abc import Callable
 
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 
 from src.config.settings import Settings, get_settings
 from src.data.database import create_engine_from_url, create_session_factory

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -10,16 +10,9 @@ import logging
 import threading
 from collections.abc import Callable
 
-from sqlalchemy import select
-from sqlalchemy.orm import Session
-
-from src.config.settings import Settings, get_settings
-from src.data.database import create_engine_from_url, create_session_factory
-from src.data.db_models import AssetORM
-from src.data.real_data_fetcher import RealDataFetcher
-from src.data.repository import AssetGraphRepository
-from src.data.sample_data import create_sample_database
 from src.logic.asset_graph import AssetRelationshipGraph
+
+from . import graph_lifecycle_providers
 
 logger = logging.getLogger(__name__)
 
@@ -106,7 +99,7 @@ def reset_graph() -> None:
     """
     # Clear settings cache to preserve reset semantics: environment variable
     # changes made after reset should be picked up on next initialization.
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
     set_graph_factory(None)
 
 
@@ -118,15 +111,14 @@ def _initialize_graph() -> AssetRelationshipGraph:
         - If `graph_state.graph_factory` is set, return the factory result.
         - If `settings.asset_graph_database_url` is set and the configured
           store has at least one persisted asset row, load and return the graph
-          via ``AssetGraphRepository``. Configured-persistence failures raise
+          through the lifecycle provider. Configured-persistence failures raise
           ``RuntimeError`` and do not fall through to later steps.
-        - If `settings.graph_cache_path` is set, create a `RealDataFetcher`
-          with that path. Network access is enabled when
+        - If `settings.graph_cache_path` is set, create a real-data graph
+          through the lifecycle provider. Network access is enabled when
           `settings.use_real_data_fetcher` is enabled.
         - If `settings.graph_cache_path` is not set, but
-          `settings.use_real_data_fetcher` is enabled, create a
-          `RealDataFetcher` using `settings.real_data_cache_path` with network
-          access enabled.
+          `settings.use_real_data_fetcher` is enabled, create a real-data graph
+          through the lifecycle provider with network access enabled.
         - Otherwise, return the sample in-memory graph.
 
     Returns:
@@ -135,8 +127,8 @@ def _initialize_graph() -> AssetRelationshipGraph:
     if graph_state.graph_factory is not None:
         return graph_state.graph_factory()
 
-    settings = get_settings()
-    persisted_graph = _load_persisted_graph_if_available(settings)
+    settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
+    persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(settings.asset_graph_database_url)
     if persisted_graph is not None:
         return persisted_graph
 
@@ -144,67 +136,16 @@ def _initialize_graph() -> AssetRelationshipGraph:
     use_real_data = settings.use_real_data_fetcher
 
     if cache_path:
-        fetcher = RealDataFetcher(
-            cache_path=cache_path,
+        return graph_lifecycle_providers.create_real_data_graph(
+            cache_path,
             enable_network=use_real_data,
         )
-        return fetcher.create_real_database()
 
     if use_real_data:
         real_data_cache_path = settings.real_data_cache_path
-        fetcher = RealDataFetcher(
-            cache_path=real_data_cache_path,
+        return graph_lifecycle_providers.create_real_data_graph(
+            real_data_cache_path,
             enable_network=True,
         )
-        return fetcher.create_real_database()
 
-    return create_sample_database()
-
-
-def _load_persisted_graph_if_available(
-    settings: Settings,
-) -> AssetRelationshipGraph | None:
-    """
-    Load a persisted graph when graph persistence is explicitly configured.
-
-    Returns ``None`` only when graph persistence is not configured or when the
-    configured store is reachable and schema-ready but has no persisted asset
-    rows. Configured load failures are raised so startup does not silently fall
-    back to sample or cache data.
-    """
-    database_url = (settings.asset_graph_database_url or "").strip()
-    if not database_url:
-        return None
-
-    engine = None
-    session = None
-    load_error: RuntimeError | None = None
-    persisted_graph: AssetRelationshipGraph | None = None
-    try:
-        engine = create_engine_from_url(database_url)
-        session_factory = create_session_factory(engine)
-        session = session_factory()
-        if not _has_persisted_graph_rows(session):
-            return None
-        persisted_graph = AssetGraphRepository(session).load_graph()
-    except Exception as exc:
-        logger.error(
-            "Failed to load persisted graph during startup: %s",
-            exc.__class__.__name__,
-        )
-        load_error = RuntimeError("Failed to load persisted graph during startup")
-    finally:
-        if session is not None:
-            session.close()
-        if engine is not None:
-            engine.dispose()
-
-    if load_error is not None:
-        raise load_error
-
-    return persisted_graph
-
-
-def _has_persisted_graph_rows(session: Session) -> bool:
-    """Return whether the asset graph store contains at least one asset row."""
-    return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None
+    return graph_lifecycle_providers.create_sample_graph()

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -105,20 +105,16 @@ def reset_graph() -> None:
 
 def _initialize_graph() -> AssetRelationshipGraph:
     """
-    Constructs the global AssetRelationshipGraph according to the configured factory and lifecycle settings.
+    Initialize the graph from the configured startup source.
 
-    Initialization precedence:
-    1. If a custom `graph_state.graph_factory` is configured, return its result.
-    2. If `settings.asset_graph_database_url` is configured, attempt to load a persisted graph via the lifecycle provider and return it if found; persistence loading failures propagate as errors.
-    3. If `settings.graph_cache_path` is configured, load and return a graph from that cache (network access enabled when `settings.use_real_data_fetcher` is true).
-    4. If no cache path but `settings.use_real_data_fetcher` is true, build and return a graph from the real-data fetcher (using `settings.real_data_cache_path`).
-    5. Otherwise, return the sample in-memory graph provided by the lifecycle provider.
+    Precedence:
+    1. custom graph factory;
+    2. persisted graph when durable persistence is configured and populated;
+    3. graph cache path;
+    4. real-data fetcher;
+    5. sample graph.
 
-    Returns:
-        AssetRelationshipGraph: The initialized graph instance.
-
-    Raises:
-        RuntimeError: If configured persistence is enabled but loading the persisted graph fails.
+    Configured persistence failures raise RuntimeError.
     """
     if graph_state.graph_factory is not None:
         return graph_state.graph_factory()

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -12,7 +12,6 @@ from collections.abc import Callable
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from sqlalchemy.orm import Session
 
 from src.config.settings import Settings, get_settings
 from src.data.database import create_engine_from_url, create_session_factory

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -178,22 +178,31 @@ def _load_persisted_graph_if_available(
 
     engine = None
     session = None
+    load_error: RuntimeError | None = None
+    persisted_graph: AssetRelationshipGraph | None = None
     try:
         engine = create_engine_from_url(database_url)
         session_factory = create_session_factory(engine)
         session = session_factory()
         if not _has_persisted_graph_rows(session):
             return None
-        return AssetGraphRepository(session).load_graph()
-
-    except Exception:
-        logger.error("Failed to load persisted graph during startup (sanitized)")
-        raise RuntimeError("Failed to load persisted graph during startup")
+        persisted_graph = AssetGraphRepository(session).load_graph()
+    except Exception as exc:
+        logger.error(
+            "Failed to load persisted graph during startup: %s",
+            exc.__class__.__name__,
+        )
+        load_error = RuntimeError("Failed to load persisted graph during startup")
     finally:
         if session is not None:
             session.close()
         if engine is not None:
             engine.dispose()
+
+    if load_error is not None:
+        raise load_error
+
+    return persisted_graph
 
 
 def _has_persisted_graph_rows(session: Session) -> bool:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -179,9 +179,9 @@ def _load_persisted_graph_if_available(
         if not _has_persisted_graph_rows(session):
             return None
         return AssetGraphRepository(session).load_graph()
-    except Exception as exc:
-        logger.exception("Failed to load persisted graph during startup")
-        raise RuntimeError("Failed to load persisted graph during startup") from exc
+except Exception:
+        logger.error("Failed to load persisted graph during startup (sanitized)")
+        raise RuntimeError("Failed to load persisted graph during startup")
     finally:
         if session is not None:
             session.close()

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -189,6 +189,6 @@ def _load_persisted_graph_if_available(
             engine.dispose()
 
 
-def _has_persisted_graph_rows(session) -> bool:
+def _has_persisted_graph_rows(session: Session) -> bool:
     """Return whether the asset graph store contains at least one asset row."""
     return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -136,16 +136,15 @@ def _initialize_graph() -> AssetRelationshipGraph:
     use_real_data = settings.use_real_data_fetcher
 
     if cache_path:
-        return graph_lifecycle_providers.create_real_data_graph(
+        return graph_lifecycle_providers.load_graph_from_cache_path(
             cache_path,
             enable_network=use_real_data,
         )
 
     if use_real_data:
         real_data_cache_path = settings.real_data_cache_path
-        return graph_lifecycle_providers.create_real_data_graph(
+        return graph_lifecycle_providers.load_graph_from_real_data_fetcher(
             real_data_cache_path,
-            enable_network=True,
         )
 
     return graph_lifecycle_providers.create_sample_graph()

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -8,8 +8,13 @@ import logging
 import threading
 from collections.abc import Callable
 
-from src.config.settings import get_settings
+from sqlalchemy import select
+
+from src.config.settings import Settings, get_settings
+from src.data.database import create_engine_from_url, create_session_factory
+from src.data.db_models import AssetORM
 from src.data.real_data_fetcher import RealDataFetcher
+from src.data.repository import AssetGraphRepository
 from src.data.sample_data import create_sample_database
 from src.logic.asset_graph import AssetRelationshipGraph
 
@@ -124,6 +129,10 @@ def _initialize_graph() -> AssetRelationshipGraph:
         return graph_state.graph_factory()
 
     settings = get_settings()
+    persisted_graph = _load_persisted_graph_if_available(settings)
+    if persisted_graph is not None:
+        return persisted_graph
+
     cache_path = settings.graph_cache_path
     use_real_data = settings.use_real_data_fetcher
 
@@ -143,3 +152,42 @@ def _initialize_graph() -> AssetRelationshipGraph:
         return fetcher.create_real_database()
 
     return create_sample_database()
+
+
+def _load_persisted_graph_if_available(
+    settings: Settings,
+) -> AssetRelationshipGraph | None:
+    """
+    Load a persisted graph when graph persistence is explicitly configured.
+
+    Returns ``None`` only when graph persistence is not configured or when the
+    configured store is reachable and schema-ready but has no persisted asset
+    rows. Configured load failures are raised so startup does not silently fall
+    back to sample or cache data.
+    """
+    database_url = (settings.asset_graph_database_url or "").strip()
+    if not database_url:
+        return None
+
+    engine = None
+    session = None
+    try:
+        engine = create_engine_from_url(database_url)
+        session_factory = create_session_factory(engine)
+        session = session_factory()
+        if not _has_persisted_graph_rows(session):
+            return None
+        return AssetGraphRepository(session).load_graph()
+    except Exception as exc:
+        logger.exception("Failed to load persisted graph during startup")
+        raise RuntimeError("Failed to load persisted graph during startup") from exc
+    finally:
+        if session is not None:
+            session.close()
+        if engine is not None:
+            engine.dispose()
+
+
+def _has_persisted_graph_rows(session) -> bool:
+    """Return whether the asset graph store contains at least one asset row."""
+    return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -116,6 +116,10 @@ def _initialize_graph() -> AssetRelationshipGraph:
 
     Initialization order:
         - If `graph_state.graph_factory` is set, return the factory result.
+        - If `settings.asset_graph_database_url` is set and the configured
+          store has at least one persisted asset row, load and return the graph
+          via ``AssetGraphRepository``. Configured-persistence failures raise
+          ``RuntimeError`` and do not fall through to later steps.
         - If `settings.graph_cache_path` is set, create a `RealDataFetcher`
           with that path. Network access is enabled when
           `settings.use_real_data_fetcher` is enabled.
@@ -182,8 +186,7 @@ def _load_persisted_graph_if_available(
             return None
         return AssetGraphRepository(session).load_graph()
 
-
-except Exception:
+    except Exception:
         logger.error("Failed to load persisted graph during startup (sanitized)")
         raise RuntimeError("Failed to load persisted graph during startup")
     finally:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -179,6 +179,8 @@ def _load_persisted_graph_if_available(
         if not _has_persisted_graph_rows(session):
             return None
         return AssetGraphRepository(session).load_graph()
+
+
 except Exception:
         logger.error("Failed to load persisted graph during startup (sanitized)")
         raise RuntimeError("Failed to load persisted graph during startup")

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -106,17 +106,17 @@ def reset_graph() -> None:
 def _initialize_graph() -> AssetRelationshipGraph:
     """
     Constructs the global AssetRelationshipGraph according to the configured factory and lifecycle settings.
-    
+
     Initialization precedence:
     1. If a custom `graph_state.graph_factory` is configured, return its result.
     2. If `settings.asset_graph_database_url` is configured, attempt to load a persisted graph via the lifecycle provider and return it if found; persistence loading failures propagate as errors.
     3. If `settings.graph_cache_path` is configured, load and return a graph from that cache (network access enabled when `settings.use_real_data_fetcher` is true).
     4. If no cache path but `settings.use_real_data_fetcher` is true, build and return a graph from the real-data fetcher (using `settings.real_data_cache_path`).
     5. Otherwise, return the sample in-memory graph provided by the lifecycle provider.
-    
+
     Returns:
         AssetRelationshipGraph: The initialized graph instance.
-    
+
     Raises:
         RuntimeError: If configured persistence is enabled but loading the persisted graph fails.
     """

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -4,6 +4,8 @@ This module provides thread-safe initialization and management of the global
 AssetRelationshipGraph instance used by the API.
 """
 
+from __future__ import annotations
+
 import logging
 import threading
 from collections.abc import Callable

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 
 from sqlalchemy import select
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session
 
 from src.config.settings import Settings, get_settings
 from src.data.database import create_engine_from_url, create_session_factory

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -6,6 +6,8 @@ import logging
 from dataclasses import dataclass
 
 from sqlalchemy import select
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 from sqlalchemy.orm import Session
 
 from src.config.settings import get_settings
@@ -56,6 +58,11 @@ def load_persisted_graph_if_available(
     """
     Attempt to load a persisted AssetRelationshipGraph from the given database URL if the URL is configured and the store contains at least one persisted asset.
 
+    In-memory SQLite URLs (``sqlite:///:memory:`` and ``?mode=memory`` variants) are
+    skipped with a warning: a brand-new engine always connects to a fresh empty
+    in-memory store and cannot hold rows persisted by a previous engine or process.
+    Configure a file-based or network database URL for startup persistence.
+
     Parameters:
         database_url (str | None): Database URL for the persisted asset graph; when None or empty (after trimming) no load is attempted.
 
@@ -69,6 +76,15 @@ def load_persisted_graph_if_available(
     if not resolved_database_url:
         return None
 
+    if _is_in_memory_sqlite_url(resolved_database_url):
+        logger.warning(
+            "ASSET_GRAPH_DATABASE_URL points to an in-memory SQLite database; "
+            "a new engine always connects to a fresh empty in-memory store and cannot "
+            "load previously persisted rows. Configure a file-based or network database "
+            "URL for startup persistence. Skipping persisted graph load."
+        )
+        return None
+
     engine = None
     session = None
     load_error: RuntimeError | None = None
@@ -80,11 +96,8 @@ def load_persisted_graph_if_available(
         if not _has_persisted_graph_rows(session):
             return None
         persisted_graph = AssetGraphRepository(session).load_graph()
-    except Exception as exc:
-        logger.error(
-            "Failed to load persisted graph during startup: %s",
-            exc.__class__.__name__,
-        )
+    except Exception:
+        logger.exception("Failed to load persisted graph during startup")
         load_error = RuntimeError("Failed to load persisted graph during startup")
     finally:
         if session is not None:
@@ -120,6 +133,50 @@ def create_real_data_graph(
     return fetcher.create_real_database()
 
 
+def load_graph_from_cache_path(
+    cache_path: str,
+    *,
+    enable_network: bool,
+) -> AssetRelationshipGraph:
+    """
+    Load an AssetRelationshipGraph via the real-data fetcher using a configured cache path.
+
+    This provider is called when ``GRAPH_CACHE_PATH`` is set. It is a distinct
+    entry point from :func:`load_graph_from_real_data_fetcher` so that each
+    startup source can be individually patched in tests.
+
+    Parameters:
+        cache_path (str): Filesystem path used for caching fetched real data.
+        enable_network (bool): Whether network access is permitted during the load.
+
+    Returns:
+        AssetRelationshipGraph: Graph constructed from the cached or fetched real data.
+    """
+    fetcher = RealDataFetcher(cache_path=cache_path, enable_network=enable_network)
+    return fetcher.create_real_database()
+
+
+def load_graph_from_real_data_fetcher(
+    cache_path: str | None,
+) -> AssetRelationshipGraph:
+    """
+    Load an AssetRelationshipGraph via the real-data fetcher with network access enabled.
+
+    This provider is called when ``USE_REAL_DATA_FETCHER`` is set but
+    ``GRAPH_CACHE_PATH`` is not. It is a distinct entry point from
+    :func:`load_graph_from_cache_path` so that each startup source can be
+    individually patched in tests.
+
+    Parameters:
+        cache_path (str | None): Optional filesystem path for caching fetched real data.
+
+    Returns:
+        AssetRelationshipGraph: Graph constructed from the fetched real data.
+    """
+    fetcher = RealDataFetcher(cache_path=cache_path, enable_network=True)
+    return fetcher.create_real_database()
+
+
 def create_sample_graph() -> AssetRelationshipGraph:
     """
     Create an asset relationship graph populated with the default sample dataset.
@@ -138,3 +195,26 @@ def _has_persisted_graph_rows(session: Session) -> bool:
         True if the store has at least one asset row, False otherwise.
     """
     return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None
+
+
+def _is_in_memory_sqlite_url(url: str) -> bool:
+    """
+    Return True when *url* refers to an in-memory SQLite database.
+
+    In-memory SQLite databases (``sqlite:///:memory:`` and the
+    ``?mode=memory`` URI variant) are transient: each new SQLAlchemy engine
+    created from such a URL connects to a completely fresh, empty database.
+    Startup persistence loading must be skipped for these URLs because there
+    are no previously persisted rows to load.
+
+    Returns False for any non-SQLite URL or any URL that cannot be parsed.
+    """
+    try:
+        parsed = make_url(url)
+    except ArgumentError:
+        return False
+    if parsed.get_backend_name() != "sqlite":
+        return False
+    database = parsed.database or ""
+    query = parsed.query or {}
+    return database == ":memory:" or query.get("mode") == "memory"

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -32,7 +32,7 @@ class GraphLifecycleSettings:
 def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
     """
     Constructs a GraphLifecycleSettings instance populated from the application's settings.
-    
+
     Returns:
         GraphLifecycleSettings: Configuration containing `asset_graph_database_url`, `graph_cache_path`, `real_data_cache_path`, and `use_real_data_fetcher` taken from the global application settings.
     """
@@ -55,13 +55,13 @@ def load_persisted_graph_if_available(
 ) -> AssetRelationshipGraph | None:
     """
     Attempt to load a persisted AssetRelationshipGraph from the given database URL if the URL is configured and the store contains at least one persisted asset.
-    
+
     Parameters:
         database_url (str | None): Database URL for the persisted asset graph; when None or empty (after trimming) no load is attempted.
-    
+
     Returns:
         AssetRelationshipGraph | None: The loaded persisted graph if the configured store is reachable and contains persisted asset rows, otherwise `None`.
-    
+
     Raises:
         RuntimeError: If a configured load is attempted but fails (errors during engine/session creation, row-check, or graph load).
     """
@@ -105,13 +105,13 @@ def create_real_data_graph(
 ) -> AssetRelationshipGraph:
     """
     Create an AssetRelationshipGraph using the real-data fetcher.
-    
+
     Parameters:
-    	cache_path (str | None): Optional filesystem path for caching fetched real data.
-    	enable_network (bool): Whether the fetcher is allowed to access the network.
-    
+        cache_path (str | None): Optional filesystem path for caching fetched real data.
+        enable_network (bool): Whether the fetcher is allowed to access the network.
+
     Returns:
-    	AssetRelationshipGraph: Graph constructed from the fetched real data.
+        AssetRelationshipGraph: Graph constructed from the fetched real data.
     """
     fetcher = RealDataFetcher(
         cache_path=cache_path,
@@ -123,7 +123,7 @@ def create_real_data_graph(
 def create_sample_graph() -> AssetRelationshipGraph:
     """
     Create an asset relationship graph populated with the default sample dataset.
-    
+
     Returns:
         AssetRelationshipGraph: A graph populated with the module's default sample data.
     """
@@ -133,7 +133,7 @@ def create_sample_graph() -> AssetRelationshipGraph:
 def _has_persisted_graph_rows(session: Session) -> bool:
     """
     Determine whether the asset graph store contains at least one persisted asset row.
-    
+
     Returns:
         True if the store has at least one asset row, False otherwise.
     """

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -50,7 +50,20 @@ def clear_graph_lifecycle_settings_cache() -> None:
 def load_persisted_graph_if_available(
     database_url: str | None,
 ) -> AssetRelationshipGraph | None:
-    """Load a persisted graph when graph persistence is configured."""
+    """
+    Attempt to load an AssetRelationshipGraph from the configured persistence store.
+    
+    If `database_url` is unset/blank or refers to an in-memory SQLite database, no durable load is attempted and `None` is returned. Otherwise the function attempts to load a persisted graph from the configured store.
+    
+    Parameters:
+        database_url (str | None): Optional persistence database URL; blank or whitespace-only values are treated as unset.
+    
+    Returns:
+        AssetRelationshipGraph | None: The loaded persisted graph when available, `None` if no durable persistence is configured or an in-memory SQLite URL is provided.
+    
+    Raises:
+        RuntimeError: If a durable persistence URL is configured but loading fails; the exception message includes the original exception class name.
+    """
     resolved_url = _resolve_persistence_database_url(database_url)
     if resolved_url is None:
         return None
@@ -74,7 +87,16 @@ def load_graph_from_cache_path(
     *,
     enable_network: bool,
 ) -> AssetRelationshipGraph:
-    """Load a graph via the real-data fetcher using a configured cache path."""
+    """
+    Load an AssetRelationshipGraph using a RealDataFetcher configured with the given cache path.
+    
+    Parameters:
+    	cache_path (str): Filesystem path used by the fetcher to read/write cached real-data artifacts.
+    	enable_network (bool): Whether the fetcher may access network resources to populate or refresh the cache.
+    
+    Returns:
+    	asset_graph (AssetRelationshipGraph): Graph constructed from the real-data cache (and network if enabled).
+    """
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=enable_network)
     return fetcher.create_real_database()
 
@@ -82,24 +104,44 @@ def load_graph_from_cache_path(
 def load_graph_from_real_data_fetcher(
     cache_path: str | None,
 ) -> AssetRelationshipGraph:
-    """Load a graph via the real-data fetcher with network access enabled."""
+    """
+    Create an AssetRelationshipGraph using the real-data fetcher with network access enabled.
+    
+    Parameters:
+        cache_path (str | None): Optional path to a local cache used by the fetcher; if `None`, the fetcher uses its default cache location.
+    
+    Returns:
+        AssetRelationshipGraph: Graph constructed from fetched real-world data.
+    """
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=True)
     return fetcher.create_real_database()
 
 
 def create_sample_graph() -> AssetRelationshipGraph:
-    """Create a graph populated with the default sample dataset."""
+    """
+    Create a graph populated with the default sample dataset.
+    
+    Returns:
+        AssetRelationshipGraph: An asset relationship graph populated with the module's default sample data.
+    """
     return create_sample_database()
 
 
 def _resolve_persistence_database_url(database_url: str | None) -> str | None:
-    """Return a stripped persistence URL, or None when unset."""
+    """
+    Resolve and normalize a persistence database URL.
+    
+    Returns:
+        The trimmed URL string if non-empty, otherwise None.
+    """
     resolved_url = (database_url or "").strip()
     return resolved_url or None
 
 
 def _log_in_memory_sqlite_persistence_skip() -> None:
-    """Log that in-memory SQLite cannot be used for durable startup loading."""
+    """
+    Emit a warning that an in-memory SQLite database URL was detected and persisted graph loading will be skipped because in-memory SQLite is not durable.
+    """
     logger.warning(
         "ASSET_GRAPH_DATABASE_URL points to an in-memory SQLite database; "
         "startup persistence loading requires a file-based or network database. "
@@ -110,7 +152,17 @@ def _log_in_memory_sqlite_persistence_skip() -> None:
 def _load_persisted_graph_from_configured_store(
     database_url: str,
 ) -> AssetRelationshipGraph | None:
-    """Load a persisted graph from a configured durable store."""
+    """
+    Load an AssetRelationshipGraph from the persistent store identified by database_url.
+    
+    If the persistent store contains no persisted graph rows, returns None.
+    
+    Parameters:
+        database_url (str): Database connection URL for the persistent store.
+    
+    Returns:
+        AssetRelationshipGraph | None: The loaded graph, or `None` when no persisted graph rows exist.
+    """
     engine = create_engine_from_url(database_url)
     try:
         session_factory = create_session_factory(engine)
@@ -126,12 +178,25 @@ def _load_persisted_graph_from_configured_store(
 
 
 def _has_persisted_graph_rows(session: Session) -> bool:
-    """Return True if the store has at least one persisted asset row."""
+    """
+    Determine whether the persistence store contains at least one persisted asset row.
+    
+    Returns:
+        `True` if the store contains at least one persisted `AssetORM` row, `False` otherwise.
+    """
     return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None
 
 
 def _is_in_memory_sqlite_url(url: str) -> bool:
-    """Return True when url refers to an in-memory SQLite database."""
+    """
+    Determine whether a SQLAlchemy database URL refers to an in-memory SQLite database.
+    
+    Parameters:
+        url (str): The database URL to inspect (SQLAlchemy URL string).
+    
+    Returns:
+        bool: `True` if the URL denotes an in-memory SQLite database (database == ":memory:" or query `mode=memory`), `False` otherwise. Parsing errors are treated as non-matching and return `False`.
+    """
     try:
         parsed = make_url(url)
     except ArgumentError:

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -113,7 +113,8 @@ def _resolve_persistence_database_url(database_url: str | None) -> str | None:
 
 def _log_in_memory_sqlite_persistence_skip() -> None:
     """
-    Emit a warning that an in-memory SQLite database URL was detected and persisted graph loading will be skipped because in-memory SQLite is not durable.
+    Emit a warning that an in-memory SQLite database URL was detected and persisted graph
+    loading will be skipped because in-memory SQLite is not durable.
     """
     logger.warning(
         "ASSET_GRAPH_DATABASE_URL points to an in-memory SQLite database; "

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -30,7 +30,12 @@ class GraphLifecycleSettings:
 
 
 def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
-    """Return settings required by graph lifecycle initialization."""
+    """
+    Constructs a GraphLifecycleSettings instance populated from the application's settings.
+    
+    Returns:
+        GraphLifecycleSettings: Configuration containing `asset_graph_database_url`, `graph_cache_path`, `real_data_cache_path`, and `use_real_data_fetcher` taken from the global application settings.
+    """
     settings = get_settings()
     return GraphLifecycleSettings(
         asset_graph_database_url=settings.asset_graph_database_url,
@@ -49,12 +54,16 @@ def load_persisted_graph_if_available(
     database_url: str | None,
 ) -> AssetRelationshipGraph | None:
     """
-    Load a persisted graph when graph persistence is explicitly configured.
-
-    Returns ``None`` only when graph persistence is not configured or when the
-    configured store is reachable and schema-ready but has no persisted asset
-    rows. Configured load failures are raised so startup does not silently fall
-    back to sample or cache data.
+    Attempt to load a persisted AssetRelationshipGraph from the given database URL if the URL is configured and the store contains at least one persisted asset.
+    
+    Parameters:
+        database_url (str | None): Database URL for the persisted asset graph; when None or empty (after trimming) no load is attempted.
+    
+    Returns:
+        AssetRelationshipGraph | None: The loaded persisted graph if the configured store is reachable and contains persisted asset rows, otherwise `None`.
+    
+    Raises:
+        RuntimeError: If a configured load is attempted but fails (errors during engine/session creation, row-check, or graph load).
     """
     resolved_database_url = (database_url or "").strip()
     if not resolved_database_url:
@@ -94,7 +103,16 @@ def create_real_data_graph(
     *,
     enable_network: bool,
 ) -> AssetRelationshipGraph:
-    """Create a graph through the configured real-data fetcher."""
+    """
+    Create an AssetRelationshipGraph using the real-data fetcher.
+    
+    Parameters:
+    	cache_path (str | None): Optional filesystem path for caching fetched real data.
+    	enable_network (bool): Whether the fetcher is allowed to access the network.
+    
+    Returns:
+    	AssetRelationshipGraph: Graph constructed from the fetched real data.
+    """
     fetcher = RealDataFetcher(
         cache_path=cache_path,
         enable_network=enable_network,
@@ -103,10 +121,20 @@ def create_real_data_graph(
 
 
 def create_sample_graph() -> AssetRelationshipGraph:
-    """Create the default sample graph."""
+    """
+    Create an asset relationship graph populated with the default sample dataset.
+    
+    Returns:
+        AssetRelationshipGraph: A graph populated with the module's default sample data.
+    """
     return create_sample_database()
 
 
 def _has_persisted_graph_rows(session: Session) -> bool:
-    """Return whether the asset graph store contains at least one asset row."""
+    """
+    Determine whether the asset graph store contains at least one persisted asset row.
+    
+    Returns:
+        True if the store has at least one asset row, False otherwise.
+    """
     return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -5,15 +5,15 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 
-from sqlalchemy import select
-from sqlalchemy.engine import make_url
-from sqlalchemy.exc import ArgumentError
-from sqlalchemy.orm import Session
+from sqlalchemy import select  # pylint: disable=import-error
+from sqlalchemy.engine import make_url  # pylint: disable=import-error
+from sqlalchemy.exc import ArgumentError  # pylint: disable=import-error
+from sqlalchemy.orm import Session  # pylint: disable=import-error
 
 from src.config.settings import get_settings
 from src.data.database import create_engine_from_url, create_session_factory
 from src.data.db_models import AssetORM
-from src.data.real_data_fetcher import RealDataFetcher
+from src.data.real_data_fetcher import RealDataFetcher  # pylint: disable=import-error
 from src.data.repository import AssetGraphRepository
 from src.data.sample_data import create_sample_database
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -32,12 +32,7 @@ class GraphLifecycleSettings:
 
 
 def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
-    """
-    Constructs a GraphLifecycleSettings instance populated from the application's settings.
-
-    Returns:
-        GraphLifecycleSettings: Configuration containing `asset_graph_database_url`, `graph_cache_path`, `real_data_cache_path`, and `use_real_data_fetcher` taken from the global application settings.
-    """
+    """Construct a GraphLifecycleSettings instance from the application settings."""
     settings = get_settings()
     return GraphLifecycleSettings(
         asset_graph_database_url=settings.asset_graph_database_url,
@@ -55,82 +50,23 @@ def clear_graph_lifecycle_settings_cache() -> None:
 def load_persisted_graph_if_available(
     database_url: str | None,
 ) -> AssetRelationshipGraph | None:
-    """
-    Attempt to load a persisted AssetRelationshipGraph from the given database URL if the URL is configured and the store contains at least one persisted asset.
-
-    In-memory SQLite URLs (``sqlite:///:memory:`` and ``?mode=memory`` variants) are
-    skipped with a warning: a brand-new engine always connects to a fresh empty
-    in-memory store and cannot hold rows persisted by a previous engine or process.
-    Configure a file-based or network database URL for startup persistence.
-
-    Parameters:
-        database_url (str | None): Database URL for the persisted asset graph; when None or empty (after trimming) no load is attempted.
-
-    Returns:
-        AssetRelationshipGraph | None: The loaded persisted graph if the configured store is reachable and contains persisted asset rows, otherwise `None`.
-
-    Raises:
-        RuntimeError: If a configured load is attempted but fails (errors during engine/session creation, row-check, or graph load).
-    """
-    resolved_database_url = (database_url or "").strip()
-    if not resolved_database_url:
+    """Load a persisted graph when graph persistence is configured."""
+    resolved_url = _resolve_persistence_database_url(database_url)
+    if resolved_url is None:
         return None
 
-    if _is_in_memory_sqlite_url(resolved_database_url):
-        logger.warning(
-            "ASSET_GRAPH_DATABASE_URL points to an in-memory SQLite database; "
-            "a new engine always connects to a fresh empty in-memory store and cannot "
-            "load previously persisted rows. Configure a file-based or network database "
-            "URL for startup persistence. Skipping persisted graph load."
-        )
+    if _is_in_memory_sqlite_url(resolved_url):
+        _log_in_memory_sqlite_persistence_skip()
         return None
 
-    engine = None
-    session = None
-    load_error: RuntimeError | None = None
-    persisted_graph: AssetRelationshipGraph | None = None
     try:
-        engine = create_engine_from_url(resolved_database_url)
-        session_factory = create_session_factory(engine)
-        session = session_factory()
-        if not _has_persisted_graph_rows(session):
-            return None
-        persisted_graph = AssetGraphRepository(session).load_graph()
-    except Exception:
-        logger.exception("Failed to load persisted graph during startup")
-        load_error = RuntimeError("Failed to load persisted graph during startup")
-    finally:
-        if session is not None:
-            session.close()
-        if engine is not None:
-            engine.dispose()
-
-    if load_error is not None:
-        raise load_error
-
-    return persisted_graph
-
-
-def create_real_data_graph(
-    cache_path: str | None,
-    *,
-    enable_network: bool,
-) -> AssetRelationshipGraph:
-    """
-    Create an AssetRelationshipGraph using the real-data fetcher.
-
-    Parameters:
-        cache_path (str | None): Optional filesystem path for caching fetched real data.
-        enable_network (bool): Whether the fetcher is allowed to access the network.
-
-    Returns:
-        AssetRelationshipGraph: Graph constructed from the fetched real data.
-    """
-    fetcher = RealDataFetcher(
-        cache_path=cache_path,
-        enable_network=enable_network,
-    )
-    return fetcher.create_real_database()
+        return _load_persisted_graph_from_configured_store(resolved_url)
+    except Exception as exc:
+        logger.error(
+            "Failed to load persisted graph during startup: %s",
+            exc.__class__.__name__,
+        )
+        raise RuntimeError(f"Failed to load persisted graph during startup: {exc.__class__.__name__}") from None
 
 
 def load_graph_from_cache_path(
@@ -138,20 +74,7 @@ def load_graph_from_cache_path(
     *,
     enable_network: bool,
 ) -> AssetRelationshipGraph:
-    """
-    Load an AssetRelationshipGraph via the real-data fetcher using a configured cache path.
-
-    This provider is called when ``GRAPH_CACHE_PATH`` is set. It is a distinct
-    entry point from :func:`load_graph_from_real_data_fetcher` so that each
-    startup source can be individually patched in tests.
-
-    Parameters:
-        cache_path (str): Filesystem path used for caching fetched real data.
-        enable_network (bool): Whether network access is permitted during the load.
-
-    Returns:
-        AssetRelationshipGraph: Graph constructed from the cached or fetched real data.
-    """
+    """Load a graph via the real-data fetcher using a configured cache path."""
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=enable_network)
     return fetcher.create_real_database()
 
@@ -159,56 +82,56 @@ def load_graph_from_cache_path(
 def load_graph_from_real_data_fetcher(
     cache_path: str | None,
 ) -> AssetRelationshipGraph:
-    """
-    Load an AssetRelationshipGraph via the real-data fetcher with network access enabled.
-
-    This provider is called when ``USE_REAL_DATA_FETCHER`` is set but
-    ``GRAPH_CACHE_PATH`` is not. It is a distinct entry point from
-    :func:`load_graph_from_cache_path` so that each startup source can be
-    individually patched in tests.
-
-    Parameters:
-        cache_path (str | None): Optional filesystem path for caching fetched real data.
-
-    Returns:
-        AssetRelationshipGraph: Graph constructed from the fetched real data.
-    """
+    """Load a graph via the real-data fetcher with network access enabled."""
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=True)
     return fetcher.create_real_database()
 
 
 def create_sample_graph() -> AssetRelationshipGraph:
-    """
-    Create an asset relationship graph populated with the default sample dataset.
-
-    Returns:
-        AssetRelationshipGraph: A graph populated with the module's default sample data.
-    """
+    """Create a graph populated with the default sample dataset."""
     return create_sample_database()
 
 
-def _has_persisted_graph_rows(session: Session) -> bool:
-    """
-    Determine whether the asset graph store contains at least one persisted asset row.
+def _resolve_persistence_database_url(database_url: str | None) -> str | None:
+    """Return a stripped persistence URL, or None when unset."""
+    resolved_url = (database_url or "").strip()
+    return resolved_url or None
 
-    Returns:
-        True if the store has at least one asset row, False otherwise.
-    """
+
+def _log_in_memory_sqlite_persistence_skip() -> None:
+    """Log that in-memory SQLite cannot be used for durable startup loading."""
+    logger.warning(
+        "ASSET_GRAPH_DATABASE_URL points to an in-memory SQLite database; "
+        "startup persistence loading requires a file-based or network database. "
+        "Skipping persisted graph load."
+    )
+
+
+def _load_persisted_graph_from_configured_store(
+    database_url: str,
+) -> AssetRelationshipGraph | None:
+    """Load a persisted graph from a configured durable store."""
+    engine = create_engine_from_url(database_url)
+    try:
+        session_factory = create_session_factory(engine)
+        session = session_factory()
+        try:
+            if not _has_persisted_graph_rows(session):
+                return None
+            return AssetGraphRepository(session).load_graph()
+        finally:
+            session.close()
+    finally:
+        engine.dispose()
+
+
+def _has_persisted_graph_rows(session: Session) -> bool:
+    """Return True if the store has at least one persisted asset row."""
     return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None
 
 
 def _is_in_memory_sqlite_url(url: str) -> bool:
-    """
-    Return True when *url* refers to an in-memory SQLite database.
-
-    In-memory SQLite databases (``sqlite:///:memory:`` and the
-    ``?mode=memory`` URI variant) are transient: each new SQLAlchemy engine
-    created from such a URL connects to a completely fresh, empty database.
-    Startup persistence loading must be skipped for these URLs because there
-    are no previously persisted rows to load.
-
-    Returns False for any non-SQLite URL or any URL that cannot be parsed.
-    """
+    """Return True when url refers to an in-memory SQLite database."""
     try:
         parsed = make_url(url)
     except ArgumentError:

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -1,0 +1,112 @@
+"""Boundary providers for graph lifecycle initialization."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from src.config.settings import get_settings
+from src.data.database import create_engine_from_url, create_session_factory
+from src.data.db_models import AssetORM
+from src.data.real_data_fetcher import RealDataFetcher
+from src.data.repository import AssetGraphRepository
+from src.data.sample_data import create_sample_database
+from src.logic.asset_graph import AssetRelationshipGraph
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GraphLifecycleSettings:
+    """Settings needed by graph lifecycle initialization."""
+
+    asset_graph_database_url: str | None
+    graph_cache_path: str | None
+    real_data_cache_path: str | None
+    use_real_data_fetcher: bool
+
+
+def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
+    """Return settings required by graph lifecycle initialization."""
+    settings = get_settings()
+    return GraphLifecycleSettings(
+        asset_graph_database_url=settings.asset_graph_database_url,
+        graph_cache_path=settings.graph_cache_path,
+        real_data_cache_path=settings.real_data_cache_path,
+        use_real_data_fetcher=settings.use_real_data_fetcher,
+    )
+
+
+def clear_graph_lifecycle_settings_cache() -> None:
+    """Clear cached settings used by graph lifecycle initialization."""
+    get_settings.cache_clear()
+
+
+def load_persisted_graph_if_available(
+    database_url: str | None,
+) -> AssetRelationshipGraph | None:
+    """
+    Load a persisted graph when graph persistence is explicitly configured.
+
+    Returns ``None`` only when graph persistence is not configured or when the
+    configured store is reachable and schema-ready but has no persisted asset
+    rows. Configured load failures are raised so startup does not silently fall
+    back to sample or cache data.
+    """
+    resolved_database_url = (database_url or "").strip()
+    if not resolved_database_url:
+        return None
+
+    engine = None
+    session = None
+    load_error: RuntimeError | None = None
+    persisted_graph: AssetRelationshipGraph | None = None
+    try:
+        engine = create_engine_from_url(resolved_database_url)
+        session_factory = create_session_factory(engine)
+        session = session_factory()
+        if not _has_persisted_graph_rows(session):
+            return None
+        persisted_graph = AssetGraphRepository(session).load_graph()
+    except Exception as exc:
+        logger.error(
+            "Failed to load persisted graph during startup: %s",
+            exc.__class__.__name__,
+        )
+        load_error = RuntimeError("Failed to load persisted graph during startup")
+    finally:
+        if session is not None:
+            session.close()
+        if engine is not None:
+            engine.dispose()
+
+    if load_error is not None:
+        raise load_error
+
+    return persisted_graph
+
+
+def create_real_data_graph(
+    cache_path: str | None,
+    *,
+    enable_network: bool,
+) -> AssetRelationshipGraph:
+    """Create a graph through the configured real-data fetcher."""
+    fetcher = RealDataFetcher(
+        cache_path=cache_path,
+        enable_network=enable_network,
+    )
+    return fetcher.create_real_database()
+
+
+def create_sample_graph() -> AssetRelationshipGraph:
+    """Create the default sample graph."""
+    return create_sample_database()
+
+
+def _has_persisted_graph_rows(session: Session) -> bool:
+    """Return whether the asset graph store contains at least one asset row."""
+    return session.execute(select(AssetORM.id).limit(1)).scalar_one_or_none() is not None

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -13,7 +13,6 @@ from sqlalchemy.orm import Session  # pylint: disable=import-error
 from src.config.settings import get_settings
 from src.data.database import create_engine_from_url, create_session_factory
 from src.data.db_models import AssetORM
-from src.data.real_data_fetcher import RealDataFetcher  # pylint: disable=import-error
 from src.data.repository import AssetGraphRepository
 from src.data.sample_data import create_sample_database
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -50,20 +49,7 @@ def clear_graph_lifecycle_settings_cache() -> None:
 def load_persisted_graph_if_available(
     database_url: str | None,
 ) -> AssetRelationshipGraph | None:
-    """
-    Attempt to load an AssetRelationshipGraph from the configured persistence store.
-
-    If `database_url` is unset/blank or refers to an in-memory SQLite database, no durable load is attempted and `None` is returned. Otherwise the function attempts to load a persisted graph from the configured store.
-
-    Parameters:
-        database_url (str | None): Optional persistence database URL; blank or whitespace-only values are treated as unset.
-
-    Returns:
-        AssetRelationshipGraph | None: The loaded persisted graph when available, `None` if no durable persistence is configured or an in-memory SQLite URL is provided.
-
-    Raises:
-        RuntimeError: If a durable persistence URL is configured but loading fails; the exception message includes the original exception class name.
-    """
+    """Load persisted graph truth from a configured durable store."""
     resolved_url = _resolve_persistence_database_url(database_url)
     if resolved_url is None:
         return None
@@ -79,7 +65,7 @@ def load_persisted_graph_if_available(
             "Failed to load persisted graph during startup: %s",
             exc.__class__.__name__,
         )
-        raise RuntimeError(f"Failed to load persisted graph during startup: {exc.__class__.__name__}") from None
+        raise RuntimeError("Failed to load persisted graph during startup") from None
 
 
 def load_graph_from_cache_path(
@@ -87,16 +73,9 @@ def load_graph_from_cache_path(
     *,
     enable_network: bool,
 ) -> AssetRelationshipGraph:
-    """
-    Load an AssetRelationshipGraph using a RealDataFetcher configured with the given cache path.
+    """Load a graph through the real-data cache path."""
+    from src.data.real_data_fetcher import RealDataFetcher  # pylint: disable=import-error,import-outside-toplevel
 
-    Parameters:
-        cache_path (str): Filesystem path used by the fetcher to read/write cached real-data artifacts.
-        enable_network (bool): Whether the fetcher may access network resources to populate or refresh the cache.
-
-    Returns:
-        asset_graph (AssetRelationshipGraph): Graph constructed from the real-data cache (and network if enabled).
-    """
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=enable_network)
     return fetcher.create_real_database()
 
@@ -104,15 +83,9 @@ def load_graph_from_cache_path(
 def load_graph_from_real_data_fetcher(
     cache_path: str | None,
 ) -> AssetRelationshipGraph:
-    """
-    Create an AssetRelationshipGraph using the real-data fetcher with network access enabled.
+    """Load a graph from the real-data fetcher with network access."""
+    from src.data.real_data_fetcher import RealDataFetcher  # pylint: disable=import-error,import-outside-toplevel
 
-    Parameters:
-        cache_path (str | None): Optional path to a local cache used by the fetcher; if `None`, the fetcher uses its default cache location.
-
-    Returns:
-        AssetRelationshipGraph: Graph constructed from fetched real-world data.
-    """
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=True)
     return fetcher.create_real_database()
 
@@ -188,21 +161,20 @@ def _has_persisted_graph_rows(session: Session) -> bool:
 
 
 def _is_in_memory_sqlite_url(url: str) -> bool:
-    """
-    Determine whether a SQLAlchemy database URL refers to an in-memory SQLite database.
-
-    Parameters:
-        url (str): The database URL to inspect (SQLAlchemy URL string).
-
-    Returns:
-        bool: `True` if the URL denotes an in-memory SQLite database (database == ":memory:" or query `mode=memory`), `False` otherwise. Parsing errors are treated as non-matching and return `False`.
-    """
+    """Return whether a SQLAlchemy URL points to in-memory SQLite."""
     try:
         parsed = make_url(url)
     except ArgumentError:
         return False
+
     if parsed.get_backend_name() != "sqlite":
         return False
+
     database = parsed.database or ""
     query = parsed.query or {}
-    return database == ":memory:" or query.get("mode") == "memory"
+
+    if database in {"", ":memory:"}:
+        return True
+    if database.startswith("file::memory:"):
+        return True
+    return database.startswith("file:") and query.get("mode") == "memory"

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -52,15 +52,15 @@ def load_persisted_graph_if_available(
 ) -> AssetRelationshipGraph | None:
     """
     Attempt to load an AssetRelationshipGraph from the configured persistence store.
-    
+
     If `database_url` is unset/blank or refers to an in-memory SQLite database, no durable load is attempted and `None` is returned. Otherwise the function attempts to load a persisted graph from the configured store.
-    
+
     Parameters:
         database_url (str | None): Optional persistence database URL; blank or whitespace-only values are treated as unset.
-    
+
     Returns:
         AssetRelationshipGraph | None: The loaded persisted graph when available, `None` if no durable persistence is configured or an in-memory SQLite URL is provided.
-    
+
     Raises:
         RuntimeError: If a durable persistence URL is configured but loading fails; the exception message includes the original exception class name.
     """
@@ -89,13 +89,13 @@ def load_graph_from_cache_path(
 ) -> AssetRelationshipGraph:
     """
     Load an AssetRelationshipGraph using a RealDataFetcher configured with the given cache path.
-    
+
     Parameters:
-    	cache_path (str): Filesystem path used by the fetcher to read/write cached real-data artifacts.
-    	enable_network (bool): Whether the fetcher may access network resources to populate or refresh the cache.
-    
+        cache_path (str): Filesystem path used by the fetcher to read/write cached real-data artifacts.
+        enable_network (bool): Whether the fetcher may access network resources to populate or refresh the cache.
+
     Returns:
-    	asset_graph (AssetRelationshipGraph): Graph constructed from the real-data cache (and network if enabled).
+        asset_graph (AssetRelationshipGraph): Graph constructed from the real-data cache (and network if enabled).
     """
     fetcher = RealDataFetcher(cache_path=cache_path, enable_network=enable_network)
     return fetcher.create_real_database()
@@ -106,10 +106,10 @@ def load_graph_from_real_data_fetcher(
 ) -> AssetRelationshipGraph:
     """
     Create an AssetRelationshipGraph using the real-data fetcher with network access enabled.
-    
+
     Parameters:
         cache_path (str | None): Optional path to a local cache used by the fetcher; if `None`, the fetcher uses its default cache location.
-    
+
     Returns:
         AssetRelationshipGraph: Graph constructed from fetched real-world data.
     """
@@ -120,7 +120,7 @@ def load_graph_from_real_data_fetcher(
 def create_sample_graph() -> AssetRelationshipGraph:
     """
     Create a graph populated with the default sample dataset.
-    
+
     Returns:
         AssetRelationshipGraph: An asset relationship graph populated with the module's default sample data.
     """
@@ -130,7 +130,7 @@ def create_sample_graph() -> AssetRelationshipGraph:
 def _resolve_persistence_database_url(database_url: str | None) -> str | None:
     """
     Resolve and normalize a persistence database URL.
-    
+
     Returns:
         The trimmed URL string if non-empty, otherwise None.
     """
@@ -154,12 +154,12 @@ def _load_persisted_graph_from_configured_store(
 ) -> AssetRelationshipGraph | None:
     """
     Load an AssetRelationshipGraph from the persistent store identified by database_url.
-    
+
     If the persistent store contains no persisted graph rows, returns None.
-    
+
     Parameters:
         database_url (str): Database connection URL for the persistent store.
-    
+
     Returns:
         AssetRelationshipGraph | None: The loaded graph, or `None` when no persisted graph rows exist.
     """
@@ -180,7 +180,7 @@ def _load_persisted_graph_from_configured_store(
 def _has_persisted_graph_rows(session: Session) -> bool:
     """
     Determine whether the persistence store contains at least one persisted asset row.
-    
+
     Returns:
         `True` if the store contains at least one persisted `AssetORM` row, `False` otherwise.
     """
@@ -190,10 +190,10 @@ def _has_persisted_graph_rows(session: Session) -> bool:
 def _is_in_memory_sqlite_url(url: str) -> bool:
     """
     Determine whether a SQLAlchemy database URL refers to an in-memory SQLite database.
-    
+
     Parameters:
         url (str): The database URL to inspect (SQLAlchemy URL string).
-    
+
     Returns:
         bool: `True` if the URL denotes an in-memory SQLite database (database == ":memory:" or query `mode=memory`), `False` otherwise. Parsing errors are treated as non-matching and return `False`.
     """

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.unit
 def reset_lifecycle(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """
     Reset the graph lifecycle and clear persistence-related environment variables before each test, then reset the lifecycle again after the test.
-    
+
     This fixture removes the environment variables ASSET_GRAPH_DATABASE_URL, GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, and USE_REAL_DATA_FETCHER to ensure tests start with a clean persisted-graph configuration and to prevent leakage between tests.
     """
     for name in (
@@ -83,10 +83,10 @@ def _relationship_strength(
 ) -> float:
     """
     Retrieve the stored strength value for the specified relationship.
-    
+
     @returns
         The relationship strength as a float.
-    
+
     @raises AssertionError
         If no relationship matching `source_id`, `target_id`, and `relationship_type` is found.
     """
@@ -99,11 +99,11 @@ def _relationship_strength(
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
     """
     Construct a file-backed SQLite URL pointing to a database file under the given directory.
-    
+
     Parameters:
         tmp_path (Path): Directory in which the SQLite file will be placed.
         name (str): Filename for the SQLite database (defaults to "asset_graph.db").
-    
+
     Returns:
         str: A SQLite URL string referencing the file (e.g., "sqlite:///path/to/{name}").
     """
@@ -122,11 +122,11 @@ def _init_empty_db(database_url: str) -> None:
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
     """
     Persist the given AssetRelationshipGraph into the database identified by `database_url`.
-    
+
     Parameters:
         database_url (str): SQLAlchemy database URL for the test database (file-backed or in-memory).
         graph (AssetRelationshipGraph): In-memory graph snapshot to be saved.
-    
+
     """
     engine = create_engine(database_url)
     init_db(engine)
@@ -142,7 +142,7 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 def _asset_only_graph() -> AssetRelationshipGraph:
     """
     Create an in-memory asset relationship graph containing a single equity and no relationships or events.
-    
+
     Returns:
         AssetRelationshipGraph: Graph with one asset (id "ASSET_ONLY", symbol "ONLY") and no relationships or regulatory events.
     """
@@ -154,7 +154,7 @@ def _asset_only_graph() -> AssetRelationshipGraph:
 def _full_graph() -> AssetRelationshipGraph:
     """
     Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
-    
+
     Returns:
         AssetRelationshipGraph: Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships
         "ASSET_A" -> "ASSET_B" with type "directed_alpha" and strength 0.4, and
@@ -177,7 +177,7 @@ def _full_graph() -> AssetRelationshipGraph:
 def _initialize_graph_for_test() -> AssetRelationshipGraph:
     """
     Initialize the asset relationship graph via the lifecycle test seam.
-    
+
     Returns:
         AssetRelationshipGraph: The initialized graph instance used by tests.
     """
@@ -195,7 +195,7 @@ class _ClosingSessionProxy:
     def __init__(self, session: Any, close_counter: Callable[[], None]) -> None:
         """
         Initialize the proxy with a wrapped session and a callback to record close calls.
-        
+
         Parameters:
             session: The underlying SQLAlchemy session to proxy.
             close_counter: A zero-argument callable invoked each time the proxy's `close()` is called to increment the external close-call counter.
@@ -206,13 +206,13 @@ class _ClosingSessionProxy:
     def __getattr__(self, name: str) -> Any:
         """
         Delegate attribute access to the wrapped SQLAlchemy session.
-        
+
         Parameters:
             name (str): The attribute name to retrieve from the wrapped session.
-        
+
         Returns:
             Any: The attribute value from the underlying session.
-        
+
         Raises:
             AttributeError: If the underlying session does not have the requested attribute.
         """
@@ -221,7 +221,7 @@ class _ClosingSessionProxy:
     def close(self) -> None:
         """
         Increment the tracked close counter and close the wrapped SQLAlchemy session.
-        
+
         Increments the provided close-call counter and then delegates to the underlying
         session's `close()` method to release database resources.
         """
@@ -232,12 +232,12 @@ class _ClosingSessionProxy:
 def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
     """
     Patch the session factory so created sessions are wrapped and their `.close()` calls are counted.
-    
+
     This replaces graph_lifecycle_providers.create_session_factory via the provided pytest monkeypatch so sessions returned by the factory are proxied to increment an internal counter each time `close()` is invoked.
-    
+
     Parameters:
         monkeypatch (pytest.MonkeyPatch): Fixture used to set the patched session factory.
-    
+
     Returns:
         Callable[[], int]: A zero-argument callable that returns the current count of `close()` calls.
     """
@@ -247,7 +247,7 @@ def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[]
     def increment_close_calls() -> None:
         """
         Increment the internal counter tracking how many times proxied sessions were closed.
-        
+
         Used by the session proxy to record each `.close()` invocation.
         """
         nonlocal close_calls
@@ -256,12 +256,12 @@ def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[]
     def tracking_session_factory(engine: Any) -> Any:
         """
         Create a session factory that produces sessions wrapped with a proxy which increments a close-call counter when closed.
-        
+
         The returned callable takes no arguments and produces a `_ClosingSessionProxy` that delegates to a real SQLAlchemy session while incrementing the provided close-count on each `.close()` call.
-        
+
         Parameters:
             engine: The SQLAlchemy engine passed through to the underlying session factory.
-        
+
         Returns:
             session_factory (Callable[[], Any]): A zero-argument callable that returns a proxied session whose `close()` increments the tracked close-call counter and then closes the underlying session.
         """
@@ -270,10 +270,10 @@ def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[]
         def make_session() -> Any:
             """
             Return a session proxy that increments a close-call counter each time its .close() is invoked.
-            
+
             This wraps a real SQLAlchemy session produced by the factory and delegates all attributes
             and method calls to it while counting calls to .close().
-            
+
             Returns:
                 _ClosingSessionProxy: Proxy around the real session that increments the configured counter on `.close()` and forwards all other behavior to the underlying session.
             """
@@ -301,7 +301,7 @@ def _assert_empty_db_uses_configured_source(
 ) -> None:
     """
     Verify that when a persisted database exists but contains no graph rows, startup falls through to a configured non-persistent graph provider and does not attempt to save to the database.
-    
+
     This test helper:
     - Creates an empty file-backed SQLite database and sets ASSET_GRAPH_DATABASE_URL to it.
     - Monkeypatches the specified provider (given by `provider_attr`) to return a configured in-memory graph and replaces AssetGraphRepository.save_graph with a function that fails if called.
@@ -315,7 +315,7 @@ def _assert_empty_db_uses_configured_source(
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         """
         Raise an AssertionError to indicate startup attempted to save graph data.
-        
+
         Raises:
             AssertionError: Always raised with message "startup load must not save graph data".
         """
@@ -326,7 +326,7 @@ def _assert_empty_db_uses_configured_source(
     def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
         """
         Provide the preconfigured fallback AssetRelationshipGraph instance.
-        
+
         Returns:
             AssetRelationshipGraph: The configured fallback graph object.
         """
@@ -362,7 +362,7 @@ def test_factory_precedence_skips_persistence_load(
     def fail_create_engine(_url: str) -> Any:
         """
         Fail when called to indicate persistence engine creation must not occur when a graph factory is configured.
-        
+
         Raises:
             AssertionError: always raised with message "persistence load should not be attempted".
         """
@@ -554,7 +554,7 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
 ) -> None:
     """
     Ensure startup fails when ASSET_GRAPH_DATABASE_URL is invalid and that the resulting error message and logs do not expose the raw URL or embedded secrets.
-    
+
     Verifies that initializing the graph raises a RuntimeError with the text "Failed to load persisted graph during startup" and that neither the full configured URL nor secret substrings appear in the exception message or captured log output.
     """
     raw_url = "not-a-real-driver://user:secret@example.invalid/db"
@@ -670,9 +670,9 @@ def test_reset_reloads_persisted_graph_without_saving(
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         """
         Raise an AssertionError to fail tests when a reset or startup load attempts to persist the graph.
-        
+
         Used as a test stub replacement for persistence calls to ensure startup/reset code does not write to storage.
-        
+
         Raises:
             AssertionError: always; indicates the code under test attempted to save graph data when it must not.
         """

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -382,6 +382,56 @@ def test_persisted_full_graph_loads(
     assert [event.id for event in loaded.regulatory_events] == ["EVENT_A"]
 
 
+def test_populated_persistence_wins_over_graph_cache_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Populated persistence should win over GRAPH_CACHE_PATH."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    _configure_persistence_url(monkeypatch, database_url)
+    monkeypatch.setenv("GRAPH_CACHE_PATH", "/tmp/graph-cache.json")
+
+    def fail_cache_load(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
+        """Fail if cache fallback is used before persistence."""
+        raise AssertionError("cache fallback must not run when persistence is populated")
+
+    monkeypatch.setattr(
+        graph_lifecycle_providers,
+        "load_graph_from_cache_path",
+        fail_cache_load,
+    )
+
+    loaded = _initialize_graph_for_test()
+
+    assert set(loaded.assets) == {"ASSET_ONLY"}
+
+
+def test_populated_persistence_wins_over_real_data_fetcher(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Populated persistence should win over USE_REAL_DATA_FETCHER."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    _configure_persistence_url(monkeypatch, database_url)
+    monkeypatch.setenv("USE_REAL_DATA_FETCHER", "1")
+
+    def fail_real_data_load(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
+        """Fail if real-data fallback is used before persistence."""
+        raise AssertionError("real-data fallback must not run when persistence is populated")
+
+    monkeypatch.setattr(
+        graph_lifecycle_providers,
+        "load_graph_from_real_data_fetcher",
+        fail_real_data_load,
+    )
+
+    loaded = _initialize_graph_for_test()
+
+    assert set(loaded.assets) == {"ASSET_ONLY"}
+
+
 def test_legacy_bidirectional_row_survives_startup_load(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -229,6 +229,32 @@ def test_persistence_disabled_preserves_sample_fallback(
 
 
 @pytest.mark.parametrize(
+    "in_memory_url",
+    [
+        "sqlite:///:memory:",
+        "sqlite:///:memory:?check_same_thread=false",
+        "sqlite:///file:testmem?mode=memory",
+    ],
+)
+def test_in_memory_sqlite_url_skips_persistence_load(
+    in_memory_url: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """In-memory SQLite URLs must be skipped rather than creating a fresh empty engine."""
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", in_memory_url)
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+
+    def fail_create_engine(_url: str) -> Any:
+        raise AssertionError("engine creation must not be attempted for in-memory URL")
+
+    monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
+
+    graph = graph_lifecycle._initialize_graph()
+
+    assert graph.assets  # falls back to sample data
+
+
+@pytest.mark.parametrize(
     ("env_name", "env_value", "provider_attr"),
     [
         ("GRAPH_CACHE_PATH", "/tmp/graph-cache.json", "load_graph_from_cache_path"),

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 
 import api.graph_lifecycle as graph_lifecycle
 from src.config.settings import get_settings
@@ -286,6 +286,31 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
     assert "Failed to load persisted graph during startup" in message
     assert "secret" not in message
     assert raw_url not in message
+
+
+def test_malformed_asset_class_persisted_row_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured persistence with a corrupt enum value should fail startup load."""
+    database_url = _sqlite_url(tmp_path)
+    engine = create_engine(database_url)
+    init_db(engine)
+    with engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO assets (id, symbol, name, asset_class, sector, price, currency)"
+                " VALUES ('BAD_ASSET', 'BAD', 'Bad Asset', 'NOT_A_VALID_CLASS', 'Tech', 1.0, 'USD')"
+            )
+        )
+        conn.commit()
+    engine.dispose()
+
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
+        graph_lifecycle._initialize_graph()
 
 
 def test_session_closes_on_success_empty_and_failure(

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -282,6 +282,7 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
     with pytest.raises(RuntimeError) as exc_info:
         graph_lifecycle._initialize_graph()
 
+    assert exc_info.value.__context__ is None
     message = str(exc_info.value)
     assert "Failed to load persisted graph during startup" in message
     assert "secret" not in message

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import importlib
 import logging
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable  # noqa: UP035  # Callable from typing for Prospector/Pylint compatibility
 
 import pytest
 from sqlalchemy import create_engine, text  # pylint: disable=import-error
@@ -28,11 +28,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture(autouse=True)
 def reset_lifecycle(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """
-    Reset the graph lifecycle and clear persistence-related environment variables before each test, then reset the lifecycle again after the test.
-
-    This fixture removes the environment variables ASSET_GRAPH_DATABASE_URL, GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, and USE_REAL_DATA_FETCHER to ensure tests start with a clean persisted-graph configuration and to prevent leakage between tests.
-    """
+    """Reset graph lifecycle and clear persistence env vars."""
     for name in (
         "ASSET_GRAPH_DATABASE_URL",
         "GRAPH_CACHE_PATH",
@@ -81,15 +77,7 @@ def _relationship_strength(
     target_id: str,
     relationship_type: str,
 ) -> float:
-    """
-    Retrieve the stored strength value for the specified relationship.
-
-    @returns
-        The relationship strength as a float.
-
-    @raises AssertionError
-        If no relationship matching `source_id`, `target_id`, and `relationship_type` is found.
-    """
+    """Retrieve the stored strength value for the specified relationship."""
     for target, rel_type, strength in graph.relationships.get(source_id, []):
         if target == target_id and rel_type == relationship_type:
             return strength
@@ -97,16 +85,7 @@ def _relationship_strength(
 
 
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
-    """
-    Construct a file-backed SQLite URL pointing to a database file under the given directory.
-
-    Parameters:
-        tmp_path (Path): Directory in which the SQLite file will be placed.
-        name (str): Filename for the SQLite database (defaults to "asset_graph.db").
-
-    Returns:
-        str: A SQLite URL string referencing the file (e.g., "sqlite:///path/to/{name}").
-    """
+    """Construct a file-backed SQLite URL."""
     return f"sqlite:///{tmp_path / name}"
 
 
@@ -120,14 +99,7 @@ def _init_empty_db(database_url: str) -> None:
 
 
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
-    """
-    Persist the given AssetRelationshipGraph into the database identified by `database_url`.
-
-    Parameters:
-        database_url (str): SQLAlchemy database URL for the test database (file-backed or in-memory).
-        graph (AssetRelationshipGraph): In-memory graph snapshot to be saved.
-
-    """
+    """Persist the given graph into the database."""
     engine = create_engine(database_url)
     init_db(engine)
     session = create_session_factory(engine)()
@@ -140,27 +112,14 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 
 
 def _asset_only_graph() -> AssetRelationshipGraph:
-    """
-    Create an in-memory asset relationship graph containing a single equity and no relationships or events.
-
-    Returns:
-        AssetRelationshipGraph: Graph with one asset (id "ASSET_ONLY", symbol "ONLY") and no relationships or regulatory events.
-    """
+    """Create a graph with one asset and no relationships or events."""
     graph = AssetRelationshipGraph()
     graph.add_asset(_equity("ASSET_ONLY", "ONLY"))
     return graph
 
 
 def _full_graph() -> AssetRelationshipGraph:
-    """
-    Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
-
-    Returns:
-        AssetRelationshipGraph: Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships
-        "ASSET_A" -> "ASSET_B" with type "directed_alpha" and strength 0.4, and
-        "ASSET_B" -> "ASSET_A" with type "directed_alpha" and strength 0.9; and a regulatory
-        event "EVENT_A" attached to "ASSET_A" with related assets ["ASSET_B", "ASSET_C"].
-    """
+    """Create a graph with assets, relationships, and a regulatory event."""
     graph = AssetRelationshipGraph()
     for asset in (
         _equity("ASSET_A", "A"),
@@ -175,12 +134,7 @@ def _full_graph() -> AssetRelationshipGraph:
 
 
 def _initialize_graph_for_test() -> AssetRelationshipGraph:
-    """
-    Initialize the asset relationship graph via the lifecycle test seam.
-
-    Returns:
-        AssetRelationshipGraph: The initialized graph instance used by tests.
-    """
+    """Initialize the graph via the lifecycle test seam."""
     return graph_lifecycle._initialize_graph()  # pylint: disable=protected-access
 
 
@@ -189,94 +143,49 @@ def _initialize_graph_for_test() -> AssetRelationshipGraph:
 # ---------------------------------------------------------------------------
 
 
+def _configure_persistence_url(
+    monkeypatch: pytest.MonkeyPatch,
+    database_url: str,
+) -> None:
+    """Set graph persistence URL and clear cached lifecycle settings."""
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+
+
 class _ClosingSessionProxy:
     """Proxy a SQLAlchemy session and count close calls."""
 
     def __init__(self, session: Any, close_counter: Callable[[], None]) -> None:
-        """
-        Initialize the proxy with a wrapped session and a callback to record close calls.
-
-        Parameters:
-            session: The underlying SQLAlchemy session to proxy.
-            close_counter: A zero-argument callable invoked each time the proxy's `close()` is called to increment the external close-call counter.
-        """
+        """Initialize the proxy with a session and close-call callback."""
         self._session = session
         self._close_counter = close_counter
 
     def __getattr__(self, name: str) -> Any:
-        """
-        Delegate attribute access to the wrapped SQLAlchemy session.
-
-        Parameters:
-            name (str): The attribute name to retrieve from the wrapped session.
-
-        Returns:
-            Any: The attribute value from the underlying session.
-
-        Raises:
-            AttributeError: If the underlying session does not have the requested attribute.
-        """
+        """Delegate attribute access to the wrapped session."""
         return getattr(self._session, name)
 
     def close(self) -> None:
-        """
-        Increment the tracked close counter and close the wrapped SQLAlchemy session.
-
-        Increments the provided close-call counter and then delegates to the underlying
-        session's `close()` method to release database resources.
-        """
+        """Increment the close counter and close the session."""
         self._close_counter()
         self._session.close()
 
 
 def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
-    """
-    Patch the session factory so created sessions are wrapped and their `.close()` calls are counted.
-
-    This replaces graph_lifecycle_providers.create_session_factory via the provided pytest monkeypatch so sessions returned by the factory are proxied to increment an internal counter each time `close()` is invoked.
-
-    Parameters:
-        monkeypatch (pytest.MonkeyPatch): Fixture used to set the patched session factory.
-
-    Returns:
-        Callable[[], int]: A zero-argument callable that returns the current count of `close()` calls.
-    """
+    """Patch session factory to count close calls."""
     close_calls = 0
     real_create_session_factory = graph_lifecycle_providers.create_session_factory
 
     def increment_close_calls() -> None:
-        """
-        Increment the internal counter tracking how many times proxied sessions were closed.
-
-        Used by the session proxy to record each `.close()` invocation.
-        """
+        """Increment the close-call counter."""
         nonlocal close_calls
         close_calls += 1
 
     def tracking_session_factory(engine: Any) -> Any:
-        """
-        Create a session factory that produces sessions wrapped with a proxy which increments a close-call counter when closed.
-
-        The returned callable takes no arguments and produces a `_ClosingSessionProxy` that delegates to a real SQLAlchemy session while incrementing the provided close-count on each `.close()` call.
-
-        Parameters:
-            engine: The SQLAlchemy engine passed through to the underlying session factory.
-
-        Returns:
-            session_factory (Callable[[], Any]): A zero-argument callable that returns a proxied session whose `close()` increments the tracked close-call counter and then closes the underlying session.
-        """
+        """Create a session factory that produces close-counting sessions."""
         real_factory = real_create_session_factory(engine)
 
         def make_session() -> Any:
-            """
-            Return a session proxy that increments a close-call counter each time its .close() is invoked.
-
-            This wraps a real SQLAlchemy session produced by the factory and delegates all attributes
-            and method calls to it while counting calls to .close().
-
-            Returns:
-                _ClosingSessionProxy: Proxy around the real session that increments the configured counter on `.close()` and forwards all other behavior to the underlying session.
-            """
+            """Return a session proxy that counts close calls."""
             return _ClosingSessionProxy(real_factory(), increment_close_calls)
 
         return make_session
@@ -299,37 +208,19 @@ def _assert_empty_db_uses_configured_source(
     monkeypatch: pytest.MonkeyPatch,
     provider_attr: str,
 ) -> None:
-    """
-    Verify that when a persisted database exists but contains no graph rows, startup falls through to a configured non-persistent graph provider and does not attempt to save to the database.
-
-    This test helper:
-    - Creates an empty file-backed SQLite database and sets ASSET_GRAPH_DATABASE_URL to it.
-    - Monkeypatches the specified provider (given by `provider_attr`) to return a configured in-memory graph and replaces AssetGraphRepository.save_graph with a function that fails if called.
-    - Calls the lifecycle initializer and asserts the returned graph is the configured graph and contains only the expected asset ("ASSET_ONLY").
-    """
+    """Verify empty DB falls through to configured provider."""
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """
-        Raise an AssertionError to indicate startup attempted to save graph data.
-
-        Raises:
-            AssertionError: Always raised with message "startup load must not save graph data".
-        """
+        """Fail if startup attempts to save graph data."""
         raise AssertionError("startup load must not save graph data")
 
     configured_graph = _asset_only_graph()
 
     def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
-        """
-        Provide the preconfigured fallback AssetRelationshipGraph instance.
-
-        Returns:
-            AssetRelationshipGraph: The configured fallback graph object.
-        """
+        """Provide the preconfigured fallback graph."""
         return configured_graph
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
@@ -360,12 +251,7 @@ def test_factory_precedence_skips_persistence_load(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
 
     def fail_create_engine(_url: str) -> Any:
-        """
-        Fail when called to indicate persistence engine creation must not occur when a graph factory is configured.
-
-        Raises:
-            AssertionError: always raised with message "persistence load should not be attempted".
-        """
+        """Fail to indicate persistence must not be attempted."""
         raise AssertionError("persistence load should not be attempted")
 
     factory_graph = AssetRelationshipGraph()
@@ -384,8 +270,7 @@ def test_persistence_disabled_preserves_sample_fallback(
     if configured_value is None:
         monkeypatch.delenv("ASSET_GRAPH_DATABASE_URL", raising=False)
     else:
-        monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", configured_value)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+        _configure_persistence_url(monkeypatch, configured_value)
 
     def fail_create_engine(_url: str) -> Any:
         """Fail if engine creation is attempted for a disabled persistence URL."""
@@ -404,15 +289,18 @@ def test_persistence_disabled_preserves_sample_fallback(
         "sqlite:///:memory:",
         "sqlite:///:memory:?check_same_thread=false",
         "sqlite:///file:testmem?mode=memory",
+        "sqlite://",
+        "sqlite+pysqlite://",
+        "sqlite:///file::memory:?cache=shared",
+        "sqlite+pysqlite:///file::memory:?cache=shared",
     ],
 )
 def test_in_memory_sqlite_url_skips_persistence_load(
     in_memory_url: str,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """In-memory SQLite URLs must be skipped rather than creating a fresh empty engine."""
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", in_memory_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    """In-memory SQLite URLs must be skipped."""
+    _configure_persistence_url(monkeypatch, in_memory_url)
 
     def fail_create_engine(_url: str) -> Any:
         """Fail if in-memory SQLite attempts engine creation."""
@@ -468,8 +356,7 @@ def test_persisted_asset_only_graph_loads(
     """One persisted asset is enough to select repository startup loading."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     loaded = _initialize_graph_for_test()
 
@@ -485,8 +372,7 @@ def test_persisted_full_graph_loads(
     """Startup loading should reconstruct persisted graph truth."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _full_graph())
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     loaded = _initialize_graph_for_test()
 
@@ -521,8 +407,7 @@ def test_legacy_bidirectional_row_survives_startup_load(
         session.close()
         engine.dispose()
 
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     loaded = _initialize_graph_for_test()
 
@@ -541,8 +426,7 @@ def test_missing_schema_fails_without_fallback(
 ) -> None:
     """Configured persistence with missing tables should fail startup load."""
     database_url = _sqlite_url(tmp_path)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
         _initialize_graph_for_test()
@@ -552,14 +436,9 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """
-    Ensure startup fails when ASSET_GRAPH_DATABASE_URL is invalid and that the resulting error message and logs do not expose the raw URL or embedded secrets.
-
-    Verifies that initializing the graph raises a RuntimeError with the text "Failed to load persisted graph during startup" and that neither the full configured URL nor secret substrings appear in the exception message or captured log output.
-    """
+    """Ensure startup fails on invalid URL without leaking secrets."""
     raw_url = "not-a-real-driver://user:secret@example.invalid/db"
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", raw_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, raw_url)
 
     with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
         _initialize_graph_for_test()
@@ -592,8 +471,7 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
         conn.commit()
     engine.dispose()
 
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
         _initialize_graph_for_test()
@@ -611,8 +489,7 @@ def test_session_closes_on_persisted_load_success(
     """Startup load should close the session after persisted load."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
     close_count = _patch_session_close_counter(monkeypatch)
 
     _initialize_graph_for_test()
@@ -627,8 +504,7 @@ def test_session_closes_on_empty_persistence_fallback(
     """Startup load should close the session before empty-store fallback."""
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
     close_count = _patch_session_close_counter(monkeypatch)
 
     _initialize_graph_for_test()
@@ -642,8 +518,7 @@ def test_session_closes_on_persistence_failure(
 ) -> None:
     """Startup load should close the session after load failure."""
     database_url = _sqlite_url(tmp_path)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
     close_count = _patch_session_close_counter(monkeypatch)
 
     with pytest.raises(RuntimeError):
@@ -664,18 +539,10 @@ def test_reset_reloads_persisted_graph_without_saving(
     """reset_graph should clear cached state and reload without mutating storage."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """
-        Raise an AssertionError to fail tests when a reset or startup load attempts to persist the graph.
-
-        Used as a test stub replacement for persistence calls to ensure startup/reset code does not write to storage.
-
-        Raises:
-            AssertionError: always; indicates the code under test attempted to save graph data when it must not.
-        """
+        """Fail if reset/startup attempts to save graph data."""
         raise AssertionError("reset/startup load must not save graph data")
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
@@ -695,8 +562,7 @@ def test_api_main_and_router_helper_compatibility(
     """Compatibility graph references should converge around lifecycle loading."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    _configure_persistence_url(monkeypatch, database_url)
 
     import api.main as api_main  # pylint: disable=import-outside-toplevel
     import api.router_helpers as router_helpers  # pylint: disable=import-outside-toplevel

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -53,7 +53,17 @@ def _equity(asset_id: str, symbol: str) -> Equity:
 
 
 def _event(event_id: str, asset_id: str, related_assets: list[str] | None = None) -> RegulatoryEvent:
-    """Build a regulatory event for lifecycle persistence tests."""
+    """
+    Constructs a RegulatoryEvent with sensible default fields used by persistence tests.
+    
+    Parameters:
+        event_id (str): Unique identifier for the event.
+        asset_id (str): ID of the asset the event is associated with.
+        related_assets (list[str] | None): Optional list of related asset IDs; defaults to an empty list when None.
+    
+    Returns:
+        RegulatoryEvent: A RegulatoryEvent populated with the provided IDs, a fixed SEC filing type and date, a short description, and an impact score.
+    """
     return RegulatoryEvent(
         id=event_id,
         asset_id=asset_id,
@@ -71,7 +81,15 @@ def _relationship_strength(
     target_id: str,
     relationship_type: str,
 ) -> float:
-    """Return the strength for one graph relationship."""
+    """
+    Retrieve the stored strength of the relationship from source_id to target_id for the given relationship_type.
+    
+    Returns:
+        float: The relationship strength.
+    
+    Raises:
+        AssertionError: If no matching relationship exists in the graph.
+    """
     for target, rel_type, strength in graph.relationships.get(source_id, []):
         if target == target_id and rel_type == relationship_type:
             return strength
@@ -79,12 +97,26 @@ def _relationship_strength(
 
 
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
-    """Return a temporary file-backed SQLite URL."""
+    """
+    Build a file-backed SQLite connection URL located under the given directory.
+    
+    Parameters:
+        tmp_path (Path): Directory in which to place the SQLite database file.
+        name (str): Filename for the SQLite database (defaults to "asset_graph.db").
+    
+    Returns:
+        sqlite_url (str): A SQLite connection URL pointing to the file at tmp_path / name.
+    """
     return f"sqlite:///{tmp_path / name}"
 
 
 def _init_empty_db(database_url: str) -> None:
-    """Create an empty schema-ready graph database."""
+    """
+    Initialize the database schema at the given database URL.
+    
+    Parameters:
+        database_url (str): SQLAlchemy connection URL for the target database; the function will create the necessary tables/schema at this location.
+    """
     engine = create_engine(database_url)
     try:
         init_db(engine)
@@ -93,7 +125,13 @@ def _init_empty_db(database_url: str) -> None:
 
 
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
-    """Persist a graph snapshot to a temporary graph database."""
+    """
+    Persist a graph snapshot into the database at the given SQLAlchemy URL.
+    
+    Parameters:
+        database_url (str): SQLAlchemy connection URL for the target database.
+        graph (AssetRelationshipGraph): AssetRelationshipGraph instance to persist.
+    """
     engine = create_engine(database_url)
     init_db(engine)
     session = create_session_factory(engine)()
@@ -106,14 +144,24 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 
 
 def _asset_only_graph() -> AssetRelationshipGraph:
-    """Build a graph with one persisted asset and no relationships or events."""
+    """
+    Builds an AssetRelationshipGraph containing a single equity asset and no relationships or events.
+    
+    Returns:
+        AssetRelationshipGraph: Graph containing one asset with id "ASSET_ONLY" and symbol "ONLY".
+    """
     graph = AssetRelationshipGraph()
     graph.add_asset(_equity("ASSET_ONLY", "ONLY"))
     return graph
 
 
 def _full_graph() -> AssetRelationshipGraph:
-    """Build a graph with assets, directed relationships, and an event."""
+    """
+    Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
+    
+    Returns:
+        graph (AssetRelationshipGraph): Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships "ASSET_A" -> "ASSET_B" with `directed_alpha` 0.4 and "ASSET_B" -> "ASSET_A" with `directed_alpha` 0.9; and a regulatory event "EVENT_A" attached to "ASSET_A" referencing "ASSET_B" and "ASSET_C".
+    """
     graph = AssetRelationshipGraph()
     for asset in (
         _equity("ASSET_A", "A"),
@@ -137,6 +185,12 @@ def test_factory_precedence_skips_persistence_load(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
 
     def fail_create_engine(_url: str) -> Any:
+        """
+        Always raise an AssertionError to signal that engine creation must not be attempted.
+        
+        Raises:
+            AssertionError: Always raised with the message "persistence load should not be attempted".
+        """
         raise AssertionError("persistence load should not be attempted")
 
     factory_graph = AssetRelationshipGraph()
@@ -159,6 +213,12 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_create_engine(_url: str) -> Any:
+        """
+        Always raise an AssertionError to signal that engine creation must not be attempted.
+        
+        Raises:
+            AssertionError: Always raised with the message "persistence load should not be attempted".
+        """
         raise AssertionError("persistence load should not be attempted")
 
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
@@ -179,6 +239,11 @@ def test_empty_configured_db_falls_back_without_saving(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
+        """
+        Raise an AssertionError to fail the test if an attempt is made to save the graph during startup.
+        
+        This helper always raises AssertionError("startup load must not save graph data") to indicate that saving persisted graph data during initialization is unexpected.
+        """
         raise AssertionError("startup load must not save graph data")
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
@@ -327,9 +392,24 @@ def test_session_closes_on_success_empty_and_failure(
     real_create_session_factory = graph_lifecycle_providers.create_session_factory
 
     def tracking_session_factory(engine: Any) -> Any:
+        """
+        Create a session factory whose sessions are wrapped with ClosingSessionProxy.
+        
+        Parameters:
+            engine: The database engine used to build the underlying session factory.
+        
+        Returns:
+            A callable that, when invoked, returns a session proxy delegating to a real session created from `engine`, with `close()` proxied for tracking.
+        """
         real_factory = real_create_session_factory(engine)
 
         def make_session() -> Any:
+            """
+            Create a new database session wrapped by a ClosingSessionProxy.
+            
+            Returns:
+                ClosingSessionProxy: A proxy around the newly created session that delegates session operations to the real session and exposes a close() implementation suitable for tracking/overriding close calls.
+            """
             session = real_factory()
             return ClosingSessionProxy(session)
 
@@ -339,12 +419,36 @@ def test_session_closes_on_success_empty_and_failure(
         """Proxy a SQLAlchemy session and count close calls."""
 
         def __init__(self, session: Any) -> None:
+            """
+            Initialize the repository with a database session.
+            
+            Parameters:
+                session (Any): A database session instance used for persistence operations (short-lived SQLAlchemy
+                    session or equivalent). The repository retains this session for its lifetime.
+            """
             self._session = session
 
         def __getattr__(self, name: str) -> Any:
+            """
+            Delegate attribute access to the proxied session.
+            
+            Forward attribute lookups to self._session so that attributes and methods on the underlying session
+            are accessible through this proxy.
+            
+            Parameters:
+                name (str): Name of the attribute being accessed.
+            
+            Returns:
+                Any: The attribute value from the underlying session.
+            """
             return getattr(self._session, name)
 
         def close(self) -> None:
+            """
+            Increment the external close counter and close the proxied session.
+            
+            Increments the nonlocal `close_calls` counter used by tests and delegates to the wrapped session's `close()` method.
+            """
             nonlocal close_calls
             close_calls += 1
             self._session.close()
@@ -379,6 +483,15 @@ def test_reset_reloads_persisted_graph_without_saving(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
+        """
+        Fail the test if a graph save is attempted during reset or startup load.
+        
+        This helper unconditionally raises an AssertionError to ensure code paths invoked
+        during reset/startup do not attempt to persist graph data.
+        
+        Raises:
+            AssertionError: with message "reset/startup load must not save graph data".
+        """
         raise AssertionError("reset/startup load must not save graph data")
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -28,7 +28,11 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture(autouse=True)
 def reset_lifecycle(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
-    """Reset graph lifecycle state and graph-source environment for each test."""
+    """
+    Reset the graph lifecycle and clear persistence-related environment variables before each test, then reset the lifecycle again after the test.
+    
+    This fixture removes the environment variables ASSET_GRAPH_DATABASE_URL, GRAPH_CACHE_PATH, REAL_DATA_CACHE_PATH, and USE_REAL_DATA_FETCHER to ensure tests start with a clean persisted-graph configuration and to prevent leakage between tests.
+    """
     for name in (
         "ASSET_GRAPH_DATABASE_URL",
         "GRAPH_CACHE_PATH",
@@ -77,7 +81,15 @@ def _relationship_strength(
     target_id: str,
     relationship_type: str,
 ) -> float:
-    """Return the stored relationship strength."""
+    """
+    Retrieve the stored strength value for the specified relationship.
+    
+    @returns
+        The relationship strength as a float.
+    
+    @raises AssertionError
+        If no relationship matching `source_id`, `target_id`, and `relationship_type` is found.
+    """
     for target, rel_type, strength in graph.relationships.get(source_id, []):
         if target == target_id and rel_type == relationship_type:
             return strength
@@ -85,7 +97,16 @@ def _relationship_strength(
 
 
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
-    """Build a file-backed SQLite URL under tmp_path."""
+    """
+    Construct a file-backed SQLite URL pointing to a database file under the given directory.
+    
+    Parameters:
+        tmp_path (Path): Directory in which the SQLite file will be placed.
+        name (str): Filename for the SQLite database (defaults to "asset_graph.db").
+    
+    Returns:
+        str: A SQLite URL string referencing the file (e.g., "sqlite:///path/to/{name}").
+    """
     return f"sqlite:///{tmp_path / name}"
 
 
@@ -99,7 +120,14 @@ def _init_empty_db(database_url: str) -> None:
 
 
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
-    """Persist a graph snapshot to a test database."""
+    """
+    Persist the given AssetRelationshipGraph into the database identified by `database_url`.
+    
+    Parameters:
+        database_url (str): SQLAlchemy database URL for the test database (file-backed or in-memory).
+        graph (AssetRelationshipGraph): In-memory graph snapshot to be saved.
+    
+    """
     engine = create_engine(database_url)
     init_db(engine)
     session = create_session_factory(engine)()
@@ -112,14 +140,27 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 
 
 def _asset_only_graph() -> AssetRelationshipGraph:
-    """Build a graph containing one asset and no relationships."""
+    """
+    Create an in-memory asset relationship graph containing a single equity and no relationships or events.
+    
+    Returns:
+        AssetRelationshipGraph: Graph with one asset (id "ASSET_ONLY", symbol "ONLY") and no relationships or regulatory events.
+    """
     graph = AssetRelationshipGraph()
     graph.add_asset(_equity("ASSET_ONLY", "ONLY"))
     return graph
 
 
 def _full_graph() -> AssetRelationshipGraph:
-    """Build a graph with assets, relationships, and one event."""
+    """
+    Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
+    
+    Returns:
+        AssetRelationshipGraph: Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships
+        "ASSET_A" -> "ASSET_B" with type "directed_alpha" and strength 0.4, and
+        "ASSET_B" -> "ASSET_A" with type "directed_alpha" and strength 0.9; and a regulatory
+        event "EVENT_A" attached to "ASSET_A" with related assets ["ASSET_B", "ASSET_C"].
+    """
     graph = AssetRelationshipGraph()
     for asset in (
         _equity("ASSET_A", "A"),
@@ -134,7 +175,12 @@ def _full_graph() -> AssetRelationshipGraph:
 
 
 def _initialize_graph_for_test() -> AssetRelationshipGraph:
-    """Initialize the graph through the lifecycle test seam."""
+    """
+    Initialize the asset relationship graph via the lifecycle test seam.
+    
+    Returns:
+        AssetRelationshipGraph: The initialized graph instance used by tests.
+    """
     return graph_lifecycle._initialize_graph()  # pylint: disable=protected-access
 
 
@@ -147,34 +193,90 @@ class _ClosingSessionProxy:
     """Proxy a SQLAlchemy session and count close calls."""
 
     def __init__(self, session: Any, close_counter: Callable[[], None]) -> None:
+        """
+        Initialize the proxy with a wrapped session and a callback to record close calls.
+        
+        Parameters:
+            session: The underlying SQLAlchemy session to proxy.
+            close_counter: A zero-argument callable invoked each time the proxy's `close()` is called to increment the external close-call counter.
+        """
         self._session = session
         self._close_counter = close_counter
 
     def __getattr__(self, name: str) -> Any:
-        """Delegate attribute access to the underlying session."""
+        """
+        Delegate attribute access to the wrapped SQLAlchemy session.
+        
+        Parameters:
+            name (str): The attribute name to retrieve from the wrapped session.
+        
+        Returns:
+            Any: The attribute value from the underlying session.
+        
+        Raises:
+            AttributeError: If the underlying session does not have the requested attribute.
+        """
         return getattr(self._session, name)
 
     def close(self) -> None:
-        """Increment the close counter and close the underlying session."""
+        """
+        Increment the tracked close counter and close the wrapped SQLAlchemy session.
+        
+        Increments the provided close-call counter and then delegates to the underlying
+        session's `close()` method to release database resources.
+        """
         self._close_counter()
         self._session.close()
 
 
 def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
-    """Patch startup session creation and return the close-call count."""
+    """
+    Patch the session factory so created sessions are wrapped and their `.close()` calls are counted.
+    
+    This replaces graph_lifecycle_providers.create_session_factory via the provided pytest monkeypatch so sessions returned by the factory are proxied to increment an internal counter each time `close()` is invoked.
+    
+    Parameters:
+        monkeypatch (pytest.MonkeyPatch): Fixture used to set the patched session factory.
+    
+    Returns:
+        Callable[[], int]: A zero-argument callable that returns the current count of `close()` calls.
+    """
     close_calls = 0
     real_create_session_factory = graph_lifecycle_providers.create_session_factory
 
     def increment_close_calls() -> None:
+        """
+        Increment the internal counter tracking how many times proxied sessions were closed.
+        
+        Used by the session proxy to record each `.close()` invocation.
+        """
         nonlocal close_calls
         close_calls += 1
 
     def tracking_session_factory(engine: Any) -> Any:
-        """Create sessions wrapped with a close-counting proxy."""
+        """
+        Create a session factory that produces sessions wrapped with a proxy which increments a close-call counter when closed.
+        
+        The returned callable takes no arguments and produces a `_ClosingSessionProxy` that delegates to a real SQLAlchemy session while incrementing the provided close-count on each `.close()` call.
+        
+        Parameters:
+            engine: The SQLAlchemy engine passed through to the underlying session factory.
+        
+        Returns:
+            session_factory (Callable[[], Any]): A zero-argument callable that returns a proxied session whose `close()` increments the tracked close-call counter and then closes the underlying session.
+        """
         real_factory = real_create_session_factory(engine)
 
         def make_session() -> Any:
-            """Create a close-counting session proxy."""
+            """
+            Return a session proxy that increments a close-call counter each time its .close() is invoked.
+            
+            This wraps a real SQLAlchemy session produced by the factory and delegates all attributes
+            and method calls to it while counting calls to .close().
+            
+            Returns:
+                _ClosingSessionProxy: Proxy around the real session that increments the configured counter on `.close()` and forwards all other behavior to the underlying session.
+            """
             return _ClosingSessionProxy(real_factory(), increment_close_calls)
 
         return make_session
@@ -197,20 +299,37 @@ def _assert_empty_db_uses_configured_source(
     monkeypatch: pytest.MonkeyPatch,
     provider_attr: str,
 ) -> None:
-    """Assert empty persistence falls through to a configured graph source."""
+    """
+    Verify that when a persisted database exists but contains no graph rows, startup falls through to a configured non-persistent graph provider and does not attempt to save to the database.
+    
+    This test helper:
+    - Creates an empty file-backed SQLite database and sets ASSET_GRAPH_DATABASE_URL to it.
+    - Monkeypatches the specified provider (given by `provider_attr`) to return a configured in-memory graph and replaces AssetGraphRepository.save_graph with a function that fails if called.
+    - Calls the lifecycle initializer and asserts the returned graph is the configured graph and contains only the expected asset ("ASSET_ONLY").
+    """
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """Fail if startup attempts to save graph data."""
+        """
+        Raise an AssertionError to indicate startup attempted to save graph data.
+        
+        Raises:
+            AssertionError: Always raised with message "startup load must not save graph data".
+        """
         raise AssertionError("startup load must not save graph data")
 
     configured_graph = _asset_only_graph()
 
     def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
-        """Return the configured fallback graph."""
+        """
+        Provide the preconfigured fallback AssetRelationshipGraph instance.
+        
+        Returns:
+            AssetRelationshipGraph: The configured fallback graph object.
+        """
         return configured_graph
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
@@ -241,7 +360,12 @@ def test_factory_precedence_skips_persistence_load(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
 
     def fail_create_engine(_url: str) -> Any:
-        """Fail if persistence load is attempted when a factory is set."""
+        """
+        Fail when called to indicate persistence engine creation must not occur when a graph factory is configured.
+        
+        Raises:
+            AssertionError: always raised with message "persistence load should not be attempted".
+        """
         raise AssertionError("persistence load should not be attempted")
 
     factory_graph = AssetRelationshipGraph()
@@ -428,7 +552,11 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Invalid configured persistence should fail with sanitized lifecycle text."""
+    """
+    Ensure startup fails when ASSET_GRAPH_DATABASE_URL is invalid and that the resulting error message and logs do not expose the raw URL or embedded secrets.
+    
+    Verifies that initializing the graph raises a RuntimeError with the text "Failed to load persisted graph during startup" and that neither the full configured URL nor secret substrings appear in the exception message or captured log output.
+    """
     raw_url = "not-a-real-driver://user:secret@example.invalid/db"
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", raw_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
@@ -540,7 +668,14 @@ def test_reset_reloads_persisted_graph_without_saving(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """Fail if reset or startup load attempts to save graph data."""
+        """
+        Raise an AssertionError to fail tests when a reset or startup load attempts to persist the graph.
+        
+        Used as a test stub replacement for persistence calls to ensure startup/reset code does not write to storage.
+        
+        Raises:
+            AssertionError: always; indicates the code under test attempted to save graph data when it must not.
+        """
         raise AssertionError("reset/startup load must not save graph data")
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -55,12 +55,12 @@ def _equity(asset_id: str, symbol: str) -> Equity:
 def _event(event_id: str, asset_id: str, related_assets: list[str] | None = None) -> RegulatoryEvent:
     """
     Constructs a RegulatoryEvent with sensible default fields used by persistence tests.
-    
+
     Parameters:
         event_id (str): Unique identifier for the event.
         asset_id (str): ID of the asset the event is associated with.
         related_assets (list[str] | None): Optional list of related asset IDs; defaults to an empty list when None.
-    
+
     Returns:
         RegulatoryEvent: A RegulatoryEvent populated with the provided IDs, a fixed SEC filing type and date, a short description, and an impact score.
     """
@@ -83,10 +83,10 @@ def _relationship_strength(
 ) -> float:
     """
     Retrieve the stored strength of the relationship from source_id to target_id for the given relationship_type.
-    
+
     Returns:
         float: The relationship strength.
-    
+
     Raises:
         AssertionError: If no matching relationship exists in the graph.
     """
@@ -99,11 +99,11 @@ def _relationship_strength(
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
     """
     Build a file-backed SQLite connection URL located under the given directory.
-    
+
     Parameters:
         tmp_path (Path): Directory in which to place the SQLite database file.
         name (str): Filename for the SQLite database (defaults to "asset_graph.db").
-    
+
     Returns:
         sqlite_url (str): A SQLite connection URL pointing to the file at tmp_path / name.
     """
@@ -113,7 +113,7 @@ def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
 def _init_empty_db(database_url: str) -> None:
     """
     Initialize the database schema at the given database URL.
-    
+
     Parameters:
         database_url (str): SQLAlchemy connection URL for the target database; the function will create the necessary tables/schema at this location.
     """
@@ -127,7 +127,7 @@ def _init_empty_db(database_url: str) -> None:
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
     """
     Persist a graph snapshot into the database at the given SQLAlchemy URL.
-    
+
     Parameters:
         database_url (str): SQLAlchemy connection URL for the target database.
         graph (AssetRelationshipGraph): AssetRelationshipGraph instance to persist.
@@ -146,7 +146,7 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 def _asset_only_graph() -> AssetRelationshipGraph:
     """
     Builds an AssetRelationshipGraph containing a single equity asset and no relationships or events.
-    
+
     Returns:
         AssetRelationshipGraph: Graph containing one asset with id "ASSET_ONLY" and symbol "ONLY".
     """
@@ -158,7 +158,7 @@ def _asset_only_graph() -> AssetRelationshipGraph:
 def _full_graph() -> AssetRelationshipGraph:
     """
     Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
-    
+
     Returns:
         graph (AssetRelationshipGraph): Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships "ASSET_A" -> "ASSET_B" with `directed_alpha` 0.4 and "ASSET_B" -> "ASSET_A" with `directed_alpha` 0.9; and a regulatory event "EVENT_A" attached to "ASSET_A" referencing "ASSET_B" and "ASSET_C".
     """
@@ -187,7 +187,7 @@ def test_factory_precedence_skips_persistence_load(
     def fail_create_engine(_url: str) -> Any:
         """
         Always raise an AssertionError to signal that engine creation must not be attempted.
-        
+
         Raises:
             AssertionError: Always raised with the message "persistence load should not be attempted".
         """
@@ -215,7 +215,7 @@ def test_persistence_disabled_preserves_sample_fallback(
     def fail_create_engine(_url: str) -> Any:
         """
         Always raise an AssertionError to signal that engine creation must not be attempted.
-        
+
         Raises:
             AssertionError: Always raised with the message "persistence load should not be attempted".
         """
@@ -252,7 +252,7 @@ def test_empty_configured_db_honors_configured_source_before_sample_fallback(
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         """
         Raise an AssertionError to fail the test if an attempt is made to save the graph during startup.
-        
+
         This helper always raises AssertionError("startup load must not save graph data") to indicate that saving persisted graph data during initialization is unexpected.
         """
         raise AssertionError("startup load must not save graph data")
@@ -415,10 +415,10 @@ def test_session_closes_on_success_empty_and_failure(
     def tracking_session_factory(engine: Any) -> Any:
         """
         Create a session factory whose sessions are wrapped with ClosingSessionProxy.
-        
+
         Parameters:
             engine: The database engine used to build the underlying session factory.
-        
+
         Returns:
             A callable that, when invoked, returns a session proxy delegating to a real session created from `engine`, with `close()` proxied for tracking.
         """
@@ -427,7 +427,7 @@ def test_session_closes_on_success_empty_and_failure(
         def make_session() -> Any:
             """
             Create a new database session wrapped by a ClosingSessionProxy.
-            
+
             Returns:
                 ClosingSessionProxy: A proxy around the newly created session that delegates session operations to the real session and exposes a close() implementation suitable for tracking/overriding close calls.
             """
@@ -442,7 +442,7 @@ def test_session_closes_on_success_empty_and_failure(
         def __init__(self, session: Any) -> None:
             """
             Initialize the repository with a database session.
-            
+
             Parameters:
                 session (Any): A database session instance used for persistence operations (short-lived SQLAlchemy
                     session or equivalent). The repository retains this session for its lifetime.
@@ -452,13 +452,13 @@ def test_session_closes_on_success_empty_and_failure(
         def __getattr__(self, name: str) -> Any:
             """
             Delegate attribute access to the proxied session.
-            
+
             Forward attribute lookups to self._session so that attributes and methods on the underlying session
             are accessible through this proxy.
-            
+
             Parameters:
                 name (str): Name of the attribute being accessed.
-            
+
             Returns:
                 Any: The attribute value from the underlying session.
             """
@@ -467,7 +467,7 @@ def test_session_closes_on_success_empty_and_failure(
         def close(self) -> None:
             """
             Increment the external close counter and close the proxied session.
-            
+
             Increments the nonlocal `close_calls` counter used by tests and delegates to the wrapped session's `close()` method.
             """
             nonlocal close_calls
@@ -506,10 +506,10 @@ def test_reset_reloads_persisted_graph_without_saving(
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         """
         Fail the test if a graph save is attempted during reset or startup load.
-        
+
         This helper unconditionally raises an AssertionError to ensure code paths invoked
         during reset/startup do not attempt to persist graph data.
-        
+
         Raises:
             AssertionError: with message "reset/startup load must not save graph data".
         """

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import importlib
-from collections.abc import Iterator
+import logging
+from collections.abc import Callable, Iterator
 from pathlib import Path
 from typing import Any
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine, text  # pylint: disable=import-error
 
 import api.graph_lifecycle as graph_lifecycle
 import api.graph_lifecycle_providers as graph_lifecycle_providers
@@ -40,6 +41,11 @@ def reset_lifecycle(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     graph_lifecycle.reset_graph()
 
 
+# ---------------------------------------------------------------------------
+# Module-level helpers and data builders
+# ---------------------------------------------------------------------------
+
+
 def _equity(asset_id: str, symbol: str) -> Equity:
     """Build a minimal equity asset for lifecycle persistence tests."""
     return Equity(
@@ -53,17 +59,7 @@ def _equity(asset_id: str, symbol: str) -> Equity:
 
 
 def _event(event_id: str, asset_id: str, related_assets: list[str] | None = None) -> RegulatoryEvent:
-    """
-    Constructs a RegulatoryEvent with sensible default fields used by persistence tests.
-
-    Parameters:
-        event_id (str): Unique identifier for the event.
-        asset_id (str): ID of the asset the event is associated with.
-        related_assets (list[str] | None): Optional list of related asset IDs; defaults to an empty list when None.
-
-    Returns:
-        RegulatoryEvent: A RegulatoryEvent populated with the provided IDs, a fixed SEC filing type and date, a short description, and an impact score.
-    """
+    """Build a regulatory event for persistence tests."""
     return RegulatoryEvent(
         id=event_id,
         asset_id=asset_id,
@@ -81,15 +77,7 @@ def _relationship_strength(
     target_id: str,
     relationship_type: str,
 ) -> float:
-    """
-    Retrieve the stored strength of the relationship from source_id to target_id for the given relationship_type.
-
-    Returns:
-        float: The relationship strength.
-
-    Raises:
-        AssertionError: If no matching relationship exists in the graph.
-    """
+    """Return the stored relationship strength."""
     for target, rel_type, strength in graph.relationships.get(source_id, []):
         if target == target_id and rel_type == relationship_type:
             return strength
@@ -97,26 +85,12 @@ def _relationship_strength(
 
 
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
-    """
-    Build a file-backed SQLite connection URL located under the given directory.
-
-    Parameters:
-        tmp_path (Path): Directory in which to place the SQLite database file.
-        name (str): Filename for the SQLite database (defaults to "asset_graph.db").
-
-    Returns:
-        sqlite_url (str): A SQLite connection URL pointing to the file at tmp_path / name.
-    """
+    """Build a file-backed SQLite URL under tmp_path."""
     return f"sqlite:///{tmp_path / name}"
 
 
 def _init_empty_db(database_url: str) -> None:
-    """
-    Initialize the database schema at the given database URL.
-
-    Parameters:
-        database_url (str): SQLAlchemy connection URL for the target database; the function will create the necessary tables/schema at this location.
-    """
+    """Create the graph database schema without graph rows."""
     engine = create_engine(database_url)
     try:
         init_db(engine)
@@ -125,13 +99,7 @@ def _init_empty_db(database_url: str) -> None:
 
 
 def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
-    """
-    Persist a graph snapshot into the database at the given SQLAlchemy URL.
-
-    Parameters:
-        database_url (str): SQLAlchemy connection URL for the target database.
-        graph (AssetRelationshipGraph): AssetRelationshipGraph instance to persist.
-    """
+    """Persist a graph snapshot to a test database."""
     engine = create_engine(database_url)
     init_db(engine)
     session = create_session_factory(engine)()
@@ -144,24 +112,14 @@ def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
 
 
 def _asset_only_graph() -> AssetRelationshipGraph:
-    """
-    Builds an AssetRelationshipGraph containing a single equity asset and no relationships or events.
-
-    Returns:
-        AssetRelationshipGraph: Graph containing one asset with id "ASSET_ONLY" and symbol "ONLY".
-    """
+    """Build a graph containing one asset and no relationships."""
     graph = AssetRelationshipGraph()
     graph.add_asset(_equity("ASSET_ONLY", "ONLY"))
     return graph
 
 
 def _full_graph() -> AssetRelationshipGraph:
-    """
-    Create an AssetRelationshipGraph containing three equities, two directed relationships, and one regulatory event.
-
-    Returns:
-        graph (AssetRelationshipGraph): Graph with assets "ASSET_A", "ASSET_B", and "ASSET_C"; relationships "ASSET_A" -> "ASSET_B" with `directed_alpha` 0.4 and "ASSET_B" -> "ASSET_A" with `directed_alpha` 0.9; and a regulatory event "EVENT_A" attached to "ASSET_A" referencing "ASSET_B" and "ASSET_C".
-    """
+    """Build a graph with assets, relationships, and one event."""
     graph = AssetRelationshipGraph()
     for asset in (
         _equity("ASSET_A", "A"),
@@ -175,6 +133,104 @@ def _full_graph() -> AssetRelationshipGraph:
     return graph
 
 
+def _initialize_graph_for_test() -> AssetRelationshipGraph:
+    """Initialize the graph through the lifecycle test seam."""
+    return graph_lifecycle._initialize_graph()  # pylint: disable=protected-access
+
+
+# ---------------------------------------------------------------------------
+# Session-close tracking proxy and patch helper
+# ---------------------------------------------------------------------------
+
+
+class _ClosingSessionProxy:
+    """Proxy a SQLAlchemy session and count close calls."""
+
+    def __init__(self, session: Any, close_counter: Callable[[], None]) -> None:
+        self._session = session
+        self._close_counter = close_counter
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate attribute access to the underlying session."""
+        return getattr(self._session, name)
+
+    def close(self) -> None:
+        """Increment the close counter and close the underlying session."""
+        self._close_counter()
+        self._session.close()
+
+
+def _patch_session_close_counter(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Patch startup session creation and return the close-call count."""
+    close_calls = 0
+    real_create_session_factory = graph_lifecycle_providers.create_session_factory
+
+    def increment_close_calls() -> None:
+        nonlocal close_calls
+        close_calls += 1
+
+    def tracking_session_factory(engine: Any) -> Any:
+        """Create sessions wrapped with a close-counting proxy."""
+        real_factory = real_create_session_factory(engine)
+
+        def make_session() -> Any:
+            """Create a close-counting session proxy."""
+            return _ClosingSessionProxy(real_factory(), increment_close_calls)
+
+        return make_session
+
+    monkeypatch.setattr(
+        graph_lifecycle_providers,
+        "create_session_factory",
+        tracking_session_factory,
+    )
+    return lambda: close_calls
+
+
+# ---------------------------------------------------------------------------
+# Empty-persistence fallback helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_empty_db_uses_configured_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    provider_attr: str,
+) -> None:
+    """Assert empty persistence falls through to a configured graph source."""
+    database_url = _sqlite_url(tmp_path)
+    _init_empty_db(database_url)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+
+    def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
+        """Fail if startup attempts to save graph data."""
+        raise AssertionError("startup load must not save graph data")
+
+    configured_graph = _asset_only_graph()
+
+    def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
+        """Return the configured fallback graph."""
+        return configured_graph
+
+    monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
+    monkeypatch.setattr(
+        graph_lifecycle_providers,
+        provider_attr,
+        load_configured_graph,
+    )
+
+    graph = _initialize_graph_for_test()
+
+    assert graph is configured_graph
+    assert set(graph.assets) == {"ASSET_ONLY"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: factory and persistence-disabled precedence
+# ---------------------------------------------------------------------------
+
+
 def test_factory_precedence_skips_persistence_load(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -185,19 +241,14 @@ def test_factory_precedence_skips_persistence_load(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
 
     def fail_create_engine(_url: str) -> Any:
-        """
-        Always raise an AssertionError to signal that engine creation must not be attempted.
-
-        Raises:
-            AssertionError: Always raised with the message "persistence load should not be attempted".
-        """
+        """Fail if persistence load is attempted when a factory is set."""
         raise AssertionError("persistence load should not be attempted")
 
     factory_graph = AssetRelationshipGraph()
     graph_lifecycle.set_graph_factory(lambda: factory_graph)
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
-    assert graph_lifecycle._initialize_graph() is factory_graph
+    assert _initialize_graph_for_test() is factory_graph
 
 
 @pytest.mark.parametrize("configured_value", [None, "", "   "])
@@ -213,17 +264,12 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_create_engine(_url: str) -> Any:
-        """
-        Always raise an AssertionError to signal that engine creation must not be attempted.
-
-        Raises:
-            AssertionError: Always raised with the message "persistence load should not be attempted".
-        """
+        """Fail if engine creation is attempted for a disabled persistence URL."""
         raise AssertionError("persistence load should not be attempted")
 
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
-    graph = graph_lifecycle._initialize_graph()
+    graph = _initialize_graph_for_test()
 
     assert graph.assets
 
@@ -245,60 +291,50 @@ def test_in_memory_sqlite_url_skips_persistence_load(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_create_engine(_url: str) -> Any:
+        """Fail if in-memory SQLite attempts engine creation."""
         raise AssertionError("engine creation must not be attempted for in-memory URL")
 
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
-    graph = graph_lifecycle._initialize_graph()
+    graph = _initialize_graph_for_test()
 
     assert graph.assets  # falls back to sample data
 
 
-@pytest.mark.parametrize(
-    ("env_name", "env_value", "provider_attr"),
-    [
-        ("GRAPH_CACHE_PATH", "/tmp/graph-cache.json", "load_graph_from_cache_path"),
-        ("USE_REAL_DATA_FETCHER", "1", "load_graph_from_real_data_fetcher"),
-    ],
-)
-def test_empty_configured_db_honors_configured_source_before_sample_fallback(
+# ---------------------------------------------------------------------------
+# Tests: empty-store fallback honors configured sources
+# ---------------------------------------------------------------------------
+
+
+def test_empty_configured_db_honors_graph_cache_path_before_sample_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    env_name: str,
-    env_value: str,
-    provider_attr: str,
 ) -> None:
-    """An empty configured persistence store must still honor higher-precedence configured sources."""
-    database_url = _sqlite_url(tmp_path)
-    _init_empty_db(database_url)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    monkeypatch.setenv(env_name, env_value)
-    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
-
-    def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """
-        Raise an AssertionError to fail the test if an attempt is made to save the graph during startup.
-
-        This helper always raises AssertionError("startup load must not save graph data") to indicate that saving persisted graph data during initialization is unexpected.
-        """
-        raise AssertionError("startup load must not save graph data")
-
-    configured_graph = _asset_only_graph()
-
-    def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
-        return configured_graph
-
-    monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
-    monkeypatch.setattr(
-        graph_lifecycle_providers,
-        provider_attr,
-        load_configured_graph,
+    """Empty persistence should fall through to GRAPH_CACHE_PATH."""
+    monkeypatch.setenv("GRAPH_CACHE_PATH", "/tmp/graph-cache.json")
+    _assert_empty_db_uses_configured_source(
+        tmp_path,
+        monkeypatch,
+        "load_graph_from_cache_path",
     )
 
-    graph = graph_lifecycle._initialize_graph()
 
-    assert graph is configured_graph
-    assert set(graph.assets) == {"ASSET_ONLY"}
+def test_empty_configured_db_honors_real_data_fetcher_before_sample_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty persistence should fall through to USE_REAL_DATA_FETCHER."""
+    monkeypatch.setenv("USE_REAL_DATA_FETCHER", "1")
+    _assert_empty_db_uses_configured_source(
+        tmp_path,
+        monkeypatch,
+        "load_graph_from_real_data_fetcher",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: successful persisted loads
+# ---------------------------------------------------------------------------
 
 
 def test_persisted_asset_only_graph_loads(
@@ -311,7 +347,7 @@ def test_persisted_asset_only_graph_loads(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
-    loaded = graph_lifecycle._initialize_graph()
+    loaded = _initialize_graph_for_test()
 
     assert set(loaded.assets) == {"ASSET_ONLY"}
     assert not loaded.relationships
@@ -328,7 +364,7 @@ def test_persisted_full_graph_loads(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
-    loaded = graph_lifecycle._initialize_graph()
+    loaded = _initialize_graph_for_test()
 
     assert set(loaded.assets) == {"ASSET_A", "ASSET_B", "ASSET_C"}
     assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
@@ -364,10 +400,15 @@ def test_legacy_bidirectional_row_survives_startup_load(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
-    loaded = graph_lifecycle._initialize_graph()
+    loaded = _initialize_graph_for_test()
 
     assert _relationship_strength(loaded, "LEGACY_A", "LEGACY_B", "same_sector") == pytest.approx(0.7)
     assert _relationship_strength(loaded, "LEGACY_B", "LEGACY_A", "same_sector") == pytest.approx(0.7)
+
+
+# ---------------------------------------------------------------------------
+# Tests: failure paths
+# ---------------------------------------------------------------------------
 
 
 def test_missing_schema_fails_without_fallback(
@@ -380,25 +421,29 @@ def test_missing_schema_fails_without_fallback(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
-        graph_lifecycle._initialize_graph()
+        _initialize_graph_for_test()
 
 
 def test_invalid_configured_database_url_fails_without_leaking_url(
     monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Invalid configured persistence should fail with sanitized lifecycle text."""
-    raw_url = "not-a-sqlalchemy-url://user:secret@example.invalid/db"
+    raw_url = "not-a-real-driver://user:secret@example.invalid/db"
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", raw_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
-    with pytest.raises(RuntimeError) as exc_info:
-        graph_lifecycle._initialize_graph()
+    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
+        _initialize_graph_for_test()
 
-    assert exc_info.value.__context__ is None
+    assert exc_info.value.__suppress_context__ is True
     message = str(exc_info.value)
     assert "Failed to load persisted graph during startup" in message
     assert "secret" not in message
     assert raw_url not in message
+    log_output = " ".join(record.getMessage() for record in caplog.records)
+    assert "secret" not in log_output
+    assert raw_url not in log_output
 
 
 def test_malformed_asset_class_persisted_row_fails_without_fallback(
@@ -423,100 +468,65 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
-        graph_lifecycle._initialize_graph()
+        _initialize_graph_for_test()
 
 
-def test_session_closes_on_success_empty_and_failure(
+# ---------------------------------------------------------------------------
+# Tests: session cleanup
+# ---------------------------------------------------------------------------
+
+
+def test_session_closes_on_persisted_load_success(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Startup load should close its short-lived session in every path."""
+    """Startup load should close the session after persisted load."""
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
-    close_calls = 0
-    real_create_session_factory = graph_lifecycle_providers.create_session_factory
+    close_count = _patch_session_close_counter(monkeypatch)
 
-    def tracking_session_factory(engine: Any) -> Any:
-        """
-        Create a session factory whose sessions are wrapped with ClosingSessionProxy.
+    _initialize_graph_for_test()
 
-        Parameters:
-            engine: The database engine used to build the underlying session factory.
+    assert close_count() == 1
 
-        Returns:
-            A callable that, when invoked, returns a session proxy delegating to a real session created from `engine`, with `close()` proxied for tracking.
-        """
-        real_factory = real_create_session_factory(engine)
 
-        def make_session() -> Any:
-            """
-            Create a new database session wrapped by a ClosingSessionProxy.
-
-            Returns:
-                ClosingSessionProxy: A proxy around the newly created session that delegates session operations to the real session and exposes a close() implementation suitable for tracking/overriding close calls.
-            """
-            session = real_factory()
-            return ClosingSessionProxy(session)
-
-        return make_session
-
-    class ClosingSessionProxy:
-        """Proxy a SQLAlchemy session and count close calls."""
-
-        def __init__(self, session: Any) -> None:
-            """
-            Initialize the repository with a database session.
-
-            Parameters:
-                session (Any): A database session instance used for persistence operations (short-lived SQLAlchemy
-                    session or equivalent). The repository retains this session for its lifetime.
-            """
-            self._session = session
-
-        def __getattr__(self, name: str) -> Any:
-            """
-            Delegate attribute access to the proxied session.
-
-            Forward attribute lookups to self._session so that attributes and methods on the underlying session
-            are accessible through this proxy.
-
-            Parameters:
-                name (str): Name of the attribute being accessed.
-
-            Returns:
-                Any: The attribute value from the underlying session.
-            """
-            return getattr(self._session, name)
-
-        def close(self) -> None:
-            """
-            Increment the external close counter and close the proxied session.
-
-            Increments the nonlocal `close_calls` counter used by tests and delegates to the wrapped session's `close()` method.
-            """
-            nonlocal close_calls
-            close_calls += 1
-            self._session.close()
-
-    monkeypatch.setattr(graph_lifecycle_providers, "create_session_factory", tracking_session_factory)
-    graph_lifecycle._initialize_graph()
-    assert close_calls == 1
-
-    empty_url = _sqlite_url(tmp_path, "empty.db")
-    _init_empty_db(empty_url)
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", empty_url)
+def test_session_closes_on_empty_persistence_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup load should close the session before empty-store fallback."""
+    database_url = _sqlite_url(tmp_path)
+    _init_empty_db(database_url)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
-    graph_lifecycle._initialize_graph()
-    assert close_calls == 2
+    close_count = _patch_session_close_counter(monkeypatch)
 
-    missing_schema_url = _sqlite_url(tmp_path, "missing.db")
-    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", missing_schema_url)
+    _initialize_graph_for_test()
+
+    assert close_count() == 1
+
+
+def test_session_closes_on_persistence_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup load should close the session after load failure."""
+    database_url = _sqlite_url(tmp_path)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
+    close_count = _patch_session_close_counter(monkeypatch)
+
     with pytest.raises(RuntimeError):
-        graph_lifecycle._initialize_graph()
-    assert close_calls == 3
+        _initialize_graph_for_test()
+
+    assert close_count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: reset and compatibility
+# ---------------------------------------------------------------------------
 
 
 def test_reset_reloads_persisted_graph_without_saving(
@@ -530,15 +540,7 @@ def test_reset_reloads_persisted_graph_without_saving(
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """
-        Fail the test if a graph save is attempted during reset or startup load.
-
-        This helper unconditionally raises an AssertionError to ensure code paths invoked
-        during reset/startup do not attempt to persist graph data.
-
-        Raises:
-            AssertionError: with message "reset/startup load must not save graph data".
-        """
+        """Fail if reset or startup load attempts to save graph data."""
         raise AssertionError("reset/startup load must not save graph data")
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
@@ -561,8 +563,8 @@ def test_api_main_and_router_helper_compatibility(
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
-    import api.main as api_main
-    import api.router_helpers as router_helpers
+    import api.main as api_main  # pylint: disable=import-outside-toplevel
+    import api.router_helpers as router_helpers  # pylint: disable=import-outside-toplevel
 
     api_main = importlib.reload(api_main)
     try:

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -379,17 +379,20 @@ def test_api_main_and_router_helper_compatibility(
     import api.router_helpers as router_helpers
 
     api_main = importlib.reload(api_main)
-    loaded = api_main.get_graph()
+    try:
+        loaded = api_main.get_graph()
 
-    assert set(loaded.assets) == {"ASSET_ONLY"}
-    assert graph_lifecycle.get_graph() is loaded
-    assert router_helpers.get_graph() is api_main.graph
+        assert set(loaded.assets) == {"ASSET_ONLY"}
+        assert graph_lifecycle.get_graph() is loaded
+        assert router_helpers.get_graph() is api_main.graph
 
-    api_main.reset_graph()
-    assert api_main.graph is None
-    reloaded = router_helpers.get_graph()
-    assert set(reloaded.assets) == {"ASSET_ONLY"}
+        api_main.reset_graph()
+        assert api_main.graph is None
+        reloaded = router_helpers.get_graph()
+        assert set(reloaded.assets) == {"ASSET_ONLY"}
 
-    custom_graph = AssetRelationshipGraph()
-    api_main.set_graph(custom_graph)
-    assert router_helpers.get_graph() is custom_graph
+        custom_graph = AssetRelationshipGraph()
+        api_main.set_graph(custom_graph)
+        assert router_helpers.get_graph() is custom_graph
+    finally:
+        api_main.reset_graph()

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -1,0 +1,395 @@
+"""Unit tests for persisted graph startup loading."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine
+
+import api.graph_lifecycle as graph_lifecycle
+from src.config.settings import get_settings
+from src.data.database import create_session_factory, init_db
+from src.data.repository import AssetGraphRepository
+from src.logic.asset_graph import AssetRelationshipGraph
+from src.models.financial_models import (
+    AssetClass,
+    Equity,
+    RegulatoryActivity,
+    RegulatoryEvent,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(autouse=True)
+def reset_lifecycle(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Reset graph lifecycle state and graph-source environment for each test."""
+    for name in (
+        "ASSET_GRAPH_DATABASE_URL",
+        "GRAPH_CACHE_PATH",
+        "REAL_DATA_CACHE_PATH",
+        "USE_REAL_DATA_FETCHER",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    graph_lifecycle.reset_graph()
+    yield
+    graph_lifecycle.reset_graph()
+
+
+def _equity(asset_id: str, symbol: str) -> Equity:
+    """Build a minimal equity asset for lifecycle persistence tests."""
+    return Equity(
+        id=asset_id,
+        symbol=symbol,
+        name=f"{symbol} Equity",
+        asset_class=AssetClass.EQUITY,
+        sector="Technology",
+        price=100.0,
+    )
+
+
+def _event(event_id: str, asset_id: str, related_assets: list[str] | None = None) -> RegulatoryEvent:
+    """Build a regulatory event for lifecycle persistence tests."""
+    return RegulatoryEvent(
+        id=event_id,
+        asset_id=asset_id,
+        event_type=RegulatoryActivity.SEC_FILING,
+        date="2024-01-15",
+        description=f"{event_id} filing",
+        impact_score=0.5,
+        related_assets=related_assets or [],
+    )
+
+
+def _relationship_strength(
+    graph: AssetRelationshipGraph,
+    source_id: str,
+    target_id: str,
+    relationship_type: str,
+) -> float:
+    """Return the strength for one graph relationship."""
+    for target, rel_type, strength in graph.relationships.get(source_id, []):
+        if target == target_id and rel_type == relationship_type:
+            return strength
+    raise AssertionError(f"Missing relationship {source_id}->{target_id} ({relationship_type})")
+
+
+def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
+    """Return a temporary file-backed SQLite URL."""
+    return f"sqlite:///{tmp_path / name}"
+
+
+def _init_empty_db(database_url: str) -> None:
+    """Create an empty schema-ready graph database."""
+    engine = create_engine(database_url)
+    try:
+        init_db(engine)
+    finally:
+        engine.dispose()
+
+
+def _save_graph(database_url: str, graph: AssetRelationshipGraph) -> None:
+    """Persist a graph snapshot to a temporary graph database."""
+    engine = create_engine(database_url)
+    init_db(engine)
+    session = create_session_factory(engine)()
+    try:
+        AssetGraphRepository(session).save_graph(graph)
+        session.commit()
+    finally:
+        session.close()
+        engine.dispose()
+
+
+def _asset_only_graph() -> AssetRelationshipGraph:
+    """Build a graph with one persisted asset and no relationships or events."""
+    graph = AssetRelationshipGraph()
+    graph.add_asset(_equity("ASSET_ONLY", "ONLY"))
+    return graph
+
+
+def _full_graph() -> AssetRelationshipGraph:
+    """Build a graph with assets, directed relationships, and an event."""
+    graph = AssetRelationshipGraph()
+    for asset in (
+        _equity("ASSET_A", "A"),
+        _equity("ASSET_B", "B"),
+        _equity("ASSET_C", "C"),
+    ):
+        graph.add_asset(asset)
+    graph.add_relationship("ASSET_A", "ASSET_B", "directed_alpha", 0.4)
+    graph.add_relationship("ASSET_B", "ASSET_A", "directed_alpha", 0.9)
+    graph.add_regulatory_event(_event("EVENT_A", "ASSET_A", ["ASSET_B", "ASSET_C"]))
+    return graph
+
+
+def test_factory_precedence_skips_persistence_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured factories should win before any repository load attempt."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+
+    def fail_create_engine(_url: str) -> Any:
+        raise AssertionError("persistence load should not be attempted")
+
+    factory_graph = AssetRelationshipGraph()
+    graph_lifecycle.set_graph_factory(lambda: factory_graph)
+    monkeypatch.setattr(graph_lifecycle, "create_engine_from_url", fail_create_engine)
+
+    assert graph_lifecycle._initialize_graph() is factory_graph
+
+
+@pytest.mark.parametrize("configured_value", [None, "", "   "])
+def test_persistence_disabled_preserves_sample_fallback(
+    configured_value: str | None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unset or blank graph persistence should preserve existing fallback behavior."""
+    if configured_value is None:
+        monkeypatch.delenv("ASSET_GRAPH_DATABASE_URL", raising=False)
+    else:
+        monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", configured_value)
+    get_settings.cache_clear()
+
+    def fail_create_engine(_url: str) -> Any:
+        raise AssertionError("persistence load should not be attempted")
+
+    monkeypatch.setattr(graph_lifecycle, "create_engine_from_url", fail_create_engine)
+
+    graph = graph_lifecycle._initialize_graph()
+
+    assert graph.assets
+
+
+def test_empty_configured_db_falls_back_without_saving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schema-ready empty graph store should fall through to current fallback."""
+    database_url = _sqlite_url(tmp_path)
+    _init_empty_db(database_url)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("startup load must not save graph data")
+
+    monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
+
+    graph = graph_lifecycle._initialize_graph()
+
+    assert graph.assets
+    assert "ASSET_ONLY" not in graph.assets
+
+
+def test_persisted_asset_only_graph_loads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One persisted asset is enough to select repository startup loading."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    loaded = graph_lifecycle._initialize_graph()
+
+    assert set(loaded.assets) == {"ASSET_ONLY"}
+    assert not loaded.relationships
+    assert not loaded.regulatory_events
+
+
+def test_persisted_full_graph_loads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup loading should reconstruct persisted graph truth."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _full_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    loaded = graph_lifecycle._initialize_graph()
+
+    assert set(loaded.assets) == {"ASSET_A", "ASSET_B", "ASSET_C"}
+    assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
+    assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == pytest.approx(0.9)
+    assert [event.id for event in loaded.regulatory_events] == ["EVENT_A"]
+
+
+def test_legacy_bidirectional_row_survives_startup_load(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy bidirectional rows should keep repository load compatibility."""
+    database_url = _sqlite_url(tmp_path)
+    engine = create_engine(database_url)
+    init_db(engine)
+    session = create_session_factory(engine)()
+    try:
+        repository = AssetGraphRepository(session)
+        repository.upsert_asset(_equity("LEGACY_A", "LA"))
+        repository.upsert_asset(_equity("LEGACY_B", "LB"))
+        repository.add_or_update_relationship(
+            "LEGACY_A",
+            "LEGACY_B",
+            "same_sector",
+            0.7,
+            bidirectional=True,
+        )
+        session.commit()
+    finally:
+        session.close()
+        engine.dispose()
+
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    loaded = graph_lifecycle._initialize_graph()
+
+    assert _relationship_strength(loaded, "LEGACY_A", "LEGACY_B", "same_sector") == pytest.approx(0.7)
+    assert _relationship_strength(loaded, "LEGACY_B", "LEGACY_A", "same_sector") == pytest.approx(0.7)
+
+
+def test_missing_schema_fails_without_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Configured persistence with missing tables should fail startup load."""
+    database_url = _sqlite_url(tmp_path)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
+        graph_lifecycle._initialize_graph()
+
+
+def test_invalid_configured_database_url_fails_without_leaking_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Invalid configured persistence should fail with sanitized lifecycle text."""
+    raw_url = "not-a-sqlalchemy-url://user:secret@example.invalid/db"
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", raw_url)
+    get_settings.cache_clear()
+
+    with pytest.raises(RuntimeError) as exc_info:
+        graph_lifecycle._initialize_graph()
+
+    message = str(exc_info.value)
+    assert "Failed to load persisted graph during startup" in message
+    assert "secret" not in message
+    assert raw_url not in message
+
+
+def test_session_closes_on_success_empty_and_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Startup load should close its short-lived session in every path."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+    close_calls = 0
+    real_create_session_factory = graph_lifecycle.create_session_factory
+
+    def tracking_session_factory(engine: Any) -> Any:
+        real_factory = real_create_session_factory(engine)
+
+        def make_session() -> Any:
+            session = real_factory()
+            return ClosingSessionProxy(session)
+
+        return make_session
+
+    class ClosingSessionProxy:
+        """Proxy a SQLAlchemy session and count close calls."""
+
+        def __init__(self, session: Any) -> None:
+            self._session = session
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._session, name)
+
+        def close(self) -> None:
+            nonlocal close_calls
+            close_calls += 1
+            self._session.close()
+
+    monkeypatch.setattr(graph_lifecycle, "create_session_factory", tracking_session_factory)
+    graph_lifecycle._initialize_graph()
+    assert close_calls == 1
+
+    empty_url = _sqlite_url(tmp_path, "empty.db")
+    _init_empty_db(empty_url)
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", empty_url)
+    get_settings.cache_clear()
+    graph_lifecycle._initialize_graph()
+    assert close_calls == 2
+
+    missing_schema_url = _sqlite_url(tmp_path, "missing.db")
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", missing_schema_url)
+    get_settings.cache_clear()
+    with pytest.raises(RuntimeError):
+        graph_lifecycle._initialize_graph()
+    assert close_calls == 3
+
+
+def test_reset_reloads_persisted_graph_without_saving(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """reset_graph should clear cached state and reload without mutating storage."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError("reset/startup load must not save graph data")
+
+    monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
+
+    first = graph_lifecycle.get_graph()
+    graph_lifecycle.reset_graph()
+    second = graph_lifecycle.get_graph()
+
+    assert first is not second
+    assert set(second.assets) == {"ASSET_ONLY"}
+
+
+def test_api_main_and_router_helper_compatibility(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Compatibility graph references should converge around lifecycle loading."""
+    database_url = _sqlite_url(tmp_path)
+    _save_graph(database_url, _asset_only_graph())
+    monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    get_settings.cache_clear()
+
+    import api.main as api_main
+    import api.router_helpers as router_helpers
+
+    api_main = importlib.reload(api_main)
+    loaded = api_main.get_graph()
+
+    assert set(loaded.assets) == {"ASSET_ONLY"}
+    assert graph_lifecycle.get_graph() is loaded
+    assert router_helpers.get_graph() is api_main.graph
+
+    api_main.reset_graph()
+    assert api_main.graph is None
+    reloaded = router_helpers.get_graph()
+    assert set(reloaded.assets) == {"ASSET_ONLY"}
+
+    custom_graph = AssetRelationshipGraph()
+    api_main.set_graph(custom_graph)
+    assert router_helpers.get_graph() is custom_graph

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -11,7 +11,7 @@ import pytest
 from sqlalchemy import create_engine, text
 
 import api.graph_lifecycle as graph_lifecycle
-from src.config.settings import get_settings
+import api.graph_lifecycle_providers as graph_lifecycle_providers
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -141,7 +141,7 @@ def test_factory_precedence_skips_persistence_load(
 
     factory_graph = AssetRelationshipGraph()
     graph_lifecycle.set_graph_factory(lambda: factory_graph)
-    monkeypatch.setattr(graph_lifecycle, "create_engine_from_url", fail_create_engine)
+    monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
     assert graph_lifecycle._initialize_graph() is factory_graph
 
@@ -156,12 +156,12 @@ def test_persistence_disabled_preserves_sample_fallback(
         monkeypatch.delenv("ASSET_GRAPH_DATABASE_URL", raising=False)
     else:
         monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", configured_value)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_create_engine(_url: str) -> Any:
         raise AssertionError("persistence load should not be attempted")
 
-    monkeypatch.setattr(graph_lifecycle, "create_engine_from_url", fail_create_engine)
+    monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
     graph = graph_lifecycle._initialize_graph()
 
@@ -176,7 +176,7 @@ def test_empty_configured_db_falls_back_without_saving(
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         raise AssertionError("startup load must not save graph data")
@@ -197,7 +197,7 @@ def test_persisted_asset_only_graph_loads(
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     loaded = graph_lifecycle._initialize_graph()
 
@@ -214,7 +214,7 @@ def test_persisted_full_graph_loads(
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _full_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     loaded = graph_lifecycle._initialize_graph()
 
@@ -250,7 +250,7 @@ def test_legacy_bidirectional_row_survives_startup_load(
         engine.dispose()
 
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     loaded = graph_lifecycle._initialize_graph()
 
@@ -265,7 +265,7 @@ def test_missing_schema_fails_without_fallback(
     """Configured persistence with missing tables should fail startup load."""
     database_url = _sqlite_url(tmp_path)
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
         graph_lifecycle._initialize_graph()
@@ -277,7 +277,7 @@ def test_invalid_configured_database_url_fails_without_leaking_url(
     """Invalid configured persistence should fail with sanitized lifecycle text."""
     raw_url = "not-a-sqlalchemy-url://user:secret@example.invalid/db"
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", raw_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     with pytest.raises(RuntimeError) as exc_info:
         graph_lifecycle._initialize_graph()
@@ -308,7 +308,7 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
     engine.dispose()
 
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
         graph_lifecycle._initialize_graph()
@@ -322,9 +322,9 @@ def test_session_closes_on_success_empty_and_failure(
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
     close_calls = 0
-    real_create_session_factory = graph_lifecycle.create_session_factory
+    real_create_session_factory = graph_lifecycle_providers.create_session_factory
 
     def tracking_session_factory(engine: Any) -> Any:
         real_factory = real_create_session_factory(engine)
@@ -349,20 +349,20 @@ def test_session_closes_on_success_empty_and_failure(
             close_calls += 1
             self._session.close()
 
-    monkeypatch.setattr(graph_lifecycle, "create_session_factory", tracking_session_factory)
+    monkeypatch.setattr(graph_lifecycle_providers, "create_session_factory", tracking_session_factory)
     graph_lifecycle._initialize_graph()
     assert close_calls == 1
 
     empty_url = _sqlite_url(tmp_path, "empty.db")
     _init_empty_db(empty_url)
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", empty_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
     graph_lifecycle._initialize_graph()
     assert close_calls == 2
 
     missing_schema_url = _sqlite_url(tmp_path, "missing.db")
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", missing_schema_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
     with pytest.raises(RuntimeError):
         graph_lifecycle._initialize_graph()
     assert close_calls == 3
@@ -376,7 +376,7 @@ def test_reset_reloads_persisted_graph_without_saving(
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
         raise AssertionError("reset/startup load must not save graph data")
@@ -399,7 +399,7 @@ def test_api_main_and_router_helper_compatibility(
     database_url = _sqlite_url(tmp_path)
     _save_graph(database_url, _asset_only_graph())
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
-    get_settings.cache_clear()
+    graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     import api.main as api_main
     import api.router_helpers as router_helpers

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -228,14 +228,25 @@ def test_persistence_disabled_preserves_sample_fallback(
     assert graph.assets
 
 
-def test_empty_configured_db_falls_back_without_saving(
+@pytest.mark.parametrize(
+    ("env_name", "env_value", "provider_attr"),
+    [
+        ("GRAPH_CACHE_PATH", "/tmp/graph-cache.json", "load_graph_from_cache_path"),
+        ("USE_REAL_DATA_FETCHER", "1", "load_graph_from_real_data_fetcher"),
+    ],
+)
+def test_empty_configured_db_honors_configured_source_before_sample_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    env_name: str,
+    env_value: str,
+    provider_attr: str,
 ) -> None:
-    """A schema-ready empty graph store should fall through to current fallback."""
+    """An empty configured persistence store must still honor higher-precedence configured sources."""
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     monkeypatch.setenv("ASSET_GRAPH_DATABASE_URL", database_url)
+    monkeypatch.setenv(env_name, env_value)
     graph_lifecycle_providers.clear_graph_lifecycle_settings_cache()
 
     def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
@@ -246,12 +257,22 @@ def test_empty_configured_db_falls_back_without_saving(
         """
         raise AssertionError("startup load must not save graph data")
 
+    configured_graph = _asset_only_graph()
+
+    def load_configured_graph(*_args: Any, **_kwargs: Any) -> AssetRelationshipGraph:
+        return configured_graph
+
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
+    monkeypatch.setattr(
+        graph_lifecycle_providers,
+        provider_attr,
+        load_configured_graph,
+    )
 
     graph = graph_lifecycle._initialize_graph()
 
-    assert graph.assets
-    assert "ASSET_ONLY" not in graph.assets
+    assert graph is configured_graph
+    assert set(graph.assets) == {"ASSET_ONLY"}
 
 
 def test_persisted_asset_only_graph_loads(

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -18,7 +18,11 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def repository_factory(tmp_path):
-    """Create fresh repositories backed by one temporary SQLite database."""
+    """
+    Provides a factory for creating AssetGraphRepository instances backed by a temporary SQLite database.
+    
+    Yields a callable that creates new repositories each with its own SQLAlchemy session tied to the same temporary database file; after the fixture completes all created sessions are closed and the engine is disposed.
+    """
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,6 +1,8 @@
 """Unit tests for repository graph persistence helpers."""
 
 import pytest
+
+pytest.importorskip("sqlalchemy")
 from sqlalchemy import create_engine  # pylint: disable=import-error
 
 from src.data.database import create_session_factory, init_db

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -13,7 +13,6 @@ from src.models.financial_models import (
     RegulatoryEvent,
 )
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -24,8 +23,6 @@ def repository_factory(tmp_path):
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)
     factory = create_session_factory(engine)
-pytest.importorskip("sqlalchemy")
-
 
     sessions = []
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -18,11 +18,7 @@ pytestmark = pytest.mark.unit
 
 @pytest.fixture
 def repository_factory(tmp_path):
-    """
-    Provides a factory for creating AssetGraphRepository instances backed by a temporary SQLite database.
-
-    Yields a callable that creates new repositories each with its own SQLAlchemy session tied to the same temporary database file; after the fixture completes all created sessions are closed and the engine is disposed.
-    """
+    """Provide a factory for creating repository instances."""
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,7 +1,7 @@
 """Unit tests for repository graph persistence helpers."""
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine  # pylint: disable=import-error
 
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -13,8 +13,6 @@ from src.models.financial_models import (
     RegulatoryEvent,
 )
 
-pytest.importorskip("sqlalchemy")
-
 
 pytestmark = pytest.mark.unit
 
@@ -26,6 +24,9 @@ def repository_factory(tmp_path):
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)
     factory = create_session_factory(engine)
+pytest.importorskip("sqlalchemy")
+
+
     sessions = []
 
     def make_repository() -> AssetGraphRepository:

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,8 +1,6 @@
 """Unit tests for repository graph persistence helpers."""
 
 import pytest
-
-pytest.importorskip("sqlalchemy")
 from sqlalchemy import create_engine  # pylint: disable=import-error
 
 from src.data.database import create_session_factory, init_db
@@ -14,6 +12,9 @@ from src.models.financial_models import (
     RegulatoryActivity,
     RegulatoryEvent,
 )
+
+pytest.importorskip("sqlalchemy")
+
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -1,6 +1,7 @@
 """Unit tests for repository graph persistence helpers."""
 
 import pytest
+from sqlalchemy import create_engine
 
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
@@ -12,7 +13,6 @@ from src.models.financial_models import (
     RegulatoryEvent,
 )
 
-
 pytestmark = pytest.mark.unit
 
 
@@ -22,10 +22,6 @@ def repository_factory(tmp_path):
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
     init_db(engine)
-_sqlalchemy = pytest.importorskip("sqlalchemy")
-create_engine = _sqlalchemy.create_engine
-
-
     factory = create_session_factory(engine)
     sessions = []
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -20,7 +20,7 @@ pytestmark = pytest.mark.unit
 def repository_factory(tmp_path):
     """
     Provides a factory for creating AssetGraphRepository instances backed by a temporary SQLite database.
-    
+
     Yields a callable that creates new repositories each with its own SQLAlchemy session tied to the same temporary database file; after the fixture completes all created sessions are closed and the engine is disposed.
     """
     db_path = tmp_path / "graph_persistence.db"


### PR DESCRIPTION
## **User description**
## Summary

- Loads persisted graph truth during startup when `ASSET_GRAPH_DATABASE_URL` is configured and persisted asset rows exist.
- Preserves existing factory/cache/real-data/sample fallback behavior when persistence is not configured or configured persistence is empty.
- Uses a short-lived startup database session and closes it on success, empty fallback, and failure.
- Fails configured persistence-load errors with sanitized startup text, suppressing exception context so credentials or driver URL details are not exposed through the raised `RuntimeError`.
- Isolates graph lifecycle implementation dependencies behind an `api` provider boundary so `api.graph_lifecycle` no longer imports settings, SQLAlchemy database factories, ORM models, repository classes, real-data fetchers, or sample-data constructors directly.
- Repairs the existing repository graph persistence test collection blocker so this PR no longer depends on a red full-pytest collection state.

## Design Decisions

- Startup graph persistence is governed by `ASSET_GRAPH_DATABASE_URL` / `settings.asset_graph_database_url`.
- Persisted graph existence requires at least one persisted asset row.
- Empty configured persistence falls through to existing initialization behavior.
- Missing schema, invalid URL, unreachable DB, or malformed persisted data fail startup rather than silently falling back.
- Startup load does not call `init_db()`.
- Startup load never calls `save_graph()`.

## Scope

In scope:

- startup graph load from repository persistence;
- lifecycle provider boundary for settings/source/repository resolution;
- empty persistence fallback;
- explicit configured-persistence failure behavior;
- short-lived startup DB session handling;
- lifecycle / `api.main` / router helper compatibility tests;
- syntax/collection repair for `tests/unit/test_repository_graph_persistence.py`.

Out of scope:

- no `save_graph()` trigger implementation;
- no hosted readiness changes;
- no migrations/Alembic;
- no frontend changes;
- no layout persistence;
- no broad scanner/lint cleanup;
- no #1028 updates.

## Files Changed

- `api/graph_lifecycle.py` - adds the private startup persistence-load seam and depends on the lifecycle provider boundary.
- `api/graph_lifecycle_providers.py` - resolves settings, real-data/sample graph sources, and repository persistence loading behind the lifecycle boundary.
- `tests/unit/test_graph_lifecycle_persistence.py` - adds focused lifecycle persistence tests for issue #1126, including context-suppression coverage.
- `tests/unit/test_repository_graph_persistence.py` - repairs the existing SQLAlchemy import/fixture indentation collection failure.

## Validation

Passed:

```bash
python -m pytest tests/unit/test_repository_graph_persistence.py -q
python -m pytest tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py -q
python -m pytest tests/unit/test_api_main.py::TestGraphInitialization tests/unit/test_api_main.py::TestSetGraphFunctions tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py -q
python -m black --check api/graph_lifecycle.py api/graph_lifecycle_providers.py tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py
python -m ruff check api/graph_lifecycle.py api/graph_lifecycle_providers.py tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py
python -m flake8 api/graph_lifecycle.py api/graph_lifecycle_providers.py tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py
```

Known validation notes:

- `python -m pre_commit run --files api/graph_lifecycle.py tests/unit/test_graph_lifecycle_persistence.py tests/unit/test_repository_graph_persistence.py` previously printed successful early hooks through `black`, then the local tool session became stale; `ps` showed no remaining `pre_commit`, formatter, linter, mypy, or pytest process. Direct Black, Ruff, and flake8 checks passed for the changed files.
- Earlier `mypy` attempts against these entry files reported existing imported-module typing errors in unrelated modules (`src/data/sample_data.py`, `src/data/database.py`, `api/routers/visualization.py`, `api/routers/system.py`, and `api/app_factory.py`).

## Merge Criteria

- Focused graph lifecycle persistence tests pass.
- Existing graph lifecycle/API main tests pass.
- Repository graph persistence tests collect and pass.
- Reviewers agree unrelated mypy findings remain out of scope for this PR.

Refs #1126.


___

## **CodeAnt-AI Description**
**Load persisted graph data during startup with safe fallback behavior**

### What Changed
- Startup now loads the saved graph when a durable database is configured and contains persisted asset data.
- If persistence is not configured, empty, or uses an in-memory SQLite URL, startup keeps the existing fallback path instead of loading saved data.
- When a configured persistence load fails, startup stops with a sanitized error message instead of falling back or exposing connection details.
- Startup now closes its database session after a successful load, an empty-store fallback, or a failure.
- Added coverage for persisted graph loading, fallback behavior, failure cases, and compatibility with existing startup paths.

### Impact
`✅ Restored graph state after restart`
`✅ Fewer startup surprises with empty persistence`
`✅ Clearer startup failures without leaking database details`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=Ssa1_9m0zteoyGCtVXO3gNV5po_X7wDiBu0ED4ltTUc&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
