### PR TITLE
test: add unit tests for lock refresh retry behavior (#1237)

### DIFF
--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -57,7 +57,7 @@ def test_check_state_reraises_unexpected_runtime_error(monkeypatch: pytest.Monke
 
 @pytest.fixture
 def mock_lock_env(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, DistributedLock]:
-    """Provide a mocked repository and a DistributedLock with session_scope and sleep patched."""
+    """Return (mock_repo, lock): a MagicMock CoordinationLockRepository and a DistributedLock instance with session_scope and sleep patched for tests."""
     mock_repo = MagicMock()
     monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
     monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from unittest.mock import MagicMock
+from types import SimpleNamespace
+from sqlalchemy.orm import Session
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
@@ -13,8 +15,8 @@ from src.data.distributed_lock import DistributedLock, LockLifecycleState
 
 @contextmanager
 def _mock_session_scope(factory):
-    """Mock session_scope that yields a MagicMock session."""
-    yield MagicMock()
+    '''Mock session_scope that yields a MagicMock session with Session spec.'''
+    yield MagicMock(spec=Session)
 
 
 @pytest.mark.unit
@@ -53,45 +55,44 @@ def test_check_state_reraises_unexpected_runtime_error(monkeypatch: pytest.Monke
         lock.check_state()
 
 
-@pytest.mark.unit
-def test_refresh_success_after_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify refresh succeeds after recovering from transient failures."""
+@pytest.fixture
+def mock_lock_env(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, DistributedLock]:
     mock_repo = MagicMock()
+    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
+    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
+    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
+    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
+    return mock_repo, lock
+
+
+@pytest.mark.unit
+def test_refresh_success_after_transient_failures(mock_lock_env: tuple[MagicMock, DistributedLock]) -> None:
+    """Verify refresh succeeds after recovering from transient failures."""
+    mock_repo, lock = mock_lock_env
     # Attempt 1 -> SQLAlchemyError
     # Attempt 2 -> SQLAlchemyError
     # Attempt 3 -> Success
     mock_repo.refresh_lock.side_effect = [
         SQLAlchemyError("transient 1"),
         SQLAlchemyError("transient 2"),
-        MagicMock(success=True, fencing_token=123),
+        SimpleNamespace(success=True, fencing_token=123),
     ]
 
-    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
-    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
-    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
-
-    # DistributedLock requires a session factory
-    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
     res = lock.refresh(max_retries=2)
 
-    assert res is not False
+    assert isinstance(res, LockRefreshResult)  # or a type check appropriate to the actual return type
     assert res.state == LockLifecycleState.REFRESHED
     assert res.fencing_token == 123
     assert mock_repo.refresh_lock.call_count == 3
 
 
 @pytest.mark.unit
-def test_refresh_retry_budget_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_refresh_retry_budget_exhausted(mock_lock_env: tuple[MagicMock, DistributedLock]) -> None:
     """Verify refresh fails when retry budget for transient errors is exhausted."""
-    mock_repo = MagicMock()
+    mock_repo, lock = mock_lock_env
     # Always raise SQLAlchemyError
     mock_repo.refresh_lock.side_effect = SQLAlchemyError("persistent failure")
 
-    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
-    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
-    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
-
-    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
     res = lock.refresh(max_retries=2)
 
     assert res is False
@@ -99,17 +100,12 @@ def test_refresh_retry_budget_exhausted(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.unit
-def test_refresh_no_retry_on_contention(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_refresh_no_retry_on_contention(mock_lock_env: tuple[MagicMock, DistributedLock]) -> None:
     """Verify refresh does not retry when the lock is held by another owner."""
-    mock_repo = MagicMock()
+    mock_repo, lock = mock_lock_env
     # Return success=False (contention), not an exception
     mock_repo.refresh_lock.return_value = MagicMock(success=False)
 
-    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
-    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
-    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
-
-    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
     res = lock.refresh(max_retries=2)
 
     assert res is False
@@ -117,17 +113,11 @@ def test_refresh_no_retry_on_contention(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 @pytest.mark.unit
-def test_refresh_no_retry_on_unexpected_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_refresh_no_retry_on_unexpected_exception(mock_lock_env: tuple[MagicMock, DistributedLock]) -> None:
     """Verify refresh fails immediately on unexpected non-transient exceptions."""
-    mock_repo = MagicMock()
+    mock_repo, lock = mock_lock_env
     # Raise an exception not in (SQLAlchemyError, OSError)
     mock_repo.refresh_lock.side_effect = ValueError("unexpected bug")
-
-    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
-    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
-    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
-
-    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
 
     # In the current implementation, unexpected exceptions are caught and return False
     res = lock.refresh(max_retries=2)

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -57,6 +57,7 @@ def test_check_state_reraises_unexpected_runtime_error(monkeypatch: pytest.Monke
 
 @pytest.fixture
 def mock_lock_env(monkeypatch: pytest.MonkeyPatch) -> tuple[MagicMock, DistributedLock]:
+    """Provide a mocked repository and a DistributedLock with session_scope and sleep patched."""
     mock_repo = MagicMock()
     monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
     monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
-import pytest
+from contextlib import contextmanager
+from unittest.mock import MagicMock
 
-from src.data.distributed_lock import DistributedLock
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.data.distributed_lock import DistributedLock, LockLifecycleState
+
+
+@contextmanager
+def _mock_session_scope(factory):
+    """Mock session_scope that yields a MagicMock session."""
+    yield MagicMock()
 
 
 @pytest.mark.unit
@@ -41,3 +51,86 @@ def test_check_state_reraises_unexpected_runtime_error(monkeypatch: pytest.Monke
 
     with pytest.raises(RuntimeError, match="db unavailable"):
         lock.check_state()
+
+
+@pytest.mark.unit
+def test_refresh_success_after_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify refresh succeeds after recovering from transient failures."""
+    mock_repo = MagicMock()
+    # Attempt 1 -> SQLAlchemyError
+    # Attempt 2 -> SQLAlchemyError
+    # Attempt 3 -> Success
+    mock_repo.refresh_lock.side_effect = [
+        SQLAlchemyError("transient 1"),
+        SQLAlchemyError("transient 2"),
+        MagicMock(success=True, fencing_token=123),
+    ]
+
+    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
+    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
+    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
+
+    # DistributedLock requires a session factory
+    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
+    res = lock.refresh(max_retries=2)
+
+    assert res is not False
+    assert res.state == LockLifecycleState.REFRESHED
+    assert res.fencing_token == 123
+    assert mock_repo.refresh_lock.call_count == 3
+
+
+@pytest.mark.unit
+def test_refresh_retry_budget_exhausted(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify refresh fails when retry budget for transient errors is exhausted."""
+    mock_repo = MagicMock()
+    # Always raise SQLAlchemyError
+    mock_repo.refresh_lock.side_effect = SQLAlchemyError("persistent failure")
+
+    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
+    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
+    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
+
+    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
+    res = lock.refresh(max_retries=2)
+
+    assert res is False
+    assert mock_repo.refresh_lock.call_count == 3
+
+
+@pytest.mark.unit
+def test_refresh_no_retry_on_contention(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify refresh does not retry when the lock is held by another owner."""
+    mock_repo = MagicMock()
+    # Return success=False (contention), not an exception
+    mock_repo.refresh_lock.return_value = MagicMock(success=False)
+
+    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
+    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
+    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
+
+    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
+    res = lock.refresh(max_retries=2)
+
+    assert res is False
+    assert mock_repo.refresh_lock.call_count == 1
+
+
+@pytest.mark.unit
+def test_refresh_no_retry_on_unexpected_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify refresh fails immediately on unexpected non-transient exceptions."""
+    mock_repo = MagicMock()
+    # Raise an exception not in (SQLAlchemyError, OSError)
+    mock_repo.refresh_lock.side_effect = ValueError("unexpected bug")
+
+    monkeypatch.setattr("src.data.distributed_lock.session_scope", _mock_session_scope)
+    monkeypatch.setattr("src.data.distributed_lock.CoordinationLockRepository", lambda session: mock_repo)
+    monkeypatch.setattr("src.data.distributed_lock.sleep", lambda seconds: None)
+
+    lock = DistributedLock(lambda: None, "test_lock")  # type: ignore[arg-type]
+
+    # In the current implementation, unexpected exceptions are caught and return False
+    res = lock.refresh(max_retries=2)
+
+    assert res is False
+    assert mock_repo.refresh_lock.call_count == 1

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -81,7 +81,7 @@ def test_refresh_success_after_transient_failures(mock_lock_env: tuple[MagicMock
 
     res = lock.refresh(max_retries=2)
 
-    assert isinstance(res, LockRefreshResult)  # or a type check appropriate to the actual return type
+    assert res is not False
     assert res.state == LockLifecycleState.REFRESHED
     assert res.fencing_token == 123
     assert mock_repo.refresh_lock.call_count == 3

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -10,7 +10,7 @@ import pytest
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
-from src.data.distributed_lock import DistributedLock, LockLifecycleState
+from src.data.distributed_lock import DistributedLock, LockLease, LockLifecycleState
 
 
 @contextmanager
@@ -81,7 +81,7 @@ def test_refresh_success_after_transient_failures(mock_lock_env: tuple[MagicMock
 
     res = lock.refresh(max_retries=2)
 
-    assert res is not False
+    assert isinstance(res, LockLease)
     assert res.state == LockLifecycleState.REFRESHED
     assert res.fencing_token == 123
     assert mock_repo.refresh_lock.call_count == 3
@@ -105,8 +105,7 @@ def test_refresh_no_retry_on_contention(mock_lock_env: tuple[MagicMock, Distribu
     """Verify refresh does not retry when the lock is held by another owner."""
     mock_repo, lock = mock_lock_env
     # Return success=False (contention), not an exception
-    mock_repo.refresh_lock.return_value = MagicMock(success=False)
-
+    mock_repo.refresh_lock.return_value = SimpleNamespace(success=False)
     res = lock.refresh(max_retries=2)
 
     assert res is False

--- a/tests/unit/test_distributed_lock_runtime.py
+++ b/tests/unit/test_distributed_lock_runtime.py
@@ -3,19 +3,19 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from unittest.mock import MagicMock
 from types import SimpleNamespace
-from sqlalchemy.orm import Session
+from unittest.mock import MagicMock
 
 import pytest
 from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from src.data.distributed_lock import DistributedLock, LockLifecycleState
 
 
 @contextmanager
 def _mock_session_scope(factory):
-    '''Mock session_scope that yields a MagicMock session with Session spec.'''
+    """Mock session_scope that yields a MagicMock session with Session spec."""
     yield MagicMock(spec=Session)
 
 


### PR DESCRIPTION
## **User description**
## Architectural Alignment
- Backend: FastAPI (production path)
- Frontend: Next.js (production path)

Establish a formal behavioural contract for distributed lock refresh retry logic.

## Primary Objective
Add unit tests verifying the transient-error retry behaviour for distributed lock refresh operations (#1237).

## Scope
### In Scope
- Tests for success after transient failures.
- Tests for retry budget exhaustion.
- Tests ensuring no retry on contention or unexpected exceptions.
- Consistent mocking using monkeypatch and MagicMock.

### Out of Scope
- No changes to runtime code or database schema.

## Validation Commands
```
pytest tests/unit/test_distributed_lock_runtime.py
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds unit tests for `src.data.distributed_lock` refresh retry behavior for Linear #1237. Extends coverage to assert `LockLease` on success and refactors mocks with a `Session`-spec and structured contention responses.

- **New Tests and Refactor**
  - Retries transient `SQLAlchemyError`; succeeds with `LockLifecycleState.REFRESHED` and fencing token; asserts return is `LockLease`.
  - Returns False when retry budget is exhausted or on contention (`success=False`); no retries on unexpected errors (e.g., `ValueError`).
  - Adds `mock_lock_env` and `_mock_session_scope`; monkeypatches `session_scope`, `CoordinationLockRepository`, and `sleep` using a `Session`-spec.

<sup>Written for commit bc588ee0e259952c0fb7f4993efc1f86a5a62b88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add coverage for lock refresh retry behavior**

### What Changed
- Added unit tests for refreshing a lock after temporary database errors, including success after retries and exhaustion of the retry limit
- Added coverage for cases where refresh should stop immediately: lock contention and unexpected errors
- Refined test setup to reuse a shared mocked lock environment for these scenarios

### Impact
`✅ Safer lock refresh retries`
`✅ Fewer missed refresh recovery cases`
`✅ Clearer lock failure handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
