### PR TITLE
Replace defensive lock TTL access with typed configuration (#1233)

### DIFF
--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -44,24 +44,31 @@ def _is_getattr_for_rebuild_lock_ttl(node: ast.AST) -> bool:
     return isinstance(name_arg, ast.Constant) and name_arg.value == "rebuild_lock_ttl_seconds"
 
 
-def _is_lock_ttl_runtime_guard(node: ast.AST) -> bool:
-    """Return True if node re-validates or corrects lock_ttl at runtime."""
-    if isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id == "lock_ttl":
-        for op, comp in zip(node.ops, node.comparators, strict=False):
-            if isinstance(op, ast.LtE) and isinstance(comp, ast.Constant) and comp.value == 0:
-                return True
-            if isinstance(op, ast.Lt) and isinstance(comp, ast.Constant) and comp.value == 1:
-                return True
-    if (
+def _is_non_positive_lock_ttl_compare(node: ast.AST) -> bool:
+    if not (isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id == "lock_ttl"):
+        return False
+    for op, comp in zip(node.ops, node.comparators, strict=False):
+        if isinstance(op, ast.LtE) and isinstance(comp, ast.Constant) and comp.value == 0:
+            return True
+        if isinstance(op, ast.Lt) and isinstance(comp, ast.Constant) and comp.value == 1:
+            return True
+    return False
+
+
+def _is_lock_ttl_isinstance_check(node: ast.AST) -> bool:
+    return (
         isinstance(node, ast.Call)
         and isinstance(node.func, ast.Name)
         and node.func.id == "isinstance"
-        and node.args
+        and bool(node.args)
         and isinstance(node.args[0], ast.Name)
         and node.args[0].id == "lock_ttl"
-    ):
-        return True
-    return False
+    )
+
+
+def _is_lock_ttl_runtime_guard(node: ast.AST) -> bool:
+    """Return True if node re-validates or corrects lock_ttl at runtime."""
+    return _is_non_positive_lock_ttl_compare(node) or _is_lock_ttl_isinstance_check(node)    
 
 
 def test_graph_admin_does_not_use_getattr_for_rebuild_lock_ttl() -> None:

--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -1,7 +1,13 @@
-"""Unit tests for typed rebuild lock TTL access in graph admin."""
+"""Contract tests for typed rebuild lock TTL access in graph admin.
+
+Ensures Task 3.1 (#1233): graph admin uses GraphLifecycleSettings.rebuild_lock_ttl_seconds
+directly without defensive getattr fallbacks or duplicate runtime validation.
+"""
 
 from __future__ import annotations
 
+import ast
+import functools
 import threading
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -17,19 +23,61 @@ from src.data.distributed_lock import LockLifecycleState, LockState
 
 pytestmark = pytest.mark.unit
 
-_GRAPH_ADMIN_SOURCE = Path(graph_admin.__file__).read_text(encoding="utf-8")
+
+@functools.lru_cache(maxsize=1)
+def _graph_admin_module_ast() -> ast.Module:
+    """Parse graph_admin source once for structural contract checks."""
+    source = Path(graph_admin.__file__).read_text(encoding="utf-8")
+    return ast.parse(source)
+
+
+def _is_getattr_for_rebuild_lock_ttl(node: ast.AST) -> bool:
+    """Return True if node is getattr(..., 'rebuild_lock_ttl_seconds', ...)."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if not isinstance(func, ast.Name) or func.id != "getattr":
+        return False
+    if len(node.args) < 2:
+        return False
+    name_arg = node.args[1]
+    return isinstance(name_arg, ast.Constant) and name_arg.value == "rebuild_lock_ttl_seconds"
+
+
+def _is_lock_ttl_runtime_guard(node: ast.AST) -> bool:
+    """Return True if node re-validates or corrects lock_ttl at runtime."""
+    if isinstance(node, ast.Compare) and isinstance(node.left, ast.Name) and node.left.id == "lock_ttl":
+        for op, comp in zip(node.ops, node.comparators, strict=False):
+            if isinstance(op, ast.LtE) and isinstance(comp, ast.Constant) and comp.value == 0:
+                return True
+            if isinstance(op, ast.Lt) and isinstance(comp, ast.Constant) and comp.value == 1:
+                return True
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "isinstance"
+        and node.args
+        and isinstance(node.args[0], ast.Name)
+        and node.args[0].id == "lock_ttl"
+    ):
+        return True
+    return False
 
 
 def test_graph_admin_does_not_use_getattr_for_rebuild_lock_ttl() -> None:
     """Rebuild lock TTL must not use defensive getattr fallbacks."""
-    assert 'getattr(settings, "rebuild_lock_ttl_seconds"' not in _GRAPH_ADMIN_SOURCE
-    assert "getattr(settings, 'rebuild_lock_ttl_seconds'" not in _GRAPH_ADMIN_SOURCE
+    for node in ast.walk(_graph_admin_module_ast()):
+        if _is_getattr_for_rebuild_lock_ttl(node):
+            pytest.fail(
+                f"Found getattr fallback for rebuild_lock_ttl_seconds at line {getattr(node, 'lineno', '?')}"
+            )
 
 
 def test_graph_admin_does_not_correct_lock_ttl_at_runtime() -> None:
     """Lock TTL must not be re-validated or silently corrected in graph admin."""
-    assert "if lock_ttl <= 0" not in _GRAPH_ADMIN_SOURCE
-    assert "if not isinstance(lock_ttl" not in _GRAPH_ADMIN_SOURCE
+    for node in ast.walk(_graph_admin_module_ast()):
+        if _is_lock_ttl_runtime_guard(node):
+            pytest.fail(f"Found runtime lock_ttl guard at line {getattr(node, 'lineno', '?')}")
 
 
 def test_perform_rebuild_uses_typed_lock_ttl_for_distributed_lock(
@@ -52,6 +100,7 @@ def test_perform_rebuild_uses_typed_lock_ttl_for_distributed_lock(
     mock_lock.state = LockLifecycleState.ACQUIRED
 
     def distributed_lock_factory(**kwargs: object) -> MagicMock:
+        """Capture DistributedLock kwargs for TTL contract verification."""
         captured["ttl_seconds"] = kwargs.get("ttl_seconds")
         return mock_lock
 
@@ -69,6 +118,7 @@ def test_perform_rebuild_uses_typed_lock_ttl_for_distributed_lock(
 
     @contextmanager
     def fake_heartbeat(*_args: object, **_kwargs: object):
+        """No-op heartbeat context for isolated rebuild sync testing."""
         yield threading.Event()
 
     monkeypatch.setattr(graph_admin, "_orchestrate_heartbeat", fake_heartbeat)

--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -1,0 +1,93 @@
+"""Unit tests for typed rebuild lock TTL access in graph admin."""
+
+from __future__ import annotations
+
+import threading
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import api.routers.graph_admin as graph_admin
+from api.api_models import GraphRebuildResponse
+from api.graph_lifecycle_providers import GraphLifecycleSettings
+from src.data.distributed_lock import LockLifecycleState, LockState
+
+pytestmark = pytest.mark.unit
+
+_GRAPH_ADMIN_SOURCE = Path(graph_admin.__file__).read_text(encoding="utf-8")
+
+
+def test_graph_admin_does_not_use_getattr_for_rebuild_lock_ttl() -> None:
+    """Rebuild lock TTL must not use defensive getattr fallbacks."""
+    assert 'getattr(settings, "rebuild_lock_ttl_seconds"' not in _GRAPH_ADMIN_SOURCE
+    assert "getattr(settings, 'rebuild_lock_ttl_seconds'" not in _GRAPH_ADMIN_SOURCE
+
+
+def test_graph_admin_does_not_correct_lock_ttl_at_runtime() -> None:
+    """Lock TTL must not be re-validated or silently corrected in graph admin."""
+    assert "if lock_ttl <= 0" not in _GRAPH_ADMIN_SOURCE
+    assert "if not isinstance(lock_ttl" not in _GRAPH_ADMIN_SOURCE
+
+
+def test_perform_rebuild_uses_typed_lock_ttl_for_distributed_lock(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """DistributedLock must receive TTL from GraphLifecycleSettings without fallback injection."""
+    db_url = f"sqlite:///{tmp_path / 'graph.db'}"
+    settings = GraphLifecycleSettings(
+        asset_graph_database_url=db_url,
+        coordination_database_url=db_url,
+        rebuild_lock_ttl_seconds=42,
+    )
+    captured: dict[str, object] = {}
+
+    mock_lock = MagicMock()
+    mock_lock.acquire.return_value = MagicMock()
+    mock_lock.check_state.return_value = LockState.VALID
+    mock_lock.holder_id = "test-holder"
+    mock_lock.state = LockLifecycleState.ACQUIRED
+
+    def distributed_lock_factory(**kwargs: object) -> MagicMock:
+        captured["ttl_seconds"] = kwargs.get("ttl_seconds")
+        return mock_lock
+
+    monkeypatch.setattr(graph_admin, "DistributedLock", distributed_lock_factory)
+    monkeypatch.setattr(
+        graph_admin.RecoveryGate,
+        "ensure_safe_to_execute",
+        lambda self: None,
+    )
+    monkeypatch.setattr(
+        graph_admin,
+        "_create_and_start_rebuild_job",
+        lambda *_args, **_kwargs: ("job-typed-ttl", datetime.now(timezone.utc)),
+    )
+
+    @contextmanager
+    def fake_heartbeat(*_args: object, **_kwargs: object):
+        yield threading.Event()
+
+    monkeypatch.setattr(graph_admin, "_orchestrate_heartbeat", fake_heartbeat)
+    monkeypatch.setattr(
+        graph_admin,
+        "_run_rebuild_pipeline",
+        lambda *_args, **_kwargs: GraphRebuildResponse(
+            source="sample",
+            asset_count=0,
+            relationship_count=0,
+            regulatory_event_count=0,
+        ),
+    )
+
+    response = graph_admin._perform_rebuild_and_persist_sync(  # pylint: disable=protected-access
+        settings,
+        user_ref="operator",
+    )
+
+    assert captured["ttl_seconds"] == settings.rebuild_lock_ttl_seconds
+    assert captured["ttl_seconds"] == 42
+    assert response.source == "sample"

--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -68,7 +68,7 @@ def _is_lock_ttl_isinstance_check(node: ast.AST) -> bool:
 
 def _is_lock_ttl_runtime_guard(node: ast.AST) -> bool:
     """Return True if node re-validates or corrects lock_ttl at runtime."""
-    return _is_non_positive_lock_ttl_compare(node) or _is_lock_ttl_isinstance_check(node)    
+    return _is_non_positive_lock_ttl_compare(node) or _is_lock_ttl_isinstance_check(node)
 
 
 def test_graph_admin_does_not_use_getattr_for_rebuild_lock_ttl() -> None:

--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -68,9 +68,7 @@ def test_graph_admin_does_not_use_getattr_for_rebuild_lock_ttl() -> None:
     """Rebuild lock TTL must not use defensive getattr fallbacks."""
     for node in ast.walk(_graph_admin_module_ast()):
         if _is_getattr_for_rebuild_lock_ttl(node):
-            pytest.fail(
-                f"Found getattr fallback for rebuild_lock_ttl_seconds at line {getattr(node, 'lineno', '?')}"
-            )
+            pytest.fail(f"Found getattr fallback for rebuild_lock_ttl_seconds at line {getattr(node, 'lineno', '?')}")
 
 
 def test_graph_admin_does_not_correct_lock_ttl_at_runtime() -> None:


### PR DESCRIPTION
## **User description**
## Architectural Alignment

- **Backend:** FastAPI (production path) — graph admin rebuild orchestration
- **Frontend:** Next.js — no changes
- **Gradio:** non-production — no changes

## Primary Objective

Complete Task 3.1: remove legacy defensive lock TTL handling from the graph admin rebuild path and rely on validated `GraphLifecycleSettings.rebuild_lock_ttl_seconds`.

```text
REBUILD_LOCK_TTL_SECONDS → Settings (Pydantic) → GraphLifecycleSettings → graph_admin (typed access)
```

## Context (relationship to prior PRs)

| PR | Delivered |
|----|-----------|
| #1220 | Typed `Settings` field, `graph_admin` uses `settings.rebuild_lock_ttl_seconds` (replaced `getattr`) |
| #1230 / #1231 | Settings → lifecycle propagation and tests |

**This PR** adds **contract tests** that lock in Task 3.1 acceptance criteria; no functional change to `graph_admin.py` on `main`.

## Problem Statement

Downstream code must not re-validate or silently correct TTL values already validated by Pydantic (`Field(gt=0)`). Duplicate guards (`getattr`, `isinstance`, `<= 0` fallbacks) risk diverging from the settings layer.

## Design Rationale

| Decision | Choice |
|----------|--------|
| Access pattern | `lock_ttl = settings.rebuild_lock_ttl_seconds` |
| Validation owner | `Settings` / `load_settings()` only |
| Invalid config | Fail at settings construction, not mid-rebuild |
| Behaviour for valid config | Unchanged |

Current implementation (`api/routers/graph_admin.py` ~909):

```python
lock_ttl = settings.rebuild_lock_ttl_seconds
```

## File-by-File Summary

| File | Change |
|------|--------|
| `tests/unit/test_graph_admin_typed_lock_ttl.py` | **New** — source contract + `_perform_rebuild_and_persist_sync` TTL propagation test |

**Not changed:** `api/routers/graph_admin.py` (already compliant on `main`).

## Scope

### In Scope

- Regression tests: no `getattr` for `rebuild_lock_ttl_seconds`
- Regression tests: no runtime TTL correction guards
- Unit test: `DistributedLock(ttl_seconds=...)` receives lifecycle settings value

### Out of Scope

- Lock acquisition / refresh / scheduling changes
- Default TTL changes
- Settings or lifecycle provider changes

## Validation Commands

```bash
pytest tests/unit/test_graph_admin_typed_lock_ttl.py -v
pytest tests/integration/test_graph_rebuild_persistence.py -k lock_ttl -v
```

## Test Plan

- [x] Source does not contain `getattr(settings, "rebuild_lock_ttl_seconds", ...)`
- [x] Source does not contain `if lock_ttl <= 0` / `isinstance(lock_ttl` guards
- [x] `_perform_rebuild_and_persist_sync` passes TTL 42 → `DistributedLock(ttl_seconds=42)`
- [ ] CI green

## Merge Criteria

- [x] Tests document typed-access contract for #1233
- [x] No duplicate validation introduced
- [x] No graph_admin behaviour change for valid configuration

## Reviewer Guidance

Do not re-open: typed field location, Pydantic `gt=0`, or removal of defensive fallbacks — settled in #1220.

Verify tests would fail if someone reintroduces `getattr(..., 300)` or runtime correction.

## Issues

Closes #1233

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add AST-based contract tests to ensure graph admin reads `GraphLifecycleSettings.rebuild_lock_ttl_seconds` directly and passes it unchanged to `DistributedLock(ttl_seconds=...)` for #1233. No changes to `api/routers/graph_admin.py`.

- **Refactors**
  - Simplified test helpers for lock TTL guard detection; no behavior change.
  - Applied pre-commit formatting to tests.

<sup>Written for commit 517cbda1259519993d4dd78b89794a99675bbee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Verify graph admin uses the configured rebuild lock TTL directly

### What Changed
- Added checks that graph admin reads the rebuild lock TTL from the validated settings value instead of using fallback lookup or runtime correction
- Added a rebuild flow test to confirm the distributed lock receives the exact TTL from graph lifecycle settings

### Impact
`✅ Fewer rebuild lock mismatches`
`✅ Clearer settings-driven rebuild behavior`
`✅ Safer graph rebuild lock handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
