### PR TITLE
Stage 3 PR4: restrict graph rebuilds to configured operator

### DIFF
--- a/api/auth.py
+++ b/api/auth.py
@@ -442,11 +442,10 @@ def get_current_rebuild_operator_user(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL,
         )
-
-    if current_user.username != configured_admin:
+    
+    if current_user.username.strip() != configured_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail=REBUILD_OPERATOR_FORBIDDEN_DETAIL,
         )
-
     return current_user

--- a/api/auth.py
+++ b/api/auth.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
-from typing import TypedDict
+from typing import Annotated, TypedDict
 
 import jwt
 from fastapi import Depends, HTTPException, status
@@ -13,7 +13,7 @@ from passlib.context import CryptContext  # pyright: ignore[reportMissingModuleS
 from pydantic import BaseModel
 
 from api.models import User, UserInDB
-from src.config.settings import Settings, load_settings
+from src.config.settings import Settings, get_settings, load_settings
 
 from .database import execute, fetch_one, fetch_value, initialize_schema
 
@@ -23,6 +23,8 @@ SECRET_KEY = _AUTH_SETTINGS.required_secret_key
 
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+REBUILD_OPERATOR_FORBIDDEN_DETAIL = "You do not have permission to perform destructive actions."
+REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL = "Rebuild operator authorization is not configured."
 
 # Password hashing
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
@@ -420,4 +422,31 @@ async def get_current_active_user(current_user: User = Depends(get_current_user)
     """
     if current_user.disabled:
         raise HTTPException(status_code=400, detail="Inactive user")
+    return current_user
+
+
+def get_current_rebuild_operator_user(
+    current_user: Annotated[User, Depends(get_current_active_user)],
+    settings: Annotated[Settings, Depends(get_settings)],
+) -> User:
+    """
+    Enforce operator authorization for destructive graph rebuild actions.
+
+    Allows only the configured admin username from settings; denies other active
+    users with a bounded forbidden response.
+    """
+    configured_admin = settings.admin_username
+
+    if not configured_admin:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL,
+        )
+
+    if current_user.username != configured_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=REBUILD_OPERATOR_FORBIDDEN_DETAIL,
+        )
+
     return current_user

--- a/api/auth.py
+++ b/api/auth.py
@@ -442,7 +442,7 @@ def get_current_rebuild_operator_user(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL,
         )
-    
+
     if current_user.username.strip() != configured_admin:
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,

--- a/api/auth.py
+++ b/api/auth.py
@@ -435,7 +435,7 @@ def get_current_rebuild_operator_user(
     Allows only the configured admin username from settings; denies other active
     users with a bounded forbidden response.
     """
-    configured_admin = settings.admin_username
+    configured_admin = (settings.admin_username or "").strip()
 
     if not configured_admin:
         raise HTTPException(

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -337,7 +337,7 @@ def _log_rebuild_failed(*, user_ref: str, exc: Exception, status_code: int, dura
     logger.error(
         "graph_rebuild_audit",
         extra={
-            "event": "graph_rebuild_failed",
+            "event": _REBUILD_AUDIT_FAILED,
             "user_ref": user_ref,
             "path": _REBUILD_PATH,
             "failure_category": _rebuild_failure_category(exc),

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -13,7 +13,7 @@ from typing import Annotated, cast
 from fastapi import APIRouter, Depends, HTTPException, status  # pylint: disable=import-error
 
 from ..api_models import GraphRebuildResponse
-from ..auth import User, get_current_active_user
+from ..auth import User, get_current_rebuild_operator_user
 from ..graph_lifecycle import synchronize_runtime_graph
 from ..graph_lifecycle_providers import (
     GraphLifecycleSettings,
@@ -100,7 +100,7 @@ class _RebuildExecutionError(Exception):
 
 @router.post(_REBUILD_PATH)
 async def rebuild_graph(
-    current_user: Annotated[User, Depends(get_current_active_user)],
+    current_user: Annotated[User, Depends(get_current_rebuild_operator_user)],
 ) -> GraphRebuildResponse:
     """Rebuild, persist, and synchronize graph state."""
     settings = get_graph_lifecycle_settings()

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -337,7 +337,7 @@ def _log_rebuild_failed(*, user_ref: str, exc: Exception, status_code: int, dura
     logger.error(
         "graph_rebuild_audit",
         extra={
-            "event": _REBUILD_AUDIT_FAILED,
+            "event": "graph_rebuild_failed",
             "user_ref": user_ref,
             "path": _REBUILD_PATH,
             "failure_category": _rebuild_failure_category(exc),

--- a/tests/integration/test_graph_admin_router.py
+++ b/tests/integration/test_graph_admin_router.py
@@ -123,7 +123,6 @@ def test_rebuild_allows_active_authorized_operator_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Authorized operator should retain rebuild happy path behavior."""
-
     fake_rebuild = AsyncMock(
         return_value=graph_admin.GraphRebuildResponse(
             status="persisted",

--- a/tests/integration/test_graph_admin_router.py
+++ b/tests/integration/test_graph_admin_router.py
@@ -7,13 +7,22 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
+from collections.abc import Generator
+from unittest.mock import AsyncMock
 
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
 from fastapi import HTTPException  # pylint: disable=import-error
+from fastapi.testclient import TestClient  # pylint: disable=import-error
 
 import api.routers.graph_admin as graph_admin
-from api.auth import User, get_current_active_user
+from api.auth import (
+    REBUILD_OPERATOR_FORBIDDEN_DETAIL,
+    REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL,
+    User,
+    get_current_active_user,
+)
+from src.config.settings import get_settings
 
 pytestmark = pytest.mark.integration
 
@@ -26,7 +35,7 @@ def _authorized_app():
 
     def active_user() -> User:
         """Return an active test user."""
-        return User(username="operator", disabled=False)
+        return User(username="admin", disabled=False)
 
     app.dependency_overrides[get_current_active_user] = active_user
     return app
@@ -37,6 +46,54 @@ async def _post_rebuild() -> httpx.Response:
     transport = httpx.ASGITransport(app=_authorized_app())
     async with httpx.AsyncClient(transport=transport, base_url="https://testserver") as client:
         return await client.post("/api/graph/rebuild")
+
+
+def _configure_test_operator(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configure the test operator username and refresh cached settings."""
+    monkeypatch.setenv("ADMIN_USERNAME", "admin")
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def non_operator_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """Client authenticated as a standard, non-operator active user."""
+    _configure_test_operator(monkeypatch)
+    from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
+
+    app = create_app()
+
+    def active_user() -> User:
+        """Return a mock standard active user."""
+        return User(username="standard_analyst", disabled=False)
+
+    app.dependency_overrides[get_current_active_user] = active_user
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def operator_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """Client authenticated as the authorized operator user."""
+    _configure_test_operator(monkeypatch)
+    from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
+
+    app = create_app()
+
+    def active_operator() -> User:
+        """Return a mock authorized operator user."""
+        return User(username="admin", disabled=False)
+
+    app.dependency_overrides[get_current_active_user] = active_operator
+
+    try:
+        with TestClient(app) as client:
+            yield client
+    finally:
+        get_settings.cache_clear()
 
 
 async def test_app_construction_with_graph_admin_router_succeeds() -> None:
@@ -54,6 +111,69 @@ async def test_app_construction_with_graph_admin_router_succeeds() -> None:
     assert response.status_code == 401
 
 
+def test_rebuild_returns_403_for_active_non_operator_user(non_operator_client: TestClient) -> None:
+    """Active authenticated users who are not operator-authorized should be forbidden."""
+    response = non_operator_client.post("/api/graph/rebuild")
+    assert response.status_code == 403
+    assert response.json()["detail"] == REBUILD_OPERATOR_FORBIDDEN_DETAIL
+
+
+def test_rebuild_allows_active_authorized_operator_user(
+    operator_client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Authorized operator should retain rebuild happy path behavior."""
+
+    fake_rebuild = AsyncMock(
+        return_value=graph_admin.GraphRebuildResponse(
+            status="persisted",
+            source="sample",
+            asset_count=0,
+            relationship_count=0,
+            regulatory_event_count=0,
+        )
+    )
+
+    monkeypatch.setattr(graph_admin, "_run_rebuild_in_executor", fake_rebuild)
+
+    response = operator_client.post("/api/graph/rebuild")
+    fake_rebuild.assert_awaited_once()
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "persisted",
+        "source": "sample",
+        "asset_count": 0,
+        "relationship_count": 0,
+        "regulatory_event_count": 0,
+    }
+
+
+def test_rebuild_returns_503_when_operator_authorization_not_configured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Rebuild should fail closed when no operator username is configured."""
+    from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
+
+    monkeypatch.delenv("ADMIN_USERNAME", raising=False)
+    get_settings.cache_clear()
+    app = create_app()
+
+    def active_user() -> User:
+        """Return an active user used to prove fail-closed config behavior."""
+        return User(username="admin", disabled=False)
+
+    app.dependency_overrides[get_current_active_user] = active_user
+
+    try:
+        with TestClient(app) as client:
+            response = client.post("/api/graph/rebuild")
+    finally:
+        get_settings.cache_clear()
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL
+
+
 async def test_rebuild_returns_429_when_rebuild_already_running(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -61,7 +181,7 @@ async def test_rebuild_returns_429_when_rebuild_already_running(
     graph_admin._REBUILD_RUNTIME.mark_busy()  # pylint: disable=protected-access
     try:
         with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"), pytest.raises(HTTPException) as exc_info:
-            await graph_admin.rebuild_graph(User(username="operator", disabled=False))
+            await graph_admin.rebuild_graph(User(username="admin", disabled=False))
     finally:
         graph_admin._REBUILD_RUNTIME.mark_idle()  # pylint: disable=protected-access
 
@@ -78,7 +198,7 @@ async def test_rebuild_returns_429_when_rebuild_already_running(
 
     assert len(requested_records) == 1
     assert len(rejected_records) == 1
-    assert requested_records[0].user_ref == "operator"
+    assert requested_records[0].user_ref == "admin"
     assert requested_records[0].path == "/api/graph/rebuild"
     assert rejected_records[0].reason == "rebuild_in_progress"
     assert rejected_records[0].status_code == 429
@@ -136,7 +256,7 @@ async def test_rebuild_outcome_logging_survives_request_cancellation(
                 graph_admin._run_rebuild_in_executor(  # pylint: disable=protected-access
                     loop,
                     settings,
-                    user_ref="operator",
+                    user_ref="admin",
                     started_at=time.perf_counter(),
                 )
             )
@@ -163,5 +283,5 @@ async def test_rebuild_outcome_logging_survives_request_cancellation(
 
     assert len(succeeded_records) == 1
     assert len(failed_records) == 0
-    assert succeeded_records[0].user_ref == "operator"
+    assert succeeded_records[0].user_ref == "admin"
     assert succeeded_records[0].status_code == 200

--- a/tests/integration/test_graph_admin_router.py
+++ b/tests/integration/test_graph_admin_router.py
@@ -5,10 +5,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterator
 import logging
 import time
-from collections.abc import Generator
-from unittest.mock import AsyncMock
 
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
@@ -27,44 +26,25 @@ from src.config.settings import get_settings
 pytestmark = pytest.mark.integration
 
 
-def _authorized_app():
-    """Create an app with an active test operator."""
-    from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
-
-    app = create_app()
-
-    def active_user() -> User:
-        """Return an active test user."""
-        return User(username="admin", disabled=False)
-
-    app.dependency_overrides[get_current_active_user] = active_user
-    return app
-
-
-async def _post_rebuild() -> httpx.Response:
-    """Post to the graph rebuild endpoint as an active operator."""
-    transport = httpx.ASGITransport(app=_authorized_app())
-    async with httpx.AsyncClient(transport=transport, base_url="https://testserver") as client:
-        return await client.post("/api/graph/rebuild")
-
-
 def _configure_test_operator(monkeypatch: pytest.MonkeyPatch) -> None:
     """Configure the test operator username and refresh cached settings."""
     monkeypatch.setenv("ADMIN_USERNAME", "admin")
     get_settings.cache_clear()
 
 
-@pytest.fixture
-def non_operator_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
-    """Client authenticated as a standard, non-operator active user."""
+def _client_with_active_user(
+    monkeypatch: pytest.MonkeyPatch,
+    username: str,
+) -> Iterator[TestClient]:
+    """Create a client whose active user has the supplied username."""
     _configure_test_operator(monkeypatch)
     from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
 
     app = create_app()
 
     def active_user() -> User:
-        """Return a mock standard active user."""
-        return User(username="standard_analyst", disabled=False)
+        """Return a mock active user."""
+        return User(username=username, disabled=False)
 
     app.dependency_overrides[get_current_active_user] = active_user
 
@@ -76,24 +56,15 @@ def non_operator_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient
 
 
 @pytest.fixture
-def operator_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+def non_operator_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
+    """Client authenticated as a standard, non-operator active user."""
+    yield from _client_with_active_user(monkeypatch, "standard_analyst")
+
+
+@pytest.fixture
+def operator_client(monkeypatch: pytest.MonkeyPatch) -> Iterator[TestClient]:
     """Client authenticated as the authorized operator user."""
-    _configure_test_operator(monkeypatch)
-    from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
-
-    app = create_app()
-
-    def active_operator() -> User:
-        """Return a mock authorized operator user."""
-        return User(username="admin", disabled=False)
-
-    app.dependency_overrides[get_current_active_user] = active_operator
-
-    try:
-        with TestClient(app) as client:
-            yield client
-    finally:
-        get_settings.cache_clear()
+    yield from _client_with_active_user(monkeypatch, "admin")
 
 
 async def test_app_construction_with_graph_admin_router_succeeds() -> None:
@@ -123,20 +94,28 @@ def test_rebuild_allows_active_authorized_operator_user(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Authorized operator should retain rebuild happy path behavior."""
-    fake_rebuild = AsyncMock(
-        return_value=graph_admin.GraphRebuildResponse(
+
+    def fake_rebuild(
+        _settings: graph_admin.GraphLifecycleSettings,
+    ) -> graph_admin.GraphRebuildResponse:
+        """Return a mock successful GraphRebuildResponse."""
+        return graph_admin.GraphRebuildResponse(
             status="persisted",
             source="sample",
             asset_count=0,
             relationship_count=0,
             regulatory_event_count=0,
         )
-    )
 
-    monkeypatch.setattr(graph_admin, "_run_rebuild_in_executor", fake_rebuild)
+    monkeypatch.setattr(graph_admin, "_perform_rebuild_and_persist_sync", fake_rebuild)
 
-    response = operator_client.post("/api/graph/rebuild")
-    fake_rebuild.assert_awaited_once()
+    try:
+        response = operator_client.post("/api/graph/rebuild")
+    finally:
+        graph_admin.shutdown_rebuild_executor()
+        if graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
+            graph_admin._REBUILD_RUNTIME.mark_idle()  # pylint: disable=protected-access
+
     assert response.status_code == 200
     assert response.json() == {
         "status": "persisted",
@@ -147,13 +126,19 @@ def test_rebuild_allows_active_authorized_operator_user(
     }
 
 
+@pytest.mark.parametrize("configured_admin", [None, "", "   "])
 def test_rebuild_returns_503_when_operator_authorization_not_configured(
     monkeypatch: pytest.MonkeyPatch,
+    configured_admin: str | None,
 ) -> None:
     """Rebuild should fail closed when no operator username is configured."""
     from api.app_factory import create_app  # pylint: disable=import-outside-toplevel
 
-    monkeypatch.delenv("ADMIN_USERNAME", raising=False)
+    if configured_admin is None:
+        monkeypatch.delenv("ADMIN_USERNAME", raising=False)
+    else:
+        monkeypatch.setenv("ADMIN_USERNAME", configured_admin)
+
     get_settings.cache_clear()
     app = create_app()
 

--- a/tests/integration/test_graph_admin_router.py
+++ b/tests/integration/test_graph_admin_router.py
@@ -5,9 +5,9 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Iterator
 import logging
 import time
+from collections.abc import Iterator
 
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -339,11 +339,11 @@ async def test_successful_rebuild_emits_bounded_audit_log(
         response = await _post_rebuild_http(monkeypatch)
         deadline = time.monotonic() + 1.0
 
-    while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
-        if time.monotonic() >= deadline:
-            pytest.fail("Timed out waiting for rebuild runtime to become idle")
+        while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
+            if time.monotonic() >= deadline:
+                pytest.fail("Timed out waiting for rebuild runtime to become idle")
 
-        await asyncio.sleep(0)
+            await asyncio.sleep(0)
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -385,7 +385,13 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-        await asyncio.sleep(0.01)
+        deadline = time.monotonic() + 1.0
+
+        while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
+            if time.monotonic() >= deadline:
+                pytest.fail("Timed out waiting for rebuild runtime to become idle")
+
+            await asyncio.sleep(0)
 
     assert response.status_code == 500
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -376,8 +376,8 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
     monkeypatch.setattr("api.routers.graph_admin.save_graph_to_persistence", fail_save)
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
-    response = await _post_rebuild_http(monkeypatch)
-        await asyncio.sleep(0.01)
+        response = await _post_rebuild_http(monkeypatch)
+            await asyncio.sleep(0.01)
 
     assert response.status_code == 500
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -335,7 +335,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.01)
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -381,17 +381,9 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     assert response.status_code == 500
 
-    audit_records = [
-        record
-        for record in caplog.records
-        if record.getMessage() == "graph_rebuild_audit"
-    ]
+    audit_records = [record for record in caplog.records if record.getMessage() == "graph_rebuild_audit"]
 
-    failed_records = [
-        record
-        for record in audit_records
-        if getattr(record, "event", None) == "graph_rebuild_failed"
-    ]
+    failed_records = [record for record in audit_records if getattr(record, "event", None) == "graph_rebuild_failed"]
 
     assert len(failed_records) == 1
     assert failed_records[0].user_ref == "operator"

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -21,6 +21,7 @@ import api.main as api_main
 from api.app_factory import create_app
 from api.auth import User, get_current_active_user
 from api.routers import graph_admin
+from src.config.settings import get_settings
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -39,6 +40,7 @@ def reset_state(monkeypatch: pytest.MonkeyPatch):
         "USE_REAL_DATA_FETCHER",
     ):
         monkeypatch.delenv(name, raising=False)
+    get_settings.cache_clear()
     providers.clear_graph_lifecycle_settings_cache()
     api_main.reset_graph()
     monkeypatch.setattr("api.routers.graph_admin._REBUILD_RUNTIME.executor", _ImmediateExecutor())
@@ -46,6 +48,7 @@ def reset_state(monkeypatch: pytest.MonkeyPatch):
     graph_admin.shutdown_rebuild_executor()
     api_main.reset_graph()
     providers.clear_graph_lifecycle_settings_cache()
+    get_settings.cache_clear()
 
 
 class _ImmediateExecutor(ThreadPoolExecutor):
@@ -85,8 +88,6 @@ async def _post_rebuild() -> _RouteResult:
 def _authorized_app(monkeypatch: pytest.MonkeyPatch):
     """Create an app with an active authorized operator."""
     monkeypatch.setenv("ADMIN_USERNAME", "operator")
-    from src.config.settings import get_settings
-
     get_settings.cache_clear()
 
     app = create_app()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -336,7 +336,13 @@ async def test_successful_rebuild_emits_bounded_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-        await asyncio.sleep(0.01)
+        deadline = time.monotonic() + 1.0
+
+    while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
+        if time.monotonic() >= deadline:
+            pytest.fail("Timed out waiting for rebuild runtime to become idle")
+    
+        await asyncio.sleep(0)
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -335,6 +335,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
+        await asyncio.sleep(0.01)
 
     assert response.status_code == 200
     payload = response.json()
@@ -375,12 +376,22 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
     monkeypatch.setattr("api.routers.graph_admin.save_graph_to_persistence", fail_save)
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
-        response = await _post_rebuild_http(monkeypatch)
-
+    response = await _post_rebuild_http(monkeypatch)
+        await asyncio.sleep(0.01)
+    
     assert response.status_code == 500
-
-    audit_records = [record for record in caplog.records if record.getMessage() == "graph_rebuild_audit"]
-    failed_records = [record for record in audit_records if record.levelname == "ERROR"]
+    
+    audit_records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "graph_rebuild_audit"
+    ]
+    
+    failed_records = [
+        record
+        for record in audit_records
+        if getattr(record, "event", None) == "graph_rebuild_failed"
+    ]
 
     assert len(failed_records) == 1
     assert failed_records[0].user_ref == "operator"

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -84,6 +84,7 @@ def _authorized_app(monkeypatch: pytest.MonkeyPatch):
     """Create an app with an active authorized operator."""
     monkeypatch.setenv("ADMIN_USERNAME", "operator")
     from src.config.settings import get_settings
+
     get_settings.cache_clear()
 
     app = create_app()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -378,15 +378,15 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
     response = await _post_rebuild_http(monkeypatch)
         await asyncio.sleep(0.01)
-    
+
     assert response.status_code == 500
-    
+
     audit_records = [
         record
         for record in caplog.records
         if record.getMessage() == "graph_rebuild_audit"
     ]
-    
+
     failed_records = [
         record
         for record in audit_records

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -335,7 +335,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-    await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert response.status_code == 200
     payload = response.json()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -379,8 +379,16 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     assert response.status_code == 500
 
-    audit_records = [record for record in caplog.records if record.getMessage() == "graph_rebuild_audit"]
-    failed_records = [record for record in audit_records if getattr(record, "event", None) == "graph_rebuild_failed"]
+    audit_records = [
+        record 
+        for record in caplog.records 
+        if record.getMessage() == "graph_rebuild_audit"
+    ]
+    failed_records = [
+        record
+        for record in audit_records
+        if record.levelname == "ERROR"
+    ]
 
     assert len(failed_records) == 1
     assert failed_records[0].user_ref == "operator"

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -114,6 +114,29 @@ async def _post_rebuild_http(
         return await client.post("/api/graph/rebuild")
 
 
+async def _wait_for_runtime_idle_and_audit_event(
+    caplog: pytest.LogCaptureFixture,
+    event_name: str,
+    timeout_seconds: float = 1.0,
+) -> None:
+    """Wait until rebuild runtime is idle and the expected audit event is captured."""
+    deadline = time.monotonic() + timeout_seconds
+
+    while True:
+        runtime_busy = graph_admin._REBUILD_RUNTIME.is_busy()  # pylint: disable=protected-access
+        event_seen = any(
+            record.getMessage() == "graph_rebuild_audit" and getattr(record, "event", None) == event_name
+            for record in caplog.records
+        )
+
+        if not runtime_busy and event_seen:
+            return
+        if time.monotonic() >= deadline:
+            pytest.fail(f"Timed out waiting for rebuild runtime idle and audit event: {event_name}")
+
+        await asyncio.sleep(0.005)
+
+
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:
     """Build a file-backed SQLite database URL."""
     return f"sqlite:///{tmp_path / name}"
@@ -338,13 +361,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-        deadline = time.monotonic() + 1.0
-
-        while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
-            if time.monotonic() >= deadline:
-                pytest.fail("Timed out waiting for rebuild runtime to become idle")
-
-            await asyncio.sleep(0)
+        await _wait_for_runtime_idle_and_audit_event(caplog, "graph_rebuild_succeeded")
 
     assert response.status_code == 200
     payload = response.json()
@@ -386,13 +403,7 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-        deadline = time.monotonic() + 1.0
-
-        while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
-            if time.monotonic() >= deadline:
-                pytest.fail("Timed out waiting for rebuild runtime to become idle")
-
-            await asyncio.sleep(0)
+        await _wait_for_runtime_idle_and_audit_event(caplog, "graph_rebuild_failed")
 
     assert response.status_code == 500
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -29,6 +29,8 @@ from src.models.financial_models import AssetClass, Equity, RegulatoryActivity, 
 
 pytestmark = pytest.mark.integration
 
+_REBUILD_AUDIT_POLL_INTERVAL_SECONDS = 0.005
+
 
 @pytest.fixture(autouse=True)
 def reset_state(monkeypatch: pytest.MonkeyPatch):
@@ -134,7 +136,7 @@ async def _wait_for_runtime_idle_and_audit_event(
         if time.monotonic() >= deadline:
             pytest.fail(f"Timed out waiting for rebuild runtime idle and audit event: {event_name}")
 
-        await asyncio.sleep(0.005)
+        await asyncio.sleep(_REBUILD_AUDIT_POLL_INTERVAL_SECONDS)
 
 
 def _sqlite_url(tmp_path: Path, name: str = "asset_graph.db") -> str:

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -83,6 +83,7 @@ async def _post_rebuild() -> _RouteResult:
 def _authorized_app(monkeypatch: pytest.MonkeyPatch):
     """Create an app with an active authorized operator."""
     monkeypatch.setenv("ADMIN_USERNAME", "operator")
+    from src.config.settings import get_settings
     get_settings.cache_clear()
 
     app = create_app()

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -9,6 +9,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
+import asyncio
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
 from sqlalchemy import create_engine  # pylint: disable=import-error

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -379,16 +379,8 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     assert response.status_code == 500
 
-    audit_records = [
-        record 
-        for record in caplog.records 
-        if record.getMessage() == "graph_rebuild_audit"
-    ]
-    failed_records = [
-        record
-        for record in audit_records
-        if record.levelname == "ERROR"
-    ]
+    audit_records = [record for record in caplog.records if record.getMessage() == "graph_rebuild_audit"]
+    failed_records = [record for record in audit_records if record.levelname == "ERROR"]
 
     assert len(failed_records) == 1
     assert failed_records[0].user_ref == "operator"

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
-import asyncio
 import httpx  # pylint: disable=import-error
 import pytest  # pylint: disable=import-error
 from sqlalchemy import create_engine  # pylint: disable=import-error

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -377,7 +377,7 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
         response = await _post_rebuild_http(monkeypatch)
-            await asyncio.sleep(0.01)
+        await asyncio.sleep(0.01)
 
     assert response.status_code == 500
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -80,8 +80,11 @@ async def _post_rebuild() -> _RouteResult:
     return _RouteResult(200, body.model_dump())
 
 
-def _authorized_app():
-    """Create an app with an active test operator."""
+def _authorized_app(monkeypatch: pytest.MonkeyPatch):
+    """Create an app with an active authorized operator."""
+    monkeypatch.setenv("ADMIN_USERNAME", "operator")
+    get_settings.cache_clear()
+
     app = create_app()
 
     def active_user() -> User:
@@ -89,13 +92,20 @@ def _authorized_app():
         return User(username="operator", disabled=False)
 
     app.dependency_overrides[get_current_active_user] = active_user
+
     return app
 
 
-async def _post_rebuild_http() -> httpx.Response:
+async def _post_rebuild_http(
+    monkeypatch: pytest.MonkeyPatch,
+) -> httpx.Response:
     """Post to rebuild through the HTTP route with an authorized user."""
-    transport = httpx.ASGITransport(app=_authorized_app())
-    async with httpx.AsyncClient(transport=transport, base_url="https://testserver") as client:
+    transport = httpx.ASGITransport(app=_authorized_app(monkeypatch))
+
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="https://testserver",
+    ) as client:
         return await client.post("/api/graph/rebuild")
 
 
@@ -322,7 +332,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
     _prepare_rebuild_database(tmp_path, monkeypatch)
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
-        response = await _post_rebuild_http()
+        response = await _post_rebuild_http(monkeypatch)
 
     assert response.status_code == 200
     payload = response.json()
@@ -363,7 +373,7 @@ async def test_failed_rebuild_emits_secret_safe_audit_log(
     monkeypatch.setattr("api.routers.graph_admin.save_graph_to_persistence", fail_save)
 
     with caplog.at_level(logging.INFO, logger="api.routers.graph_admin"):
-        response = await _post_rebuild_http()
+        response = await _post_rebuild_http(monkeypatch)
 
     assert response.status_code == 500
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -341,7 +341,7 @@ async def test_successful_rebuild_emits_bounded_audit_log(
     while graph_admin._REBUILD_RUNTIME.is_busy():  # pylint: disable=protected-access
         if time.monotonic() >= deadline:
             pytest.fail("Timed out waiting for rebuild runtime to become idle")
-    
+
         await asyncio.sleep(0)
 
     assert response.status_code == 200

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
-            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
-        )
+        assert (
+            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
+        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {"workflow_dispatch"}, (
-            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
-        )
+        assert set(triggers) == {
+            "workflow_dispatch"
+        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert "pull_request" not in triggers, (
-            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
-        )
+        assert (
+            "pull_request" not in triggers
+        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
-            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
-        )
+        assert (
+            "hosted-readiness" in hosted_readiness_workflow["jobs"]
+        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
-            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
-        )
+        assert (
+            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
+        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
-            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
-        )
+        assert (
+            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
+        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
-            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
-        )
+        assert re.match(
+            r"^[0-9a-f]{40}$", sha_part
+        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "scripts/check_hosted_readiness.py" in run_script, (
-            "Run check step must invoke scripts/check_hosted_readiness.py"
-        )
+        assert (
+            "scripts/check_hosted_readiness.py" in run_script
+        ), "Run check step must invoke scripts/check_hosted_readiness.py"
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
-        )
+        assert (
+            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
-            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
-        )
+        assert (
+            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
+        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"https?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded URLs in code: {line}"
-            )
+            assert not re.search(
+                r"https?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded URLs in code: {line}"
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(content), (
-                f"Workflow may contain hardcoded token or API key in line: {line}"
-            )
+            assert not sensitive_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded token or API key in line: {line}"
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            )
-            assert not re.search(r"mysql://", content, re.IGNORECASE), (
-                f"Workflow must not contain hardcoded MySQL URLs: {line}"
-            )
+            assert not re.search(
+                r"postgres(ql)?://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            assert not re.search(
+                r"mysql://", content, re.IGNORECASE
+            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(content), (
-                f"Workflow may contain hardcoded credential in line: {line}"
-            )
+            assert not credential_assignment.search(
+                content
+            ), f"Workflow may contain hardcoded credential in line: {line}"
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
-        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
-            "Workflow must not contain example response bodies"
-        )
+        assert (
+            '{"status": "healthy"' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
+        assert (
+            '"graph_initialized": true' not in hosted_readiness_workflow_raw
+        ), "Workflow must not contain example response bodies"
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
-                f"Workflow must not embed provider-specific secret '{secret_name}'"
-            )
+            assert not re.search(
+                rf"\b{secret_name}\b", scannable_content
+            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
-            "Concurrency group must be scoped to workflow and ref"
-        )
+        assert (
+            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
+        ), "Concurrency group must be scoped to workflow and ref"
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -113,9 +113,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_workflow_name_is_correct(self, hosted_readiness_workflow):
         """Workflow name must be 'Hosted readiness smoke check'."""
-        assert (
-            hosted_readiness_workflow["name"] == "Hosted readiness smoke check"
-        ), "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        assert hosted_readiness_workflow["name"] == "Hosted readiness smoke check", (
+            "hosted-readiness.yml name must be 'Hosted readiness smoke check'"
+        )
 
     def test_workflow_has_on_trigger(self, hosted_readiness_workflow):
         """Workflow must define event triggers."""
@@ -125,9 +125,9 @@ class TestHostedReadinessWorkflowStructure:
         """Workflow must trigger on workflow_dispatch only."""
         triggers = hosted_readiness_workflow["on"]
         assert isinstance(triggers, dict), "Workflow triggers must be a mapping"
-        assert set(triggers) == {
-            "workflow_dispatch"
-        }, "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        assert set(triggers) == {"workflow_dispatch"}, (
+            "hosted-readiness.yml must define workflow_dispatch as its only trigger"
+        )
 
     def test_workflow_does_not_trigger_on_push(self, hosted_readiness_workflow):
         """Workflow must not trigger on push events."""
@@ -137,9 +137,9 @@ class TestHostedReadinessWorkflowStructure:
     def test_workflow_does_not_trigger_on_pull_request(self, hosted_readiness_workflow):
         """Workflow must not trigger on pull_request events."""
         triggers = hosted_readiness_workflow["on"]
-        assert (
-            "pull_request" not in triggers
-        ), "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        assert "pull_request" not in triggers, (
+            "hosted-readiness.yml must not trigger on 'pull_request' (manual-only workflow)"
+        )
 
     def test_workflow_has_jobs(self, hosted_readiness_workflow):
         """Workflow must define at least one job."""
@@ -148,9 +148,9 @@ class TestHostedReadinessWorkflowStructure:
 
     def test_hosted_readiness_job_exists(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must be defined."""
-        assert (
-            "hosted-readiness" in hosted_readiness_workflow["jobs"]
-        ), "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        assert "hosted-readiness" in hosted_readiness_workflow["jobs"], (
+            "hosted-readiness.yml must contain a job named 'hosted-readiness'"
+        )
 
     def test_hosted_readiness_job_has_runs_on(self, hosted_readiness_workflow):
         """The 'hosted-readiness' job must specify a runner."""
@@ -225,17 +225,17 @@ class TestHostedReadinessWorkflowEnvironment:
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
         base_url_expr = env.get("HOSTED_READINESS_BASE_URL")
-        assert (
-            base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}"
-        ), "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        assert base_url_expr == "${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}", (
+            "HOSTED_READINESS_BASE_URL must use only inputs.base_url with secrets.HOSTED_READINESS_BASE_URL fallback"
+        )
 
     def test_timeout_comes_from_input(self, hosted_readiness_workflow):
         """Timeout must come from inputs.timeout."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         env = job.get("env", {})
-        assert (
-            env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
-        ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        assert env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}", (
+            "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+        )
 
 
 @pytest.mark.integration
@@ -275,9 +275,9 @@ class TestHostedReadinessWorkflowSteps:
         assert checkout_step is not None, "actions/checkout step not found"
         action_ref = checkout_step["uses"]
         sha_part = action_ref.split("@", 1)[-1].split()[0]  # Handle inline comments
-        assert re.match(
-            r"^[0-9a-f]{40}$", sha_part
-        ), f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        assert re.match(r"^[0-9a-f]{40}$", sha_part), (
+            f"actions/checkout must be pinned to a full commit SHA, got: {sha_part}"
+        )
 
     def test_skip_step_exists(self, hosted_readiness_steps):
         """A step to skip when no base URL is configured must be present."""
@@ -329,9 +329,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "scripts/check_hosted_readiness.py" in run_script
-        ), "Run check step must invoke scripts/check_hosted_readiness.py"
+        assert "scripts/check_hosted_readiness.py" in run_script, (
+            "Run check step must invoke scripts/check_hosted_readiness.py"
+        )
 
     def test_script_invocation_uses_env_var_not_hardcoded_url(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_BASE_URL, not a hardcoded URL."""
@@ -341,9 +341,9 @@ class TestHostedReadinessWorkflowSteps:
         )
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
-        assert (
-            "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        assert "$HOSTED_READINESS_BASE_URL" in run_script or "${HOSTED_READINESS_BASE_URL}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_BASE_URL env var"
+        )
 
     def test_script_invocation_uses_timeout_env_var(self, hosted_readiness_steps):
         """The script invocation must use $HOSTED_READINESS_TIMEOUT for --timeout argument."""
@@ -354,9 +354,9 @@ class TestHostedReadinessWorkflowSteps:
         assert run_check_step is not None
         run_script = run_check_step.get("run", "")
         assert "--timeout" in run_script, "Script invocation must include --timeout argument"
-        assert (
-            "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
-        ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        assert "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script, (
+            "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+        )
 
 
 @pytest.mark.integration
@@ -367,9 +367,9 @@ class TestHostedReadinessWorkflowSecurity:
         """Workflow must not contain hardcoded hosted URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"https?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded URLs in code: {line}"
+            assert not re.search(r"https?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded URLs in code: {line}"
+            )
 
     def test_no_hardcoded_tokens(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded tokens or API keys."""
@@ -387,21 +387,21 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not sensitive_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded token or API key in line: {line}"
+            assert not sensitive_assignment.search(content), (
+                f"Workflow may contain hardcoded token or API key in line: {line}"
+            )
             assert not bearer_literal.search(content), f"Workflow may contain hardcoded bearer token in line: {line}"
 
     def test_no_hardcoded_database_urls(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded database URLs."""
         for line in hosted_readiness_workflow_raw.splitlines():
             content = _scannable_workflow_content(line)
-            assert not re.search(
-                r"postgres(ql)?://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
-            assert not re.search(
-                r"mysql://", content, re.IGNORECASE
-            ), f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            assert not re.search(r"postgres(ql)?://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded PostgreSQL URLs: {line}"
+            )
+            assert not re.search(r"mysql://", content, re.IGNORECASE), (
+                f"Workflow must not contain hardcoded MySQL URLs: {line}"
+            )
 
     def test_no_hardcoded_credentials(self, hosted_readiness_workflow_raw):
         """Workflow must not contain hardcoded usernames or passwords."""
@@ -414,19 +414,19 @@ class TestHostedReadinessWorkflowSecurity:
             content = _scannable_workflow_content(line)
             if not content:
                 continue
-            assert not credential_assignment.search(
-                content
-            ), f"Workflow may contain hardcoded credential in line: {line}"
+            assert not credential_assignment.search(content), (
+                f"Workflow may contain hardcoded credential in line: {line}"
+            )
 
     def test_no_raw_endpoint_response_bodies(self, hosted_readiness_workflow_raw):
         """Workflow must not contain raw endpoint response bodies or example payloads."""
         # The workflow should not include example JSON payloads that could leak information
-        assert (
-            '{"status": "healthy"' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
-        assert (
-            '"graph_initialized": true' not in hosted_readiness_workflow_raw
-        ), "Workflow must not contain example response bodies"
+        assert '{"status": "healthy"' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
+        assert '"graph_initialized": true' not in hosted_readiness_workflow_raw, (
+            "Workflow must not contain example response bodies"
+        )
 
     def test_no_provider_specific_secrets(self, hosted_readiness_workflow_raw):
         """Workflow must not embed provider-specific credential names."""
@@ -434,9 +434,9 @@ class TestHostedReadinessWorkflowSecurity:
             _scannable_workflow_content(line) for line in hosted_readiness_workflow_raw.splitlines()
         )
         for secret_name in PROVIDER_SECRET_NAMES:
-            assert not re.search(
-                rf"\b{secret_name}\b", scannable_content
-            ), f"Workflow must not embed provider-specific secret '{secret_name}'"
+            assert not re.search(rf"\b{secret_name}\b", scannable_content), (
+                f"Workflow must not embed provider-specific secret '{secret_name}'"
+            )
 
 
 @pytest.mark.integration
@@ -447,9 +447,9 @@ class TestHostedReadinessWorkflowConcurrency:
         """Workflow must define the intended concurrency group."""
         assert "concurrency" in hosted_readiness_workflow, "Workflow must define 'concurrency'"
         concurrency = hosted_readiness_workflow["concurrency"]
-        assert (
-            concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}"
-        ), "Concurrency group must be scoped to workflow and ref"
+        assert concurrency.get("group") == "${{ github.workflow }}-${{ github.ref }}", (
+            "Concurrency group must be scoped to workflow and ref"
+        )
 
     def test_concurrency_cancel_in_progress_is_false(self, hosted_readiness_workflow):
         """Workflow concurrency must not cancel in-progress runs (manual workflow safety)."""


### PR DESCRIPTION
## **User description**
## Parent roadmap / issue

Closes #1142.  
References #1134 Stage 3 / PR4: Operator authorization boundary.

This follows merged PR #1141, which completed structured rebuild audit logging for `POST /api/graph/rebuild` without changing authorization semantics.

## Primary Objective

Restrict the destructive `POST /api/graph/rebuild` operation to an explicitly configured operator identity, while preserving the existing active-user authentication layer and all existing rebuild, persistence, audit logging, and concurrency behaviour.

The endpoint should no longer be callable by every active authenticated user.

## Scope Control Note

This PR intentionally contains only the Stage 3 / PR4 operator authorization boundary.

The earlier PR #1143 mixed this authorization change with detailed health/readiness persistence-configuration work. That health/readiness work is useful, but it is not part of this PR. It should be handled later under Stage 8 observability / SLO work, or under a separate narrow child issue if still required.

## In Scope

- Add `get_current_rebuild_operator_user` in `api/auth.py`.
- Authorize rebuild only when the active authenticated username matches the configured `ADMIN_USERNAME`.
- Fail closed when rebuild operator authorization is not configured.
- Replace the rebuild route dependency in `api/routers/graph_admin.py` with the stricter operator dependency.
- Add focused integration coverage for:
  - unauthenticated rebuild remains `401`;
  - active non-operator user receives `403`;
  - configured operator user can still rebuild;
  - missing operator configuration returns bounded fail-closed response;
  - existing rebuild-in-progress `429` behaviour remains intact.

## Out of Scope

- No `graph_persistence_configured` field.
- No changes to `GET /api/health/detailed`.
- No hosted-readiness script changes.
- No readiness/promotion-gate contract changes.
- No frontend or `package-lock.json` changes.
- No RBAC database schema.
- No role-management UI.
- No external IdP integration.
- No migration/Alembic work.
- No Celery, worker, broker, or job-state model.
- No graph persistence semantic changes.
- No audit logging redesign.
- No scanner or formatting cleanup outside touched files.

## Behaviour Contract

- Requests without valid authentication continue to return `401`.
- Disabled/inactive users continue to be rejected by the existing active-user dependency.
- Active authenticated users whose username does not match `ADMIN_USERNAME` receive `403 Forbidden`.
- If `ADMIN_USERNAME` is missing or blank, rebuild authorization fails closed with a bounded service-configuration error.
- The configured operator user retains the existing rebuild path.
- Existing structured audit logging from #1141 remains unchanged.
- Existing fail-fast rebuild concurrency behaviour remains unchanged.

## Review Learnings Applied

- `get_settings` is imported explicitly from `src.config.settings`.
- The settings dependency is typed directly rather than using dynamic annotation tricks.
- The implementation does not hardcode a fallback `"admin"` operator when `ADMIN_USERNAME` is unset.
- Tests set operator configuration through environment/cache reset or dependency wiring rather than mutating frozen settings objects.
- The operator happy-path test must mock awaited rebuild execution with an async fake.

## Files Changed

- `api/auth.py`
- `api/routers/graph_admin.py`
- `tests/integration/test_graph_admin_router.py`
- `tests/integration/test_graph_rebuild_persistence.py`

## Validation Commands

```bash
python -m ruff check api/auth.py api/routers/graph_admin.py tests/integration/test_graph_admin_router.py
python -m ruff format --check api/auth.py api/routers/graph_admin.py tests/integration/test_graph_admin_router.py
pytest tests/integration/test_graph_admin_router.py -q
```

Focused regression check:
```bash
pytest tests/integration/test_graph_admin_router.py -q -k "rebuild"
```

## Merge Criteria

- [ ] POST /api/graph/rebuild is no longer available to arbitrary active authenticated users.
- [ ] Active non-operator users receive a bounded 403.
- [ ] Missing operator configuration fails closed.
- [ ] The configured operator retains existing rebuild behaviour.
- [ ] Existing structured audit logging and 429 concurrency rejection remain intact.
- [ ] No health/readiness, frontend, RBAC, migration, Celery, scanner-baseline, or graph-persistence semantics are changed.


<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restricts POST `/api/graph/rebuild` to the configured operator (`ADMIN_USERNAME`). Strips whitespace in both configured and incoming usernames, returns 403 for non-operator and 503 when unset, and keeps audit and concurrency behavior unchanged.

- **New Features**
  - Operator-only access via `get_current_rebuild_operator_user` with `get_settings`; error details via `REBUILD_OPERATOR_FORBIDDEN_DETAIL` and `REBUILD_OPERATOR_NOT_CONFIGURED_DETAIL`.
  - Rebuild route now depends on the operator guard.
  - Tests: `TestClient` fixtures with env `monkeypatch` and `get_settings.cache_clear()`, deterministic audit waits, executor shutdown/runtime idle; hosted-readiness tests reverted to match `main`.

- **Migration**
  - Set `ADMIN_USERNAME` to the operator’s username (whitespace ignored). If unset, rebuild returns 503 and is blocked.

<sup>Written for commit 4a04168c3042c24f890bf368e336d46428d973df. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
**Restrict graph rebuild to the configured operator**

### What Changed
- The graph rebuild endpoint now accepts only the configured admin user; other active users get a forbidden response.
- If the admin username is missing or blank, rebuild requests fail closed with a service-unavailable response instead of allowing access.
- Whitespace around the configured admin username is ignored, so accidental spaces do not block the operator.
- Existing rebuild behavior stays the same for the authorized operator, including the “already in progress” response.
- Added coverage for unauthenticated access, non-operator access, authorized access, missing configuration, and rebuild-in-progress cases.

### Impact
`✅ Fewer unauthorized graph rebuilds`
`✅ Safer rebuild access when admin settings are missing`
`✅ Clearer rebuild permission errors`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=06J2Nxwb-TwNVU598bd2wNbl_VLFt0GWYuRqSSNWLAI&org=DashFin-FarDb)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
