### PR TITLE
PR 1 — Protocol Boundaries and Database-Behaviour Tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -319,6 +319,7 @@ Configuration + persistence:
 ## Repo-specific conventions to keep in mind
 
 - **Production architecture:** FastAPI + Next.js is the declared production stack. Prioritize work on this stack. See `.github/AUTOMATION_SCOPE_POLICY.md`.
+- **Enterprise Readiness:** The system is transitioning to an enterprise-grade posture. Refer to `docs/enterprise-readiness-index.md` for the audit, roadmap, and PR plan. Ensure work aligns with these plans, particularly the rule that **durable persistence is the gating dependency** for restart, promotion, and DR. SQLite compatibility must be preserved.
 - **PR scope guardrails:** All PRs must include Primary Objective, In Scope, Out of Scope, Files Expected to Change, Validation Commands, and Merge Criteria.
 - **High-risk work:** Database, auth, deployment, CI, security scanner config, and persistence changes require low-autonomy contracts. See "High-risk change control" in `.github/AI_AGENT_GUARDRAILS.md`.
 - **Runtime configuration:** use `src/config/settings.py` and `load_settings()` or `get_settings()` for centralized settings. Auth settings (`SECRET_KEY`, `ADMIN_*`), CORS settings, and database URL resolution are centralized through the settings layer. Some legacy/runtime seams may still use direct `os.getenv()` access where migration has been intentionally deferred; do not assume full migration away from environment reads.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -30,3 +30,13 @@ The Issue Manager ensures abstract roadmap objectives are translated into immuta
 - **Single Invariant Principle:** One issue = one logical slice of the system. Cross-layer changes must be shredded into isolated issues.
 - **No Implied Context:** If a technical dependency or constraint isn't in the issue text, it doesn't exist.
 - **Immutable Boundaries:** Once assigned, scope is locked. Edge cases or peripheral optimizations require new issues.
+
+## 5. Enterprise Readiness & Production Gates
+
+All work must adhere to the Enterprise Readiness Roadmap and Release Checklist (`docs/enterprise-readiness-index.md`).
+
+- **Durable Persistence is the Gating Dependency:** Durable graph persistence is required for restart, promotion, and disaster recovery. When implementing persistence, **SQLite compatibility MUST be preserved** for local development.
+- **Promotion Requirements:** Bounded health checks are insufficient for promotion. Promotion to staging/production requires explicit durable graph-persistence smoke procedures.
+- **API Contracts:** Any changes to API contracts must eliminate ambiguity: density semantics must be normalized end-to-end, visualization payloads must be explicitly modeled, and pagination must be consistently applied.
+- **Distributed Hosting & Recovery:** Stale owners must never mutate state after a restart or lock loss. Rebuild cancellation, lock-loss, and multi-instance behavior must be deterministic.
+- **PR Scope Strictness:** Work mapped to the Enterprise Readiness PR Plan must contain **one primary decision per PR** and rigorously enforce stated out-of-scope boundaries.

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -25,7 +25,7 @@ from sqlalchemy.orm import Session
 from src.data.database import create_engine_from_url, create_session_factory
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
 from src.data.distributed_lock import DistributedLock, LockAcquisitionTimeout, LockLifecycleState, LockState
-from src.data.repository import AssetGraphRepository, RebuildCancellationRequestedError, session_scope
+from src.data.repository import RebuildFailureDetails, AssetGraphRepository, RebuildCancellationRequestedError, session_scope
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
@@ -1522,9 +1522,11 @@ def _mark_job_failed_safe(
         lambda repo: repo.mark_rebuild_job_failed(
             job_id,
             execution_id=execution_id,
+            details=RebuildFailureDetails(
             failure_category=_rebuild_failure_category(exc),
             failure_message=_sanitize_failure_message(exc),
-            duration_ms=duration_ms,
+            duration_ms=duration_ms
+        ),
         ),
         "Failed to persist rebuild job failure state.",
     )

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -25,7 +25,12 @@ from sqlalchemy.orm import Session
 from src.data.database import create_engine_from_url, create_session_factory
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
 from src.data.distributed_lock import DistributedLock, LockAcquisitionTimeout, LockLifecycleState, LockState
-from src.data.repository import RebuildFailureDetails, AssetGraphRepository, RebuildCancellationRequestedError, session_scope
+from src.data.repository import (
+    AssetGraphRepository,
+    RebuildCancellationRequestedError,
+    RebuildFailureDetails,
+    session_scope,
+)
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
@@ -1523,10 +1528,10 @@ def _mark_job_failed_safe(
             job_id,
             execution_id=execution_id,
             details=RebuildFailureDetails(
-            failure_category=_rebuild_failure_category(exc),
-            failure_message=_sanitize_failure_message(exc),
-            duration_ms=duration_ms
-        ),
+                failure_category=_rebuild_failure_category(exc),
+                failure_message=_sanitize_failure_message(exc),
+                duration_ms=duration_ms,
+            ),
         ),
         "Failed to persist rebuild job failure state.",
     )

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -12,14 +12,14 @@ from .db_models import (
 from .protocols import (
     IAssetGraphRepository,
     ICoordinationLockRepository,
-    LockStateSnapshot,
-    LockWriteResult,
-    RebuildCancellationRequestedError,
-    RebuildFailureDetails,
 )
 from .repository import (
     AssetGraphRepository,
     CoordinationLockRepository,
+    LockStateSnapshot,
+    LockWriteResult,
+    RebuildCancellationRequestedError,
+    RebuildFailureDetails,
     RelationshipRecord,
     session_scope,
 )

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -1,1 +1,43 @@
 """Data access and ORM package."""
+
+from .db_models import (
+    AssetORM,
+    AssetRelationshipORM,
+    DistributedLockORM,
+    RebuildJobORM,
+    RebuildJobStatus,
+    RegulatoryEventAssetORM,
+    RegulatoryEventORM,
+)
+from .protocols import (
+    IAssetGraphRepository,
+    ICoordinationLockRepository,
+    LockStateSnapshot,
+    LockWriteResult,
+    RebuildCancellationRequestedError,
+)
+from .repository import (
+    AssetGraphRepository,
+    CoordinationLockRepository,
+    RelationshipRecord,
+    session_scope,
+)
+
+__all__ = [
+    "AssetGraphRepository",
+    "AssetORM",
+    "AssetRelationshipORM",
+    "CoordinationLockRepository",
+    "DistributedLockORM",
+    "IAssetGraphRepository",
+    "ICoordinationLockRepository",
+    "LockStateSnapshot",
+    "LockWriteResult",
+    "RelationshipRecord",
+    "RebuildCancellationRequestedError",
+    "RebuildJobORM",
+    "RebuildJobStatus",
+    "RegulatoryEventAssetORM",
+    "RegulatoryEventORM",
+    "session_scope",
+]

--- a/src/data/__init__.py
+++ b/src/data/__init__.py
@@ -15,6 +15,7 @@ from .protocols import (
     LockStateSnapshot,
     LockWriteResult,
     RebuildCancellationRequestedError,
+    RebuildFailureDetails,
 )
 from .repository import (
     AssetGraphRepository,
@@ -33,6 +34,7 @@ __all__ = [
     "ICoordinationLockRepository",
     "LockStateSnapshot",
     "LockWriteResult",
+    "RebuildFailureDetails",
     "RelationshipRecord",
     "RebuildCancellationRequestedError",
     "RebuildJobORM",

--- a/src/data/distributed_lock.py
+++ b/src/data/distributed_lock.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 from time import sleep, time
 from typing import Any
@@ -51,7 +51,7 @@ class LockEvent:
     event_type: LockEventType
     lock_name: str
     holder_id: str
-    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
+    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -114,8 +114,9 @@ class DistributedLock:
         holder_id: str | None = None,
         ttl_seconds: int = 300,
     ) -> None:
-        """Create a DistributedLock configured with a database session factory, lock identity,
-        and optional observability hooks.
+        """Create a DistributedLock configured with a database session factory.
+
+        Configure with lock identity and optional observability hooks.
 
         Parameters:
             session_factory (Callable[[], Session] | None): Backward-compatible factory for DB sessions;
@@ -615,7 +616,7 @@ class DistributedLock:
             return LockState.UNKNOWN
 
         if not snapshot.valid:
-            now = datetime.now(UTC)
+            now = datetime.now(timezone.utc)
             if snapshot.expires_at and snapshot.expires_at <= now:
                 return LockState.EXPIRED
             return LockState.UNKNOWN

--- a/src/data/distributed_lock.py
+++ b/src/data/distributed_lock.py
@@ -6,7 +6,7 @@ import logging
 import uuid
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from time import sleep, time
 from typing import Any
@@ -51,7 +51,7 @@ class LockEvent:
     event_type: LockEventType
     lock_name: str
     holder_id: str
-    timestamp: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = field(default_factory=lambda: datetime.now(UTC))
     metadata: dict[str, Any] = field(default_factory=dict)
 
 
@@ -615,7 +615,7 @@ class DistributedLock:
             return LockState.UNKNOWN
 
         if not snapshot.valid:
-            now = datetime.now(timezone.utc)
+            now = datetime.now(UTC)
             if snapshot.expires_at and snapshot.expires_at <= now:
                 return LockState.EXPIRED
             return LockState.UNKNOWN

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -1,0 +1,178 @@
+"""Protocol boundaries for repository-style data access."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Protocol, runtime_checkable
+
+from sqlalchemy.orm import Session
+
+from src.logic.asset_graph import AssetRelationshipGraph
+from src.models.financial_models import Asset, RegulatoryEvent
+
+from .db_models import RebuildJobORM
+from .repository import (
+    LockStateSnapshot,
+    LockWriteResult,
+    RebuildCancellationRequestedError,
+    RelationshipRecord,
+)
+
+
+@runtime_checkable
+class ICoordinationLockRepository(Protocol):
+    """Protocol for distributed lock coordination repositories."""
+
+    session: Session
+
+    def acquire_lock(self, *, lock_name: str, holder_id: str, ttl_seconds: int) -> LockWriteResult:
+        """Docstring."""
+        ...
+
+    def refresh_lock(self, *, lock_name: str, holder_id: str, ttl_seconds: int) -> LockWriteResult:
+        """Docstring."""
+        ...
+
+    def release_lock(self, *, lock_name: str, holder_id: str) -> bool:
+        """Docstring."""
+        ...
+
+    def get_lock_state(self, *, lock_name: str, holder_id: str) -> LockStateSnapshot:
+        """Docstring."""
+        ...
+
+
+@runtime_checkable
+class IAssetGraphRepository(Protocol):
+    """Protocol for asset graph persistence and rebuild-job repositories."""
+
+    session: Session
+
+    def save_graph(self, graph: AssetRelationshipGraph) -> None:
+        """Docstring."""
+        ...
+
+    def load_graph(self) -> AssetRelationshipGraph:
+        """Docstring."""
+        ...
+
+    def replace_assets(self, assets: Iterable[Asset]) -> None:
+        """Docstring."""
+        ...
+
+    def replace_relationships_from_graph(self, relationships: dict[str, list[tuple[str, str, float]]]) -> None:
+        """Docstring."""
+        ...
+
+    def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
+        """Docstring."""
+        ...
+
+    def upsert_asset(self, asset: Asset) -> None:
+        """Docstring."""
+        ...
+
+    def upsert_assets(self, assets: Iterable[Asset]) -> None:
+        """Docstring."""
+        ...
+
+    def list_assets(self) -> list[Asset]:
+        """Docstring."""
+        ...
+
+    def get_assets_map(self) -> dict[str, Asset]:
+        """Docstring."""
+        ...
+
+    def get_asset_by_id(self, asset_id: str) -> Asset | None:
+        """Docstring."""
+        ...
+
+    def delete_asset(self, asset_id: str) -> None:
+        """Docstring."""
+        ...
+
+    def add_or_update_relationship(self, *args: object, **kwargs: object) -> None:
+        """Docstring."""
+        ...
+
+    def list_relationships(self) -> list[RelationshipRecord]:
+        """Docstring."""
+        ...
+
+    def get_relationship(self, source_id: str, target_id: str, rel_type: str) -> RelationshipRecord | None:
+        """Docstring."""
+        ...
+
+    def delete_relationship(self, source_id: str, target_id: str, rel_type: str) -> None:
+        """Docstring."""
+        ...
+
+    def upsert_regulatory_event(self, event: RegulatoryEvent) -> None:
+        """Docstring."""
+        ...
+
+    def list_regulatory_events(self) -> list[RegulatoryEvent]:
+        """Docstring."""
+        ...
+
+    def delete_regulatory_event(self, event_id: str) -> None:
+        """Docstring."""
+        ...
+
+    def create_rebuild_job(self, *, requested_by: str, source: str | None = None) -> str:
+        """Docstring."""
+        ...
+
+    def mark_rebuild_job_running(self, job_id: str, execution_id: str) -> None:
+        """Docstring."""
+        ...
+
+    def mark_rebuild_job_succeeded(
+        self,
+        job_id: str,
+        *,
+        execution_id: str,
+        node_count: int | None = None,
+        edge_count: int | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        """Docstring."""
+        ...
+
+    def mark_rebuild_job_cancel_requested(self, job_id: str) -> None:
+        """Docstring."""
+        ...
+
+    def mark_rebuild_job_cancelled(self, job_id: str, *, execution_id: str) -> None:
+        """Docstring."""
+        ...
+
+    def mark_rebuild_job_failed(
+        self,
+        job_id: str,
+        *,
+        execution_id: str,
+        error: Exception | None = None,
+        sanitized_failure_category: str | None = None,
+        sanitized_failure_message: str | None = None,
+    ) -> None:
+        """Docstring."""
+        ...
+
+    def get_rebuild_job(self, job_id: str) -> RebuildJobORM | None:
+        """Docstring."""
+        ...
+
+    def list_rebuild_jobs(self, *, limit: int | None = None, offset: int = 0) -> list[RebuildJobORM]:
+        """Docstring."""
+        ...
+
+
+__all__ = [
+    "IAssetGraphRepository",
+    "ICoordinationLockRepository",
+    "LockStateSnapshot",
+    "LockWriteResult",
+    "RebuildCancellationRequestedError",
+]

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -14,7 +14,6 @@ from .db_models import RebuildJobORM
 from .repository import (
     LockStateSnapshot,
     LockWriteResult,
-    RebuildCancellationRequestedError,
     RebuildFailureDetails,
     RelationshipRecord,
 )
@@ -193,5 +192,4 @@ __all__ = [
     "ICoordinationLockRepository",
     "LockStateSnapshot",
     "LockWriteResult",
-    "RebuildCancellationRequestedError",
 ]

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -15,6 +15,7 @@ from .repository import (
     LockStateSnapshot,
     LockWriteResult,
     RebuildCancellationRequestedError,
+    RebuildFailureDetails,
     RelationshipRecord,
 )
 
@@ -148,9 +149,7 @@ class IAssetGraphRepository(Protocol):
         """Transition a job to CANCELLED."""
         ...
 
-    def mark_rebuild_job_failed(
-        self, job_id: str, *, execution_id: str | None, failure_category: str, failure_message: str, duration_ms: int
-    ) -> None:
+    def mark_rebuild_job_failed(self, job_id: str, *, execution_id: str | None, details: RebuildFailureDetails) -> None:
         """Transition a job to FAILED and record failure details."""
         ...
 

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -123,7 +123,7 @@ class IAssetGraphRepository(Protocol):
         """Delete a regulatory event."""
         ...
 
-    def create_rebuild_job(self, *, requested_by: str, source: str | None = None) -> RebuildJobORM:
+    def create_rebuild_job(self, *, requested_by: str, source: str | None = None) -> str:
         """Create a new pending rebuild job."""
         ...
 
@@ -158,7 +158,7 @@ class IAssetGraphRepository(Protocol):
         ...
 
     def list_rebuild_jobs(
-        self, *, limit: int = 50, offset: int | None = None, status: str | None = None
+        self, *, limit: int | None = None, offset: int | None = None, status: str | None = None
     ) -> list[RebuildJobORM]:
         """List rebuild jobs, optionally filtered by status."""
         ...

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -93,7 +93,7 @@ class IAssetGraphRepository(Protocol):
         """Delete an asset and cascading relationships/events."""
         ...
 
-    def add_or_update_relationship(
+    def add_or_update_relationship(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self, source_id: str, target_id: str, rel_type: str, strength: float, bidirectional: bool = False
     ) -> None:
         """Create or update an asset relationship and stage it on the repository session."""
@@ -135,7 +135,7 @@ class IAssetGraphRepository(Protocol):
         """Transition a job from PENDING to RUNNING."""
         ...
 
-    def mark_rebuild_job_succeeded(
+    def mark_rebuild_job_succeeded(  # pylint: disable=too-many-arguments
         self, job_id: str, *, execution_id: str, node_count: int, edge_count: int, duration_ms: int
     ) -> None:
         """Transition a job to SUCCEEDED and record metrics."""

--- a/src/data/protocols.py
+++ b/src/data/protocols.py
@@ -26,19 +26,19 @@ class ICoordinationLockRepository(Protocol):
     session: Session
 
     def acquire_lock(self, *, lock_name: str, holder_id: str, ttl_seconds: int) -> LockWriteResult:
-        """Docstring."""
+        """Acquire or refresh a distributed lock in the database."""
         ...
 
     def refresh_lock(self, *, lock_name: str, holder_id: str, ttl_seconds: int) -> LockWriteResult:
-        """Docstring."""
+        """Refresh a distributed lock in the database."""
         ...
 
     def release_lock(self, *, lock_name: str, holder_id: str) -> bool:
-        """Docstring."""
+        """Release a distributed lock if held by the specified holder."""
         ...
 
     def get_lock_state(self, *, lock_name: str, holder_id: str) -> LockStateSnapshot:
-        """Docstring."""
+        """Check the current state of a distributed lock and return a materialized snapshot."""
         ...
 
 
@@ -49,123 +49,143 @@ class IAssetGraphRepository(Protocol):
     session: Session
 
     def save_graph(self, graph: AssetRelationshipGraph) -> None:
-        """Docstring."""
+        """Persist an AssetRelationshipGraph snapshot to the database."""
         ...
 
     def load_graph(self) -> AssetRelationshipGraph:
-        """Docstring."""
+        """Reconstruct an in-memory asset relationship graph from persisted rows."""
         ...
 
     def replace_assets(self, assets: Iterable[Asset]) -> None:
-        """Docstring."""
+        """Replace persisted assets with the supplied collection."""
         ...
 
     def replace_relationships_from_graph(self, relationships: dict[str, list[tuple[str, str, float]]]) -> None:
-        """Docstring."""
+        """Replace all persisted relationships with directed adjacency data."""
         ...
 
     def replace_regulatory_events(self, events: Iterable[RegulatoryEvent]) -> None:
-        """Docstring."""
+        """Replace all persisted regulatory events with the supplied collection."""
         ...
 
     def upsert_asset(self, asset: Asset) -> None:
-        """Docstring."""
+        """Create or update the persistent record for a domain Asset."""
         ...
 
     def upsert_assets(self, assets: Iterable[Asset]) -> None:
-        """Docstring."""
+        """Create or update multiple assets in a single repository session."""
         ...
 
     def list_assets(self) -> list[Asset]:
-        """Docstring."""
+        """Retrieve all assets ordered by id."""
         ...
 
     def get_assets_map(self) -> dict[str, Asset]:
-        """Docstring."""
+        """Return a mapping of asset id to the corresponding Asset domain object."""
         ...
 
     def get_asset_by_id(self, asset_id: str) -> Asset | None:
-        """Docstring."""
+        """Return a single asset by its ID, or None if not found."""
         ...
 
     def delete_asset(self, asset_id: str) -> None:
-        """Docstring."""
+        """Delete an asset and cascading relationships/events."""
         ...
 
-    def add_or_update_relationship(self, *args: object, **kwargs: object) -> None:
-        """Docstring."""
+    def add_or_update_relationship(
+        self, source_id: str, target_id: str, rel_type: str, strength: float, bidirectional: bool = False
+    ) -> None:
+        """Create or update an asset relationship and stage it on the repository session."""
         ...
 
     def list_relationships(self) -> list[RelationshipRecord]:
-        """Docstring."""
+        """Retrieve all persisted relationships."""
         ...
 
     def get_relationship(self, source_id: str, target_id: str, rel_type: str) -> RelationshipRecord | None:
-        """Docstring."""
+        """Return a single relationship by its composite key, or None if not found."""
         ...
 
     def delete_relationship(self, source_id: str, target_id: str, rel_type: str) -> None:
-        """Docstring."""
+        """Delete a relationship by its composite key."""
         ...
 
     def upsert_regulatory_event(self, event: RegulatoryEvent) -> None:
-        """Docstring."""
+        """Create or update a regulatory event."""
         ...
 
     def list_regulatory_events(self) -> list[RegulatoryEvent]:
-        """Docstring."""
+        """Retrieve all regulatory events."""
         ...
 
     def delete_regulatory_event(self, event_id: str) -> None:
-        """Docstring."""
+        """Delete a regulatory event."""
         ...
 
-    def create_rebuild_job(self, *, requested_by: str, source: str | None = None) -> str:
-        """Docstring."""
+    def create_rebuild_job(self, *, requested_by: str, source: str | None = None) -> RebuildJobORM:
+        """Create a new pending rebuild job."""
+        ...
+
+    def update_rebuild_job_source(self, job_id: str, execution_id: str, source: str | None) -> None:
+        """Update the source field of a rebuild job."""
         ...
 
     def mark_rebuild_job_running(self, job_id: str, execution_id: str) -> None:
-        """Docstring."""
+        """Transition a job from PENDING to RUNNING."""
         ...
 
     def mark_rebuild_job_succeeded(
-        self,
-        job_id: str,
-        *,
-        execution_id: str,
-        node_count: int | None = None,
-        edge_count: int | None = None,
-        duration_ms: int | None = None,
+        self, job_id: str, *, execution_id: str, node_count: int, edge_count: int, duration_ms: int
     ) -> None:
-        """Docstring."""
+        """Transition a job to SUCCEEDED and record metrics."""
         ...
 
     def mark_rebuild_job_cancel_requested(self, job_id: str) -> None:
-        """Docstring."""
+        """Mark a job for cancellation."""
         ...
 
     def mark_rebuild_job_cancelled(self, job_id: str, *, execution_id: str) -> None:
-        """Docstring."""
+        """Transition a job to CANCELLED."""
         ...
 
     def mark_rebuild_job_failed(
-        self,
-        job_id: str,
-        *,
-        execution_id: str,
-        error: Exception | None = None,
-        sanitized_failure_category: str | None = None,
-        sanitized_failure_message: str | None = None,
+        self, job_id: str, *, execution_id: str | None, failure_category: str, failure_message: str, duration_ms: int
     ) -> None:
-        """Docstring."""
+        """Transition a job to FAILED and record failure details."""
         ...
 
     def get_rebuild_job(self, job_id: str) -> RebuildJobORM | None:
-        """Docstring."""
+        """Retrieve a rebuild job by its ID."""
         ...
 
-    def list_rebuild_jobs(self, *, limit: int | None = None, offset: int = 0) -> list[RebuildJobORM]:
-        """Docstring."""
+    def list_rebuild_jobs(
+        self, *, limit: int = 50, offset: int | None = None, status: str | None = None
+    ) -> list[RebuildJobORM]:
+        """List rebuild jobs, optionally filtered by status."""
+        ...
+
+    def get_latest_successful_rebuild_job(self) -> RebuildJobORM | None:
+        """Return the most recently completed SUCCEEDED job."""
+        ...
+
+    def update_rebuild_heartbeat(self, job_id: str, execution_id: str, worker_id: str) -> None:
+        """Update the heartbeat timestamp for a running rebuild job."""
+        ...
+
+    def update_rebuild_checkpoint(self, job_id: str, execution_id: str, data: str | None) -> None:
+        """Save an intermediate checkpoint for a running rebuild job."""
+        ...
+
+    def get_active_rebuild_state(self) -> RebuildJobORM | None:
+        """Return the currently RUNNING or CANCEL_REQUESTED job, if any."""
+        ...
+
+    def get_last_successful_rebuild(self) -> RebuildJobORM | None:
+        """Return the most recently completed SUCCEEDED job."""
+        ...
+
+    def get_latest_rebuild_job(self) -> RebuildJobORM | None:
+        """Return the most recently created rebuild job."""
         ...
 
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -275,7 +275,7 @@ def session_scope(
         session.close()
 
 
-@dataclass
+@dataclass(frozen=True, slots=True)
 class RebuildFailureDetails:
     """Encapsulates failure metadata for a rebuild job."""
 

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -276,6 +276,15 @@ def session_scope(
 
 
 @dataclass
+class RebuildFailureDetails:
+    """Encapsulates failure metadata for a rebuild job."""
+
+    failure_category: str
+    failure_message: str
+    duration_ms: int
+
+
+@dataclass
 class RelationshipRecord:
     """Lightweight relationship representation returned by the repository."""
 
@@ -1400,9 +1409,7 @@ class AssetGraphRepository:
         job_id: str,
         *,
         execution_id: str | None,
-        failure_category: str,
-        failure_message: str,
-        duration_ms: int,
+        details: RebuildFailureDetails,
     ) -> None:
         """
         Mark rebuild job as failed and persist sanitized failure metadata atomatically.
@@ -1419,10 +1426,10 @@ class AssetGraphRepository:
                 execution_id mismatches, or failure metadata exceeds bounds.
         """
         self._validate_failure_metadata(
-            failure_category=failure_category,
-            failure_message=failure_message,
+            failure_category=details.failure_category,
+            failure_message=details.failure_message,
         )
-        self._validate_non_negative_metrics(duration_ms=duration_ms)
+        self._validate_non_negative_metrics(duration_ms=details.duration_ms)
 
         # Flush any pending ORM changes to ensure UPDATE sees current state
         self.session.flush()
@@ -1447,9 +1454,9 @@ class AssetGraphRepository:
                 status=RebuildJobStatus.FAILED,
                 completed_at=now,
                 updated_at=now,
-                sanitized_failure_category=failure_category,
-                sanitized_failure_message=failure_message,
-                duration_ms=duration_ms,
+                sanitized_failure_category=details.failure_category,
+                sanitized_failure_message=details.failure_message,
+                duration_ms=details.duration_ms,
             )
         )
         result = self.session.execute(stmt)

--- a/src/logic/rebuild_drift_evaluator.py
+++ b/src/logic/rebuild_drift_evaluator.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from sqlalchemy.exc import SQLAlchemyError
@@ -201,7 +201,7 @@ class RebuildDriftEvaluator:
             # Ensure timezone-aware
             # Note: Assumes DB returns UTC-naive datetimes or timezone-aware UTC datetimes
             if heartbeat_time.tzinfo is None:
-                heartbeat_time = heartbeat_time.replace(tzinfo=timezone.utc)
+                heartbeat_time = heartbeat_time.replace(tzinfo=UTC)
             return heartbeat_time
         except (ValueError, AttributeError, TypeError):
             # Unparseable heartbeat treated as None (caller will treat as stale).
@@ -231,7 +231,7 @@ class RebuildDriftEvaluator:
         if heartbeat_time is None:
             return True  # Missing or unparseable is considered stale
 
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         heartbeat_age_seconds = (now - heartbeat_time).total_seconds()
         return heartbeat_age_seconds >= self.lock_ttl_seconds
 

--- a/src/logic/rebuild_failure_detection.py
+++ b/src/logic/rebuild_failure_detection.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
@@ -42,7 +42,7 @@ def _to_aware_utc(value: datetime) -> datetime:
     this normalization would misinterpret the instant.
     """
     if value.tzinfo is None:
-        return value.replace(tzinfo=timezone.utc)
+        return value.replace(tzinfo=UTC)
     return value
 
 
@@ -76,7 +76,7 @@ def detect_stale_ownership(
         # Running without any heartbeat is stale
         return True
 
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
     heartbeat_at = _to_aware_utc(job.last_heartbeat_at)
     age = current_time - heartbeat_at
     return age.total_seconds() > ttl_seconds
@@ -140,7 +140,7 @@ def detect_crash_suspicion(
         # Worker assigned but never heartbeat - suspicious
         return True
 
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
     heartbeat_at = _to_aware_utc(job.last_heartbeat_at)
     age = current_time - heartbeat_at
     return age.total_seconds() > heartbeat_stale_threshold_seconds
@@ -271,7 +271,7 @@ def detect_rebuild_inconsistency(
     Returns:
         RebuildInconsistency describing the detected issue or NONE.
     """
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
     heartbeat_threshold = heartbeat_threshold_seconds if heartbeat_threshold_seconds is not None else lock_ttl_seconds
 
     # No job in DB - check if runtime thinks it's running

--- a/src/logic/rebuild_failure_detection.py
+++ b/src/logic/rebuild_failure_detection.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 from enum import Enum
 
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
@@ -42,7 +42,7 @@ def _to_aware_utc(value: datetime) -> datetime:
     this normalization would misinterpret the instant.
     """
     if value.tzinfo is None:
-        return value.replace(tzinfo=UTC)
+        return value.replace(tzinfo=timezone.utc)
     return value
 
 
@@ -76,7 +76,7 @@ def detect_stale_ownership(
         # Running without any heartbeat is stale
         return True
 
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
     heartbeat_at = _to_aware_utc(job.last_heartbeat_at)
     age = current_time - heartbeat_at
     return age.total_seconds() > ttl_seconds
@@ -140,7 +140,7 @@ def detect_crash_suspicion(
         # Worker assigned but never heartbeat - suspicious
         return True
 
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
     heartbeat_at = _to_aware_utc(job.last_heartbeat_at)
     age = current_time - heartbeat_at
     return age.total_seconds() > heartbeat_stale_threshold_seconds
@@ -271,7 +271,7 @@ def detect_rebuild_inconsistency(
     Returns:
         RebuildInconsistency describing the detected issue or NONE.
     """
-    current_time = _to_aware_utc(now) if now is not None else datetime.now(UTC)
+    current_time = _to_aware_utc(now) if now is not None else datetime.now(timezone.utc)
     heartbeat_threshold = heartbeat_threshold_seconds if heartbeat_threshold_seconds is not None else lock_ttl_seconds
 
     # No job in DB - check if runtime thinks it's running

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -11,7 +11,7 @@ from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy.orm import Session
 
 from src.data.distributed_lock import DistributedLock, LockAcquisitionTimeout, LockState
-from src.data.repository import AssetGraphRepository
+from src.data.repository import AssetGraphRepository, RebuildFailureDetails
 from src.logic.rebuild_drift_evaluator import RebuildDriftEvaluator
 from src.logic.rebuild_failure_detection import InconsistencyType
 from src.logic.reconciliation_engine import (
@@ -145,7 +145,7 @@ class RecoveryGate:
         import src.logic.rebuild_drift_evaluator as drift_evaluator_module
 
         orig_repo = getattr(drift_evaluator_module, "AssetGraphRepository", None)
-        setattr(drift_evaluator_module, "AssetGraphRepository", AssetGraphRepository)
+        drift_evaluator_module.AssetGraphRepository = AssetGraphRepository
 
         try:
             try:
@@ -165,7 +165,7 @@ class RecoveryGate:
                 return self._create_unsafe_plan_from_error(exc, "unexpected error during rebuild state query", "error")
         finally:
             if orig_repo is not None:
-                setattr(drift_evaluator_module, "AssetGraphRepository", orig_repo)
+                drift_evaluator_module.AssetGraphRepository = orig_repo
 
         if increment_metric and plan.drift_type != InconsistencyType.NONE.value:
             # Handle possible conversion errors if drift_type isn't an InconsistencyType enum value
@@ -382,9 +382,11 @@ class RecoveryGate:
                 repo.mark_rebuild_job_failed(
                     active_job.job_id,
                     execution_id=active_job.execution_id,
-                    failure_category="recovery_reset",
-                    failure_message="Recovered from orphaned state by RecoveryGate",
-                    duration_ms=0,
+                    details=RebuildFailureDetails(
+                        failure_category="recovery_reset",
+                        failure_message="Recovered from orphaned state by RecoveryGate",
+                        duration_ms=0,
+                    ),
                 )
                 session.commit()
                 log_event(

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -145,7 +145,7 @@ class RecoveryGate:
         import src.logic.rebuild_drift_evaluator as drift_evaluator_module
 
         orig_repo = getattr(drift_evaluator_module, "AssetGraphRepository", None)
-        drift_evaluator_module.AssetGraphRepository = AssetGraphRepository
+        drift_evaluator_module.AssetGraphRepository = AssetGraphRepository  # type: ignore[misc]
 
         try:
             try:
@@ -165,7 +165,7 @@ class RecoveryGate:
                 return self._create_unsafe_plan_from_error(exc, "unexpected error during rebuild state query", "error")
         finally:
             if orig_repo is not None:
-                drift_evaluator_module.AssetGraphRepository = orig_repo
+                drift_evaluator_module.AssetGraphRepository = orig_repo  # type: ignore[misc]
 
         if increment_metric and plan.drift_type != InconsistencyType.NONE.value:
             # Handle possible conversion errors if drift_type isn't an InconsistencyType enum value

--- a/src/observability/context.py
+++ b/src/observability/context.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import contextlib
 import re
+from collections.abc import AsyncIterator, Iterator
 from contextvars import ContextVar
-from typing import TYPE_CHECKING, AsyncIterator, Iterator
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from contextvars import Token

--- a/src/reports/schema_report.py
+++ b/src/reports/schema_report.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -349,7 +349,7 @@ def generate_schema_report(graph: AssetRelationshipGraph) -> str:
     lines: list[str] = [
         "# Financial Asset Relationship Database Schema & Rules",
         "",
-        f"Generated: {datetime.now(timezone.utc).strftime('%Y-%m-%d')}",
+        f"Generated: {datetime.now(UTC).strftime('%Y-%m-%d')}",
         "",
         "## Schema Overview",
         "",

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests package."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ os.environ["ADMIN_EMAIL"] = "admin@example.com"
 os.environ["ADMIN_FULL_NAME"] = "Test Admin"
 os.environ["ADMIN_DISABLED"] = "false"
 
-from datetime import UTC  # noqa: E402
+from datetime import timezone  # noqa: E402
 
 from src.logic.asset_graph import AssetRelationshipGraph  # noqa: E402
 from src.models.financial_models import (  # noqa: E402
@@ -311,7 +311,7 @@ def mock_rebuild_job():
         if status is None:
             status = RebuildJobStatus.RUNNING
         if heartbeat_at is None:
-            heartbeat_at = datetime.now(UTC)
+            heartbeat_at = datetime.now(timezone.utc)
 
         job = Mock()
         job.job_id = job_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ os.environ["ADMIN_EMAIL"] = "admin@example.com"
 os.environ["ADMIN_FULL_NAME"] = "Test Admin"
 os.environ["ADMIN_DISABLED"] = "false"
 
-from datetime import UTC
+from datetime import UTC  # noqa: E402
 
 from src.logic.asset_graph import AssetRelationshipGraph  # noqa: E402
 from src.models.financial_models import (  # noqa: E402
@@ -187,20 +187,20 @@ def _reset_graph():
     yield
 
 
+def _set_sqlite_pragma(dbapi_connection: Any, _connection_record: Any) -> None:
+    """Execute PRAGMA foreign_keys=ON for an SQLite connection."""
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
 def enable_sqlite_foreign_keys(engine: Engine) -> None:
     """Ensure SQLite engines enforce foreign-key constraints in tests."""
     if engine.url.get_backend_name() != "sqlite":
         return
 
-    if getattr(engine, "_sqlite_fk_enabled", False):
-        return
-    engine._sqlite_fk_enabled = True  # type: ignore[attr-defined]
-
-    @event.listens_for(engine, "connect")
-    def _set_sqlite_pragma(dbapi_connection: Any, _connection_record: Any) -> None:
-        cursor = dbapi_connection.cursor()
-        cursor.execute("PRAGMA foreign_keys=ON")
-        cursor.close()
+    if not event.contains(engine, "connect", _set_sqlite_pragma):
+        event.listen(engine, "connect", _set_sqlite_pragma)
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
 
 # Ensure a clean SQLite database for the authentication layer before any modules import it.
 _db_path = Path(__file__).resolve().parent / "test_auth.db"
@@ -181,6 +183,18 @@ def _reset_graph():
 
     reset_graph()
     yield
+
+
+def enable_sqlite_foreign_keys(engine: Engine) -> None:
+    """Ensure SQLite engines enforce foreign-key constraints in tests."""
+    if engine.url.get_backend_name() != "sqlite":
+        return
+
+    @event.listens_for(engine, "connect")
+    def _set_sqlite_pragma(dbapi_connection: Any, _connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        cursor.close()
 
 
 def pytest_addoption(parser: Any) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -190,6 +190,10 @@ def enable_sqlite_foreign_keys(engine: Engine) -> None:
     if engine.url.get_backend_name() != "sqlite":
         return
 
+    if getattr(engine, "_sqlite_fk_enabled", False):
+        return
+    engine._sqlite_fk_enabled = True  # type: ignore[attr-defined]
+
     @event.listens_for(engine, "connect")
     def _set_sqlite_pragma(dbapi_connection: Any, _connection_record: Any) -> None:
         cursor = dbapi_connection.cursor()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,8 @@ os.environ["ADMIN_EMAIL"] = "admin@example.com"
 os.environ["ADMIN_FULL_NAME"] = "Test Admin"
 os.environ["ADMIN_DISABLED"] = "false"
 
+from datetime import UTC
+
 from src.logic.asset_graph import AssetRelationshipGraph  # noqa: E402
 from src.models.financial_models import (  # noqa: E402
     AssetClass,
@@ -295,7 +297,7 @@ def mock_lock():
 @pytest.fixture
 def mock_rebuild_job():
     """Create mock rebuild jobs with specific configurations."""
-    from datetime import datetime, timezone
+    from datetime import datetime
     from unittest.mock import Mock
 
     from src.data.db_models import RebuildJobStatus
@@ -309,7 +311,7 @@ def mock_rebuild_job():
         if status is None:
             status = RebuildJobStatus.RUNNING
         if heartbeat_at is None:
-            heartbeat_at = datetime.now(timezone.utc)
+            heartbeat_at = datetime.now(UTC)
 
         job = Mock()
         job.job_id = job_id

--- a/tests/integration/test_graph_admin_router.py
+++ b/tests/integration/test_graph_admin_router.py
@@ -33,7 +33,7 @@ from api.auth import (
 from api.graph_lifecycle import reset_graph
 from src.config.settings import get_settings
 from src.data.database import create_engine_from_url, create_session_factory, init_db
-from src.data.repository import AssetGraphRepository, session_scope
+from src.data.repository import AssetGraphRepository, RebuildFailureDetails, session_scope
 
 pytestmark = pytest.mark.integration
 
@@ -649,9 +649,9 @@ def test_get_rebuild_job_exposes_sanitized_failure_fields(
             repo.mark_rebuild_job_failed(
                 job_id,
                 execution_id=execution_id,
-                failure_category="database_error",
-                failure_message="Connection timeout",
-                duration_ms=2000,
+                details=RebuildFailureDetails(
+                    failure_category="database_error", failure_message="Connection timeout", duration_ms=2000
+                ),
             )
 
         response = operator_client.get(f"/api/graph/rebuild/jobs/{job_id}")

--- a/tests/integration/test_graph_rebuild_cancellation.py
+++ b/tests/integration/test_graph_rebuild_cancellation.py
@@ -6,7 +6,6 @@ import threading
 import time
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -421,7 +421,7 @@ async def test_lock_ttl_with_job_status_tracking(session_factory_provider, monke
 
         mock_repo.mark_rebuild_job_failed.assert_called_once()
         call_args = mock_repo.mark_rebuild_job_failed.call_args
-        error_msg = call_args[1].get("failure_message", call_args[0][2] if len(call_args[0]) > 2 else "")
+        error_msg = call_args[1]["details"].failure_message
         assert "Lock lease expired" in error_msg
 
 

--- a/tests/integration/test_rebuild_checkpoint_resume.py
+++ b/tests/integration/test_rebuild_checkpoint_resume.py
@@ -3,9 +3,9 @@
 import json
 import threading
 import time
+from collections.abc import AsyncGenerator, Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import AsyncGenerator, Iterator
 from unittest.mock import MagicMock, patch
 
 import httpx

--- a/tests/unit/api/middleware/test_correlation.py
+++ b/tests/unit/api/middleware/test_correlation.py
@@ -3,7 +3,7 @@
 import asyncio
 import re
 import uuid
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from fastapi import FastAPI, Request

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from datetime import UTC
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -242,7 +243,6 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     monkeypatch.setattr("src.logic.rebuild_drift_evaluator.RebuildDriftEvaluator", MagicMock())
 
     # Mock ReconciliationEngine to return a reset plan with automatic execution mode
-    from datetime import timezone
 
     mock_plan = ReconciliationPlan(
         drift_type="orphaned_running",
@@ -253,7 +253,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="test reset",
         metadata={},
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
     class FakeEngine:

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import UTC
+from datetime import timezone
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -253,7 +253,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="test reset",
         metadata={},
-        created_at=datetime.now(UTC),
+        created_at=datetime.now(timezone.utc),
     )
 
     class FakeEngine:

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -10,7 +10,7 @@ This module tests:
 """
 
 import os
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -952,7 +952,7 @@ class TestGetCurrentUserEdgeCases:
         from api.auth import ALGORITHM, SECRET_KEY
 
         # Create token without 'sub'
-        token_data = {"exp": datetime.now(timezone.utc) + timedelta(minutes=30)}
+        token_data = {"exp": datetime.now(UTC) + timedelta(minutes=30)}
         token = jwt.encode(token_data, SECRET_KEY, algorithm=ALGORITHM)
 
         with pytest.raises(HTTPException) as exc_info:

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -343,7 +343,7 @@ def test_get_json_reports_invalid_json_with_endpoint_only(monkeypatch: pytest.Mo
 
         status = 200
 
-        def __enter__(self) -> FakeResponse:
+        def __enter__(self) -> "FakeResponse":
             """Enter the fake response context."""
             return self
 
@@ -355,7 +355,7 @@ def test_get_json_reports_invalid_json_with_endpoint_only(monkeypatch: pytest.Mo
             """Return invalid JSON bytes."""
             return b"not-json"
 
-    def fake_urlopen(request: object, timeout: float) -> FakeResponse:
+    def fake_urlopen(request: object, timeout: float) -> "FakeResponse":
         """Return a fake response with invalid JSON."""
         return FakeResponse()
 

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -343,7 +343,7 @@ def test_get_json_reports_invalid_json_with_endpoint_only(monkeypatch: pytest.Mo
 
         status = 200
 
-        def __enter__(self) -> "FakeResponse":
+        def __enter__(self) -> FakeResponse:
             """Enter the fake response context."""
             return self
 

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -9,7 +9,7 @@ This module contains comprehensive unit tests for the database models including:
 - Model field validation and nullable constraints
 """
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 
 import pytest
 from sqlalchemy import create_engine, inspect
@@ -981,7 +981,7 @@ class TestRebuildJobORM:
 
     def test_rebuild_job_invalid_status_fails_db_check_constraint(self, db_session):
         """Test that invalid statuses are rejected by the database CHECK constraint."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         job = RebuildJobORM(
             job_id="invalid-status",
             requested_by="test_user",
@@ -996,7 +996,7 @@ class TestRebuildJobORM:
 
     def test_rebuild_job_cancel_statuses_round_trip(self, db_session):
         """Test that cancel-requested and cancelled statuses round-trip correctly."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         cancel_requested = RebuildJobORM(
             job_id="cancel-requested",
             requested_by="test_user",
@@ -1049,7 +1049,7 @@ class TestDistributedLockORM:
 
     def test_distributed_lock_crud_and_timestamp_round_trip(self, db_session):
         """Test distributed lock CRUD and timestamp persistence."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         lock = DistributedLockORM(
             lock_name="test-lock",
             holder_id="holder-1",

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -15,7 +15,6 @@ import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import IntegrityError
 
-from conftest import enable_sqlite_foreign_keys
 from src.data.database import create_session_factory, init_db
 from src.data.db_models import (
     AssetORM,
@@ -26,6 +25,7 @@ from src.data.db_models import (
     RegulatoryEventAssetORM,
     RegulatoryEventORM,
 )
+from tests.conftest import enable_sqlite_foreign_keys
 
 pytest.importorskip("sqlalchemy")
 

--- a/tests/unit/test_db_models.py
+++ b/tests/unit/test_db_models.py
@@ -15,10 +15,12 @@ import pytest
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.exc import IntegrityError
 
+from conftest import enable_sqlite_foreign_keys
 from src.data.database import create_session_factory, init_db
 from src.data.db_models import (
     AssetORM,
     AssetRelationshipORM,
+    DistributedLockORM,
     RebuildJobORM,
     RebuildJobStatus,
     RegulatoryEventAssetORM,
@@ -43,6 +45,7 @@ def db_session(tmp_path):
     """
     db_path = tmp_path / "test.db"
     engine = create_engine(f"sqlite:///{db_path}")
+    enable_sqlite_foreign_keys(engine)
     init_db(engine)
     factory = create_session_factory(engine)
     session = factory()
@@ -331,7 +334,7 @@ class TestAssetRelationshipORM:
             db_session.commit()
 
     def test_relationship_cascade_delete(self, db_session):
-        """Test that relationships are deleted when assets are deleted."""
+        """Test that relationships are deleted by the database when assets are deleted."""
         asset1 = AssetORM(
             id="CASCADE1",
             symbol="C1",
@@ -362,13 +365,63 @@ class TestAssetRelationshipORM:
         db_session.add(rel)
         db_session.commit()
 
-        # Delete source asset
-        db_session.delete(asset1)
+        # Delete source asset using raw SQL so the cascade is enforced by the database.
+        db_session.execute(AssetORM.__table__.delete().where(AssetORM.id == "CASCADE1"))
         db_session.commit()
 
         # Relationship should be deleted
         remaining = db_session.query(AssetRelationshipORM).filter_by(source_asset_id="CASCADE1").first()
         assert remaining is None
+
+    def test_relationship_cascade_delete_on_target_asset(self, db_session):
+        """Test that target-side cascades are enforced by the database."""
+        source = AssetORM(
+            id="TARGET_SRC",
+            symbol="TS",
+            name="Target Source",
+            asset_class="equity",
+            sector="Tech",
+            price=100.0,
+            currency="USD",
+        )
+        target = AssetORM(
+            id="TARGET_DST",
+            symbol="TD",
+            name="Target Destination",
+            asset_class="equity",
+            sector="Tech",
+            price=200.0,
+            currency="USD",
+        )
+        db_session.add_all([source, target])
+        db_session.commit()
+
+        relationship = AssetRelationshipORM(
+            source_asset_id="TARGET_SRC",
+            target_asset_id="TARGET_DST",
+            relationship_type="target_cascade",
+            strength=0.5,
+        )
+        db_session.add(relationship)
+        db_session.commit()
+
+        db_session.execute(AssetORM.__table__.delete().where(AssetORM.id == "TARGET_DST"))
+        db_session.commit()
+
+        assert db_session.query(AssetRelationshipORM).filter_by(source_asset_id="TARGET_SRC").first() is None
+
+    def test_foreign_key_violation_requires_enforcement(self, db_session):
+        """Test that FK violations fail when SQLite foreign keys are enabled."""
+        relationship = AssetRelationshipORM(
+            source_asset_id="missing-source",
+            target_asset_id="missing-target",
+            relationship_type="invalid_fk",
+            strength=0.5,
+        )
+        db_session.add(relationship)
+
+        with pytest.raises(IntegrityError):
+            db_session.commit()
 
     def test_bidirectional_flag(self, db_session):
         """Test bidirectional flag on relationships."""
@@ -443,6 +496,42 @@ class TestAssetRelationshipORM:
         relationships = db_session.query(AssetRelationshipORM).filter_by(source_asset_id="STRENGTH1").all()
         assert len(relationships) == 3
 
+    def test_relationship_strength_boundary_values(self, db_session):
+        """Test that the database round-trips strength boundary values."""
+        asset1 = AssetORM(
+            id="BOUNDARY1",
+            symbol="B1",
+            name="Boundary 1",
+            asset_class="equity",
+            sector="Tech",
+            price=100.0,
+            currency="USD",
+        )
+        asset2 = AssetORM(
+            id="BOUNDARY2",
+            symbol="B2",
+            name="Boundary 2",
+            asset_class="equity",
+            sector="Tech",
+            price=200.0,
+            currency="USD",
+        )
+        db_session.add_all([asset1, asset2])
+        db_session.commit()
+
+        for strength in [0.0, 1.0, -1.0]:
+            rel = AssetRelationshipORM(
+                source_asset_id="BOUNDARY1",
+                target_asset_id="BOUNDARY2",
+                relationship_type=f"boundary_{strength}",
+                strength=strength,
+            )
+            db_session.add(rel)
+        db_session.commit()
+
+        relationships = db_session.query(AssetRelationshipORM).filter_by(source_asset_id="BOUNDARY1").all()
+        assert {rel.strength for rel in relationships} == {0.0, 1.0, -1.0}
+
 
 @pytest.mark.unit
 class TestRegulatoryEventORM:
@@ -516,6 +605,35 @@ class TestRegulatoryEventORM:
         # Event should be deleted
         remaining = db_session.query(RegulatoryEventORM).filter_by(id="EVENT_002").first()
         assert remaining is None
+
+    def test_regulatory_event_related_assets_empty_round_trip(self, db_session):
+        """Test that events with no related assets persist cleanly."""
+        asset = AssetORM(
+            id="EMPTY_EVENT_ASSET",
+            symbol="EE",
+            name="Empty Event Asset",
+            asset_class="equity",
+            sector="Tech",
+            price=100.0,
+            currency="USD",
+        )
+        db_session.add(asset)
+        db_session.commit()
+
+        event = RegulatoryEventORM(
+            id="EMPTY_EVENT",
+            asset_id="EMPTY_EVENT_ASSET",
+            event_type="SEC_FILING",
+            date="2024-01-01",
+            description="No related assets",
+            impact_score=0.1,
+        )
+        db_session.add(event)
+        db_session.commit()
+
+        retrieved = db_session.query(RegulatoryEventORM).filter_by(id="EMPTY_EVENT").first()
+        assert retrieved is not None
+        assert retrieved.related_assets == []
 
     def test_regulatory_event_with_related_assets(self, db_session):
         """Test regulatory event with related assets."""
@@ -860,3 +978,104 @@ class TestRebuildJobORM:
         assert retrieved.duration_ms == 1000
         assert retrieved.node_count == 50
         assert retrieved.edge_count == 100
+
+    def test_rebuild_job_invalid_status_fails_db_check_constraint(self, db_session):
+        """Test that invalid statuses are rejected by the database CHECK constraint."""
+        now = datetime.now(timezone.utc)
+        job = RebuildJobORM(
+            job_id="invalid-status",
+            requested_by="test_user",
+            status="definitely_invalid",
+            created_at=now,
+            updated_at=now,
+        )
+        db_session.add(job)
+
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+
+    def test_rebuild_job_cancel_statuses_round_trip(self, db_session):
+        """Test that cancel-requested and cancelled statuses round-trip correctly."""
+        now = datetime.now(timezone.utc)
+        cancel_requested = RebuildJobORM(
+            job_id="cancel-requested",
+            requested_by="test_user",
+            status=RebuildJobStatus.CANCEL_REQUESTED,
+            created_at=now,
+            updated_at=now,
+            cancellation_requested_at=now,
+        )
+        cancelled = RebuildJobORM(
+            job_id="cancelled",
+            requested_by="test_user",
+            status=RebuildJobStatus.CANCELLED,
+            created_at=now,
+            updated_at=now,
+            completed_at=now,
+        )
+        db_session.add_all([cancel_requested, cancelled])
+        db_session.commit()
+
+        retrieved_requested = db_session.query(RebuildJobORM).filter_by(job_id="cancel-requested").first()
+        retrieved_cancelled = db_session.query(RebuildJobORM).filter_by(job_id="cancelled").first()
+
+        assert retrieved_requested is not None
+        assert retrieved_requested.status == RebuildJobStatus.CANCEL_REQUESTED
+        assert retrieved_requested.cancellation_requested_at == now.replace(tzinfo=None)
+        assert retrieved_cancelled is not None
+        assert retrieved_cancelled.status == RebuildJobStatus.CANCELLED
+
+    def test_rebuild_job_recovery_columns_exist_after_init_db(self, tmp_path):
+        """Test that migration-added recovery columns are present after init_db."""
+        db_path = tmp_path / "rebuild_columns.db"
+        engine = create_engine(f"sqlite:///{db_path}")
+        enable_sqlite_foreign_keys(engine)
+        init_db(engine)
+
+        try:
+            inspector = inspect(engine)
+            columns = {column["name"] for column in inspector.get_columns("rebuild_jobs")}
+        finally:
+            engine.dispose()
+
+        assert {"active_worker_id", "last_heartbeat_at", "checkpoint_data", "cancellation_requested_at"}.issubset(
+            columns
+        )
+
+
+@pytest.mark.unit
+class TestDistributedLockORM:
+    """Test cases for DistributedLockORM model."""
+
+    def test_distributed_lock_crud_and_timestamp_round_trip(self, db_session):
+        """Test distributed lock CRUD and timestamp persistence."""
+        now = datetime.now(timezone.utc)
+        lock = DistributedLockORM(
+            lock_name="test-lock",
+            holder_id="holder-1",
+            expires_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db_session.add(lock)
+        db_session.commit()
+
+        retrieved = db_session.query(DistributedLockORM).filter_by(lock_name="test-lock").first()
+        assert retrieved is not None
+        assert retrieved.holder_id == "holder-1"
+        assert retrieved.created_at == now.replace(tzinfo=None)
+        assert retrieved.updated_at == now.replace(tzinfo=None)
+        assert retrieved.expires_at == now.replace(tzinfo=None)
+
+        retrieved.holder_id = "holder-2"
+        retrieved.updated_at = now.replace(microsecond=123456)
+        db_session.commit()
+
+        updated = db_session.query(DistributedLockORM).filter_by(lock_name="test-lock").first()
+        assert updated is not None
+        assert updated.holder_id == "holder-2"
+        assert updated.updated_at == now.replace(tzinfo=None, microsecond=123456)
+
+        db_session.delete(updated)
+        db_session.commit()
+        assert db_session.query(DistributedLockORM).filter_by(lock_name="test-lock").first() is None

--- a/tests/unit/test_graph_admin_typed_lock_ttl.py
+++ b/tests/unit/test_graph_admin_typed_lock_ttl.py
@@ -10,7 +10,7 @@ import ast
 import functools
 import threading
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -118,7 +118,7 @@ def test_perform_rebuild_uses_typed_lock_ttl_for_distributed_lock(
     monkeypatch.setattr(
         graph_admin,
         "_create_and_start_rebuild_job",
-        lambda *_args, **_kwargs: ("job-typed-ttl", datetime.now(timezone.utc)),
+        lambda *_args, **_kwargs: ("job-typed-ttl", datetime.now(UTC)),
     )
 
     @contextmanager

--- a/tests/unit/test_rebuild_drift_evaluator.py
+++ b/tests/unit/test_rebuild_drift_evaluator.py
@@ -1,6 +1,6 @@
 """Tests for RebuildDriftEvaluator integration with ReconciliationEngine."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -78,7 +78,7 @@ class TestRebuildDriftEvaluator:
                 job_id=f"test-job-{test_description}",
                 status=job_status,
                 active_worker_id="worker-456" if job_status == RebuildJobStatus.RUNNING else None,
-                heartbeat_at=datetime.now(timezone.utc),
+                heartbeat_at=datetime.now(UTC),
             )
             mock_repo.get_active_rebuild_state.return_value = job
 
@@ -104,7 +104,7 @@ class TestRebuildDriftEvaluator:
         session_factory, _ = mock_session_factory
         mock_lock.check_state.return_value = LockState.VALID
 
-        old_heartbeat = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        old_heartbeat = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
         job = mock_rebuild_job(
             job_id="test-job-stale",
             status=RebuildJobStatus.RUNNING,
@@ -135,7 +135,7 @@ class TestRebuildDriftEvaluator:
         session_factory, _ = mock_session_factory
         mock_lock.check_state.return_value = LockState.EXPIRED
 
-        old_heartbeat = datetime(2024, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        old_heartbeat = datetime(2024, 1, 1, 0, 0, 0, tzinfo=UTC)
         job = mock_rebuild_job(
             job_id="test-job-stale-owner",
             status=RebuildJobStatus.RUNNING,
@@ -187,7 +187,7 @@ class TestRebuildDriftEvaluator:
         session_factory, _ = mock_session_factory
         mock_lock.check_state.return_value = LockState.VALID
 
-        heartbeat_time = datetime.now(timezone.utc)
+        heartbeat_time = datetime.now(UTC)
         job = mock_rebuild_job(
             job_id="test-job-details",
             status=RebuildJobStatus.RUNNING,

--- a/tests/unit/test_rebuild_failure_detection.py
+++ b/tests/unit/test_rebuild_failure_detection.py
@@ -1,6 +1,6 @@
 """Unit tests for rebuild failure detection logic (Stage 5C.1)."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -17,7 +17,7 @@ from src.logic.rebuild_failure_detection import (
 @pytest.fixture
 def running_job():
     """Create a running rebuild job for testing."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return RebuildJobORM(
         job_id="test-job-1",
         requested_by="operator@example.com",
@@ -31,7 +31,7 @@ def running_job():
 @pytest.fixture
 def pending_job():
     """Create a pending rebuild job for testing."""
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     return RebuildJobORM(
         job_id="test-job-2",
         requested_by="operator@example.com",
@@ -55,25 +55,25 @@ class TestDetectStaleOwnership:
 
     def test_returns_true_when_heartbeat_exceeds_ttl(self, running_job):
         """Running job with old heartbeat is stale."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.last_heartbeat_at = now - timedelta(seconds=400)
         assert detect_stale_ownership(running_job, ttl_seconds=300, now=now) is True
 
     def test_handles_naive_heartbeat_timestamp(self, running_job):
         """Naive SQLite heartbeat timestamps are normalized before comparison."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.last_heartbeat_at = (now - timedelta(seconds=400)).replace(tzinfo=None)
         assert detect_stale_ownership(running_job, ttl_seconds=300, now=now) is True
 
     def test_returns_false_when_heartbeat_within_ttl(self, running_job):
         """Running job with recent heartbeat is not stale."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.last_heartbeat_at = now - timedelta(seconds=100)
         assert detect_stale_ownership(running_job, ttl_seconds=300, now=now) is False
 
     def test_boundary_condition_at_exactly_ttl(self, running_job):
         """Heartbeat exactly at TTL threshold is not stale."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.last_heartbeat_at = now - timedelta(seconds=300)
         # At exactly TTL, age equals TTL, should NOT be stale (>= would make it stale)
         assert detect_stale_ownership(running_job, ttl_seconds=300, now=now) is False
@@ -121,7 +121,7 @@ class TestDetectCrashSuspicion:
 
     def test_returns_true_when_heartbeat_exceeds_threshold(self, running_job):
         """Worker with stale heartbeat indicates crash."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = now - timedelta(seconds=120)
         assert (
@@ -135,14 +135,14 @@ class TestDetectCrashSuspicion:
 
     def test_handles_naive_heartbeat_timestamp(self, running_job):
         """Naive SQLite heartbeat timestamps are normalized before comparison."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = (now - timedelta(seconds=120)).replace(tzinfo=None)
         assert detect_crash_suspicion(running_job, heartbeat_stale_threshold_seconds=60, now=now) is True
 
     def test_returns_false_when_heartbeat_fresh(self, running_job):
         """Worker with recent heartbeat is not crashed."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = now - timedelta(seconds=30)
         assert (
@@ -218,7 +218,7 @@ class TestDetectRebuildInconsistency:
 
     def test_detects_crash_suspicion_when_heartbeat_stale(self, running_job):
         """Crash suspicion when heartbeat is stale."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = now - timedelta(seconds=120)
 
@@ -248,7 +248,7 @@ class TestDetectRebuildInconsistency:
 
     def test_detects_stale_ownership_when_heartbeat_exceeds_ttl(self, running_job):
         """Stale ownership when heartbeat exceeds TTL."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.last_heartbeat_at = now - timedelta(seconds=400)
 
         inconsistency = detect_rebuild_inconsistency(
@@ -263,7 +263,7 @@ class TestDetectRebuildInconsistency:
 
     def test_returns_none_when_all_consistent(self, running_job):
         """No inconsistency when everything is consistent."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = now - timedelta(seconds=30)
 
@@ -293,7 +293,7 @@ class TestDetectRebuildInconsistency:
 
     def test_priority_crash_over_stale(self, running_job):
         """Crash suspicion has higher priority than stale ownership."""
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         running_job.active_worker_id = "worker-1"
         running_job.last_heartbeat_at = now - timedelta(seconds=400)
 

--- a/tests/unit/test_rebuild_recovery.py
+++ b/tests/unit/test_rebuild_recovery.py
@@ -1,6 +1,6 @@
 """Unit tests for rebuild recovery decision logic (Stage 5C.1)."""
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import pytest
 
@@ -11,7 +11,7 @@ from src.logic.rebuild_recovery import RecoveryAction, determine_recovery_action
 @pytest.fixture
 def current_time():
     """Current timestamp for testing."""
-    return datetime.now(timezone.utc)
+    return datetime.now(UTC)
 
 
 @pytest.fixture

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -1,5 +1,6 @@
 """Tests for startup reconciliation via RecoveryGate."""
 
+from datetime import UTC
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
@@ -84,17 +85,17 @@ def test_gate_waits_on_unknown_lock_with_no_active_job(mock_session_factory, moc
 
 def test_startup_reconciliation_performs_reset_for_orphaned_job(mock_session_factory, mock_lock):
     """Test that startup reconciliation performs RESET recovery for orphaned job."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     # Setup: Orphaned RUNNING job in DB
     orphaned_job = RebuildJobORM(
         job_id="orphaned-job-1",
         requested_by="previous-worker",
         status=RebuildJobStatus.RUNNING,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
         active_worker_id="dead-worker",
-        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=timezone.utc),  # Very stale
+        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),  # Very stale
     )
 
     mock_repo = MagicMock()
@@ -181,17 +182,17 @@ def test_startup_reconciliation_blocks_on_db_error(mock_session_factory, mock_lo
 
 def test_startup_reconciliation_blocks_on_fresh_remote_heartbeat(mock_session_factory, mock_lock):
     """Test that startup reconciliation blocks when remote worker has fresh heartbeat."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     # Setup: RUNNING job with different worker but FRESH heartbeat
     remote_job = RebuildJobORM(
         job_id="remote-job-1",
         requested_by="remote-worker",
         status=RebuildJobStatus.RUNNING,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
         active_worker_id="remote-worker-id",  # Different from lock holder
-        last_heartbeat_at=datetime.now(timezone.utc),  # Fresh heartbeat
+        last_heartbeat_at=datetime.now(UTC),  # Fresh heartbeat
     )
 
     mock_repo = MagicMock()
@@ -212,17 +213,17 @@ def test_startup_reconciliation_blocks_on_fresh_remote_heartbeat(mock_session_fa
 
 def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factory, mock_lock):
     """Test that startup reconciliation reacquires lock if expired before RESET."""
-    from datetime import datetime, timezone
+    from datetime import datetime
 
     # Setup: Orphaned job + expired lock
     orphaned_job = RebuildJobORM(
         job_id="orphaned-job-2",
         requested_by="previous-worker",
         status=RebuildJobStatus.RUNNING,
-        created_at=datetime.now(timezone.utc),
-        updated_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
         active_worker_id="dead-worker",
-        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),
     )
 
     # First check: EXPIRED (initial eval), second check (during RESET): EXPIRED,

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -118,7 +118,7 @@ def test_startup_reconciliation_performs_reset_for_orphaned_job(mock_session_fac
         mock_repo.mark_rebuild_job_failed.assert_called_once()
         call_args = mock_repo.mark_rebuild_job_failed.call_args
         assert call_args[0][0] == "orphaned-job-1"
-        assert call_args[1]["failure_category"] == "recovery_reset"
+        assert call_args[1]["details"].failure_category == "recovery_reset"
 
 
 def test_startup_reconciliation_blocks_on_lost_lock_state(mock_session_factory, mock_lock):

--- a/tests/unit/test_repository_cancellation.py
+++ b/tests/unit/test_repository_cancellation.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.data.db_models import Base, RebuildJobStatus
-from src.data.repository import AssetGraphRepository, RebuildCancellationRequestedError
+from src.data.repository import AssetGraphRepository, RebuildCancellationRequestedError, RebuildFailureDetails
 
 pytestmark = pytest.mark.unit
 
@@ -58,9 +58,7 @@ def test_mark_rebuild_job_cancel_requested_fails_for_terminal_status(repo: Asset
     repo.mark_rebuild_job_failed(
         job_id_fail,
         execution_id="exec-fail",
-        failure_category="unexpected_error",
-        failure_message="oops",
-        duration_ms=100,
+        details=RebuildFailureDetails(failure_category="unexpected_error", failure_message="oops", duration_ms=100),
     )
 
     with pytest.raises(ValueError, match="Cannot transition job .* to cancel_requested"):

--- a/tests/unit/test_repository_distributed_lock.py
+++ b/tests/unit/test_repository_distributed_lock.py
@@ -1,7 +1,6 @@
 """Unit tests for AssetGraphRepository distributed lock and latest job methods."""
 
-from datetime import datetime, timedelta, timezone
-from time import sleep
+from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock
 
 import pytest
@@ -23,6 +22,7 @@ from src.data.repository import (
     CoordinationLockRepository,
     LockStateSnapshot,
     LockWriteResult,
+    RebuildFailureDetails,
     session_scope,
 )
 
@@ -30,8 +30,8 @@ from src.data.repository import (
 def _ensure_utc(dt: datetime) -> datetime:
     """Ensure the datetime is timezone-aware and normalized to UTC."""
     if dt.tzinfo is None:
-        return dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(timezone.utc)
+        return dt.replace(tzinfo=UTC)
+    return dt.astimezone(UTC)
 
 
 @pytest.fixture
@@ -100,7 +100,7 @@ class TestDistributedLockRepository:
         assert snapshot.valid is True
         assert snapshot.holder_id == "holder1"
         assert snapshot.fencing_token == res.fencing_token
-        assert _ensure_utc(snapshot.expires_at) > datetime.now(timezone.utc)
+        assert _ensure_utc(snapshot.expires_at) > datetime.now(UTC)
 
     def test_acquire_lock_held_by_other(self, lock_repository_factory):
         """Test failing to acquire a lock held by another holder."""
@@ -129,13 +129,13 @@ class TestDistributedLockRepository:
         reader = lock_repository_factory()
         snapshot = reader.get_lock_state(lock_name="test_lock", holder_id="holder1")
 
-        expected_min_expiry = datetime.now(timezone.utc) + timedelta(seconds=60)
+        expected_min_expiry = datetime.now(UTC) + timedelta(seconds=60)
         assert _ensure_utc(snapshot.expires_at) > expected_min_expiry
 
     def test_acquire_lock_takeover_expired(self, lock_repository_factory):
         """Test taking over an expired lock."""
         repo = lock_repository_factory()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         expired_lock = DistributedLockORM(
             lock_name="test_lock",
@@ -202,7 +202,7 @@ class TestDistributedLockRepository:
     def test_get_lock_state_returns_invalid_for_stale_lock(self, lock_repository_factory):
         """Expired lock rows should be marked as valid=False."""
         repo = lock_repository_factory()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
 
         repo.session.add(
             DistributedLockORM(
@@ -264,14 +264,16 @@ class TestLatestRebuildJobRepository:
 
         # Manually adjust completed_at for id1 to be older
         job1 = repo.session.get(RebuildJobORM, id1)
-        job1.completed_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        job1.completed_at = datetime.now(UTC) - timedelta(hours=1)
         repo.session.commit()
 
         # 2. Newer failed job
         id2 = repo.create_rebuild_job(requested_by="user2")
         repo.mark_rebuild_job_running(id2, "test_exec_id")
         repo.mark_rebuild_job_failed(
-            id2, execution_id="test_exec_id", failure_category="err", failure_message="err", duration_ms=1
+            id2,
+            execution_id="test_exec_id",
+            details=RebuildFailureDetails(failure_category="err", failure_message="err", duration_ms=1),
         )
         repo.session.commit()
 
@@ -312,9 +314,7 @@ class TestDistributedLockRetryLogic:
             side_effect=[
                 SQLAlchemyError("connection timeout"),
                 SQLAlchemyError("connection timeout"),
-                LockWriteResult(
-                    success=True, fencing_token=12345, updated_at=datetime.now(timezone.utc), contention=False
-                ),
+                LockWriteResult(success=True, fencing_token=12345, updated_at=datetime.now(UTC), contention=False),
             ]
         )
         monkeypatch.setattr(CoordinationLockRepository, "refresh_lock", mock_refresh_lock)
@@ -326,7 +326,7 @@ class TestDistributedLockRetryLogic:
         """Lock refresh should not retry when lock is held by another holder."""
         mock_refresh_lock = MagicMock(
             return_value=LockWriteResult(
-                success=False, fencing_token=12345, updated_at=datetime.now(timezone.utc), contention=True
+                success=False, fencing_token=12345, updated_at=datetime.now(UTC), contention=True
             )
         )
         monkeypatch.setattr(CoordinationLockRepository, "refresh_lock", mock_refresh_lock)

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -3,7 +3,6 @@
 import pytest
 from sqlalchemy import create_engine  # pylint: disable=import-error
 
-from conftest import enable_sqlite_foreign_keys
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -16,6 +15,7 @@ from src.models.financial_models import (
     RegulatoryActivity,
     RegulatoryEvent,
 )
+from tests.conftest import enable_sqlite_foreign_keys
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/test_repository_graph_persistence.py
+++ b/tests/unit/test_repository_graph_persistence.py
@@ -3,10 +3,19 @@
 import pytest
 from sqlalchemy import create_engine  # pylint: disable=import-error
 
+from conftest import enable_sqlite_foreign_keys
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
-from src.models.financial_models import AssetClass, Equity, RegulatoryActivity, RegulatoryEvent
+from src.models.financial_models import (
+    AssetClass,
+    Bond,
+    Commodity,
+    Currency,
+    Equity,
+    RegulatoryActivity,
+    RegulatoryEvent,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -16,6 +25,7 @@ def repository_factory(tmp_path):
     """Provide a factory for creating repository instances."""
     db_path = tmp_path / "graph_persistence.db"
     engine = create_engine(f"sqlite:///{db_path}")
+    enable_sqlite_foreign_keys(engine)
     init_db(engine)
     factory = create_session_factory(engine)
 
@@ -301,3 +311,138 @@ class TestGraphPersistenceRoundTrip:
         assert assets[0].name == "Second Equity"
         assert assets[0].sector == "Finance"
         assert assets[0].price == pytest.approx(250.0)
+
+    @staticmethod
+    def test_save_load_graph_preserves_bond_commodity_and_currency_subtypes(repository_factory) -> None:
+        """Persist and restore non-equity asset subtypes without losing fields."""
+        repository = repository_factory()
+        graph = AssetRelationshipGraph()
+        bond = Bond(
+            id="BOND_1",
+            symbol="B1",
+            name="Bond One",
+            asset_class=AssetClass.FIXED_INCOME,
+            sector="Finance",
+            price=101.5,
+            yield_to_maturity=0.031,
+            coupon_rate=0.028,
+            maturity_date="2031-06-01",
+            credit_rating="AA",
+            issuer_id="ISSUER_1",
+        )
+        commodity = Commodity(
+            id="COMMODITY_1",
+            symbol="C1",
+            name="Commodity One",
+            asset_class=AssetClass.COMMODITY,
+            sector="Materials",
+            price=55.0,
+            contract_size=100.0,
+            delivery_date="2025-09-30",
+            volatility=0.25,
+        )
+        currency = Currency(
+            id="CURRENCY_1",
+            symbol="CU1",
+            name="Currency One",
+            asset_class=AssetClass.CURRENCY,
+            sector="Currency",
+            price=1.05,
+            exchange_rate=1.05,
+            country="Eurozone",
+            central_bank_rate=0.04,
+        )
+        for asset in (bond, commodity, currency):
+            graph.add_asset(asset)
+
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        loaded = repository_factory().load_graph()
+        loaded_bond = loaded.assets["BOND_1"]
+        loaded_commodity = loaded.assets["COMMODITY_1"]
+        loaded_currency = loaded.assets["CURRENCY_1"]
+
+        assert isinstance(loaded_bond, Bond)
+        assert loaded_bond.issuer_id == "ISSUER_1"
+        assert loaded_bond.yield_to_maturity == pytest.approx(0.031)
+        assert loaded_bond.coupon_rate == pytest.approx(0.028)
+        assert loaded_bond.maturity_date == "2031-06-01"
+        assert loaded_bond.credit_rating == "AA"
+        assert isinstance(loaded_commodity, Commodity)
+        assert loaded_commodity.contract_size == pytest.approx(100.0)
+        assert loaded_commodity.delivery_date == "2025-09-30"
+        assert loaded_commodity.volatility == pytest.approx(0.25)
+        assert isinstance(loaded_currency, Currency)
+        assert loaded_currency.exchange_rate == pytest.approx(1.05)
+        assert loaded_currency.country == "Eurozone"
+        assert loaded_currency.central_bank_rate == pytest.approx(0.04)
+
+    @staticmethod
+    def test_save_graph_replaces_existing_snapshot_with_empty_graph(repository_factory) -> None:
+        """Saving an empty graph should remove all previously persisted rows."""
+        repository = repository_factory()
+        graph = AssetRelationshipGraph()
+        graph.add_asset(_equity("KEEP", "KEEP"))
+        graph.add_regulatory_event(_event("KEEP_EVENT", "KEEP"))
+        graph.add_relationship("KEEP", "KEEP", "self", 0.0)
+
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        repository.save_graph(AssetRelationshipGraph())
+        repository.session.commit()
+
+        reloaded = repository_factory().load_graph()
+        assert reloaded.assets == {}
+        assert reloaded.relationships == {}
+        assert reloaded.regulatory_events == []
+
+    @staticmethod
+    def test_save_graph_handles_assets_only_graph(repository_factory) -> None:
+        """Saving assets without relationships or events should round-trip cleanly."""
+        repository = repository_factory()
+        graph = AssetRelationshipGraph()
+        graph.add_asset(_equity("ASSET_ONLY_1", "A1"))
+        graph.add_asset(_equity("ASSET_ONLY_2", "A2", sector="Healthcare"))
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        loaded = repository_factory().load_graph()
+        assert set(loaded.assets) == {"ASSET_ONLY_1", "ASSET_ONLY_2"}
+        assert loaded.relationships == {}
+        assert loaded.regulatory_events == []
+
+    @staticmethod
+    def test_save_graph_preserves_empty_related_assets_on_regulatory_events(repository_factory) -> None:
+        """Events with no related assets should persist as empty collections."""
+        repository = repository_factory()
+        graph = AssetRelationshipGraph()
+        graph.add_asset(_equity("EVENT_ONLY", "EO"))
+        graph.add_regulatory_event(_event("EVENT_EMPTY", "EVENT_ONLY", []))
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        loaded_event = repository_factory().list_regulatory_events()[0]
+        assert loaded_event.related_assets == []
+
+    @staticmethod
+    def test_replace_relationships_supports_boundary_strengths(repository_factory) -> None:
+        """Relationship persistence should round-trip boundary strength values."""
+        repository = repository_factory()
+        graph = AssetRelationshipGraph()
+        graph.add_asset(_equity("SRC", "SRC"))
+        graph.add_asset(_equity("DST", "DST"))
+        graph.add_relationship("SRC", "DST", "boundary_zero", 0.0)
+        graph.add_relationship("SRC", "DST", "boundary_one", 1.0)
+        graph.add_relationship("SRC", "DST", "boundary_negative", -1.0)
+
+        repository.save_graph(graph)
+        repository.session.commit()
+
+        strengths = {record.relationship_type: record.strength for record in repository.list_relationships()}
+        assert strengths == {
+            "boundary_zero": pytest.approx(0.0),
+            "boundary_one": pytest.approx(1.0),
+            "boundary_negative": pytest.approx(-1.0),
+        }

--- a/tests/unit/test_repository_rebuild_jobs.py
+++ b/tests/unit/test_repository_rebuild_jobs.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import create_engine
 
 from src.data.database import create_session_factory, init_db
-from src.data.repository import AssetGraphRepository
+from src.data.repository import AssetGraphRepository, RebuildFailureDetails
 
 
 @pytest.fixture
@@ -249,9 +249,11 @@ class TestRebuildJobRepository:
         repo.mark_rebuild_job_failed(
             job_id,
             execution_id="test_exec_id",
-            failure_category="rebuild_source_error",
-            failure_message="Failed to load graph from cache",
-            duration_ms=500,
+            details=RebuildFailureDetails(
+                failure_category="rebuild_source_error",
+                failure_message="Failed to load graph from cache",
+                duration_ms=500,
+            ),
         )
         repo.session.commit()
 
@@ -275,9 +277,11 @@ class TestRebuildJobRepository:
         repo.mark_rebuild_job_failed(
             job_id,
             execution_id="test_exec_id",
-            failure_category="persistence_not_configured",
-            failure_message="No persistence configured",
-            duration_ms=10,
+            details=RebuildFailureDetails(
+                failure_category="persistence_not_configured",
+                failure_message="No persistence configured",
+                duration_ms=10,
+            ),
         )
         repo.session.commit()
 
@@ -298,9 +302,7 @@ class TestRebuildJobRepository:
             repo.mark_rebuild_job_failed(
                 job_id,
                 execution_id="test_exec_id",
-                failure_category="x" * 65,
-                failure_message="error",
-                duration_ms=0,
+                details=RebuildFailureDetails(failure_category="x" * 65, failure_message="error", duration_ms=0),
             )
 
     def test_mark_rebuild_job_failed_message_too_long(self, repository_factory):
@@ -314,9 +316,7 @@ class TestRebuildJobRepository:
             repo.mark_rebuild_job_failed(
                 job_id,
                 execution_id="test_exec_id",
-                failure_category="error",
-                failure_message="x" * 513,
-                duration_ms=0,
+                details=RebuildFailureDetails(failure_category="error", failure_message="x" * 513, duration_ms=0),
             )
 
     def test_mark_rebuild_job_failed_invalid_transition(self, repository_factory):
@@ -337,9 +337,7 @@ class TestRebuildJobRepository:
             repo.mark_rebuild_job_failed(
                 job_id,
                 execution_id="test_exec_id",
-                failure_category="error",
-                failure_message="test",
-                duration_ms=0,
+                details=RebuildFailureDetails(failure_category="error", failure_message="test", duration_ms=0),
             )
 
     def test_mark_rebuild_job_failed_negative_duration(self, repository_factory):
@@ -353,9 +351,7 @@ class TestRebuildJobRepository:
             repo.mark_rebuild_job_failed(
                 job_id,
                 execution_id="test_exec_id",
-                failure_category="error",
-                failure_message="test",
-                duration_ms=-1,
+                details=RebuildFailureDetails(failure_category="error", failure_message="test", duration_ms=-1),
             )
 
     def test_get_rebuild_job_not_found(self, repository_factory):


### PR DESCRIPTION
## **User description**
Resolves #1271 and #1280. Introduces repository protocol abstractions in `src/data/` without changing concrete implementations, and adds database-level constraint tests that prove actual SQLite/Postgres-style behaviour rather than ORM-side behaviour.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds typed repository protocols and database-behavior tests to harden persistence across SQLite/Postgres. Introduces an immutable `RebuildFailureDetails` and aligns protocol signatures with the concrete repo; tightens UTC handling and SQLite FK enforcement; addresses #1271 and #1280.

- **Refactors**
  - Added `src/data/protocols.py` with `IAssetGraphRepository` and `ICoordinationLockRepository`; exact parity with `AssetGraphRepository` (explicit `add_or_update_relationship` params, `create_rebuild_job` returns `str`, `list_rebuild_jobs(limit/offset/status)`, heartbeat/checkpoint/state/latest-job methods; `mark_rebuild_job_failed(details: RebuildFailureDetails)`).
  - Introduced `RebuildFailureDetails` DTO (immutable via frozen+slots) and updated call sites (`api/routers/graph_admin`, `RecoveryGate`); re-exported via `src/data/__init__.py`.
  - Guarded SQLite FK PRAGMA listener in tests and normalized UTC handling in drift evaluation/reporting; minor typing/import fixes.

- **New Features**
  - DB-level tests: FK cascades/violations (source/target), relationship strength boundaries (0, 1, -1), invalid status checks and cancel paths, recovery columns presence, distributed-lock CRUD/timestamp round-trips.
  - Graph persistence tests: round-trip `Bond`, `Commodity`, and `Currency`; saving an empty graph clears prior rows; assets-only graphs and events with empty related assets persist correctly.

<sup>Written for commit df50b566dbccf463525e4ddec3614e425586e636. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Enforce database-backed persistence rules and cover more graph cases**

### What Changed
- Graph saves and loads now keep bond, commodity, and currency details intact, including empty related-asset lists and graphs with assets only
- Clearing a graph removes previously saved assets, relationships, and events instead of leaving stale data behind
- Relationship and lock tests now rely on real database enforcement, including foreign keys, cascade deletes, boundary strength values, and lock record updates
- Rebuild job tests now cover invalid statuses, cancel states, and the recovery fields expected after database setup

### Impact
`✅ Fewer stale graph records after rebuilds`
`✅ Safer database deletes`
`✅ Clearer persistence for non-equity assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
