### PR TITLE
api: expose bounded graph startup source in detailed health (#1138)

### DIFF
--- a/api/api_models.py
+++ b/api/api_models.py
@@ -4,6 +4,15 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+GraphStartupSource = Literal[
+    "persisted_graph_store",
+    "sample_graph",
+    "cache",
+    "real_data",
+    "explicit_factory",
+    "unknown",
+]
+
 
 class AssetResponse(BaseModel):
     """Response model for asset data."""
@@ -93,6 +102,7 @@ class GraphHealthResponse(BaseModel):
     available: bool
     asset_count: int = Field(ge=0)
     relationship_count: int = Field(ge=0)
+    graph_startup_source: GraphStartupSource | None = None
 
 
 class DatabaseHealthResponse(BaseModel):

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -38,14 +38,23 @@ graph_lock = threading.Lock()
 
 def get_graph() -> AssetRelationshipGraph:
     """Get the module-global graph, initializing it when needed."""
-    if graph_state.graph is None:
-        with graph_lock:
-            if graph_state.graph is None:
-                graph_state.graph = _initialize_graph()
-                logger.info("Graph initialized successfully")
-    if graph_state.graph is None:
-        raise RuntimeError("Global graph initialization failed; graph is None.")
-    return graph_state.graph
+    graph, _startup_source = get_graph_with_startup_source()
+    return graph
+
+
+def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, GraphStartupSource | None]:
+    """Return the module-global graph and its tracked startup source atomically."""
+    with graph_lock:
+        if graph_state.graph is None:
+            graph, startup_source = _initialize_graph_with_source()
+            graph_state.graph = graph
+            graph_state.startup_source = startup_source
+            logger.info("Graph initialized successfully")
+
+        if graph_state.graph is None:
+            raise RuntimeError("Global graph initialization failed; graph is None.")
+
+        return graph_state.graph, graph_state.startup_source
 
 
 def set_graph(graph_instance: AssetRelationshipGraph) -> None:
@@ -99,8 +108,14 @@ def reset_graph() -> None:
 
 
 def _initialize_graph() -> AssetRelationshipGraph:
+    """Initialize and return a graph without mutating lifecycle state."""
+    graph, _startup_source = _initialize_graph_with_source()
+    return graph
+
+
+def _initialize_graph_with_source() -> tuple[AssetRelationshipGraph, GraphStartupSource]:
     """
-    Initialize the graph from the configured startup source.
+    Initialize a graph and return the selected startup source.
 
     Precedence:
     1. custom graph factory;
@@ -112,16 +127,13 @@ def _initialize_graph() -> AssetRelationshipGraph:
     Configured persistence failures raise RuntimeError.
     """
     if graph_state.graph_factory is not None:
-        graph = graph_state.graph_factory()
-        graph_state.startup_source = "explicit_factory"
-        return graph
+        return graph_state.graph_factory(), "explicit_factory"
 
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
     persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(settings.asset_graph_database_url)
     if persisted_graph is not None:
-        graph_state.startup_source = "persisted_graph_store"
         logger.info("Graph startup source: persisted_graph_store")
-        return persisted_graph
+        return persisted_graph, "persisted_graph_store"
 
     cache_path = settings.graph_cache_path
     use_real_data = settings.use_real_data_fetcher
@@ -131,17 +143,14 @@ def _initialize_graph() -> AssetRelationshipGraph:
             cache_path,
             enable_network=use_real_data,
         )
-        graph_state.startup_source = "cache"
-        return graph
+        return graph, "cache"
 
     if use_real_data:
         real_data_cache_path = settings.real_data_cache_path
         graph = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
             real_data_cache_path,
         )
-        graph_state.startup_source = "real_data"
-        return graph
+        return graph, "real_data"
 
-    graph_state.startup_source = "sample_graph"
     logger.info("Graph startup source: sample_graph")
-    return graph_lifecycle_providers.create_sample_graph()
+    return graph_lifecycle_providers.create_sample_graph(), "sample_graph"

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -87,12 +87,6 @@ def set_graph_factory(
         graph_state.startup_source = None
 
 
-def get_graph_startup_source() -> GraphStartupSource | None:
-    """Return the currently tracked startup source for the module-global graph."""
-    with graph_lock:
-        return graph_state.startup_source
-
-
 def reset_graph() -> None:
     """
     Reset module-level graph state so the graph will be recreated on next access.

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -38,6 +38,9 @@ graph_lock = threading.Lock()
 
 def get_graph() -> AssetRelationshipGraph:
     """Get the module-global graph, initializing it when needed."""
+    if graph_state.graph is not None:
+        return graph_state.graph
+
     graph, _startup_source = get_graph_with_startup_source()
     return graph
 

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from src.logic.asset_graph import AssetRelationshipGraph
 
 from . import graph_lifecycle_providers
+from .api_models import GraphStartupSource
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +29,7 @@ class _GraphState:
         """Create empty graph lifecycle state."""
         self.graph: AssetRelationshipGraph | None = None
         self.graph_factory: Callable[[], AssetRelationshipGraph] | None = None
+        self.startup_source: GraphStartupSource | None = None
 
 
 graph_state = _GraphState()
@@ -51,6 +53,7 @@ def set_graph(graph_instance: AssetRelationshipGraph) -> None:
     with graph_lock:
         graph_state.graph = graph_instance
         graph_state.graph_factory = None
+        graph_state.startup_source = "unknown"
 
 
 def synchronize_runtime_graph(graph_instance: AssetRelationshipGraph) -> None:
@@ -58,6 +61,7 @@ def synchronize_runtime_graph(graph_instance: AssetRelationshipGraph) -> None:
     with graph_lock:
         graph_state.graph = graph_instance
         graph_state.graph_factory = None
+        graph_state.startup_source = "unknown"
 
         api_main = sys.modules.get("api.main")
         if api_main is not None and hasattr(api_main, "graph"):
@@ -71,6 +75,13 @@ def set_graph_factory(
     with graph_lock:
         graph_state.graph_factory = factory
         graph_state.graph = None
+        graph_state.startup_source = None
+
+
+def get_graph_startup_source() -> GraphStartupSource | None:
+    """Return the currently tracked startup source for the module-global graph."""
+    with graph_lock:
+        return graph_state.startup_source
 
 
 def reset_graph() -> None:
@@ -101,11 +112,14 @@ def _initialize_graph() -> AssetRelationshipGraph:
     Configured persistence failures raise RuntimeError.
     """
     if graph_state.graph_factory is not None:
-        return graph_state.graph_factory()
+        graph = graph_state.graph_factory()
+        graph_state.startup_source = "explicit_factory"
+        return graph
 
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
     persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(settings.asset_graph_database_url)
     if persisted_graph is not None:
+        graph_state.startup_source = "persisted_graph_store"
         logger.info("Graph startup source: persisted_graph_store")
         return persisted_graph
 
@@ -113,16 +127,21 @@ def _initialize_graph() -> AssetRelationshipGraph:
     use_real_data = settings.use_real_data_fetcher
 
     if cache_path:
-        return graph_lifecycle_providers.load_graph_from_cache_path(
+        graph = graph_lifecycle_providers.load_graph_from_cache_path(
             cache_path,
             enable_network=use_real_data,
         )
+        graph_state.startup_source = "cache"
+        return graph
 
     if use_real_data:
         real_data_cache_path = settings.real_data_cache_path
-        return graph_lifecycle_providers.load_graph_from_real_data_fetcher(
+        graph = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
             real_data_cache_path,
         )
+        graph_state.startup_source = "real_data"
+        return graph
 
+    graph_state.startup_source = "sample_graph"
     logger.info("Graph startup source: sample_graph")
     return graph_lifecycle_providers.create_sample_graph()

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -1,6 +1,6 @@
 """System and metadata API routes."""
 
-from typing import Any, Literal, NoReturn, cast
+from typing import Any, Literal, NoReturn, cast, get_args
 
 from fastapi import APIRouter, HTTPException
 
@@ -13,14 +13,7 @@ from ..router_helpers import get_graph, logger
 router = APIRouter()
 
 SUPPORTED_DATABASE_TYPE = Literal["sqlite", "postgresql"]
-SUPPORTED_GRAPH_STARTUP_SOURCE_VALUES: set[GraphStartupSource] = {
-    "persisted_graph_store",
-    "sample_graph",
-    "cache",
-    "real_data",
-    "explicit_factory",
-    "unknown",
-}
+SUPPORTED_GRAPH_STARTUP_SOURCE_VALUES: frozenset[str] = frozenset(get_args(GraphStartupSource))
 
 
 @router.get("/")
@@ -48,8 +41,7 @@ async def health_check() -> dict[str, Any]:
 def _get_graph_health() -> GraphHealthResponse:
     """Return bounded, non-secret graph readiness details."""
     try:
-        graph = get_graph()
-        startup_source = graph_lifecycle.get_graph_startup_source()
+        graph, startup_source = graph_lifecycle.get_graph_with_startup_source()
         assets = getattr(graph, "assets", {})
         relationships = getattr(graph, "relationships", {})
 

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -6,12 +6,21 @@ from fastapi import APIRouter, HTTPException
 
 from src.models.financial_models import AssetClass
 
-from ..api_models import DatabaseHealthResponse, DetailedHealthResponse, GraphHealthResponse
+from .. import graph_lifecycle
+from ..api_models import DatabaseHealthResponse, DetailedHealthResponse, GraphHealthResponse, GraphStartupSource
 from ..router_helpers import get_graph, logger
 
 router = APIRouter()
 
 SUPPORTED_DATABASE_TYPE = Literal["sqlite", "postgresql"]
+SUPPORTED_GRAPH_STARTUP_SOURCE_VALUES: set[GraphStartupSource] = {
+    "persisted_graph_store",
+    "sample_graph",
+    "cache",
+    "real_data",
+    "explicit_factory",
+    "unknown",
+}
 
 
 @router.get("/")
@@ -40,6 +49,7 @@ def _get_graph_health() -> GraphHealthResponse:
     """Return bounded, non-secret graph readiness details."""
     try:
         graph = get_graph()
+        startup_source = graph_lifecycle.get_graph_startup_source()
         assets = getattr(graph, "assets", {})
         relationships = getattr(graph, "relationships", {})
 
@@ -54,12 +64,14 @@ def _get_graph_health() -> GraphHealthResponse:
                 available=False,
                 asset_count=0,
                 relationship_count=0,
+                graph_startup_source=None,
             )
 
         return GraphHealthResponse(
             available=True,
             asset_count=len(assets),
             relationship_count=sum(len(items) for items in relationships.values()),
+            graph_startup_source=_bound_graph_startup_source(startup_source),
         )
     except Exception:
         logger.warning("Detailed health graph check failed")
@@ -67,7 +79,15 @@ def _get_graph_health() -> GraphHealthResponse:
             available=False,
             asset_count=0,
             relationship_count=0,
+            graph_startup_source=None,
         )
+
+
+def _bound_graph_startup_source(value: object) -> GraphStartupSource:
+    """Return a bounded startup-source label safe for the public health response."""
+    if value in SUPPORTED_GRAPH_STARTUP_SOURCE_VALUES:
+        return cast(GraphStartupSource, value)
+    return "unknown"
 
 
 def _get_database_health() -> DatabaseHealthResponse:

--- a/tests/integration/test_hosted_graph_startup_readiness.py
+++ b/tests/integration/test_hosted_graph_startup_readiness.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import sys
+from collections.abc import Iterator
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterator
+from typing import Any
 
 import pytest  # pylint: disable=import-error
 from fastapi.testclient import TestClient  # pylint: disable=import-error
@@ -196,6 +197,7 @@ def test_hosted_startup_loads_persisted_graph_truth_via_readiness(
     assert graph_payload["available"] is True
     assert graph_payload["asset_count"] == 2
     assert graph_payload["relationship_count"] == 2
+    assert graph_payload["graph_startup_source"] == "persisted_graph_store"
 
     asset_ids = {item["id"] for item in assets.json()["items"]}
     assert {"HOSTED_A", "HOSTED_B"} <= asset_ids
@@ -280,7 +282,7 @@ def test_hosted_detailed_readiness_output_is_secret_safe(
 
     # Verify expected contract shape
     assert set(payload) == {"status", "graph", "database"}
-    assert set(payload["graph"]) == {"available", "asset_count", "relationship_count"}
+    assert set(payload["graph"]) == {"available", "asset_count", "relationship_count", "graph_startup_source"}
 
     # Recursively scan for sensitive values
     joined = " ".join(_walk_strings(payload)).lower()

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -308,6 +308,7 @@ class TestPydanticModels:
                 available=True,
                 asset_count=19,
                 relationship_count=57,
+                graph_startup_source="sample_graph",
             ),
             database=DatabaseHealthResponse(
                 configured=True,
@@ -319,6 +320,7 @@ class TestPydanticModels:
         assert response.status == "healthy"
         assert response.graph.available is True
         assert response.graph.asset_count == 19
+        assert response.graph.graph_startup_source == "sample_graph"
         assert response.database.type == "sqlite"
 
     def test_detailed_health_response_rejects_extra_fields(self) -> None:
@@ -387,6 +389,16 @@ class TestPydanticModels:
                 relationship_count=-1,
             )
 
+    def test_graph_health_response_rejects_invalid_startup_source(self) -> None:
+        """GraphHealthResponse restricts public startup-source values."""
+        with pytest.raises(ValueError):
+            GraphHealthResponse(
+                available=True,
+                asset_count=1,
+                relationship_count=0,
+                graph_startup_source="postgresql://secret@example.invalid/db",
+            )
+
 
 @pytest.mark.unit
 class TestAPIEndpoints:
@@ -452,10 +464,11 @@ class TestAPIEndpoints:
         assert set(data) == {"status", "graph", "database"}
         assert data["status"] == "healthy"
 
-        assert set(data["graph"]) == {"available", "asset_count", "relationship_count"}
+        assert set(data["graph"]) == {"available", "asset_count", "relationship_count", "graph_startup_source"}
         assert data["graph"]["available"] is True
         assert data["graph"]["asset_count"] > 0
         assert data["graph"]["relationship_count"] >= 0
+        assert data["graph"]["graph_startup_source"] == "unknown"
 
         assert set(data["database"]) == {"configured", "type", "reachable"}
         assert data["database"]["configured"] is True
@@ -478,6 +491,7 @@ class TestAPIEndpoints:
             "available": False,
             "asset_count": 0,
             "relationship_count": 0,
+            "graph_startup_source": None,
         }
 
     def test_detailed_health_degraded_when_graph_containers_are_unsupported(
@@ -500,7 +514,32 @@ class TestAPIEndpoints:
             "available": False,
             "asset_count": 0,
             "relationship_count": 0,
+            "graph_startup_source": None,
         }
+
+    def test_detailed_health_bounds_invalid_graph_startup_source(
+        self,
+        bare_client: TestClient,
+    ) -> None:
+        """Detailed health should bound unsafe startup-source values to unknown."""
+        graph = Mock()
+        graph.assets = {"A": object()}
+        graph.relationships = {"A": []}
+
+        with (
+            patch("api.routers.system.get_graph", return_value=graph),
+            patch(
+                "api.routers.system.graph_lifecycle.get_graph_startup_source",
+                return_value="sqlite:///C:/secret/path.db",
+            ),
+        ):
+            response = bare_client.get("/api/health/detailed")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["graph"]["graph_startup_source"] == "unknown"
+        assert "secret" not in str(data["graph"]).lower()
 
     def test_detailed_health_degraded_when_database_check_fails(
         self,

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -480,7 +480,10 @@ class TestAPIEndpoints:
         bare_client: TestClient,
     ) -> None:
         """Detailed health reports degraded when graph readiness fails."""
-        with patch("api.routers.system.get_graph", side_effect=RuntimeError("graph boom")):
+        with patch(
+            "api.routers.system.graph_lifecycle.get_graph_with_startup_source",
+            side_effect=RuntimeError("graph boom"),
+        ):
             response = bare_client.get("/api/health/detailed")
 
         assert response.status_code == 200
@@ -503,7 +506,10 @@ class TestAPIEndpoints:
         graph.assets = []
         graph.relationships = []
 
-        with patch("api.routers.system.get_graph", return_value=graph):
+        with patch(
+            "api.routers.system.graph_lifecycle.get_graph_with_startup_source",
+            return_value=(graph, "unknown"),
+        ):
             response = bare_client.get("/api/health/detailed")
 
         assert response.status_code == 200
@@ -526,12 +532,9 @@ class TestAPIEndpoints:
         graph.assets = {"A": object()}
         graph.relationships = {"A": []}
 
-        with (
-            patch("api.routers.system.get_graph", return_value=graph),
-            patch(
-                "api.routers.system.graph_lifecycle.get_graph_startup_source",
-                return_value="sqlite:///C:/secret/path.db",
-            ),
+        with patch(
+            "api.routers.system.graph_lifecycle.get_graph_with_startup_source",
+            return_value=(graph, "sqlite:///C:/secret/path.db"),
         ):
             response = bare_client.get("/api/health/detailed")
 

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -396,7 +396,7 @@ class TestPydanticModels:
                 available=True,
                 asset_count=1,
                 relationship_count=0,
-                graph_startup_source="postgresql://secret@example.invalid/db",
+                graph_startup_source="invalid-startup-source://redacted",
             )
 
 

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -207,6 +207,7 @@ def _assert_empty_db_uses_configured_source(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     provider_attr: str,
+    expected_source: str,
 ) -> None:
     """Verify empty DB falls through to configured provider."""
     database_url = _sqlite_url(tmp_path)
@@ -234,6 +235,7 @@ def _assert_empty_db_uses_configured_source(
 
     assert graph is configured_graph
     assert set(graph.assets) == {"ASSET_ONLY"}
+    assert graph_lifecycle.get_graph_startup_source() == expected_source
 
 
 # ---------------------------------------------------------------------------
@@ -259,6 +261,7 @@ def test_factory_precedence_skips_persistence_load(
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
     assert _initialize_graph_for_test() is factory_graph
+    assert graph_lifecycle.get_graph_startup_source() == "explicit_factory"
 
 
 @pytest.mark.parametrize("configured_value", [None, "", "   "])
@@ -281,6 +284,7 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph = _initialize_graph_for_test()
 
     assert graph.assets
+    assert graph_lifecycle.get_graph_startup_source() == "sample_graph"
 
 
 @pytest.mark.parametrize(
@@ -328,6 +332,7 @@ def test_empty_configured_db_honors_graph_cache_path_before_sample_fallback(
         tmp_path,
         monkeypatch,
         "load_graph_from_cache_path",
+        "cache",
     )
 
 
@@ -341,6 +346,7 @@ def test_empty_configured_db_honors_real_data_fetcher_before_sample_fallback(
         tmp_path,
         monkeypatch,
         "load_graph_from_real_data_fetcher",
+        "real_data",
     )
 
 
@@ -363,6 +369,7 @@ def test_persisted_asset_only_graph_loads(
     assert set(loaded.assets) == {"ASSET_ONLY"}
     assert not loaded.relationships
     assert not loaded.regulatory_events
+    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
 
 
 def test_persisted_full_graph_loads(
@@ -380,6 +387,7 @@ def test_persisted_full_graph_loads(
     assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
     assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == pytest.approx(0.9)
     assert [event.id for event in loaded.regulatory_events] == ["EVENT_A"]
+    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
 
 
 def test_populated_persistence_wins_over_graph_cache_path(
@@ -598,11 +606,14 @@ def test_reset_reloads_persisted_graph_without_saving(
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
 
     first = graph_lifecycle.get_graph()
+    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
     graph_lifecycle.reset_graph()
+    assert graph_lifecycle.get_graph_startup_source() is None
     second = graph_lifecycle.get_graph()
 
     assert first is not second
     assert set(second.assets) == {"ASSET_ONLY"}
+    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
 
 
 def test_api_main_and_router_helper_compatibility(

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -291,7 +291,7 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph = _initialize_graph_for_test()
 
     assert graph.assets
-    assert graph_lifecycle.get_graph_startup_source() is None
+    assert graph_lifecycle.graph_state.startup_source is None
 
 
 def test_initialize_graph_does_not_commit_startup_source_state(
@@ -304,7 +304,7 @@ def test_initialize_graph_does_not_commit_startup_source_state(
 
     assert graph.assets
     assert graph_lifecycle.graph_state.graph is None
-    assert graph_lifecycle.get_graph_startup_source() is None
+    assert graph_lifecycle.graph_state.startup_source is None
 
 
 @pytest.mark.parametrize(
@@ -625,15 +625,15 @@ def test_reset_reloads_persisted_graph_without_saving(
 
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
 
-    first = graph_lifecycle.get_graph()
-    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
+    first, first_startup_source = graph_lifecycle.get_graph_with_startup_source()
+    assert first_startup_source == "persisted_graph_store"
     graph_lifecycle.reset_graph()
-    assert graph_lifecycle.get_graph_startup_source() is None
-    second = graph_lifecycle.get_graph()
+    assert graph_lifecycle.graph_state.startup_source is None
+    second, second_startup_source = graph_lifecycle.get_graph_with_startup_source()
 
     assert first is not second
     assert set(second.assets) == {"ASSET_ONLY"}
-    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
+    assert second_startup_source == "persisted_graph_store"
 
 
 def test_api_main_and_router_helper_compatibility(

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -138,6 +138,11 @@ def _initialize_graph_for_test() -> AssetRelationshipGraph:
     return graph_lifecycle._initialize_graph()  # pylint: disable=protected-access
 
 
+def _get_graph_with_source_for_test() -> tuple[AssetRelationshipGraph, str | None]:
+    """Get the active graph and tracked startup source via the public lifecycle helper."""
+    return graph_lifecycle.get_graph_with_startup_source()
+
+
 # ---------------------------------------------------------------------------
 # Session-close tracking proxy and patch helper
 # ---------------------------------------------------------------------------
@@ -231,11 +236,11 @@ def _assert_empty_db_uses_configured_source(
         load_configured_graph,
     )
 
-    graph = _initialize_graph_for_test()
+    graph, startup_source = _get_graph_with_source_for_test()
 
     assert graph is configured_graph
     assert set(graph.assets) == {"ASSET_ONLY"}
-    assert graph_lifecycle.get_graph_startup_source() == expected_source
+    assert startup_source == expected_source
 
 
 # ---------------------------------------------------------------------------
@@ -260,8 +265,10 @@ def test_factory_precedence_skips_persistence_load(
     graph_lifecycle.set_graph_factory(lambda: factory_graph)
     monkeypatch.setattr(graph_lifecycle_providers, "create_engine_from_url", fail_create_engine)
 
-    assert _initialize_graph_for_test() is factory_graph
-    assert graph_lifecycle.get_graph_startup_source() == "explicit_factory"
+    graph, startup_source = _get_graph_with_source_for_test()
+
+    assert graph is factory_graph
+    assert startup_source == "explicit_factory"
 
 
 @pytest.mark.parametrize("configured_value", [None, "", "   "])
@@ -284,7 +291,20 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph = _initialize_graph_for_test()
 
     assert graph.assets
-    assert graph_lifecycle.get_graph_startup_source() == "sample_graph"
+    assert graph_lifecycle.get_graph_startup_source() is None
+
+
+def test_initialize_graph_does_not_commit_startup_source_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct `_initialize_graph()` calls should not mutate active lifecycle source state."""
+    monkeypatch.delenv("ASSET_GRAPH_DATABASE_URL", raising=False)
+
+    graph = _initialize_graph_for_test()
+
+    assert graph.assets
+    assert graph_lifecycle.graph_state.graph is None
+    assert graph_lifecycle.get_graph_startup_source() is None
 
 
 @pytest.mark.parametrize(
@@ -364,12 +384,12 @@ def test_persisted_asset_only_graph_loads(
     _save_graph(database_url, _asset_only_graph())
     _configure_persistence_url(monkeypatch, database_url)
 
-    loaded = _initialize_graph_for_test()
+    loaded, startup_source = _get_graph_with_source_for_test()
 
     assert set(loaded.assets) == {"ASSET_ONLY"}
     assert not loaded.relationships
     assert not loaded.regulatory_events
-    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
+    assert startup_source == "persisted_graph_store"
 
 
 def test_persisted_full_graph_loads(
@@ -381,13 +401,13 @@ def test_persisted_full_graph_loads(
     _save_graph(database_url, _full_graph())
     _configure_persistence_url(monkeypatch, database_url)
 
-    loaded = _initialize_graph_for_test()
+    loaded, startup_source = _get_graph_with_source_for_test()
 
     assert set(loaded.assets) == {"ASSET_A", "ASSET_B", "ASSET_C"}
     assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
     assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == pytest.approx(0.9)
     assert [event.id for event in loaded.regulatory_events] == ["EVENT_A"]
-    assert graph_lifecycle.get_graph_startup_source() == "persisted_graph_store"
+    assert startup_source == "persisted_graph_store"
 
 
 def test_populated_persistence_wins_over_graph_cache_path(


### PR DESCRIPTION
## **User description**
## Primary Objective

Implement issue #1138 by exposing a bounded `graph_startup_source` field in `GET /api/health/detailed` without changing graph initialization order or persistence semantics.

## In Scope

- Add `graph_startup_source` to `GraphHealthResponse`
- Track startup source selection in `api.graph_lifecycle`
- Clear tracked startup source during `reset_graph()` / graph-factory resets
- Surface the bounded value from the detailed health route
- Add focused unit coverage for persisted/sample/factory/reset behavior and bounded health responses
- Update the directly affected hosted-readiness integration assertions for the new graph response shape

## Out of Scope

- Repository persistence semantics
- Graph rebuild save behavior
- Broader seam-matrix expansion from earlier roadmap work
- Frontend, CI, workflow, migration, or scanner changes
- Any new public endpoint beyond the bounded field on `/api/health/detailed`

## Files Expected To Change

- `api/api_models.py`
- `api/graph_lifecycle.py`
- `api/routers/system.py`
- `tests/unit/test_graph_lifecycle_persistence.py`
- `tests/unit/test_api_main.py`
- `tests/integration/test_hosted_graph_startup_readiness.py`

## Change Summary

- Adds a typed `GraphStartupSource` literal contract and surfaces `graph.graph_startup_source` in detailed health
- Tracks startup source for persisted store, sample graph, cache, real-data fetcher, and explicit factory flows
- Reports `unknown` for manually injected runtime graphs and `null` when graph health is unavailable
- Bounds unsafe startup-source values to `unknown` before they can reach the public response

## Validation Commands

```bash
pytest tests/unit/test_graph_lifecycle_persistence.py -v
pytest tests/unit/test_api_main.py -v
pre-commit run --files api/api_models.py api/graph_lifecycle.py api/routers/system.py
```

Additional direct checks run locally:

```bash
python -m compileall api tests/unit/test_api_main.py tests/unit/test_graph_lifecycle_persistence.py tests/integration/test_hosted_graph_startup_readiness.py
python -m ruff check api/api_models.py api/graph_lifecycle.py api/routers/system.py tests/unit/test_api_main.py tests/unit/test_graph_lifecycle_persistence.py tests/integration/test_hosted_graph_startup_readiness.py
python -m ruff format --check api/api_models.py api/graph_lifecycle.py api/routers/system.py tests/unit/test_api_main.py tests/unit/test_graph_lifecycle_persistence.py tests/integration/test_hosted_graph_startup_readiness.py
```

## Validation Status

- `python -m compileall ...`: passed
- `python -m ruff check ...`: passed
- `python -m ruff format --check ...`: passed after formatting the touched files with Ruff
- `pytest ...`: blocked before collection by the repository's existing `tests/conftest.py` `--cov` option-registration conflict (`ValueError: option names {'--cov'} already added`)
- Direct runtime probe: verified `/api/health/detailed` returns `graph_startup_source` and that persisted-store startup tracks `persisted_graph_store`

## Merge Criteria

- `GET /api/health/detailed` includes `graph.graph_startup_source`
- Value remains bounded to the issue-approved literals or `null`
- No startup-order or persistence-semantics regressions are introduced
- Scope stays limited to Stage 2a health observability

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes a bounded `graph_startup_source` in `GET /api/health/detailed` and atomically tracks the graph’s startup path to meet Linear #1138. Preserves startup order and persistence, and restores the `get_graph` fast path.

- **New Features**
  - Added `GraphStartupSource` and `graph_startup_source` to `GraphHealthResponse`; returns `"persisted_graph_store" | "cache" | "real_data" | "sample_graph" | "explicit_factory" | "unknown"`, or `null` when degraded.
  - Introduced `get_graph_with_startup_source()` and `_initialize_graph_with_source()` for atomic graph+source reads; manual/runtime graphs report `unknown`, and health bounds values via an allowlist.

- **Refactors**
  - Lifecycle now tracks startup source; cleared on `reset_graph()`/`set_graph_factory()`, stamped `unknown` on `set_graph()`/`synchronize_runtime_graph()`, `_initialize_graph()` remains side-effect free; `get_graph` uses a fast path and falls back only on first init.
  - Router calls `graph_lifecycle.get_graph_with_startup_source()` and returns the bounded `graph_startup_source`.

<sup>Written for commit b7f45a75262d9002e017a4fd5e7e49367e24e7e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Expose the graph startup source in detailed health responses**

### What Changed
- The detailed health endpoint now includes the graph’s startup source alongside availability and counts.
- Startup source values are limited to a safe public set; unexpected values are shown as `unknown`, and missing graph data stays `null`.
- Graph startup source is now tracked across startup paths such as persisted data, sample graph, cache, real data, and explicit factory setup.
- Resetting the graph clears the stored startup source so the next health check reflects the latest startup path.

### Impact
`✅ Clearer health checks`
`✅ Safer public readiness output`
`✅ Fewer misleading graph startup reports`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=9LSbGOTqAvM1xq8kISlvyBkqZYT9cf1Nn9ClGs0OEhI&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
