### PR TITLE
docs: reference startup tracing and tests in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azu[...]
+[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/_boards/board/t/7f564e5b-a967-4110-9d79-7aeaaf540ef4/Microsoft.RequirementCategory)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DashFin-FarDb/financial-asset-relationship-db?utm_source=badge)
 
 # Financial Asset Relationship Database
@@ -61,7 +61,7 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
 
    Windows PowerShell users should activate `.venv\Scripts\Activate.ps1` and set the same environment variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
 
-   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${[...]
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
 
 2. **Start the Next.js frontend (in a new terminal):**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/_boards/board/t/7f564e5b-a967-4110-9d79-7aeaaf540ef4/Microsoft.RequirementCategory)
+[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4)
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DashFin-FarDb/financial-asset-relationship-db?utm_source=badge)
 
 # Financial Asset Relationship Database
@@ -59,9 +59,9 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    python -m uvicorn api.main:app --reload --port 8000
    ```
 
-   Windows PowerShell users should activate `.venv\Scripts\Activate.ps1` and set the same environment variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
+   Windows PowerShell users should activate `.venv\\Scripts\\Activate.ps1` and set the same environment variables with `$env:NAME=\"value\"` before running the `python -m uvicorn ...` command.
 
-   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${...}"
 
 2. **Start the Next.js frontend (in a new terminal):**
 
@@ -89,10 +89,10 @@ This usually means the FastAPI backend is not running or failed during startup.
 Before starting the frontend, verify the backend starts with the required environment variables:
 
 ```bash
-export DATABASE_URL="sqlite:dev.db"
-export SECRET_KEY="change-me-to-a-long-random-secret"
-export ADMIN_USERNAME="admin"
-export ADMIN_PASSWORD="change-me"
+export DATABASE_URL=\"sqlite:dev.db\"
+export SECRET_KEY=\"change-me-to-a-long-random-secret\"
+export ADMIN_USERNAME=\"admin\"
+export ADMIN_PASSWORD=\"change-me\"
 python -m uvicorn api.main:app --reload --port 8000
 ```
 
@@ -105,7 +105,13 @@ curl http://localhost:8000/api/visualization
 
 If `/api/health` fails, fix the backend startup first. If `/api/health` works but the frontend still fails, check `NEXT_PUBLIC_API_URL` and the browser Network tab.
 
-Note: the application creates a startup trace context (trace_id/span_id) during lifespan-based state initialization so observability events emitted during startup (reconciliation, get_graph, etc.) carry the same trace identifiers. See `api/app_factory.py` and the unit tests in `tests/unit/test_app_factory.py` and `tests/unit/api/observability` for details and coverage.
+Note: the application creates a startup trace context (trace_id/span_id) during lifespan-based state initialization so observability events emitted during startup (reconciliation, get_graph, etc.) carry the same trace identifiers. For implementation details see the code and tests:
+
+- api/app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/api/app_factory.py
+- tests/unit/test_app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/tests/unit/test_app_factory.py
+- tests/unit/api/observability: https://github.com/DashFin-FarDb/financial-asset-relationship-db/tree/docs/trace-startup-note/tests/unit/api/observability
+
+Format: trace_id is the full uuid4().hex (32 lowercase hex chars); span_id is the first 16 hex characters of uuid4().hex (16 lowercase hex chars).
 
 ### Demo/Internal UI: Gradio (Non-Production)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/_boards/board/t/7f564e5b-a967-4110-9d79-7aeaaf540ef4/Microsoft.RequirementCategory)
+[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azu[...]
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DashFin-FarDb/financial-asset-relationship-db?utm_source=badge)
 
 # Financial Asset Relationship Database
@@ -61,7 +61,7 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
 
    Windows PowerShell users should activate `.venv\Scripts\Activate.ps1` and set the same environment variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
 
-   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"`. See [DEPLOYMENT.md](DEPLOYMENT.md) for runtime environment details.
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${[...]
 
 2. **Start the Next.js frontend (in a new terminal):**
 
@@ -104,6 +104,8 @@ curl http://localhost:8000/api/visualization
 ```
 
 If `/api/health` fails, fix the backend startup first. If `/api/health` works but the frontend still fails, check `NEXT_PUBLIC_API_URL` and the browser Network tab.
+
+Note: the application creates a startup trace context (trace_id/span_id) during lifespan-based state initialization so observability events emitted during startup (reconciliation, get_graph, etc.) carry the same trace identifiers. See `api/app_factory.py` and the unit tests in `tests/unit/test_app_factory.py` and `tests/unit/api/observability` for details and coverage.
 
 ### Demo/Internal UI: Gradio (Non-Production)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4)
+[![Board Status](https://dev.azure.com/mohavro/2e48cc65-ae36-4c98-98b5-0eb4c1a1b5df/7f564e5b-a967-4110-9d79-7aeaaf540ef4/_apis/work/boardbadge/b59b599b-e6ab-41bd-8d76-d02d17a77a9d)](https://dev.azu[...]
 [![CodSpeed](https://img.shields.io/endpoint?url=https://codspeed.io/badge.json)](https://codspeed.io/DashFin-FarDb/financial-asset-relationship-db?utm_source=badge)
 
 # Financial Asset Relationship Database
@@ -59,9 +59,15 @@ This will start both the FastAPI backend (port 8000) and Next.js frontend (port 
    python -m uvicorn api.main:app --reload --port 8000
    ```
 
-   Windows PowerShell users should activate `.venv\\Scripts\\Activate.ps1` and set the same environment variables with `$env:NAME=\"value\"` before running the `python -m uvicorn ...` command.
+   Windows PowerShell users should activate `.venv\\Scripts\\Activate.ps1` and set the same environment variables with `$env:NAME="value"` before running the `python -m uvicorn ...` command.
 
-   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to `python -m uvicorn api.main:app --host 0.0.0.0 --port "${...}"
+   The backend production entrypoint is `api.main:app`. Production deployments should run the same app object with a command equivalent to the following; set the PORT environment variable as needed (example shown):
+
+   ```bash
+   # set a PORT env var (example)
+   export PORT=8000
+   python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"
+   ```
 
 2. **Start the Next.js frontend (in a new terminal):**
 
@@ -89,10 +95,10 @@ This usually means the FastAPI backend is not running or failed during startup.
 Before starting the frontend, verify the backend starts with the required environment variables:
 
 ```bash
-export DATABASE_URL=\"sqlite:dev.db\"
-export SECRET_KEY=\"change-me-to-a-long-random-secret\"
-export ADMIN_USERNAME=\"admin\"
-export ADMIN_PASSWORD=\"change-me\"
+export DATABASE_URL="sqlite:dev.db"
+export SECRET_KEY="change-me-to-a-long-random-secret"
+export ADMIN_USERNAME="admin"
+export ADMIN_PASSWORD="change-me"
 python -m uvicorn api.main:app --reload --port 8000
 ```
 
@@ -105,11 +111,13 @@ curl http://localhost:8000/api/visualization
 
 If `/api/health` fails, fix the backend startup first. If `/api/health` works but the frontend still fails, check `NEXT_PUBLIC_API_URL` and the browser Network tab.
 
-Note: the application creates a startup trace context (trace_id/span_id) during lifespan-based state initialization so observability events emitted during startup (reconciliation, get_graph, etc.) carry the same trace identifiers. For implementation details see the code and tests:
+Note: the application creates a startup trace context (trace_id/span_id) during lifespan-based state initialization, so observability events emitted during startup (reconciliation, get_graph, etc.) include trace metadata.
 
-- api/app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/api/app_factory.py
-- tests/unit/test_app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/tests/unit/test_app_factory.py
-- tests/unit/api/observability: https://github.com/DashFin-FarDb/financial-asset-relationship-db/tree/docs/trace-startup-note/tests/unit/api/observability
+For implementation details, see the code and tests:
+
+- [api/app_factory.py](api/app_factory.py)
+- [tests/unit/test_app_factory.py](tests/unit/test_app_factory.py)
+- [tests/unit/api/observability/](tests/unit/api/observability/)
 
 Format: trace_id is the full uuid4().hex (32 lowercase hex chars); span_id is the first 16 hex characters of uuid4().hex (16 lowercase hex chars).
 

--- a/docs/OBSERVABILITY_README.md
+++ b/docs/OBSERVABILITY_README.md
@@ -31,4 +31,10 @@ This will automatically install request and trace contexts for every incoming re
 - Respect `x-trace-id` and `x-span-id` headers when present; invalid values are dropped.
 - Ensure contexts are reset after the request completes.
 
-- Startup tracing: the application lifespan creates and applies a startup trace context (trace_id/span_id) during state initialization so observability events emitted during startup (reconciliation/get_graph/etc.) carry the same trace identifiers. See `api/app_factory.py` for implementation details.
+- Startup tracing: the application lifespan creates and applies a startup trace context (trace_id/span_id) during state initialization so observability events emitted during startup (reconciliation, get_graph, etc.) carry the same trace identifiers. For implementation details and tests, see:
+
+  - api/app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/api/app_factory.py
+  - tests/unit/test_app_factory.py: https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/docs/trace-startup-note/tests/unit/test_app_factory.py
+  - tests/unit/api/observability: https://github.com/DashFin-FarDb/financial-asset-relationship-db/tree/docs/trace-startup-note/tests/unit/api/observability
+
+  Format: trace_id is the full `uuid4().hex` (32 lowercase hex chars); span_id is the first 16 hex characters of `uuid4().hex` (16 lowercase hex chars).

--- a/docs/PR_DESCRIPTION_UPDATE.md
+++ b/docs/PR_DESCRIPTION_UPDATE.md
@@ -1,0 +1,32 @@
+PR updates for documentation fixes
+
+What I changed
+
+- Clarified the production uvicorn command in README.md to explicitly name the PORT environment variable and provide a default using `${PORT:-8000}`. Included an example `export PORT=8000`.
+- Fixed two grammar issues by adding commas: (1) after the introductory clause "For implementation details, see the code and tests:" and (2) before "so" in the startup trace sentence.
+- Replaced branch-specific permalinks to the feature branch with relative repository links for the implementation files and tests.
+
+What I checked
+
+- Performed a quick repository search for occurrences of the string `${` across the codebase. Results of note:
+  - README.md (updated)
+  - DEPLOYMENT.md already uses an explicit form: `python -m uvicorn api.main:app --host 0.0.0.0 --port "${PORT:-8000}"` (no change needed)
+  - Several shell scripts (run-dev.sh, analyze_pr_mergeability.sh, cleanup-branches.sh, .codacy/cli.sh) and other code files use `${...}` in normal shell/templating contexts; these are intentional and not ambiguous in documentation.
+
+Suggested PR description update
+
+I recommend adding the following short note to the PR description to record the doc fixes and the search that was performed:
+
+"Documentation: clarified production startup guidance and fixed grammar
+
+I updated README.md on the docs/trace-startup-note branch to:
+- Explicitly name the PORT environment variable in the production uvicorn example and provide a sensible default (`${PORT:-8000}`) with an export example.
+- Fix two small grammatical issues (missing commas) in the observability note.
+- Replace transient feature-branch permalinks with relative repository links to the implementation files and tests.
+
+I also ran a quick repository search for occurrences of the pattern `${...}` and confirmed that:
+- DEPLOYMENT.md already contains an explicit `PORT` example and needs no change.
+- The remaining results are primarily shell scripts and code (where `${...}` is valid syntax) rather than user-facing docs.
+
+If you want me to apply further doc edits or propagate the same clarity to other docs, tell me which files to update and I'll commit the changes to this branch.
+"

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -3,7 +3,7 @@
          "api.graph_lifecycle_providers.get_graph_lifecycle_settings",
          lambda: base_settings,
      )
- 
+
      # Force an exception
 -    def _raise_reconciliation_failure(*_args, **_kwargs) -> None:
 -        """Raise a simulated runtime error to represent reconciliation failure."""


### PR DESCRIPTION
## **User description**
## Architectural Alignment

- Backend: FastAPI — this change runs inside the `FastAPI` application lifespan.
- Observability: adds startup-level trace context integration using existing `src.observability` helpers so startup observability events are correlated with a `trace_id`/`span_id`.
- No changes to the frontend (`Next.js`). No changes to the production entrypoints or deployment model.

## Primary Objective

Implement a lightweight startup tracing integration so that all observability events emitted during process startup (`reconciliation`, graph `initialization`) share a generated `trace_id`/`span_id` and can be correlated in downstream `observability` systems. Add unit tests to validate `trace id`/ `span id` formatting, propagation inside the startup `lifespan`, non-leakage into background tasks, and emitted failure events when startup fails.

## Scope

### In Scope

- Generate `W3C-compatible` startup trace/span IDs and apply them for the `lifespan startup` sequence.
- Run startup `initialization` (`reconciliation`, `get_graph`) inside `async_trace_context` so emitted `ObservabilityEvent objects` include `trace_id`/`span_id`.
- Ensure `reconciliation failure` and overall `startup failure` events include `trace_id`/`span_id` metadata.
- Move a debug log into the trace context to ensure `trace-aware` logs.
- Add unit tests that:
  - assert `id format` (32-hex / 16-hex),
  - assert `failure events` are emitted with trace metadata when startup fails,
  - assert trace continuity between `reconciliation failure` and `startup_failed`,
  - assert trace context does not leak into background tasks,
  - assert `async_trace_context` clears on exceptions.
- Small docs note (`OBSERVABILITY_README.md` and `README.md`) referencing the startup tracing behavior and tests (docs-only change in follow-up branch).

### Out of Scope

- Modifying request-time tracing `middleware` semantics or `global observability API` surface beyond adding trace metadata to startup events.
- Any changes to dependency versions or CI configuration.
- Behavioral changes to request/response handling in `runtime HTTP` paths.

### Files Expected to Change

- `api/app_factory.py` — add `_generate_startup_trace_ids`, `_trace_or_unknown`, wrap startup in `async_trace_context`, attach metadata to `ObservabilityEvent(s)`.
- `tests/unit/test_app_factory.py` — new/updated tests for startup tracing, propagation, and non-leakage.
- `tests/unit/api/observability/test_context.py` — additional test ensuring `async_trace_context` clears on exception.
- `docs/OBSERVABILITY_README.md` (tiny note) — points to startup tracing implementation.
- `README.md` (tiny note) — reference to tests and startup tracing (follow-up branch).

## Validation Commands

Run the focused test targets and the full test suite locally and in CI:

```bash
# Focused tests for changed behavior
pytest tests/unit/test_app_factory.py -q
pytest tests/unit/api/observability/test_context.py -q

# Recommended full-suite run (CI)
pytest -q

# Optional static checks
python -m pip install -r requirements-dev.txt
ruff check .
black --check .
mypy --show-error-codes .
```

Notes:
- This project targets Python >=3.10 (`pyproject.toml` requires-python = ">=3.10"), so modern typing (`PEP 604` union syntax and builtin generics) is compatible.
- I ran the full test suite locally (7,000+ tests) — all tests passed.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective (no unrelated behavior changes slipped in).
- [x] Validation commands pass locally or in CI (full test suite run reported passing locally).
- [x] Changes align with production architecture (FastAPI backend + Next.js frontend) — no frontend or deployment changes.
- [x] No runtime circular import introduced: src.observability.* modules do not import api.*; this PR makes api → src.observability imports (expected direction).
- [x] All TODOs and in-code comments explaining the rationale for the chosen approach are present and clear.

## Checklist

### Scope Compliance
- [x] This PR makes one primary decision only (startup tracing integration).
- [x] I have explicitly listed what is out of scope.
- [x] This is a docs/test/code PR scoped to startup tracing; no unrelated performance or dependency changes were included.
- [x] Verified branch and base branch context before concluding PR readiness.

### Testing Best Practices
- [x] Tests verify observable behavior (`observability` events and metadata), trace continuity, and non-leakage rather than coupling to fragile internals.
- [x] Tests avoid coupling to exact log message strings where possible; they assert events and metadata content.
- [x] Tests clean up/avoid persistent global side-effects (test design uses `monkeypatch` and local capture of events).
- [x] The new tests exercise `async-to-thread handoff` semantics and verify that exceptions emitted in threads propagate to the `lifespan manager` and `generate events`.

---

Related Documentation:
- Implementation: `api/app_factory.py`
- Tests: `tests/unit/test_app_factory.py`, `tests/unit/api/observability/test_context.py`
- Observability README: `docs/OBSERVABILITY_README.md`
- PR discussion: https://github.com/DashFin-FarDb/financial-asset-relationship-db/pull/1264

Additional notes (for reviewers)
- The generated startup span_id is the first 16 hex characters of `uuid4().hex` and `trace_id` uses full `uuid4().hex` (lowercase hex) — included docstrings explain the design choice and downstream compatibility (`OpenTelemetry`/`W3C` expectations).
- If you prefer different trace id generation (e.g., `RFC4122` vs `W3C traceparent` semantics), we can adapt generation or add a configuration flag, but current implementation favors simplicity and deterministic testability.
- The tests use monkeypatch for `_run_startup_reconciliation` to simulate `thread-executed exceptions` via `asyncio.to_thread` — comments in tests explain the rationale to avoid skipping inner `log_event` checks.
---


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update README and OBSERVABILITY_README to explain the startup trace context (`trace_id`/`span_id`), link to `api/app_factory.py` and related tests, and specify trace/span ID formats. Clarify `uvicorn` production `PORT` usage, fix Windows path/quoting, and add `docs/PR_DESCRIPTION_UPDATE.md` summarizing these doc fixes; docs-only change.

<sup>Written for commit 37978bf79797a90b4130c73c0ada9e2bb7b938be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add startup tracing notes and ID format details to the README

### What Changed
- Clarifies that startup observability events share the same trace identifiers during app startup
- Adds links to the code and tests that cover startup tracing behavior
- Documents the trace ID and span ID format used during startup
- Fixes README command examples and links for Windows and deployment guidance

### Impact
`✅ Easier startup troubleshooting`
`✅ Clearer observability setup`
`✅ Faster verification of trace ID and span ID format`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
