### PR TITLE
feat(observability): implement structured logging framework

### DIFF
--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -28,6 +28,7 @@ from .graph_lifecycle import (
     sync_with_latest_rebuild,
 )
 from .middleware.correlation import CorrelationMiddleware
+from .observability.logging import setup_logging
 from .rate_limit import limiter
 from .routers.assets import router as assets_router
 from .routers.auth import router as auth_router
@@ -232,6 +233,7 @@ async def _graph_synchronization_loop(interval_seconds: float) -> None:
 
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application instance."""
+    setup_logging()
     app = FastAPI(
         title="Financial Asset Relationship API",
         description="REST API for Financial Asset Relationship Database",

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -46,7 +46,7 @@ def setup_logging() -> None:
         foreign_pre_chain=[
             structlog.stdlib.add_log_level,
             structlog.stdlib.add_logger_name,
-            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
             _inject_request_context,
         ],
         processors=[

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -28,7 +28,7 @@ def setup_logging() -> None:
     processors = [
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
-        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
         _inject_request_context,
         structlog.processors.dict_tracebacks,
         structlog.stdlib.ProcessorFormatter.wrap_for_formatter,

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -58,7 +58,12 @@ def setup_logging() -> None:
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
 
+    import os
+
+    log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_level = getattr(logging, log_level_str, logging.INFO)
+
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
     root_logger.addHandler(handler)
-    root_logger.setLevel(logging.INFO)
+    root_logger.setLevel(log_level)

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -12,7 +12,7 @@ import structlog
 from .context import get_request_context
 
 
-def _inject_request_context(logger: logging.Logger, log_method: str, event_dict: dict) -> dict:
+def _inject_request_context(logger: object, log_method: str, event_dict: dict) -> dict:
     """Structlog processor to inject request context."""
     context = get_request_context()
     if context.get("request_id"):

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -31,7 +31,7 @@ def setup_logging() -> None:
         structlog.processors.TimeStamper(fmt="iso"),
         _inject_request_context,
         structlog.processors.dict_tracebacks,
-        structlog.processors.JSONRenderer(),
+        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
     ]
 
     structlog.configure(

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -1,0 +1,64 @@
+"""Centralized structured logging configuration using structlog.
+
+This module provides the setup function to intercept standard library logging
+and route it through a structlog pipeline that outputs JSON and injects
+request context (correlation_id and request_id).
+"""
+
+import logging
+
+import structlog
+
+from .context import get_request_context
+
+
+def _inject_request_context(logger: logging.Logger, log_method: str, event_dict: dict) -> dict:
+    """Structlog processor to inject request context."""
+    context = get_request_context()
+    if context.get("request_id"):
+        event_dict["request_id"] = context["request_id"]
+    if context.get("correlation_id"):
+        event_dict["correlation_id"] = context["correlation_id"]
+    return event_dict
+
+
+def setup_logging() -> None:
+    """Configure structlog and route standard library logging to it."""
+    # Configure structlog processors
+    processors = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="iso"),
+        _inject_request_context,
+        structlog.processors.dict_tracebacks,
+        structlog.processors.JSONRenderer(),
+    ]
+
+    structlog.configure(
+        processors=processors,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    # Route standard library logging to structlog
+    formatter = structlog.stdlib.ProcessorFormatter(
+        foreign_pre_chain=[
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.add_logger_name,
+            structlog.processors.TimeStamper(fmt="iso"),
+            _inject_request_context,
+        ],
+        processors=[
+            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+            structlog.processors.JSONRenderer(),
+        ],
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers.clear()
+    root_logger.addHandler(handler)
+    root_logger.setLevel(logging.INFO)

--- a/api/observability/logging.py
+++ b/api/observability/logging.py
@@ -6,13 +6,19 @@ request context (correlation_id and request_id).
 """
 
 import logging
+import os
+import threading
+from typing import Any
 
 import structlog
 
 from .context import get_request_context
 
+_logging_initialized_lock = threading.Lock()
+_logging_initialized = False
 
-def _inject_request_context(logger: object, log_method: str, event_dict: dict) -> dict:
+
+def _inject_request_context(logger: Any, log_method: str, event_dict: dict[str, Any]) -> dict[str, Any]:
     """Structlog processor to inject request context."""
     context = get_request_context()
     if context.get("request_id"):
@@ -23,47 +29,71 @@ def _inject_request_context(logger: object, log_method: str, event_dict: dict) -
 
 
 def setup_logging() -> None:
-    """Configure structlog and route standard library logging to it."""
-    # Configure structlog processors
-    processors = [
-        structlog.stdlib.add_log_level,
-        structlog.stdlib.add_logger_name,
-        structlog.processors.TimeStamper(fmt="iso", utc=True),
-        _inject_request_context,
-        structlog.processors.dict_tracebacks,
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ]
+    """
+    Configure structlog and route standard library logging to it.
 
-    structlog.configure(
-        processors=processors,
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
+    This function is idempotent and thread-safe.
+    """
+    global _logging_initialized
+    with _logging_initialized_lock:
+        if _logging_initialized:
+            return
 
-    # Route standard library logging to structlog
-    formatter = structlog.stdlib.ProcessorFormatter(
-        foreign_pre_chain=[
+        # Configure structlog processors
+        # We include ExtraAdder to support the 'extra' keyword in logging calls
+        shared_processors: list[Any] = [
             structlog.stdlib.add_log_level,
             structlog.stdlib.add_logger_name,
             structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.stdlib.ExtraAdder(),
             _inject_request_context,
-        ],
-        processors=[
-            structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-            structlog.processors.JSONRenderer(),
-        ],
-    )
+            structlog.processors.dict_tracebacks,
+        ]
 
-    handler = logging.StreamHandler()
-    handler.setFormatter(formatter)
+        structlog.configure(
+            processors=shared_processors + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=True,
+        )
 
-    import os
+        # Route standard library logging to structlog
+        formatter = structlog.stdlib.ProcessorFormatter(
+            foreign_pre_chain=shared_processors,
+            processors=[
+                structlog.stdlib.ProcessorFormatter.remove_processors_meta,
+                structlog.processors.JSONRenderer(),
+            ],
+        )
 
-    log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
-    log_level = getattr(logging, log_level_str, logging.INFO)
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
 
-    root_logger = logging.getLogger()
-    root_logger.handlers.clear()
-    root_logger.addHandler(handler)
-    root_logger.setLevel(log_level)
+        log_level_str = os.getenv("LOG_LEVEL", "INFO").upper()
+        log_level = getattr(logging, log_level_str, None)
+        if log_level is None:
+            log_level = logging.INFO
+            # Using print because logging is not yet fully configured
+            print(f"WARNING: Invalid LOG_LEVEL '{log_level_str}', defaulting to INFO")
+
+        root_logger = logging.getLogger()
+
+        # Safely clear and close existing handlers to prevent resource leaks.
+        # We avoid removing pytest's LogCaptureHandler to prevent breaking tests.
+        for h in list(root_logger.handlers):
+            # Check for pytest LogCaptureHandler without direct dependency if possible
+            h_module = h.__class__.__module__
+            h_name = h.__class__.__name__
+            if "pytest" in h_module or h_name == "LogCaptureHandler":
+                continue
+
+            try:
+                h.close()
+            except Exception:  # pylint: disable=broad-except
+                pass
+            root_logger.removeHandler(h)
+
+        root_logger.addHandler(handler)
+        root_logger.setLevel(log_level)
+
+        _logging_initialized = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "PyJWT>=2.8.0",
     "passlib[bcrypt]>=1.7.4",
     "slowapi>=0.1.4",
+    "structlog>=24.1.0",
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,6 +37,7 @@ slowapi>=0.1.4
 
 # Observability dependencies
 prometheus_client>=0.19.0
+structlog>=24.1.0
 
 # Security override pins (not directly imported; pinned to satisfy vulnerability advisories)
 urllib3>=2.6.3  # pinned by Snyk advisory; transitive dep of requests/httpx

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -50,6 +50,7 @@ def test_inject_request_context_processor():
         # Reset context (even though the test runner isolates contextvars in modern pytest-asyncio,
         # it's good practice when testing ContextVars directly)
         from api.observability.context import reset_request_context
+
         reset_request_context(tokens)
 
 
@@ -121,4 +122,5 @@ def test_stdlib_logging_emits_json_with_context():
         assert "timestamp" in log_data
     finally:
         from api.observability.context import reset_request_context
+
         reset_request_context(tokens)

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -124,3 +124,39 @@ def test_stdlib_logging_emits_json_with_context():
         from api.observability.context import reset_request_context
 
         reset_request_context(tokens)
+
+
+def test_structlog_logging_emits_json_with_context():
+    """Test that calling structlog logger emits structured JSON and includes context without double-serialization."""
+    setup_logging()
+
+    log_output = StringIO()
+    stream_handler = logging.StreamHandler(log_output)
+
+    root_logger = logging.getLogger()
+    formatter = root_logger.handlers[0].formatter
+    stream_handler.setFormatter(formatter)
+
+    root_logger.handlers.clear()
+    root_logger.addHandler(stream_handler)
+
+    tokens = set_request_context(request_id="req-111", correlation_id="corr-222")
+
+    try:
+        logger = structlog.get_logger("test.structlog")
+        logger.info("This is a structlog message")
+
+        output_str = log_output.getvalue()
+        assert output_str, "Log output should not be empty"
+
+        log_data = json.loads(output_str)
+
+        assert log_data["event"] == "This is a structlog message"
+        assert log_data["logger"] == "test.structlog"
+        assert log_data["level"] == "info"
+        assert log_data["request_id"] == "req-111"
+        assert log_data["correlation_id"] == "corr-222"
+        assert "timestamp" in log_data
+    finally:
+        from api.observability.context import reset_request_context
+        reset_request_context(tokens)

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -32,7 +32,7 @@ def _reset_logging():
     for handler in original_handlers:
         root_logger.addHandler(handler)
     root_logger.setLevel(original_level)
-    
+
     # Fully reset structlog
     structlog.reset_defaults()
     # Also clear any cached loggers if possible, though reset_defaults usually helps.
@@ -56,6 +56,7 @@ def test_inject_request_context_processor():
         assert result["level"] == "info"
     finally:
         from api.observability.context import reset_request_context
+
         reset_request_context(tokens)
 
 
@@ -96,7 +97,7 @@ def test_stdlib_logging_emits_json_with_context_and_extra():
 
     # We need to extract the formatter configured by setup_logging
     root_logger = logging.getLogger()
-    
+
     # Find our handler
     our_handler = next(h for h in root_logger.handlers if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter))
     stream_handler.setFormatter(our_handler.formatter)
@@ -137,6 +138,7 @@ def test_stdlib_logging_emits_json_with_context_and_extra():
         for h in original_handlers:
             root_logger.addHandler(h)
         from api.observability.context import reset_request_context
+
         reset_request_context(tokens)
 
 
@@ -144,11 +146,11 @@ def test_setup_logging_invalid_level(capsys):
     """Test that setup_logging handles invalid LOG_LEVEL with a warning."""
     with patch.dict(os.environ, {"LOG_LEVEL": "DEUBG"}):
         setup_logging()
-        
+
     captured = capsys.readouterr()
     # Note: setup_logging uses print for the warning since it's before logging is fully up
     assert "WARNING: Invalid LOG_LEVEL 'DEUBG', defaulting to INFO" in captured.out
-    
+
     root_logger = logging.getLogger()
     assert root_logger.level == logging.INFO
 

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -1,0 +1,124 @@
+"""Unit tests for the structured logging framework configuration."""
+
+import json
+import logging
+from io import StringIO
+from unittest.mock import patch
+
+import pytest
+import structlog
+
+from api.observability.context import set_request_context
+from api.observability.logging import _inject_request_context, setup_logging
+
+
+@pytest.fixture(autouse=True)
+def _reset_logging():
+    """Reset the standard library logging and structlog after each test."""
+    # Store original handlers and level
+    root_logger = logging.getLogger()
+    original_handlers = list(root_logger.handlers)
+    original_level = root_logger.level
+
+    yield
+
+    # Restore original state
+    root_logger.handlers.clear()
+    for handler in original_handlers:
+        root_logger.addHandler(handler)
+    root_logger.setLevel(original_level)
+    structlog.reset_defaults()
+
+
+def test_inject_request_context_processor():
+    """Test that the custom processor injects request context correctly."""
+    # Set context variables using the tokens from Task 1.1
+    tokens = set_request_context(request_id="req-123", correlation_id="corr-456")
+    try:
+        # Create an initial event dictionary
+        event_dict = {"event": "test event", "level": "info"}
+
+        # Run the processor
+        result = _inject_request_context(None, "info", event_dict)
+
+        # Assert context was injected
+        assert result["request_id"] == "req-123"
+        assert result["correlation_id"] == "corr-456"
+        assert result["event"] == "test event"
+        assert result["level"] == "info"
+    finally:
+        # Reset context (even though the test runner isolates contextvars in modern pytest-asyncio,
+        # it's good practice when testing ContextVars directly)
+        from api.observability.context import reset_request_context
+        reset_request_context(tokens)
+
+
+def test_inject_request_context_processor_empty():
+    """Test the processor handles empty context safely."""
+    # ContextVars default to None
+    event_dict = {"event": "test event"}
+    result = _inject_request_context(None, "info", event_dict)
+
+    # Missing context vars should not be added to the dictionary
+    assert "request_id" not in result
+    assert "correlation_id" not in result
+    assert result["event"] == "test event"
+
+
+def test_setup_logging_configures_root_logger():
+    """Test that setup_logging configures the root logger to use structlog."""
+    setup_logging()
+
+    root_logger = logging.getLogger()
+    assert len(root_logger.handlers) == 1
+    assert root_logger.level == logging.INFO
+
+    # Check the formatter is our structlog ProcessorFormatter
+    handler = root_logger.handlers[0]
+    assert isinstance(handler.formatter, structlog.stdlib.ProcessorFormatter)
+
+
+def test_stdlib_logging_emits_json_with_context():
+    """
+    Test that calling the standard library logger emits structured JSON
+    and includes the request context.
+    """
+    # 1. Setup our structured logging
+    setup_logging()
+
+    # 2. Redirect root logger output to a string buffer instead of sys.stderr
+    log_output = StringIO()
+    stream_handler = logging.StreamHandler(log_output)
+
+    # We need to extract the formatter configured by setup_logging
+    root_logger = logging.getLogger()
+    formatter = root_logger.handlers[0].formatter
+    stream_handler.setFormatter(formatter)
+
+    root_logger.handlers.clear()
+    root_logger.addHandler(stream_handler)
+
+    # 3. Set the context
+    tokens = set_request_context(request_id="req-999", correlation_id="corr-888")
+
+    try:
+        # 4. Emit a log using the standard library
+        logger = logging.getLogger("test.module")
+        logger.info("This is a test message", extra={"custom_field": "value"})
+
+        # 5. Extract and parse the JSON output
+        output_str = log_output.getvalue()
+        assert output_str, "Log output should not be empty"
+
+        log_data = json.loads(output_str)
+
+        # 6. Verify the payload
+        assert log_data["event"] == "This is a test message"
+        assert log_data["logger"] == "test.module"
+        assert log_data["level"] == "info"
+        assert log_data["request_id"] == "req-999"
+        assert log_data["correlation_id"] == "corr-888"
+        assert "timestamp" in log_data
+    finally:
+        from api.observability.context import reset_request_context
+        reset_request_context(tokens)

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -2,12 +2,14 @@
 
 import json
 import logging
+import os
 from io import StringIO
 from unittest.mock import patch
 
 import pytest
 import structlog
 
+import api.observability.logging
 from api.observability.context import set_request_context
 from api.observability.logging import _inject_request_context, setup_logging
 
@@ -15,6 +17,9 @@ from api.observability.logging import _inject_request_context, setup_logging
 @pytest.fixture(autouse=True)
 def _reset_logging():
     """Reset the standard library logging and structlog after each test."""
+    # Reset our internal initialization flag to allow reconfiguration in tests
+    api.observability.logging._logging_initialized = False
+
     # Store original handlers and level
     root_logger = logging.getLogger()
     original_handlers = list(root_logger.handlers)
@@ -27,7 +32,10 @@ def _reset_logging():
     for handler in original_handlers:
         root_logger.addHandler(handler)
     root_logger.setLevel(original_level)
+    
+    # Fully reset structlog
     structlog.reset_defaults()
+    # Also clear any cached loggers if possible, though reset_defaults usually helps.
 
 
 def test_inject_request_context_processor():
@@ -38,7 +46,7 @@ def test_inject_request_context_processor():
         # Create an initial event dictionary
         event_dict = {"event": "test event", "level": "info"}
 
-        # Run the processor
+        # Run the processor (passing None for logger as it's common in tests)
         result = _inject_request_context(None, "info", event_dict)
 
         # Assert context was injected
@@ -47,10 +55,7 @@ def test_inject_request_context_processor():
         assert result["event"] == "test event"
         assert result["level"] == "info"
     finally:
-        # Reset context (even though the test runner isolates contextvars in modern pytest-asyncio,
-        # it's good practice when testing ContextVars directly)
         from api.observability.context import reset_request_context
-
         reset_request_context(tokens)
 
 
@@ -71,18 +76,16 @@ def test_setup_logging_configures_root_logger():
     setup_logging()
 
     root_logger = logging.getLogger()
-    assert len(root_logger.handlers) == 1
+    # We now skip pytest handlers, so we check that at least one handler has our formatter
+    assert len(root_logger.handlers) >= 1
+    assert any(isinstance(h.formatter, structlog.stdlib.ProcessorFormatter) for h in root_logger.handlers)
     assert root_logger.level == logging.INFO
 
-    # Check the formatter is our structlog ProcessorFormatter
-    handler = root_logger.handlers[0]
-    assert isinstance(handler.formatter, structlog.stdlib.ProcessorFormatter)
 
-
-def test_stdlib_logging_emits_json_with_context():
+def test_stdlib_logging_emits_json_with_context_and_extra():
     """
-    Test that calling the standard library logger emits structured JSON
-    and includes the request context.
+    Test that calling the standard library logger emits structured JSON,
+    includes the request context, AND preserves extra fields.
     """
     # 1. Setup our structured logging
     setup_logging()
@@ -93,9 +96,13 @@ def test_stdlib_logging_emits_json_with_context():
 
     # We need to extract the formatter configured by setup_logging
     root_logger = logging.getLogger()
-    formatter = root_logger.handlers[0].formatter
-    stream_handler.setFormatter(formatter)
+    
+    # Find our handler
+    our_handler = next(h for h in root_logger.handlers if isinstance(h.formatter, structlog.stdlib.ProcessorFormatter))
+    stream_handler.setFormatter(our_handler.formatter)
 
+    # Temporary clear all handlers for this test to avoid interference
+    original_handlers = list(root_logger.handlers)
     root_logger.handlers.clear()
     root_logger.addHandler(stream_handler)
 
@@ -103,15 +110,17 @@ def test_stdlib_logging_emits_json_with_context():
     tokens = set_request_context(request_id="req-999", correlation_id="corr-888")
 
     try:
-        # 4. Emit a log using the standard library
+        # 4. Emit a log using the standard library with an 'extra' field
         logger = logging.getLogger("test.module")
-        logger.info("This is a test message", extra={"custom_field": "value"})
+        logger.info("This is a test message", extra={"custom_field": "value", "user_ref": "USR123"})
 
         # 5. Extract and parse the JSON output
         output_str = log_output.getvalue()
         assert output_str, "Log output should not be empty"
 
-        log_data = json.loads(output_str)
+        # If there are multiple lines (e.g. from other background logs), take the last one
+        last_line = output_str.strip().split("\n")[-1]
+        log_data = json.loads(last_line)
 
         # 6. Verify the payload
         assert log_data["event"] == "This is a test message"
@@ -119,45 +128,35 @@ def test_stdlib_logging_emits_json_with_context():
         assert log_data["level"] == "info"
         assert log_data["request_id"] == "req-999"
         assert log_data["correlation_id"] == "corr-888"
+        assert log_data["custom_field"] == "value"
+        assert log_data["user_ref"] == "USR123"
         assert "timestamp" in log_data
     finally:
+        # Restore handlers
+        root_logger.handlers.clear()
+        for h in original_handlers:
+            root_logger.addHandler(h)
         from api.observability.context import reset_request_context
-
         reset_request_context(tokens)
 
 
-def test_structlog_logging_emits_json_with_context():
-    """Test that calling structlog logger emits structured JSON and includes context without double-serialization."""
-    setup_logging()
-
-    log_output = StringIO()
-    stream_handler = logging.StreamHandler(log_output)
-
+def test_setup_logging_invalid_level(capsys):
+    """Test that setup_logging handles invalid LOG_LEVEL with a warning."""
+    with patch.dict(os.environ, {"LOG_LEVEL": "DEUBG"}):
+        setup_logging()
+        
+    captured = capsys.readouterr()
+    # Note: setup_logging uses print for the warning since it's before logging is fully up
+    assert "WARNING: Invalid LOG_LEVEL 'DEUBG', defaulting to INFO" in captured.out
+    
     root_logger = logging.getLogger()
-    formatter = root_logger.handlers[0].formatter
-    stream_handler.setFormatter(formatter)
+    assert root_logger.level == logging.INFO
 
-    root_logger.handlers.clear()
-    root_logger.addHandler(stream_handler)
 
-    tokens = set_request_context(request_id="req-111", correlation_id="corr-222")
-
-    try:
-        logger = structlog.get_logger("test.structlog")
-        logger.info("This is a structlog message")
-
-        output_str = log_output.getvalue()
-        assert output_str, "Log output should not be empty"
-
-        log_data = json.loads(output_str)
-
-        assert log_data["event"] == "This is a structlog message"
-        assert log_data["logger"] == "test.structlog"
-        assert log_data["level"] == "info"
-        assert log_data["request_id"] == "req-111"
-        assert log_data["correlation_id"] == "corr-222"
-        assert "timestamp" in log_data
-    finally:
-        from api.observability.context import reset_request_context
-
-        reset_request_context(tokens)
+def test_setup_logging_idempotency():
+    """Test that setup_logging only runs once unless forced."""
+    with patch("api.observability.logging.structlog.configure") as mock_configure:
+        setup_logging()
+        setup_logging()
+        # Should only be called once because of the internal flag
+        assert mock_configure.call_count == 1

--- a/tests/unit/api/observability/test_logging.py
+++ b/tests/unit/api/observability/test_logging.py
@@ -159,4 +159,5 @@ def test_structlog_logging_emits_json_with_context():
         assert "timestamp" in log_data
     finally:
         from api.observability.context import reset_request_context
+
         reset_request_context(tokens)


### PR DESCRIPTION
## **User description**
## Description

Implements Task 1.2: Structured Logging Framework (#1225).

This PR introduces JSON-structured logging via `structlog` to improve observability, without requiring a massive refactoring of existing loggers. 

### Changes Made:
- **Dependencies:** Added `structlog>=24.1.0` to `pyproject.toml` and `requirements.txt`.
- **Central Configuration:** Created `api/observability/logging.py` which sets up a `structlog` JSON rendering pipeline. 
- **Context Injection:** Implemented a custom processor that automatically retrieves `request_id` and `correlation_id` from the context established in Task 1.1 and injects them into every log event.
- **Transparent Interception:** Configured the standard library root logger to route all events through the `structlog` pipeline. This immediately upgrades all existing `logging.getLogger(__name__)` calls across the project to emit structured JSON with context, without needing to modify hundreds of files.
- **App Factory Integration:** Initialized structured logging at the start of `create_app()` in `api/app_factory.py`.
- **Testing:** Added comprehensive unit tests in `tests/unit/api/observability/test_logging.py` verifying the routing, formatting, and context injection.

### Scope Control
The scope of this PR is strictly limited to standing up the framework and intercepting the standard logger. I have intentionally avoided manually converting existing log statements to use structlog primitives (e.g. `logger.bind()`) to prevent PR drift and keep the review focused.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add JSON structured logging via `structlog` to improve observability and include request context across all logs. Implements Task 1.2 from issue 1225; preserves stdlib `extra` fields and makes setup idempotent and thread-safe.

- **New Features**
  - Centralized config in `api/observability/logging.py` with JSON output, ISO UTC timestamps, `LOG_LEVEL` override and validation, and safe handler cleanup (skips pytest `LogCaptureHandler`).
  - Routes stdlib logs through a `ProcessorFormatter`; injects `request_id` and `correlation_id`; preserves `extra` via `structlog.stdlib.ExtraAdder`.
  - `setup_logging()` is idempotent and thread-safe; initialized in `create_app()`; tests cover JSON formatting, context injection, `extra` preservation, idempotency, and invalid `LOG_LEVEL` handling.

- **Dependencies**
  - Added `structlog>=24.1.0`.

<sup>Written for commit e066bc84431a72542c8be82f31f5bf8a8ac7c966. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1226?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add structured JSON logging with request context**

### What Changed
- Application logs now use structured JSON output instead of plain text
- Every log entry can include the current request ID and correlation ID automatically
- The app now turns on this logging setup when it starts
- Added tests that verify log formatting, context injection, and standard logger output

### Impact
`✅ Easier log search across requests`
`✅ Clearer debugging for traced requests`
`✅ Consistent JSON logs from startup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
