### PR TITLE
Propagate rebuild lock TTL to GraphLifecycleSettings (#1231)

### DIFF
--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -28,14 +28,18 @@ _GRAPH_PERSISTENCE_SAVE_ERROR_MESSAGE = "Failed to persist rebuilt graph."
 
 @dataclass(frozen=True)
 class GraphLifecycleSettings:
-    """Settings needed by graph lifecycle initialization."""
+    """Immutable lifecycle-boundary settings projected from :class:`Settings`.
+
+    Values are validated at load time on the root settings model; this dataclass
+    must not re-validate or apply defensive fallbacks.
+    """
 
     asset_graph_database_url: str | None = None
     coordination_database_url: str | None = None
     graph_cache_path: str | None = None
     real_data_cache_path: str | None = None
     use_real_data_fetcher: bool = False
-    rebuild_lock_ttl_seconds: int = 300
+    rebuild_lock_ttl_seconds: int = 300  # mirrored from Settings; env REBUILD_LOCK_TTL_SECONDS
 
 
 class GraphPersistenceNotConfiguredError(RuntimeError):

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -73,8 +73,7 @@ def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
 
 def clear_graph_lifecycle_settings_cache() -> None:
     """Clear cached settings used by graph lifecycle initialization."""
-    # This is a placeholder for later implementation
-    pass
+    get_settings.cache_clear()
 
 
 def load_persisted_graph_if_available(

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -73,7 +73,7 @@ def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
 
 def clear_graph_lifecycle_settings_cache() -> None:
     """Clear cached settings used by graph lifecycle initialization."""
-    # This is a placeholder for later implementation 
+    # This is a placeholder for later implementation
     pass
 
 

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -73,7 +73,8 @@ def get_graph_lifecycle_settings() -> GraphLifecycleSettings:
 
 def clear_graph_lifecycle_settings_cache() -> None:
     """Clear cached settings used by graph lifecycle initialization."""
-    get_settings.cache_clear()
+    # This is a placeholder for later implementation 
+    pass
 
 
 def load_persisted_graph_if_available(

--- a/tests/unit/test_graph_lifecycle_providers.py
+++ b/tests/unit/test_graph_lifecycle_providers.py
@@ -2,14 +2,13 @@
 
 from __future__ import annotations
 
-import os
 from dataclasses import FrozenInstanceError
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 import api.graph_lifecycle_providers as providers
-from src.config.settings import Settings, load_settings
+from src.config.settings import Settings, get_settings, load_settings
 from src.logic.asset_graph import AssetRelationshipGraph
 
 pytestmark = pytest.mark.unit

--- a/tests/unit/test_graph_lifecycle_providers.py
+++ b/tests/unit/test_graph_lifecycle_providers.py
@@ -9,7 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import api.graph_lifecycle_providers as providers
-from src.config.settings import Settings, get_settings, load_settings
+from src.config.settings import Settings, load_settings
 from src.logic.asset_graph import AssetRelationshipGraph
 
 pytestmark = pytest.mark.unit
@@ -46,10 +46,9 @@ def test_graph_lifecycle_settings_is_frozen() -> None:
         lifecycle_settings.rebuild_lock_ttl_seconds = 999  # type: ignore[misc]
 
 
-@patch.dict(os.environ, {"REBUILD_LOCK_TTL_SECONDS": "600"}, clear=True)
+@patch.dict(os.environ, {"REBUILD_LOCK_TTL_SECONDS": "600"})
 def test_get_graph_lifecycle_settings_propagates_ttl_from_loaded_settings() -> None:
     """Env → load_settings → get_graph_lifecycle_settings should preserve validated TTL."""
-    get_settings.cache_clear()
     providers.clear_graph_lifecycle_settings_cache()
 
     base_settings = load_settings()

--- a/tests/unit/test_graph_lifecycle_providers.py
+++ b/tests/unit/test_graph_lifecycle_providers.py
@@ -46,14 +46,12 @@ def test_graph_lifecycle_settings_is_frozen() -> None:
         lifecycle_settings.rebuild_lock_ttl_seconds = 999  # type: ignore[misc]
 
 
-@patch.dict(os.environ, {"REBUILD_LOCK_TTL_SECONDS": "600"})
-def test_get_graph_lifecycle_settings_propagates_ttl_from_loaded_settings() -> None:
-    """Env → load_settings → get_graph_lifecycle_settings should preserve validated TTL."""
+def test_get_graph_lifecycle_settings_propagates_ttl_from_loaded_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("REBUILD_LOCK_TTL_SECONDS", "600")
+    get_settings.cache_clear()
     providers.clear_graph_lifecycle_settings_cache()
-
     base_settings = load_settings()
     lifecycle_settings = providers.get_graph_lifecycle_settings()
-
     assert base_settings.rebuild_lock_ttl_seconds == 600
     assert lifecycle_settings.rebuild_lock_ttl_seconds == base_settings.rebuild_lock_ttl_seconds
 

--- a/tests/unit/test_graph_lifecycle_providers.py
+++ b/tests/unit/test_graph_lifecycle_providers.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import os
+from dataclasses import FrozenInstanceError
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 import api.graph_lifecycle_providers as providers
-from src.config.settings import Settings
+from src.config.settings import Settings, get_settings, load_settings
 from src.logic.asset_graph import AssetRelationshipGraph
 
 pytestmark = pytest.mark.unit
@@ -34,6 +36,27 @@ def test_get_graph_lifecycle_settings_maps_rebuild_lock_ttl_default(
 
     assert lifecycle_settings.rebuild_lock_ttl_seconds == base_settings.rebuild_lock_ttl_seconds
     assert lifecycle_settings.rebuild_lock_ttl_seconds == 300
+
+
+def test_graph_lifecycle_settings_is_frozen() -> None:
+    """GraphLifecycleSettings must remain an immutable configuration boundary."""
+    lifecycle_settings = providers.GraphLifecycleSettings(rebuild_lock_ttl_seconds=120)
+
+    with pytest.raises(FrozenInstanceError):
+        lifecycle_settings.rebuild_lock_ttl_seconds = 999  # type: ignore[misc]
+
+
+@patch.dict(os.environ, {"REBUILD_LOCK_TTL_SECONDS": "600"}, clear=True)
+def test_get_graph_lifecycle_settings_propagates_ttl_from_loaded_settings() -> None:
+    """Env → load_settings → get_graph_lifecycle_settings should preserve validated TTL."""
+    get_settings.cache_clear()
+    providers.clear_graph_lifecycle_settings_cache()
+
+    base_settings = load_settings()
+    lifecycle_settings = providers.get_graph_lifecycle_settings()
+
+    assert base_settings.rebuild_lock_ttl_seconds == 600
+    assert lifecycle_settings.rebuild_lock_ttl_seconds == base_settings.rebuild_lock_ttl_seconds
 
 
 def test_save_graph_with_session_runs_pre_commit_check(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## **User description**
## Architectural Alignment

- **Backend:** FastAPI (production path) — lifecycle configuration boundary
- **Frontend:** Next.js — no changes
- **Gradio:** non-production — no changes

## Primary Objective

Complete Task 2.2: propagate `rebuild_lock_ttl_seconds` from validated `Settings` into the frozen `GraphLifecycleSettings` boundary so lifecycle code consumes a complete, authoritative configuration object.

```text
REBUILD_LOCK_TTL_SECONDS → Settings → GraphLifecycleSettings → graph_admin
```

## Context (relationship to #1230)

PR #1230 merged the core field, mapping, and initial propagation tests on `main`. This PR closes **#1231** by adding the remaining acceptance coverage (frozen immutability, env→`load_settings`→lifecycle chain) and clarifying the lifecycle-boundary docstring.

## Problem Statement

Lifecycle subsystems must not read root `Settings` directly or use defensive fallbacks (`getattr(..., 300)`). Validation belongs in Pydantic; `GraphLifecycleSettings` is a typed, immutable projection.

## Design Rationale

| Decision | Choice | Why |
|----------|--------|-----|
| Validation owner | `Settings` (Pydantic `gt=0`) | Single validation site |
| Lifecycle access | `GraphLifecycleSettings.rebuild_lock_ttl_seconds` | Immutable boundary DTO |
| Mapping | `settings.rebuild_lock_ttl_seconds` direct attribute | No fallbacks, no re-validation |
| Immutability | `@dataclass(frozen=True)` | Existing lifecycle contract |

## File-by-File Summary

| File | Change |
|------|--------|
| `api/graph_lifecycle_providers.py` | Document immutable boundary; field already mapped from `Settings` |
| `tests/unit/test_graph_lifecycle_providers.py` | Frozen-dataclass test; env→load_settings→lifecycle propagation test |

**Already on `main` (from #1230):** field on dataclass, `get_graph_lifecycle_settings()` mapping, override/default propagation tests.

## Scope

### In Scope

- Lifecycle boundary documentation (#1231)
- Frozen-dataclass regression test
- End-to-end propagation test through `load_settings()`
- Existing explicit/default propagation tests (from #1230)

### Out of Scope

- `Settings` model changes (Task 2.1 / #1228 — done in #1230)
- `graph_admin` consumer changes (downstream task)
- Lock refresh retry behaviour (#1220)
- Operator / ADR documentation (#1230)

## Validation Commands

```bash
pytest tests/unit/test_graph_lifecycle_providers.py -v
```

## Test Plan

- [x] Explicit TTL mirrors `base_settings.rebuild_lock_ttl_seconds`
- [x] Default TTL (300) propagates unchanged
- [x] `GraphLifecycleSettings` rejects mutation (`FrozenInstanceError`)
- [x] `REBUILD_LOCK_TTL_SECONDS=600` flows through `load_settings()` → `get_graph_lifecycle_settings()`
- [ ] CI green

## Merge Criteria

- [x] Scope limited to lifecycle propagation boundary (#1231)
- [x] No `getattr` fallbacks or duplicate validation introduced
- [x] Dataclass remains frozen

## Reviewer Guidance

1. Confirm mapping uses `settings.rebuild_lock_ttl_seconds` only (no defensive access).
2. Confirm no lifecycle-layer `<= 0` checks were added.
3. Do not re-open field placement or Pydantic validation — settled in #1230.

## Issues

Closes #1231

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates `rebuild_lock_ttl_seconds` from validated `Settings` into frozen `GraphLifecycleSettings` so lifecycle code reads the authoritative TTL without fallbacks. Clarifies lifecycle-boundary docs and adds env→`load_settings()`→lifecycle propagation and immutability tests; completes #1231.

- **Bug Fixes**
  - Fix TTL propagation test by importing `get_settings` and clearing its cache before building lifecycle settings.

- **Refactors**
  - Keep `clear_graph_lifecycle_settings_cache()` as a no-op to avoid coupling.

<sup>Written for commit 2350d8e4f4f9c4b1513fd459884f9bfae03d9b3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Propagate the rebuild lock timeout through the lifecycle settings boundary**

### What Changed
- The graph lifecycle settings now keep the validated rebuild lock timeout from the main app settings instead of relying on a separate default
- The lifecycle settings object is explicitly treated as immutable, so its values cannot be changed after creation
- Added coverage for the full path from environment setting to loaded settings to lifecycle settings, plus a check that the lifecycle settings stay frozen
- Clarified the lifecycle settings documentation to explain that values come from validated app settings

### Impact
`✅ Consistent rebuild lock timing`
`✅ Fewer lifecycle config mismatches`
`✅ Safer graph rebuild settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
