### PR TITLE
Refactor Python script for metric verification

### DIFF
--- a/.github/workflows/ci-gate-spec.yaml
+++ b/.github/workflows/ci-gate-spec.yaml
@@ -210,8 +210,8 @@ jobs:
 
       - name: Verify lock refresh metrics exist
         run: |
-          python - <<'PY'
-          from api.metrics import LOCK_REFRESH_TOTAL, LOCK_REFRESH_DURATION, HEARTBEAT_UPDATE_TOTAL, HEARTBEAT_LAST_SUCCESS_TIMESTAMP
+          from api.metrics import (\n              LOCK_REFRESH_TOTAL,\n              LOCK_REFRESH_DURATION,\n              HEARTBEAT_UPDATE_TOTAL,\n              HEARTBEAT_LAST_SUCCESS_TIMESTAMP\n          )
+          print('All lock refresh and heartbeat metrics are defined')
           print('✅ All lock refresh and heartbeat metrics are defined')
           PY
 

--- a/.github/workflows/ci-gate-spec.yaml
+++ b/.github/workflows/ci-gate-spec.yaml
@@ -210,15 +210,10 @@ jobs:
 
       - name: Verify lock refresh metrics exist
         run: |
-          python -c "
-          from api.metrics import (
-              LOCK_REFRESH_TOTAL,
-              LOCK_REFRESH_DURATION,
-              HEARTBEAT_UPDATE_TOTAL,
-              HEARTBEAT_LAST_SUCCESS_TIMESTAMP
-          )
+          python - <<'PY'
+          from api.metrics import LOCK_REFRESH_TOTAL, LOCK_REFRESH_DURATION, HEARTBEAT_UPDATE_TOTAL, HEARTBEAT_LAST_SUCCESS_TIMESTAMP
           print('✅ All lock refresh and heartbeat metrics are defined')
-          "
+          PY
 
       - name: Run metrics unit tests
         run: |

--- a/.github/workflows/ci-gate-spec.yaml
+++ b/.github/workflows/ci-gate-spec.yaml
@@ -210,19 +210,14 @@ jobs:
 
       - name: Verify lock refresh metrics exist
         run: |
-- name: Verify lock refresh metrics exist
-  run: |
-    python - <<'PY'
-from api.metrics import (
-    LOCK_REFRESH_TOTAL,
-    LOCK_REFRESH_DURATION,
-    HEARTBEAT_UPDATE_TOTAL,
-    HEARTBEAT_LAST_SUCCESS_TIMESTAMP,
-)
-print('\u2705 All lock refresh and heartbeat metrics are defined')
-PY
-          print('All lock refresh and heartbeat metrics are defined')
-          print('✅ All lock refresh and heartbeat metrics are defined')
+          python - <<'PY'
+          from api.metrics import (
+              LOCK_REFRESH_TOTAL,
+              LOCK_REFRESH_DURATION,
+              HEARTBEAT_UPDATE_TOTAL,
+              HEARTBEAT_LAST_SUCCESS_TIMESTAMP,
+          )
+          print('\u2705 All lock refresh and heartbeat metrics are defined')
           PY
 
       - name: Run metrics unit tests

--- a/.github/workflows/ci-gate-spec.yaml
+++ b/.github/workflows/ci-gate-spec.yaml
@@ -210,7 +210,17 @@ jobs:
 
       - name: Verify lock refresh metrics exist
         run: |
-          from api.metrics import (\n              LOCK_REFRESH_TOTAL,\n              LOCK_REFRESH_DURATION,\n              HEARTBEAT_UPDATE_TOTAL,\n              HEARTBEAT_LAST_SUCCESS_TIMESTAMP\n          )
+- name: Verify lock refresh metrics exist
+  run: |
+    python - <<'PY'
+from api.metrics import (
+    LOCK_REFRESH_TOTAL,
+    LOCK_REFRESH_DURATION,
+    HEARTBEAT_UPDATE_TOTAL,
+    HEARTBEAT_LAST_SUCCESS_TIMESTAMP,
+)
+print('\u2705 All lock refresh and heartbeat metrics are defined')
+PY
           print('All lock refresh and heartbeat metrics are defined')
           print('✅ All lock refresh and heartbeat metrics are defined')
           PY

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -63,9 +63,9 @@ LOCK_REFRESH_TOTAL = Counter(
 )
 
 LOCK_REFRESH_DURATION = Histogram(
-    'rebuild_lock_refresh_duration_seconds',
-    'Time taken to refresh distributed lock.',
-    buckets=(0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')),
+    "rebuild_lock_refresh_duration_seconds",
+    "Time taken to refresh distributed lock.",
+    buckets=(0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float("inf")),
 )
 
 HEARTBEAT_UPDATE_TOTAL = Counter(

--- a/api/metrics.py
+++ b/api/metrics.py
@@ -63,8 +63,9 @@ LOCK_REFRESH_TOTAL = Counter(
 )
 
 LOCK_REFRESH_DURATION = Histogram(
-    "rebuild_lock_refresh_duration_seconds",
-    "Time taken to refresh distributed lock.",
+    'rebuild_lock_refresh_duration_seconds',
+    'Time taken to refresh distributed lock.',
+    buckets=(0.001, 0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, float('inf')),
 )
 
 HEARTBEAT_UPDATE_TOTAL = Counter(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
-    "prometheus_client>=0.19.0",
+    "prometheus-client>=0.19.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",
@@ -63,6 +63,7 @@ dev = [
     "black>=23.0.0",
     "isort>=5.13.0",
     "ruff>=0.4.0,<1.0.0",
+    "prometheus-client>=0.19.0",
     "types-PyYAML>=6.0.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
+    # `prometheus_client` pinned for build stability.
     "prometheus_client==0.25.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dependencies = [
     "pydantic==2.12.5",
     "h11==0.16.0",
     "PyYAML==6.0.3",
+    "prometheus-client>=0.19.0",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",
     "psycopg2-binary>=2.9.9",
@@ -62,7 +63,6 @@ dev = [
     "black>=23.0.0",
     "isort>=5.13.0",
     "ruff>=0.4.0,<1.0.0",
-    "prometheus-client>=0.19.0",
     "types-PyYAML>=6.0.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
+    "prometheus_client==0.25.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
-    # `prometheus_client` pinned for build stability.
-    "prometheus_client==0.25.0",
+    "prometheus_client>=0.19.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
-    "prometheus_client==0.25.0",
+    "prometheus_client>=0.25.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
     "black>=23.0.0",
     "isort>=5.13.0",
     "ruff>=0.4.0,<1.0.0",
-    "prometheus-client>=0.19.0",
+    # "prometheus-client>=0.19.0",
     "types-PyYAML>=6.0.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
-    "prometheus-client>=0.19.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",
@@ -63,7 +62,7 @@ dev = [
     "black>=23.0.0",
     "isort>=5.13.0",
     "ruff>=0.4.0,<1.0.0",
-    # "prometheus-client>=0.19.0",
+    "prometheus-client>=0.19.0",
     "types-PyYAML>=6.0.12",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "uvicorn[standard]>=0.24.0",
     "pydantic==2.12.5",
     "h11==0.16.0",
-    "prometheus_client>=0.25.0",
+    "prometheus_client==0.25.0",
     "PyYAML==6.0.3",
     "ruamel.yaml==0.18.17",
     "mangum==0.17.0",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 # Supplemental development / test / CI dependencies.
 # Install with: pip install -r requirements.txt -r requirements-dev.txt
-# prometheus-client pinned to 0.25.0 to prevent regressions.
 
 # Test libraries
 httpx==0.28.1
@@ -20,7 +19,7 @@ black>=23.0.0
 isort>=5.13.0
 ruff>=0.4.0,<1.0.0
 pre-commit>=3.0.0
-prometheus-client==0.25.0
+prometheus-client>=0.19.0
 types-PyYAML>=6.0.12
 PyGithub>=2.1.1
 Markdown>=3.4,<4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Supplemental development / test / CI dependencies.
 # Install with: pip install -r requirements.txt -r requirements-dev.txt
-# prometheus-client pinned to 0.25.0 to prevent regressions. 
+# prometheus-client pinned to 0.25.0 to prevent regressions.
 
 # Test libraries
 httpx==0.28.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ black>=23.0.0
 isort>=5.13.0
 ruff>=0.4.0,<1.0.0
 pre-commit>=3.0.0
+prometheus-client==0.25.0
 types-PyYAML>=6.0.12
 PyGithub>=2.1.1
 Markdown>=3.4,<4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ black>=23.0.0
 isort>=5.13.0
 ruff>=0.4.0,<1.0.0
 pre-commit>=3.0.0
-prometheus_client>=0.25.0
+prometheus-client==0.25.0
 types-PyYAML>=6.0.12
 PyGithub>=2.1.1
 Markdown>=3.4,<4.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 # Supplemental development / test / CI dependencies.
 # Install with: pip install -r requirements.txt -r requirements-dev.txt
+# prometheus-client pinned to 0.25.0 to prevent regressions. 
 
 # Test libraries
 httpx==0.28.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,7 +19,7 @@ black>=23.0.0
 isort>=5.13.0
 ruff>=0.4.0,<1.0.0
 pre-commit>=3.0.0
-prometheus-client==0.25.0
+prometheus_client>=0.25.0
 types-PyYAML>=6.0.12
 PyGithub>=2.1.1
 Markdown>=3.4,<4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,8 @@ passlib[bcrypt]>=1.7.4
 slowapi>=0.1.4
 
 # Observability dependencies
-prometheus_client>=0.19.0
+# proemtheus_client pinned for build and runtime observation stability. 
+prometheus_client==0.25.0
 
 # Security override pins (not directly imported; pinned to satisfy vulnerability advisories)
 urllib3>=2.6.3  # pinned by Snyk advisory; transitive dep of requests/httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ passlib[bcrypt]>=1.7.4
 slowapi>=0.1.4
 
 # Observability dependencies
-# proemtheus_client pinned for build and runtime observation stability. 
+# proemtheus_client pinned for build and runtime observation stability.
 prometheus_client==0.25.0
 
 # Security override pins (not directly imported; pinned to satisfy vulnerability advisories)

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,7 @@ passlib[bcrypt]>=1.7.4
 slowapi>=0.1.4
 
 # Observability dependencies
-# proemtheus_client pinned for build and runtime observation stability.
-prometheus_client>=0.25.0,<0.26.0  # prefer constrained range to allow patch fixes
+prometheus_client>=0.19.0
 
 # Security override pins (not directly imported; pinned to satisfy vulnerability advisories)
 urllib3>=2.6.3  # pinned by Snyk advisory; transitive dep of requests/httpx

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,7 +37,7 @@ slowapi>=0.1.4
 
 # Observability dependencies
 # proemtheus_client pinned for build and runtime observation stability.
-prometheus_client==0.25.0
+prometheus_client>=0.25.0,<0.26.0  # prefer constrained range to allow patch fixes
 
 # Security override pins (not directly imported; pinned to satisfy vulnerability advisories)
 urllib3>=2.6.3  # pinned by Snyk advisory; transitive dep of requests/httpx

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,8 +29,9 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            # Match the label values and ensure it's the _total sample (not _created)
-            if sample.labels == label_dict and sample.name.endswith("_total"):
+            # Match the label values and ensure it's the total sample for this metric (not *_created)
+            metric_name = getattr(counter, '_name', None)
+            if metric_name is not None and sample.labels == label_dict and sample.name == f'{metric_name}_total':
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,37 +19,21 @@ from src.data.db_models import RebuildJobStatus
 
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
-    """Get the current value of a Prometheus counter using public API.
-
-    Args:
-        counter: The Prometheus Counter metric.
-        **label_dict: Label key-value pairs to match.
-
-    Returns:
-        float: The value of the matching counter sample, or 0.0 if not found.
-    """
-    # Look for cached names; compute and attach them if missing
     expected_names = getattr(counter, "_cached_expected_names", None)
     if expected_names is None:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-
+        
         expected_names = {raw_name, base_name, f"{base_name}_total"}
-        counter._cached_expected_names = expected_names  # Cache on the instance
+        counter._cached_expected_names = expected_names
 
     for family in counter.collect():
         for sample in family.samples:
-            # 1. Hard-guard against metadata/creation timestamps
-            if sample.name.endswith("_created"):
+            if sample.name.endswith("_created") or sample.name not in expected_names:
                 continue
 
-            # 2. Filter by labels
-            if sample.labels != label_dict:
-                continue
-
-            # 3. Fast O(1) membership lookup
-            if sample.name in expected_names:
+            if all(sample.labels.get(k) == v for k, v in label_dict.items()):
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,19 +28,20 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    # The public describe() method returns the full metric name (e.g., 'my_counter_total')
     desc = counter.describe()
-    if desc:
-        expected_name = desc[0].name
-    else:
-        expected_name = getattr(counter, "_name", "") + "_total"
+    expected_name = desc[0].name if desc else getattr(counter, "_name", "") + "_total"
+    
+    # Pre-calculate the normalized expected name outside the loop
+    norm_expected_name = expected_name.removesuffix("_total")
+
     for family in counter.collect():
         for sample in family.samples:
-            sample_name = sample.name
-            # Normalize names to handle counters with or without the '_total' suffix.
-            norm_sample_name = sample_name[:-6] if sample_name.endswith("_total") else sample_name
-            norm_expected_name = expected_name[:-6] if expected_name.endswith("_total") else expected_name
-            if sample.labels == label_dict and (sample_name == expected_name or norm_sample_name == norm_expected_name):
+            # Guard clause: Fail fast if labels don't match to avoid compound booleans
+            if sample.labels != label_dict:
+                continue
+                
+            # Check exact match or normalized match
+            if sample.name == expected_name or sample.name.removesuffix("_total") == norm_expected_name:
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,20 +28,23 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
+    # 1. Fix Desc Fallback: Align both paths to a clean, symmetric baseline
     desc = counter.describe()
-    expected_name = desc[0].name if desc else getattr(counter, "_name", "") + "_total"
-
-    # Pre-calculate the normalized expected name outside the loop
-    norm_expected_name = expected_name.removesuffix("_total")
+    raw_name = desc[0].name if desc else getattr(counter, "_name", "")
+    base_name = raw_name.removesuffix("_total")
 
     for family in counter.collect():
         for sample in family.samples:
-            # Guard clause: Fail fast if labels don't match to avoid compound booleans
+            # 2. Fix Correctness Bug: Hard-guard against metadata/creation timestamps
+            if sample.name.endswith("_created"):
+                continue
+
+            # 3. Filter by labels
             if sample.labels != label_dict:
                 continue
 
-            # Check exact match or normalized match
-            if sample.name == expected_name or sample.name.removesuffix("_total") == norm_expected_name:
+            # 4. Fix Sample-Matching Bug: Ensure robust matching across client versions
+            if sample.name.removesuffix("_total") in (base_name, raw_name) or sample.name == raw_name:
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from typing import Any
+from prometheus_client import Counter
+
 import threading
 from unittest.mock import MagicMock
 
@@ -17,11 +20,11 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 
-def _get_counter_value(counter, **label_dict):
+def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """Get the current value of a Prometheus counter using public API.
     Args:
-        counter: The Prometheus Counter metric
-        **label_dict: Label key-value pairs to match
+        counter: The Prometheus Counter metric.
+        **label_dict: Label key-value pairs to match.
     Returns:
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -31,7 +31,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     # NOTE: Recomputing expected names on every call is an intentional trade-off.
     # Prior iterations used a weakref/id-backed cache to avoid recomputing string
     # modifications. However, the overhead of managing cross-test state isolation,
-    # avoiding fallback memory leaks, and handling mock type errors introduced 
+    # avoiding fallback memory leaks, and handling mock type errors introduced
     # accidental complexity that far outweighed the negligible cost of constructing
     # a local 3-element set during test suite execution.
     desc = counter.describe()

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,7 +29,7 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            # Match the label values and the _total sample (avoid relying on Counter internals)
+            if sample.labels == label_dict and sample.name == f"{counter._name}_total":
             if sample.labels == label_dict and sample.name == f"{counter._name}_total"
                 return sample.value
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,6 +1,7 @@
 """Unit tests for api.metrics helpers."""
 
 from __future__ import annotations
+
 import threading
 from unittest.mock import MagicMock  # Fixed: Added missing import
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -18,7 +19,7 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 
-def _get_counter_value(counter: Counter, **label_dict: str) -> float:
+def _get_counter_value(counter: Counter, **label_dict: Any) -> float:
     """Get the current value of a Prometheus counter using public API.
     Args:
         counter: The Prometheus Counter metric.

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -24,7 +24,7 @@ _FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
 
 def _fallback_cleanup(ref: weakref.ReferenceType) -> None:
     """Evict entries from the integer-keyed fallback cache upon object GC."""
-    # The dictionary key is the integer ID of the original object, 
+    # The dictionary key is the integer ID of the original object,
     # which we can extract by looking at the memory address of the dead ref.
     _FALLBACK_COUNTER_CACHE.pop(id(ref), None)
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,18 +19,15 @@ from src.data.db_models import RebuildJobStatus
 
 def _get_counter_value(counter, **label_dict):
     """Get the current value of a Prometheus counter using public API.
-
     Args:
         counter: The Prometheus Counter metric
         **label_dict: Label key-value pairs to match
-
     Returns:
         float: The current counter value, or 0.0 if not found
     """
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name == f"{counter._name}_total":
-            if sample.labels == label_dict and sample.name == f"{counter._name}_total"
+            if sample.labels == label_dict and sample.name.endswith("_total"):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -18,48 +18,20 @@ from api.metrics import (
 )
 from src.data.db_models import RebuildJobStatus
 
-_WEAK_COUNTER_CACHE = weakref.WeakKeyDictionary()
-_FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
+def _get_counter_value(counter: Counter, **label_dict: str) -> float:
+    """Get the current value of a Prometheus counter using public API.
 
+    Args:
+        counter: The Prometheus Counter metric.
+        **label_dict: Label key-value pairs to match.
 
-def _fallback_cleanup(ref: weakref.ReferenceType) -> None:
-    """Evict entries from the integer-keyed fallback cache upon object GC."""
-    # The dictionary key is the integer ID of the original object,
-    # which we can extract by looking at the memory address of the dead ref.
-    _FALLBACK_COUNTER_CACHE.pop(id(ref), None)
-
-
-def _get_or_compute_expected_names(counter: Counter) -> set[str]:
-    try:
-        expected_names = _WEAK_COUNTER_CACHE.get(counter)
-    except TypeError:
-        expected_names = _FALLBACK_COUNTER_CACHE.get(id(counter))
-
-    if expected_names is not None:
-        return expected_names
-
+    Returns:
+        float: The value of the matching counter sample, or 0.0 if not found.
+    """
     desc = counter.describe()
     raw_name = desc[0].name if desc else getattr(counter, "_name", "")
     base_name = raw_name.removesuffix("_total")
     expected_names = {raw_name, base_name, f"{base_name}_total"}
-
-    try:
-        _WEAK_COUNTER_CACHE[counter] = expected_names
-    except TypeError:
-        # Create a weak reference with a callback to safely clean up the int key
-        # id(counter) matches id(ref) when the callback executes
-        try:
-            weakref.ref(counter, _fallback_cleanup)
-            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
-        except TypeError:
-            # Absolute fallback for entirely non-weakrefable structures (e.g., builtins)
-            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
-
-    return expected_names
-
-
-def _get_counter_value(counter: Counter, **label_dict: str) -> float:
-    expected_names = _get_or_compute_expected_names(counter)
 
     for family in counter.collect():
         for sample in family.samples:

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -30,6 +30,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
     desc = counter.describe()
+    # The second argument acts as the default fallback for next(), preventing StopIteration
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -30,7 +30,7 @@ def _get_counter_value(counter, **label_dict):
     for family in counter.collect():
         for sample in family.samples:
             # Match the label values and the _total sample (avoid relying on Counter internals)
-            if sample.labels == label_dict and sample.name.endswith('_total'):
+            if sample.labels == label_dict and sample.name == f"{counter._name}_total"
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-import weakref
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -26,11 +26,13 @@ def _get_counter_value(counter, **label_dict):
 
     Returns:
         float: The current counter value, or 0.0 if not found
+    """
     for family in counter.collect():
         for sample in family.samples:
             # Match the label values and the _total sample (avoid relying on Counter internals)
             if sample.labels == label_dict and sample.name.endswith('_total'):
                 return sample.value
+    return 0.0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,23 +28,26 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    # Normalize target to a clean baseline name upfront
+    # 1. Establish structural name variations upfront
     desc = counter.describe()
     raw_name = desc[0].name if desc else getattr(counter, "_name", "")
-    target_base = raw_name.removesuffix("_total")
+    base_name = raw_name.removesuffix("_total")
+    
+    # The set guarantees an O(1) match regardless of client exposition format
+    expected_names = {raw_name, base_name, f"{base_name}_total"}
 
     for family in counter.collect():
         for sample in family.samples:
-            # 1. Skip metadata samples safely
+            # 2. Hard-guard against metadata/creation timestamps
             if sample.name.endswith("_created"):
                 continue
 
-            # 2. Filter by target labels
+            # 3. Filter by labels
             if sample.labels != label_dict:
                 continue
 
-            # 3. Clean, single-branch name comparison
-            if sample.name.removesuffix("_total") == target_base:
+            # 4. Clean, zero-transformation membership lookup
+            if sample.name in expected_names:
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -2,13 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
-from prometheus_client import Counter
-
 import threading
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
+from prometheus_client import Counter
 
 from api.metrics import (
     HEARTBEAT_LAST_SUCCESS_TIMESTAMP,
@@ -30,7 +29,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith('_total')):
+            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith("_total")):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,14 +19,17 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 _WEAK_COUNTER_CACHE = weakref.WeakKeyDictionary()
-# Fallback cache keyed by object id for counters that cannot be weak-referenced.
-# Note: using id() means entries may persist after object collection and ids can be reused.
-# This is acceptable for unit tests; for long-running processes consider a cleanup strategy (weakref.finalize) to avoid leaks.
 _FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
 
 
+def _fallback_cleanup(ref: weakref.ReferenceType) -> None:
+    """Evict entries from the integer-keyed fallback cache upon object GC."""
+    # The dictionary key is the integer ID of the original object, 
+    # which we can extract by looking at the memory address of the dead ref.
+    _FALLBACK_COUNTER_CACHE.pop(id(ref), None)
+
+
 def _get_or_compute_expected_names(counter: Counter) -> set[str]:
-    """Extract cache lookup logic to flatten cyclomatic complexity paths."""
     try:
         expected_names = _WEAK_COUNTER_CACHE.get(counter)
     except TypeError:
@@ -43,7 +46,14 @@ def _get_or_compute_expected_names(counter: Counter) -> set[str]:
     try:
         _WEAK_COUNTER_CACHE[counter] = expected_names
     except TypeError:
-        _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
+        # Create a weak reference with a callback to safely clean up the int key
+        # id(counter) matches id(ref) when the callback executes
+        try:
+            weakref.ref(counter, _fallback_cleanup)
+            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
+        except TypeError:
+            # Absolute fallback for entirely non-weakrefable structures (e.g., builtins)
+            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
 
     return expected_names
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,7 +27,7 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name.endswith('_total'):
+            if sample.labels == label_dict and sample.name.endswith("_total"):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -50,6 +50,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
 
     return 0.0
 
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("status", "expected"),

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,25 +28,27 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    # 1. Establish structural name variations upfront
-    desc = counter.describe()
-    raw_name = desc[0].name if desc else getattr(counter, "_name", "")
-    base_name = raw_name.removesuffix("_total")
-    
-    # The set guarantees an O(1) match regardless of client exposition format
-    expected_names = {raw_name, base_name, f"{base_name}_total"}
+    # Look for cached names; compute and attach them if missing
+    expected_names = getattr(counter, "_cached_expected_names", None)
+    if expected_names is None:
+        desc = counter.describe()
+        raw_name = desc[0].name if desc else getattr(counter, "_name", "")
+        base_name = raw_name.removesuffix("_total")
+        
+        expected_names = {raw_name, base_name, f"{base_name}_total"}
+        counter._cached_expected_names = expected_names  # Cache on the instance
 
     for family in counter.collect():
         for sample in family.samples:
-            # 2. Hard-guard against metadata/creation timestamps
+            # 1. Hard-guard against metadata/creation timestamps
             if sample.name.endswith("_created"):
                 continue
 
-            # 3. Filter by labels
+            # 2. Filter by labels
             if sample.labels != label_dict:
                 continue
 
-            # 4. Clean, zero-transformation membership lookup
+            # 3. Fast O(1) membership lookup
             if sample.name in expected_names:
                 return sample.value
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,7 +29,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith("_total")):
+            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith('_total')):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,6 +27,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
     desc = counter.describe()
+    # Provide explicit default to next() to avoid StopIteration if describe() yields no descriptors.
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
     target_names = {raw_name, base_name, f"{base_name}_total"}

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,11 +27,11 @@ def _get_counter_value(counter, **label_dict):
     Returns:
         float: The current counter value, or 0.0 if not found
     """
+    # Use describe() to get the metric name from the public API
+    metric_name = counter.describe()[0].name
     for family in counter.collect():
         for sample in family.samples:
-            # Match the label values and ensure it's the total sample for this metric (not *_created)
-            metric_name = getattr(counter, "_name", None)
-            if metric_name is not None and sample.labels == label_dict and sample.name == f"{metric_name}_total":
+            if sample.labels == label_dict and sample.name == f'{metric_name}_total':
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -23,11 +23,10 @@ def _get_counter_value(counter, **label_dict):
         counter: The Prometheus Counter metric
         **label_dict: Label key-value pairs to match
     Returns:
-        float: The current counter value, or 0.0 if not found
-    """
+    expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name.endswith("_total"):
+            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith('_total')):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,7 +27,7 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name == f'{counter._name}_total':
+            if sample.labels == label_dict and sample.name == f"{counter._name}_total":
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,7 +29,7 @@ def _get_counter_value(counter, **label_dict):
         for sample in family.samples:
             if sample.labels == label_dict and sample.name == f"{counter._name}_total":
             if sample.labels == label_dict and sample.name.endswith('_total'):
-    return 0.0
+    return sample.value
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -22,23 +22,31 @@ _WEAK_COUNTER_CACHE = weakref.WeakKeyDictionary()
 _FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
 
 
-def _get_counter_value(counter: Counter, **label_dict: str) -> float:
+def _get_or_compute_expected_names(counter: Counter) -> set[str]:
+    """Extract cache lookup logic to flatten cyclomatic complexity paths."""
     try:
         expected_names = _WEAK_COUNTER_CACHE.get(counter)
     except TypeError:
         expected_names = _FALLBACK_COUNTER_CACHE.get(id(counter))
 
-    if expected_names is None:
-        desc = counter.describe()
-        raw_name = desc[0].name if desc else getattr(counter, "_name", "")
-        base_name = raw_name.removesuffix("_total")
+    if expected_names is not None:
+        return expected_names
 
-        expected_names = {raw_name, base_name, f"{base_name}_total"}
+    desc = counter.describe()
+    raw_name = desc[0].name if desc else getattr(counter, "_name", "")
+    base_name = raw_name.removesuffix("_total")
+    expected_names = {raw_name, base_name, f"{base_name}_total"}
 
-        try:
-            _WEAK_COUNTER_CACHE[counter] = expected_names
-        except TypeError:
-            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
+    try:
+        _WEAK_COUNTER_CACHE[counter] = expected_names
+    except TypeError:
+        _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
+
+    return expected_names
+
+
+def _get_counter_value(counter: Counter, **label_dict: str) -> float:
+    expected_names = _get_or_compute_expected_names(counter)
 
     for family in counter.collect():
         for sample in family.samples:
@@ -49,7 +57,6 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
                 return sample.value
 
     return 0.0
-
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,23 +28,23 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    # 1. Fix Desc Fallback: Align both paths to a clean, symmetric baseline
+    # Normalize target to a clean baseline name upfront
     desc = counter.describe()
     raw_name = desc[0].name if desc else getattr(counter, "_name", "")
-    base_name = raw_name.removesuffix("_total")
+    target_base = raw_name.removesuffix("_total")
 
     for family in counter.collect():
         for sample in family.samples:
-            # 2. Fix Correctness Bug: Hard-guard against metadata/creation timestamps
+            # 1. Skip metadata samples safely
             if sample.name.endswith("_created"):
                 continue
 
-            # 3. Filter by labels
+            # 2. Filter by target labels
             if sample.labels != label_dict:
                 continue
 
-            # 4. Fix Sample-Matching Bug: Ensure robust matching across client versions
-            if sample.name.removesuffix("_total") in (base_name, raw_name) or sample.name == raw_name:
+            # 3. Clean, single-branch name comparison
+            if sample.name.removesuffix("_total") == target_base:
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -17,18 +17,18 @@ from api.metrics import (
 )
 from src.data.db_models import RebuildJobStatus
 
-
 _COUNTER_NAME_CACHE: dict[int, set[str]] = {}
+
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     counter_id = id(counter)
     expected_names = _COUNTER_NAME_CACHE.get(counter_id)
-    
+
     if expected_names is None:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-        
+
         expected_names = {raw_name, base_name, f"{base_name}_total"}
         _COUNTER_NAME_CACHE[counter_id] = expected_names
 
@@ -41,6 +41,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
                 return sample.value
 
     return 0.0
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
-import prometheus_client
 import pytest
 from prometheus_client import Counter
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import threading
+import weakref
 from unittest.mock import MagicMock
 
 import pytest
-import weakref
 from prometheus_client import Counter
 
 from api.metrics import (

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -18,20 +18,27 @@ from api.metrics import (
 )
 from src.data.db_models import RebuildJobStatus
 
-_COUNTER_NAME_CACHE = weakref.WeakKeyDictionary()
+_WEAK_COUNTER_CACHE = weakref.WeakKeyDictionary()
+_FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
 
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
-    expected_names = _COUNTER_NAME_CACHE.get(counter)
+    try:
+        expected_names = _WEAK_COUNTER_CACHE.get(counter)
+    except TypeError:
+        expected_names = _FALLBACK_COUNTER_CACHE.get(id(counter))
 
     if expected_names is None:
         desc = counter.describe()
-        # Ensure both paths drop to a pure, stripped baseline name
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
 
-        expected_names = {base_name, f"{base_name}_total"}
-        _COUNTER_NAME_CACHE[counter] = expected_names
+        expected_names = {raw_name, base_name, f"{base_name}_total"}
+
+        try:
+            _WEAK_COUNTER_CACHE[counter] = expected_names
+        except TypeError:
+            _FALLBACK_COUNTER_CACHE[id(counter)] = expected_names
 
     for family in counter.collect():
         for sample in family.samples:
@@ -42,7 +49,6 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
                 return sample.value
 
     return 0.0
-
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -30,7 +30,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """
     desc = counter.describe()
     expected_name = desc[0].name if desc else getattr(counter, "_name", "") + "_total"
-    
+
     # Pre-calculate the normalized expected name outside the loop
     norm_expected_name = expected_name.removesuffix("_total")
 
@@ -39,7 +39,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
             # Guard clause: Fail fast if labels don't match to avoid compound booleans
             if sample.labels != label_dict:
                 continue
-                
+
             # Check exact match or normalized match
             if sample.name == expected_name or sample.name.removesuffix("_total") == norm_expected_name:
                 return sample.value

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,7 +19,7 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 
-def _get_counter_value(counter: Counter, **label_dict: Any) -> float:
+def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """Get the current value of a Prometheus counter using public API.
     Args:
         counter: The Prometheus Counter metric.

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock
 
-import pytest
 import prometheus_client
+import pytest
 from prometheus_client import Counter
 
 from api.metrics import (
@@ -39,6 +39,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
             return val
 
     return 0.0
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,6 +19,9 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 _WEAK_COUNTER_CACHE = weakref.WeakKeyDictionary()
+# Fallback cache keyed by object id for counters that cannot be weak-referenced.
+# Note: using id() means entries may persist after object collection and ids can be reused.
+# This is acceptable for unit tests; for long-running processes consider a cleanup strategy (weakref.finalize) to avoid leaks.
 _FALLBACK_COUNTER_CACHE: dict[int, set[str]] = {}
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -31,7 +31,7 @@ def _get_counter_value(counter, **label_dict):
     metric_name = counter.describe()[0].name
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name == f'{metric_name}_total':
+            if sample.labels == label_dict and sample.name.endswith("_total"):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -33,12 +33,12 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
 
-        for family in counter.collect():
-            for sample in family.samples:
-                if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
-                    continue
-                if sample.labels == label_dict:
-                    return sample.value
+    for family in counter.collect():
+        for sample in family.samples:
+            if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
+                continue
+            if sample.labels == label_dict:
+                return sample.value
 
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,6 +6,7 @@ import threading
 from unittest.mock import MagicMock
 
 import pytest
+import weakref
 from prometheus_client import Counter
 
 from api.metrics import (
@@ -17,20 +18,20 @@ from api.metrics import (
 )
 from src.data.db_models import RebuildJobStatus
 
-_COUNTER_NAME_CACHE: dict[int, set[str]] = {}
+_COUNTER_NAME_CACHE = weakref.WeakKeyDictionary()
 
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
-    counter_id = id(counter)
-    expected_names = _COUNTER_NAME_CACHE.get(counter_id)
+    expected_names = _COUNTER_NAME_CACHE.get(counter)
 
     if expected_names is None:
         desc = counter.describe()
+        # Ensure both paths drop to a pure, stripped baseline name
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
 
-        expected_names = {raw_name, base_name, f"{base_name}_total"}
-        _COUNTER_NAME_CACHE[counter_id] = expected_names
+        expected_names = {base_name, f"{base_name}_total"}
+        _COUNTER_NAME_CACHE[counter] = expected_names
 
     for family in counter.collect():
         for sample in family.samples:

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -18,15 +18,19 @@ from api.metrics import (
 from src.data.db_models import RebuildJobStatus
 
 
+_COUNTER_NAME_CACHE: dict[int, set[str]] = {}
+
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
-    expected_names = getattr(counter, "_cached_expected_names", None)
+    counter_id = id(counter)
+    expected_names = _COUNTER_NAME_CACHE.get(counter_id)
+    
     if expected_names is None:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-
+        
         expected_names = {raw_name, base_name, f"{base_name}_total"}
-        counter._cached_expected_names = expected_names
+        _COUNTER_NAME_CACHE[counter_id] = expected_names
 
     for family in counter.collect():
         for sample in family.samples:
@@ -37,7 +41,6 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
                 return sample.value
 
     return 0.0
-
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -28,7 +28,7 @@ def _get_counter_value(counter, **label_dict):
     for family in counter.collect():
         for sample in family.samples:
             if sample.labels == label_dict and sample.name == f"{counter._name}_total":
-                return sample.value
+            if sample.labels == label_dict and sample.name.endswith('_total'):
     return 0.0
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,7 +29,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith('_total')):
+            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith("_total")):
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -1,9 +1,8 @@
 """Unit tests for api.metrics helpers."""
 
 from __future__ import annotations
-
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock  # Fixed: Added missing import
 
 import pytest
 from prometheus_client import Counter
@@ -20,17 +19,22 @@ from src.data.db_models import RebuildJobStatus
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """Get the current value of a Prometheus counter using public API.
+
     Args:
         counter: The Prometheus Counter metric.
         **label_dict: Label key-value pairs to match.
+
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    expected_name = f'{getattr(counter, "_name", "")}_total'
+    # The public describe() method returns the full metric name (e.g., 'my_counter_total')
+    expected_name = counter.describe()[0].name
+
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and (sample.name == expected_name or sample.name.endswith("_total")):
+            if sample.labels == label_dict and sample.name == expected_name:
                 return sample.value
+
     return 0.0
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -33,10 +33,12 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
 
-    for name in (raw_name, base_name, f"{base_name}_total"):
-        val = prometheus_client.REGISTRY.get_sample_value(name, label_dict)
-        if val is not None:
-            return val
+        for family in counter.collect():
+            for sample in family.samples:
+                if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
+                    continue
+                if sample.labels == label_dict:
+                    return sample.value
 
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,7 +27,7 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name.endswith("_total"):
+            if sample.labels == label_dict and sample.name == f'{counter._name}_total':
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,11 +29,18 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
     # The public describe() method returns the full metric name (e.g., 'my_counter_total')
-    expected_name = counter.describe()[0].name
-
+    desc = counter.describe()
+    if desc:
+        expected_name = desc[0].name
+    else:
+        expected_name = getattr(counter, '_name', '') + '_total'
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name == expected_name:
+            sample_name = sample.name
+            # Normalize names to handle counters with or without the '_total' suffix.
+            norm_sample_name = sample_name[:-6] if sample_name.endswith('_total') else sample_name
+            norm_expected_name = expected_name[:-6] if expected_name.endswith('_total') else expected_name
+            if sample.labels == label_dict and (sample_name == expected_name or norm_sample_name == norm_expected_name):
                 return sample.value
 
     return 0.0

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -6,6 +6,7 @@ import threading
 from unittest.mock import MagicMock
 
 import pytest
+import prometheus_client
 from prometheus_client import Counter
 
 from api.metrics import (
@@ -28,27 +29,16 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
-    # NOTE: Recomputing expected names on every call is an intentional trade-off.
-    # Prior iterations used a weakref/id-backed cache to avoid recomputing string
-    # modifications. However, the overhead of managing cross-test state isolation,
-    # avoiding fallback memory leaks, and handling mock type errors introduced
-    # accidental complexity that far outweighed the negligible cost of constructing
-    # a local 3-element set during test suite execution.
     desc = counter.describe()
-    raw_name = desc[0].name if desc else getattr(counter, "_name", "")
+    raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
-    expected_names = {raw_name, base_name, f"{base_name}_total"}
 
-    for family in counter.collect():
-        for sample in family.samples:
-            if sample.name.endswith("_created") or sample.name not in expected_names:
-                continue
-
-            if sample.labels == label_dict:
-                return sample.value
+    for name in (raw_name, base_name, f"{base_name}_total"):
+        val = prometheus_client.REGISTRY.get_sample_value(name, label_dict)
+        if val is not None:
+            return val
 
     return 0.0
-
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -38,7 +38,16 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
             if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
                 continue
             if sample.labels == label_dict:
+    desc = counter.describe()
+    raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
+    base_name = raw_name.removesuffix("_total")
+    for family in counter.collect():
+        for sample in family.samples:
+            if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
+                continue
+            if sample.labels == label_dict:
                 return sample.value
+    return 0.0
 
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -58,6 +58,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
 
     return 0.0
 
+
 @pytest.mark.unit
 @pytest.mark.parametrize(
     ("status", "expected"),

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import threading
-from unittest.mock import MagicMock  # Fixed: Added missing import
+from unittest.mock import MagicMock
 
 import pytest
 from prometheus_client import Counter

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,6 +29,12 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
+    # NOTE: Recomputing expected names on every call is an intentional trade-off.
+    # Prior iterations used a weakref/id-backed cache to avoid recomputing string
+    # modifications. However, the overhead of managing cross-test state isolation,
+    # avoiding fallback memory leaks, and handling mock type errors introduced 
+    # accidental complexity that far outweighed the negligible cost of constructing
+    # a local 3-element set during test suite execution.
     desc = counter.describe()
     raw_name = desc[0].name if desc else getattr(counter, "_name", "")
     base_name = raw_name.removesuffix("_total")

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,16 +19,15 @@ from src.data.db_models import RebuildJobStatus
 
 _COUNTER_NAME_CACHE: dict[int, set[str]] = {}
 
-
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     counter_id = id(counter)
     expected_names = _COUNTER_NAME_CACHE.get(counter_id)
-
+    
     if expected_names is None:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-
+        
         expected_names = {raw_name, base_name, f"{base_name}_total"}
         _COUNTER_NAME_CACHE[counter_id] = expected_names
 
@@ -37,11 +36,10 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
             if sample.name.endswith("_created") or sample.name not in expected_names:
                 continue
 
-            if all(sample.labels.get(k) == v for k, v in label_dict.items()):
+            if sample.labels == label_dict:
                 return sample.value
 
     return 0.0
-
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -33,13 +33,13 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     if desc:
         expected_name = desc[0].name
     else:
-        expected_name = getattr(counter, '_name', '') + '_total'
+        expected_name = getattr(counter, "_name", "") + "_total"
     for family in counter.collect():
         for sample in family.samples:
             sample_name = sample.name
             # Normalize names to handle counters with or without the '_total' suffix.
-            norm_sample_name = sample_name[:-6] if sample_name.endswith('_total') else sample_name
-            norm_expected_name = expected_name[:-6] if expected_name.endswith('_total') else expected_name
+            norm_sample_name = sample_name[:-6] if sample_name.endswith("_total") else sample_name
+            norm_expected_name = expected_name[:-6] if expected_name.endswith("_total") else expected_name
             if sample.labels == label_dict and (sample_name == expected_name or norm_sample_name == norm_expected_name):
                 return sample.value
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -27,9 +27,9 @@ def _get_counter_value(counter, **label_dict):
     """
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name == f"{counter._name}_total":
             if sample.labels == label_dict and sample.name.endswith('_total'):
-    return sample.value
+                return sample.value
+    return 0.0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -24,7 +24,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-        
+
         expected_names = {raw_name, base_name, f"{base_name}_total"}
         counter._cached_expected_names = expected_names
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -34,7 +34,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-        
+
         expected_names = {raw_name, base_name, f"{base_name}_total"}
         counter._cached_expected_names = expected_names  # Cache on the instance
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -30,8 +30,8 @@ def _get_counter_value(counter, **label_dict):
     for family in counter.collect():
         for sample in family.samples:
             # Match the label values and ensure it's the total sample for this metric (not *_created)
-            metric_name = getattr(counter, '_name', None)
-            if metric_name is not None and sample.labels == label_dict and sample.name == f'{metric_name}_total':
+            metric_name = getattr(counter, "_name", None)
+            if metric_name is not None and sample.labels == label_dict and sample.name == f"{metric_name}_total":
                 return sample.value
     return 0.0
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import threading
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -25,6 +24,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         counter: The Prometheus Counter metric.
         **label_dict: Label key-value pairs to match.
     Returns:
+        float: The value of the matching counter sample, or 0.0 if not found.
     """
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -26,14 +26,11 @@ def _get_counter_value(counter, **label_dict):
 
     Returns:
         float: The current counter value, or 0.0 if not found
-    """
-    # Use describe() to get the metric name from the public API
-    metric_name = counter.describe()[0].name
     for family in counter.collect():
         for sample in family.samples:
-            if sample.labels == label_dict and sample.name.endswith("_total"):
+            # Match the label values and the _total sample (avoid relying on Counter internals)
+            if sample.labels == label_dict and sample.name.endswith('_total'):
                 return sample.value
-    return 0.0
 
 
 @pytest.mark.unit

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -29,7 +29,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
     desc = counter.describe()
-    # The second argument acts as the default fallback for next(), preventing StopIteration
+    # Provide explicit default (getattr(counter, '_name', '')) to next() to avoid StopIteration if describe() yields no descriptors.
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -38,17 +38,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
             if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
                 continue
             if sample.labels == label_dict:
-    desc = counter.describe()
-    raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
-    base_name = raw_name.removesuffix("_total")
-    for family in counter.collect():
-        for sample in family.samples:
-            if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
-                continue
-            if sample.labels == label_dict:
                 return sample.value
-    return 0.0
-
     return 0.0
 
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -19,15 +19,16 @@ from src.data.db_models import RebuildJobStatus
 
 _COUNTER_NAME_CACHE: dict[int, set[str]] = {}
 
+
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     counter_id = id(counter)
     expected_names = _COUNTER_NAME_CACHE.get(counter_id)
-    
+
     if expected_names is None:
         desc = counter.describe()
         raw_name = desc[0].name if desc else getattr(counter, "_name", "")
         base_name = raw_name.removesuffix("_total")
-        
+
         expected_names = {raw_name, base_name, f"{base_name}_total"}
         _COUNTER_NAME_CACHE[counter_id] = expected_names
 
@@ -40,6 +41,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
                 return sample.value
 
     return 0.0
+
 
 @pytest.mark.unit
 @pytest.mark.parametrize(

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -20,22 +20,19 @@ from src.data.db_models import RebuildJobStatus
 
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """Get the current value of a Prometheus counter using public API.
-
     Args:
         counter: The Prometheus Counter metric.
         **label_dict: Label key-value pairs to match.
-
     Returns:
         float: The value of the matching counter sample, or 0.0 if not found.
     """
     desc = counter.describe()
-    # Provide explicit default (getattr(counter, '_name', '')) to next() to avoid StopIteration if describe() yields no descriptors.
     raw_name = next((d.name for d in desc), getattr(counter, "_name", ""))
     base_name = raw_name.removesuffix("_total")
-
+    target_names = {raw_name, base_name, f"{base_name}_total"}
     for family in counter.collect():
         for sample in family.samples:
-            if sample.name.endswith("_created") or sample.name not in {raw_name, base_name, f"{base_name}_total"}:
+            if sample.name.endswith("_created") or sample.name not in target_names:
                 continue
             if sample.labels == label_dict:
                 return sample.value

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -18,6 +18,7 @@ from api.metrics import (
 )
 from src.data.db_models import RebuildJobStatus
 
+
 def _get_counter_value(counter: Counter, **label_dict: str) -> float:
     """Get the current value of a Prometheus counter using public API.
 

--- a/tests/unit/test_metrics.py
+++ b/tests/unit/test_metrics.py
@@ -26,6 +26,7 @@ def _get_counter_value(counter: Counter, **label_dict: str) -> float:
         counter: The Prometheus Counter metric.
         **label_dict: Label key-value pairs to match.
     Returns:
+    """
     expected_name = f'{getattr(counter, "_name", "")}_total'
     for family in counter.collect():
         for sample in family.samples:


### PR DESCRIPTION
## **User description**
<!-- kody-pr-summary:start -->
Refactored the execution of the Python script responsible for verifying the existence of lock refresh and heartbeat metrics within the CI workflow. The script is now executed using a here-document (`python - <<'PY'`) instead of `python -c`, which improves readability and maintainability for multi-line Python code within shell commands. The functional check performed by the script remains unchanged.

Robust counter sample matching
The helper matched samples using sample.name.endswith("_total"), which can be fragile (it may inadvertently match other metrics that end with _total). Refactored to use the metric's registered name (counter._name) to match the exact *_total sample for this Counter.
This is a small hardening to make the test more precise and less likely to break if other metrics are added.

Added explicit histogram buckets for LOCK_REFRESH_DURATION
Currently the histogram uses default buckets. For lock-refresh latency it's helpful to declare explicit buckets capturing sub-second latencies (most lock refreshes are sub-second). This improves observability and alerting fidelity.

Added, and pinned, `prometheus_client` to v0.25.0 in `requirements.txt`, `requirements-dev.txt` and `pyproject.toml`. 
The changes were needed to avoid pylint import errors. 
v0.25.0 was pinned in both files to promote build and runtime observability consistency.

<!-- kody-pr-summary:end -->


___

## **CodeAnt-AI Description**
**Improve lock refresh timing metrics and tighten metric checks**

### What Changed
- Lock refresh timing now uses explicit sub-second to long-delay buckets, so rebuild lock refresh latency is tracked with more useful granularity
- The metric verification test keeps matching the total counter sample while avoiding reliance on internal counter details
- The CI metric check now runs as a clearer multi-line script, with the same validation result

### Impact
`✅ Clearer lock refresh latency reporting`
`✅ More reliable metric checks in CI`
`✅ Fewer false metric test failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

----
## Summary by Gitar

- **Refactored counter caching:**
  - Removed complex `WeakKeyDictionary` caching logic in favor of direct metric name calculation within `_get_counter_value`.
  - Simplified `_get_counter_value` to derive `expected_names` on-the-fly, reducing memory overhead and improving code maintainability.
- **Improved metric retrieval:**
  - Replaced manual iteration over `counter.collect()` with `prometheus_client.REGISTRY.get_sample_value` for more reliable and idiomatic counter lookups.
  - Clarified `next()` usage with an explicit default attribute fallback to prevent `StopIteration` errors when metric descriptors are missing.

<sub>This will update automatically on new commits.</sub>