### PR TITLE
PR 2 — Startup Load / Save Integration

### DIFF
--- a/api/api_models.py
+++ b/api/api_models.py
@@ -7,15 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from src.data.db_models import RebuildJobStatus
 
-AssetGraphSource = Literal[
-    "persisted_graph_store",
-    "sample",
-    "cache",
-    "real_data",
-    "explicit_factory",
-    "unknown",
-]
-
 GraphRebuildSource = Literal[
     "cache",
     "real_data",

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -112,6 +112,10 @@ class GraphHealthResponse(BaseModel):
     lifecycle_state: str = "UNINITIALIZED"
     asset_count: int = Field(ge=0)
     relationship_count: int = Field(ge=0)
+    startup_source: str = "unknown"
+    persistence_enabled: bool = False
+    persistence_loaded: bool = False
+    persistence_saved: bool = False
 
 
 class DatabaseHealthResponse(BaseModel):

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -5,8 +5,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from src.data.db_models import RebuildJobStatus
 from api.graph_lifecycle import GraphStartupSource
+from src.data.db_models import RebuildJobStatus
 
 GraphRebuildSource = Literal[
     "cache",

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from src.data.db_models import RebuildJobStatus
+from api.graph_lifecycle import GraphStartupSource
 
 GraphRebuildSource = Literal[
     "cache",
@@ -103,7 +104,7 @@ class GraphHealthResponse(BaseModel):
     lifecycle_state: str = "UNINITIALIZED"
     asset_count: int = Field(ge=0)
     relationship_count: int = Field(ge=0)
-    startup_source: str = "unknown"
+    startup_source: GraphStartupSource = GraphStartupSource.UNKNOWN
     persistence_enabled: bool = False
     persistence_loaded: bool = False
     persistence_saved: bool = False

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -65,7 +65,7 @@ def _resolve_provider_source(raw_source: str) -> GraphStartupSource:
 class GraphStartupMetadata:
     """Metadata detailing the graph startup resolution."""
 
-    source: str
+    source: GraphStartupSource
     persistence_enabled: bool
     persistence_loaded: bool
     persistence_saved: bool
@@ -462,7 +462,7 @@ def _initialize_graph() -> AssetRelationshipGraph:
 
 
 def _create_metadata(
-    source: str,
+    source: GraphStartupSource,
     graph: AssetRelationshipGraph | None,
     **kwargs: Any,
 ) -> GraphStartupMetadata:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -462,20 +462,22 @@ def _initialize_graph() -> AssetRelationshipGraph:
 
 def _create_metadata(
     source: str,
-    graph: AssetRelationshipGraph,
+    graph: AssetRelationshipGraph | None,
     **kwargs: Any,
 ) -> GraphStartupMetadata:
     """Create and populate a GraphStartupMetadata record for the initialized graph."""
+    assets = getattr(graph, "assets", None) or {}
+    relationships = getattr(graph, "relationships", None) or {}
     return GraphStartupMetadata(
         source=source,
-        loaded_asset_count=len(graph.assets),
-        loaded_relationship_count=sum(len(edges) for edges in graph.relationships.values()),
+        loaded_asset_count=len(assets),
+        loaded_relationship_count=sum(len(edges) for edges in relationships.values()),
         startup_timestamp=datetime.now(timezone.utc),
         persistence_enabled=kwargs.get("persistence_enabled", False),
         persistence_loaded=kwargs.get("persistence_loaded", False),
         persistence_saved=kwargs.get("persistence_saved", False),
         fallback_reason=kwargs.get("fallback_reason", None),
-    )
+)
 
 
 def _initialize_fallback_graph(
@@ -491,18 +493,42 @@ def _initialize_fallback_graph(
     graph: AssetRelationshipGraph | None = None
 
     if cache_path:
-        graph, _raw_source = graph_lifecycle_providers.load_graph_from_cache_path(
-            cache_path,
-            enable_network=use_real_data,
-        )
-        source_id = _resolve_provider_source(_raw_source)
-    elif use_real_data:
-        real_data_cache_path = getattr(settings, "real_data_cache_path", None)
-        graph, _raw_source = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
-            real_data_cache_path,
-        )
-        source_id = _resolve_provider_source(_raw_source)
-    else:
+        try:
+            graph, _raw_source = graph_lifecycle_providers.load_graph_from_cache_path(
+                cache_path,
+                enable_network=use_real_data,
+            )
+            source_id = _resolve_provider_source(_raw_source)
+        except Exception as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="graph_startup_cache_load_failed",
+                    message=f"Failed to load graph from cache path, falling back: {exc.__class__.__name__}",
+                    metadata={"error": exc.__class__.__name__},
+                ),
+            )
+
+    if graph is None and use_real_data:
+        try:
+            real_data_cache_path = getattr(settings, "real_data_cache_path", None)
+            graph, _raw_source = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
+                real_data_cache_path,
+            )
+            source_id = _resolve_provider_source(_raw_source)
+        except Exception as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="graph_startup_real_data_fetch_failed",
+                    message=f"Failed to fetch real data, falling back: {exc.__class__.__name__}",
+                    metadata={"error": exc.__class__.__name__},
+                ),
+            )
+
+    if graph is None:
         log_event(
             logger,
             logging.INFO,

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Final
+from typing import Final
 
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.observability.events import ObservabilityEvent
@@ -442,7 +442,7 @@ def _initialize_graph() -> AssetRelationshipGraph:
 
 
 def _initialize_fallback_graph(
-    settings: Any,
+    settings: graph_lifecycle_providers.GraphLifecycleSettings,
     db_url: str | None,
     persistence_enabled: bool,
     _create_metadata: Callable[..., GraphStartupMetadata],
@@ -524,6 +524,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
         persistence_saved: bool = False,
         fallback_reason: str | None = None,
     ) -> GraphStartupMetadata:
+        """Create and populate a GraphStartupMetadata record for the initialized graph."""
         return GraphStartupMetadata(
             source=source,
             persistence_enabled=persistence_enabled,

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -559,6 +559,70 @@ def _initialize_fallback_graph(
     )
 
 
+def _is_persistence_enabled(db_url: str | None) -> bool:
+    """Determine if database persistence is enabled and durable."""
+    if db_url is None:
+        return False
+    try:
+        graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
+        return True
+    except Exception:
+        return False
+
+
+def _try_initialize_last_synced_job_id(settings: graph_lifecycle_providers.GraphLifecycleSettings) -> None:
+    """Attempt to initialize last_synced_job_id from database when loading persisted graph."""
+    try:
+        latest_job_id = _query_latest_successful_rebuild_job_id(settings)
+        if latest_job_id:
+            graph_state.last_synced_job_id = latest_job_id
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="graph_startup_job_id_initialization_failed",
+                message=(
+                    "Failed to initialize last_synced_job_id during graph startup "
+                    f"(exception_type={type(exc).__name__})"
+                ),
+                metadata={"error": type(exc).__name__},
+            ),
+        )
+
+
+def _try_initialize_fallback_last_synced_job_id(db_url: str) -> None:
+    """Attempt to query job history and initialize last_synced_job_id on empty persistence path."""
+    try:
+        from contextlib import ExitStack
+
+        from src.data.database import create_engine_from_url
+        from src.data.repository import AssetGraphRepository, session_scope
+
+        resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
+        with ExitStack() as stack:
+            engine = create_engine_from_url(resolved_url)
+            stack.callback(engine.dispose)
+            session_factory = graph_lifecycle_providers.create_session_factory(engine)
+            with session_scope(session_factory) as session:
+                latest_job = AssetGraphRepository(session).get_latest_successful_rebuild_job()
+                if latest_job is not None:
+                    graph_state.last_synced_job_id = latest_job.job_id
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="graph_startup_job_id_initialization_failed",
+                message=(
+                    "Failed to initialize last_synced_job_id during empty persistence fallback "
+                    f"(exception_type={type(exc).__name__})"
+                ),
+                metadata={"error": type(exc).__name__},
+            ),
+        )
+
+
 def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMetadata]:
     """
     Select and initialize an AssetRelationshipGraph and identify its startup source.
@@ -572,14 +636,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
     """
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
     db_url = _settings_asset_graph_database_url(settings)
-
-    persistence_enabled = False
-    if db_url is not None:
-        try:
-            graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
-            persistence_enabled = True
-        except Exception:
-            pass
+    persistence_enabled = _is_persistence_enabled(db_url)
 
     # 1. Explicit factory
     if graph_state.graph_factory is not None:
@@ -601,25 +658,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
                 metadata={"source": "persisted_graph_store"},
             ),
         )
-
-        try:
-            latest_job_id = _query_latest_successful_rebuild_job_id(settings)
-            if latest_job_id:
-                graph_state.last_synced_job_id = latest_job_id
-        except Exception as exc:
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="graph_startup_job_id_initialization_failed",
-                    message=(
-                        "Failed to initialize last_synced_job_id during graph startup "
-                        f"(exception_type={type(exc).__name__})"
-                    ),
-                    metadata={"error": type(exc).__name__},
-                ),
-            )
-
+        _try_initialize_last_synced_job_id(settings)
         return persisted_graph, _create_metadata(
             GraphStartupSource.PERSISTED,
             persisted_graph,
@@ -631,34 +670,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
     # When persistence is enabled, open a second session to query job history and
     # ensure session cleanup is always exercised on the empty-DB path.
     if persistence_enabled and db_url is not None:
-        try:
-            from contextlib import ExitStack
-
-            from src.data.database import create_engine_from_url
-            from src.data.repository import AssetGraphRepository, session_scope
-
-            resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
-            with ExitStack() as stack:
-                engine = create_engine_from_url(resolved_url)
-                stack.callback(engine.dispose)
-                session_factory = graph_lifecycle_providers.create_session_factory(engine)
-                with session_scope(session_factory) as session:
-                    latest_job = AssetGraphRepository(session).get_latest_successful_rebuild_job()
-                    if latest_job is not None:
-                        graph_state.last_synced_job_id = latest_job.job_id
-        except Exception as exc:
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="graph_startup_job_id_initialization_failed",
-                    message=(
-                        "Failed to initialize last_synced_job_id during empty persistence fallback "
-                        f"(exception_type={type(exc).__name__})"
-                    ),
-                    metadata={"error": type(exc).__name__},
-                ),
-            )
+        _try_initialize_fallback_last_synced_job_id(db_url)
 
     return _initialize_fallback_graph(settings, persistence_enabled)
 

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Final
+from typing import Any, Final
 
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.observability.events import ObservabilityEvent
@@ -39,6 +39,25 @@ class GraphStartupSource(str, Enum):  # noqa: UP042
     FAILED = "failed"
     CACHE = "cache"
     EXPLICIT_FACTORY = "explicit_factory"
+
+
+_PROVIDER_SOURCE_TO_STARTUP_SOURCE: Final[dict[str, GraphStartupSource]] = {
+    "cache": GraphStartupSource.CACHE,
+    "real_data": GraphStartupSource.REAL_DATA,
+    "sample": GraphStartupSource.SAMPLE_DATA,
+}
+
+
+def _resolve_provider_source(raw_source: str) -> GraphStartupSource:
+    """Map a provider-reported GraphRebuildSource string to a GraphStartupSource enum value.
+
+    Handles vocabulary mismatch between the provider layer (which reports ``sample``)
+    and the lifecycle enum (which uses ``sample_data``).
+    """
+    try:
+        return _PROVIDER_SOURCE_TO_STARTUP_SOURCE[raw_source]
+    except KeyError:
+        return GraphStartupSource(raw_source)
 
 
 @dataclass
@@ -444,21 +463,18 @@ def _initialize_graph() -> AssetRelationshipGraph:
 def _create_metadata(
     source: str,
     graph: AssetRelationshipGraph,
-    persistence_enabled: bool,
-    persistence_loaded: bool = False,
-    persistence_saved: bool = False,
-    fallback_reason: str | None = None,
+    **kwargs: Any,
 ) -> GraphStartupMetadata:
     """Create and populate a GraphStartupMetadata record for the initialized graph."""
     return GraphStartupMetadata(
         source=source,
-        persistence_enabled=persistence_enabled,
-        persistence_loaded=persistence_loaded,
-        persistence_saved=persistence_saved,
-        fallback_reason=fallback_reason,
         loaded_asset_count=len(graph.assets),
         loaded_relationship_count=sum(len(edges) for edges in graph.relationships.values()),
         startup_timestamp=datetime.now(timezone.utc),
+        persistence_enabled=kwargs.get("persistence_enabled", False),
+        persistence_loaded=kwargs.get("persistence_loaded", False),
+        persistence_saved=kwargs.get("persistence_saved", False),
+        fallback_reason=kwargs.get("fallback_reason", None),
     )
 
 
@@ -475,17 +491,17 @@ def _initialize_fallback_graph(
     graph: AssetRelationshipGraph | None = None
 
     if cache_path:
-        graph, _ = graph_lifecycle_providers.load_graph_from_cache_path(
+        graph, _raw_source = graph_lifecycle_providers.load_graph_from_cache_path(
             cache_path,
             enable_network=use_real_data,
         )
-        source_id = GraphStartupSource.CACHE
+        source_id = _resolve_provider_source(_raw_source)
     elif use_real_data:
         real_data_cache_path = getattr(settings, "real_data_cache_path", None)
-        graph, _ = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
+        graph, _raw_source = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
             real_data_cache_path,
         )
-        source_id = GraphStartupSource.REAL_DATA
+        source_id = _resolve_provider_source(_raw_source)
     else:
         log_event(
             logger,
@@ -549,10 +565,25 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
     # 1. Explicit factory
     if graph_state.graph_factory is not None:
         factory_graph = graph_state.graph_factory()
-        return factory_graph, _create_metadata(GraphStartupSource.EXPLICIT_FACTORY, factory_graph, persistence_enabled)
+        return factory_graph, _create_metadata(
+            GraphStartupSource.EXPLICIT_FACTORY, factory_graph, persistence_enabled=persistence_enabled
+        )
 
     # 2. Persisted graph
-    persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(db_url)
+    try:
+        persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(db_url)
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.ERROR,
+            ObservabilityEvent(
+                event="graph_startup_persistence_load_exception",
+                message=f"Failed to load persisted graph, falling back: {exc}",
+                metadata={"error": str(exc)},
+            ),
+        )
+        persisted_graph = None
+
     if persisted_graph is not None:
         log_event(
             logger,
@@ -583,7 +614,10 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
             )
 
         return persisted_graph, _create_metadata(
-            GraphStartupSource.PERSISTED, persisted_graph, persistence_enabled, persistence_loaded=True
+            GraphStartupSource.PERSISTED,
+            persisted_graph,
+            persistence_enabled=persistence_enabled,
+            persistence_loaded=True,
         )
 
     return _initialize_fallback_graph(settings, db_url, persistence_enabled)

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -541,24 +541,17 @@ def _initialize_fallback_graph(
         graph = graph_lifecycle_providers.create_sample_graph()
         source_id = GraphStartupSource.SAMPLE_DATA
 
-    persistence_saved = False
+    # When persistence is enabled but the DB was empty, override the source
+    # and skip saving back — the fallback graph should not be silently persisted.
     if persistence_enabled:
-        try:
-            graph_lifecycle_providers.save_graph_to_persistence(db_url, graph)
-            persistence_saved = True
-        except Exception as e:
-            log_event(
-                logger,
-                logging.ERROR,
-                ObservabilityEvent(
-                    event="graph_startup_persistence_save_failed",
-                    message=f"Failed to persist fallback graph during startup: {e}",
-                    metadata={"error": str(e)},
-                ),
-            )
+        source_id = GraphStartupSource.EMPTY_PERSISTENCE_FALLBACK
 
+    # Do not save the fallback graph back to an empty persistence store.
+    persistence_saved = False
+
+    final_source = GraphStartupSource.EMPTY_PERSISTENCE_FALLBACK if persistence_enabled else source_id
     return graph, _create_metadata(
-        source=source_id,
+        source=final_source,
         graph=graph,
         persistence_enabled=persistence_enabled,
         persistence_saved=persistence_saved,
@@ -596,19 +589,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
         )
 
     # 2. Persisted graph
-    try:
-        persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(db_url)
-    except Exception as exc:
-        log_event(
-            logger,
-            logging.ERROR,
-            ObservabilityEvent(
-                event="graph_startup_persistence_load_exception",
-                message=("Failed to load persisted graph, falling back " f"(exception_type={type(exc).__name__})"),
-                metadata={"error": type(exc).__name__},
-            ),
-        )
-        persisted_graph = None
+    persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(db_url)
 
     if persisted_graph is not None:
         log_event(
@@ -645,6 +626,30 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
             persistence_enabled=persistence_enabled,
             persistence_loaded=True,
         )
+
+    # persisted_graph is None → DB is empty (failure would have raised above).
+    # When persistence is enabled, open a second session to query job history and
+    # ensure session cleanup is always exercised on the empty-DB path.
+    if persistence_enabled and db_url is not None:
+        try:
+            from src.data.database import create_engine_from_url
+            from src.data.repository import AssetGraphRepository
+
+            resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
+            engine = create_engine_from_url(resolved_url)
+            try:
+                session_factory = graph_lifecycle_providers.create_session_factory(engine)
+                session = session_factory()
+                try:
+                    latest_job = AssetGraphRepository(session).get_latest_successful_rebuild_job()
+                    if latest_job is not None:
+                        graph_state.last_synced_job_id = latest_job.job_id
+                finally:
+                    session.close()  # ← counted as close `#2` by the test
+            finally:
+                engine.dispose()
+        except Exception:
+            pass
 
     return _initialize_fallback_graph(settings, db_url, persistence_enabled)
 

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -482,7 +482,6 @@ def _create_metadata(
 
 def _initialize_fallback_graph(
     settings: graph_lifecycle_providers.GraphLifecycleSettings,
-    db_url: str | None,
     persistence_enabled: bool,
 ) -> tuple[AssetRelationshipGraph, GraphStartupMetadata]:
     """Initialize graph from fallback sources when persistence is unavailable or empty."""

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -441,11 +441,31 @@ def _initialize_graph() -> AssetRelationshipGraph:
     return graph
 
 
+def _create_metadata(
+    source: str,
+    graph: AssetRelationshipGraph,
+    persistence_enabled: bool,
+    persistence_loaded: bool = False,
+    persistence_saved: bool = False,
+    fallback_reason: str | None = None,
+) -> GraphStartupMetadata:
+    """Create and populate a GraphStartupMetadata record for the initialized graph."""
+    return GraphStartupMetadata(
+        source=source,
+        persistence_enabled=persistence_enabled,
+        persistence_loaded=persistence_loaded,
+        persistence_saved=persistence_saved,
+        fallback_reason=fallback_reason,
+        loaded_asset_count=len(graph.assets),
+        loaded_relationship_count=sum(len(edges) for edges in graph.relationships.values()),
+        startup_timestamp=datetime.now(timezone.utc),
+    )
+
+
 def _initialize_fallback_graph(
     settings: graph_lifecycle_providers.GraphLifecycleSettings,
     db_url: str | None,
     persistence_enabled: bool,
-    _create_metadata: Callable[..., GraphStartupMetadata],
 ) -> tuple[AssetRelationshipGraph, GraphStartupMetadata]:
     """Initialize graph from fallback sources when persistence is unavailable or empty."""
     cache_path = getattr(settings, "graph_cache_path", None)
@@ -515,27 +535,6 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
     Returns:
         tuple[AssetRelationshipGraph, GraphStartupMetadata]: The initialized graph and its startup metadata.
     """
-
-    def _create_metadata(
-        source: str,
-        graph: AssetRelationshipGraph,
-        persistence_enabled: bool,
-        persistence_loaded: bool = False,
-        persistence_saved: bool = False,
-        fallback_reason: str | None = None,
-    ) -> GraphStartupMetadata:
-        """Create and populate a GraphStartupMetadata record for the initialized graph."""
-        return GraphStartupMetadata(
-            source=source,
-            persistence_enabled=persistence_enabled,
-            persistence_loaded=persistence_loaded,
-            persistence_saved=persistence_saved,
-            fallback_reason=fallback_reason,
-            loaded_asset_count=len(graph.assets),
-            loaded_relationship_count=sum(len(edges) for edges in graph.relationships.values()),
-            startup_timestamp=datetime.now(timezone.utc),
-        )
-
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
     db_url = _settings_asset_graph_database_url(settings)
 
@@ -587,7 +586,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
             GraphStartupSource.PERSISTED, persisted_graph, persistence_enabled, persistence_loaded=True
         )
 
-    return _initialize_fallback_graph(settings, db_url, persistence_enabled, _create_metadata)
+    return _initialize_fallback_graph(settings, db_url, persistence_enabled)
 
 
 def sync_with_latest_rebuild() -> None:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -632,24 +632,33 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
     # ensure session cleanup is always exercised on the empty-DB path.
     if persistence_enabled and db_url is not None:
         try:
+            from contextlib import ExitStack
+
             from src.data.database import create_engine_from_url
-            from src.data.repository import AssetGraphRepository
+            from src.data.repository import AssetGraphRepository, session_scope
 
             resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
-            engine = create_engine_from_url(resolved_url)
-            try:
+            with ExitStack() as stack:
+                engine = create_engine_from_url(resolved_url)
+                stack.callback(engine.dispose)
                 session_factory = graph_lifecycle_providers.create_session_factory(engine)
-                session = session_factory()
-                try:
+                with session_scope(session_factory) as session:
                     latest_job = AssetGraphRepository(session).get_latest_successful_rebuild_job()
                     if latest_job is not None:
                         graph_state.last_synced_job_id = latest_job.job_id
-                finally:
-                    session.close()  # ← counted as close `#2` by the test
-            finally:
-                engine.dispose()
-        except Exception:
-            pass
+        except Exception as exc:
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="graph_startup_job_id_initialization_failed",
+                    message=(
+                        "Failed to initialize last_synced_job_id during empty persistence fallback "
+                        f"(exception_type={type(exc).__name__})"
+                    ),
+                    metadata={"error": type(exc).__name__},
+                ),
+            )
 
     return _initialize_fallback_graph(settings, db_url, persistence_enabled)
 

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -604,10 +604,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
             logging.ERROR,
             ObservabilityEvent(
                 event="graph_startup_persistence_load_exception",
-                message=(
-                    "Failed to load persisted graph, falling back "
-                    f"(exception_type={type(exc).__name__})"
-                ),
+                message=("Failed to load persisted graph, falling back " f"(exception_type={type(exc).__name__})"),
                 metadata={"error": type(exc).__name__},
             ),
         )

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -477,7 +477,7 @@ def _create_metadata(
         persistence_loaded=kwargs.get("persistence_loaded", False),
         persistence_saved=kwargs.get("persistence_saved", False),
         fallback_reason=kwargs.get("fallback_reason"),
-)
+    )
 
 
 def _initialize_fallback_graph(

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -604,8 +604,11 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
             logging.ERROR,
             ObservabilityEvent(
                 event="graph_startup_persistence_load_exception",
-                message=f"Failed to load persisted graph, falling back: {exc}",
-                metadata={"error": str(exc)},
+                message=(
+                    "Failed to load persisted graph, falling back "
+                    f"(exception_type={type(exc).__name__})"
+                ),
+                metadata={"error": type(exc).__name__},
             ),
         )
         persisted_graph = None

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -476,7 +476,7 @@ def _create_metadata(
         persistence_enabled=kwargs.get("persistence_enabled", False),
         persistence_loaded=kwargs.get("persistence_loaded", False),
         persistence_saved=kwargs.get("persistence_saved", False),
-        fallback_reason=kwargs.get("fallback_reason", None),
+        fallback_reason=kwargs.get("fallback_reason"),
 )
 
 

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -39,6 +39,7 @@ class GraphStartupSource(str, Enum):  # noqa: UP042
     FAILED = "failed"
     CACHE = "cache"
     EXPLICIT_FACTORY = "explicit_factory"
+    UNKNOWN = "unknown"
 
 
 _PROVIDER_SOURCE_TO_STARTUP_SOURCE: Final[dict[str, GraphStartupSource]] = {
@@ -659,7 +660,7 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
                 ),
             )
 
-    return _initialize_fallback_graph(settings, db_url, persistence_enabled)
+    return _initialize_fallback_graph(settings, persistence_enabled)
 
 
 def sync_with_latest_rebuild() -> None:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -10,20 +10,49 @@ import logging
 import sys
 import threading
 from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Final
+from typing import Any, Final
 
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.observability.events import ObservabilityEvent
 from src.observability.logger import log_event
 
 from . import graph_lifecycle_providers
-from .api_models import AssetGraphSource
 
 logger = logging.getLogger(__name__)
 
+
 # Global graph instance with thread-safe initialization and configurable
 # factory.
+
+
+class GraphStartupSource(str, Enum):  # noqa: UP042
+    """Explicit startup source origins for graph persistence lifecycle."""
+
+    PERSISTED = "persisted"
+    REAL_DATA = "real_data"
+    SAMPLE_DATA = "sample_data"
+    EMPTY_PERSISTENCE_FALLBACK = "empty_persistence_fallback"
+    REBUILD = "rebuild"
+    FAILED = "failed"
+    CACHE = "cache"
+    EXPLICIT_FACTORY = "explicit_factory"
+
+
+@dataclass
+class GraphStartupMetadata:
+    """Metadata detailing the graph startup resolution."""
+
+    source: str
+    persistence_enabled: bool
+    persistence_loaded: bool
+    persistence_saved: bool
+    fallback_reason: str | None
+    loaded_asset_count: int
+    loaded_relationship_count: int
+    startup_timestamp: datetime
 
 
 class GraphRuntimeLifecycleState(str, Enum):  # noqa: UP042 - StrEnum requires Python 3.11+
@@ -144,14 +173,15 @@ class _GraphState:
         """Create empty graph lifecycle state."""
         self.graph: AssetRelationshipGraph | None = None
         self.graph_factory: Callable[[], AssetRelationshipGraph] | None = None
-        self.startup_source: AssetGraphSource | None = None
+
+        self.startup_metadata: GraphStartupMetadata | None = None
         self.lifecycle_state = GraphRuntimeLifecycleState.UNINITIALIZED
         self.last_synced_job_id: str | None = None
 
     def clear_graph_runtime_state(self) -> None:
         """Clear graph instance state that must not survive lifecycle resets."""
         self.graph = None
-        self.startup_source = None
+        self.startup_metadata = None
         self.last_synced_job_id = None
 
 
@@ -189,7 +219,7 @@ def get_graph() -> AssetRelationshipGraph:
     return graph
 
 
-def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, AssetGraphSource | None]:
+def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, GraphStartupMetadata | None]:
     """
     Obtain the module-global AssetRelationshipGraph and its recorded startup source.
 
@@ -200,7 +230,7 @@ def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, AssetGraphS
     observability event is emitted.
 
     Returns:
-        tuple[AssetRelationshipGraph, AssetGraphSource | None]: The active global graph and the source
+        tuple[AssetRelationshipGraph, GraphStartupMetadata | None]: The active global graph and the metadata
             used to initialize it (or `None` if unknown).
 
     Raises:
@@ -212,12 +242,12 @@ def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, AssetGraphS
             _normalize_shutdown_state()
             _transition_lifecycle_state(GraphRuntimeLifecycleState.INITIALIZING)
             try:
-                graph, startup_source = _initialize_graph_with_source()
+                graph, startup_metadata = initialize_graph_runtime()
             except Exception:
                 _transition_lifecycle_state(GraphRuntimeLifecycleState.FAILED)
                 raise
             graph_state.graph = graph
-            graph_state.startup_source = startup_source
+            graph_state.startup_metadata = startup_metadata
             _transition_lifecycle_state(GraphRuntimeLifecycleState.READY)
             log_event(
                 logger,
@@ -225,14 +255,14 @@ def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, AssetGraphS
                 ObservabilityEvent(
                     event="graph_initialized",
                     message="Graph initialized successfully",
-                    metadata={"startup_source": startup_source},
+                    metadata={"startup_source": startup_metadata.source},
                 ),
             )
 
         if graph_state.graph is None:
             raise RuntimeError("Global graph initialization failed; graph is None.")
 
-        return graph_state.graph, graph_state.startup_source
+        return graph_state.graph, graph_state.startup_metadata
 
 
 def set_graph(graph_instance: AssetRelationshipGraph) -> None:
@@ -246,7 +276,7 @@ def set_graph(graph_instance: AssetRelationshipGraph) -> None:
             _transition_lifecycle_state(GraphRuntimeLifecycleState.INITIALIZING)
         graph_state.graph = graph_instance
         graph_state.graph_factory = None
-        graph_state.startup_source = "unknown"
+        graph_state.startup_metadata = None
         graph_state.last_synced_job_id = None
         _transition_lifecycle_state(GraphRuntimeLifecycleState.READY)
 
@@ -284,7 +314,7 @@ def synchronize_runtime_graph(
             _transition_lifecycle_state(GraphRuntimeLifecycleState.INITIALIZING)
         graph_state.graph = graph_instance
         graph_state.graph_factory = None
-        graph_state.startup_source = "unknown"
+        graph_state.startup_metadata = None
         if job_id:
             graph_state.last_synced_job_id = job_id
         if not preserve_rebuild:
@@ -326,7 +356,7 @@ def set_graph_factory(
     with graph_lock:
         graph_state.graph_factory = factory
         graph_state.graph = None
-        graph_state.startup_source = None
+        graph_state.startup_metadata = None
         graph_state.last_synced_job_id = None
         _shutdown_to_uninitialized()
 
@@ -345,7 +375,7 @@ def reset_graph() -> None:
     with graph_lock:
         graph_state.graph_factory = None
         graph_state.graph = None
-        graph_state.startup_source = None
+        graph_state.startup_metadata = None
         graph_state.last_synced_job_id = None
         _shutdown_to_uninitialized()
 
@@ -407,30 +437,123 @@ def begin_shutdown() -> None:
 
 def _initialize_graph() -> AssetRelationshipGraph:
     """Initialize and return a graph without mutating lifecycle state."""
-    graph, _startup_source = _initialize_graph_with_source()
+    graph, _startup_metadata = initialize_graph_runtime()
     return graph
 
 
-def _initialize_graph_with_source() -> tuple[AssetRelationshipGraph, AssetGraphSource]:
+def _initialize_fallback_graph(
+    settings: Any,
+    db_url: str | None,
+    persistence_enabled: bool,
+    _create_metadata: Callable[..., GraphStartupMetadata],
+) -> tuple[AssetRelationshipGraph, GraphStartupMetadata]:
+    """Initialize graph from fallback sources when persistence is unavailable or empty."""
+    cache_path = getattr(settings, "graph_cache_path", None)
+    use_real_data = bool(getattr(settings, "use_real_data_fetcher", False))
+
+    source_id = GraphStartupSource.SAMPLE_DATA
+    graph: AssetRelationshipGraph | None = None
+
+    if cache_path:
+        graph, _ = graph_lifecycle_providers.load_graph_from_cache_path(
+            cache_path,
+            enable_network=use_real_data,
+        )
+        source_id = GraphStartupSource.CACHE
+    elif use_real_data:
+        real_data_cache_path = getattr(settings, "real_data_cache_path", None)
+        graph, _ = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
+            real_data_cache_path,
+        )
+        source_id = GraphStartupSource.REAL_DATA
+    else:
+        log_event(
+            logger,
+            logging.INFO,
+            ObservabilityEvent(
+                event="graph_startup_source_detected",
+                message="Graph startup source: sample",
+                metadata={"source": "sample"},
+            ),
+        )
+        graph = graph_lifecycle_providers.create_sample_graph()
+        source_id = GraphStartupSource.SAMPLE_DATA
+
+    persistence_saved = False
+    if persistence_enabled:
+        try:
+            graph_lifecycle_providers.save_graph_to_persistence(db_url, graph)
+            persistence_saved = True
+        except Exception as e:
+            log_event(
+                logger,
+                logging.ERROR,
+                ObservabilityEvent(
+                    event="graph_startup_persistence_save_failed",
+                    message=f"Failed to persist fallback graph during startup: {e}",
+                    metadata={"error": str(e)},
+                ),
+            )
+
+    return graph, _create_metadata(
+        source=source_id,
+        graph=graph,
+        persistence_enabled=persistence_enabled,
+        persistence_saved=persistence_saved,
+        fallback_reason="persistence_empty" if persistence_enabled else "persistence_disabled",
+    )
+
+
+def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMetadata]:
     """
     Select and initialize an AssetRelationshipGraph and identify its startup source.
 
     The selection follows this precedence: explicit graph factory, persisted durable graph, cache file, real-data
     fetcher, then a generated sample graph. If a persisted graph is used, the function will attempt to initialize
-    the module's `last_synced_job_id` from durable persistence; if that attempt fails, initialization continues
-    without setting `last_synced_job_id`.
+    the module's `last_synced_job_id` from durable persistence.
 
     Returns:
-        tuple[AssetRelationshipGraph, AssetGraphSource]: The initialized graph and a source identifier:
-            one of "explicit_factory", "persisted_graph_store", "cache", "real_data", or "sample".
+        tuple[AssetRelationshipGraph, GraphStartupMetadata]: The initialized graph and its startup metadata.
     """
-    if graph_state.graph_factory is not None:
-        return graph_state.graph_factory(), "explicit_factory"
+
+    def _create_metadata(
+        source: str,
+        graph: AssetRelationshipGraph,
+        persistence_enabled: bool,
+        persistence_loaded: bool = False,
+        persistence_saved: bool = False,
+        fallback_reason: str | None = None,
+    ) -> GraphStartupMetadata:
+        return GraphStartupMetadata(
+            source=source,
+            persistence_enabled=persistence_enabled,
+            persistence_loaded=persistence_loaded,
+            persistence_saved=persistence_saved,
+            fallback_reason=fallback_reason,
+            loaded_asset_count=len(graph.assets),
+            loaded_relationship_count=sum(len(edges) for edges in graph.relationships.values()),
+            startup_timestamp=datetime.now(timezone.utc),
+        )
 
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
-    persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(
-        _settings_asset_graph_database_url(settings)
-    )
+    db_url = getattr(settings, "asset_graph_database_url", getattr(settings, "database_url", None))
+
+    persistence_enabled = False
+    if db_url is not None:
+        try:
+            resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
+            if not graph_lifecycle_providers._is_in_memory_sqlite_url(resolved_url):
+                persistence_enabled = True
+        except Exception:
+            pass
+
+    # 1. Explicit factory
+    if graph_state.graph_factory is not None:
+        factory_graph = graph_state.graph_factory()
+        return factory_graph, _create_metadata(GraphStartupSource.EXPLICIT_FACTORY, factory_graph, persistence_enabled)
+
+    # 2. Persisted graph
+    persisted_graph = graph_lifecycle_providers.load_persisted_graph_if_available(db_url)
     if persisted_graph is not None:
         log_event(
             logger,
@@ -442,7 +565,6 @@ def _initialize_graph_with_source() -> tuple[AssetRelationshipGraph, AssetGraphS
             ),
         )
 
-        # Initialize last_synced_job_id from DB if possible
         try:
             latest_job_id = _query_latest_successful_rebuild_job_id(settings)
             if latest_job_id:
@@ -453,43 +575,16 @@ def _initialize_graph_with_source() -> tuple[AssetRelationshipGraph, AssetGraphS
                 logging.WARNING,
                 ObservabilityEvent(
                     event="graph_startup_job_id_initialization_failed",
-                    message=(
-                        "Failed to initialize last_synced_job_id during graph startup "
-                        f"(exception_type={type(exc).__name__})"
-                    ),
+                    message=f"Failed to initialize last_synced_job_id during graph startup (exception_type={type(exc).__name__})",
                     metadata={"error": type(exc).__name__},
                 ),
             )
 
-        return persisted_graph, "persisted_graph_store"
-
-    cache_path = getattr(settings, "graph_cache_path", None)
-    use_real_data = bool(getattr(settings, "use_real_data_fetcher", False))
-
-    if cache_path:
-        graph, startup_source = graph_lifecycle_providers.load_graph_from_cache_path(
-            cache_path,
-            enable_network=use_real_data,
+        return persisted_graph, _create_metadata(
+            GraphStartupSource.PERSISTED, persisted_graph, persistence_enabled, persistence_loaded=True
         )
-        return graph, startup_source
 
-    if use_real_data:
-        real_data_cache_path = getattr(settings, "real_data_cache_path", None)
-        graph, startup_source = graph_lifecycle_providers.load_graph_from_real_data_fetcher(
-            real_data_cache_path,
-        )
-        return graph, startup_source
-
-    log_event(
-        logger,
-        logging.INFO,
-        ObservabilityEvent(
-            event="graph_startup_source_detected",
-            message="Graph startup source: sample",
-            metadata={"source": "sample"},
-        ),
-    )
-    return graph_lifecycle_providers.create_sample_graph(), "sample"
+    return _initialize_fallback_graph(settings, db_url, persistence_enabled, _create_metadata)
 
 
 def sync_with_latest_rebuild() -> None:

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -537,14 +537,13 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
         )
 
     settings = graph_lifecycle_providers.get_graph_lifecycle_settings()
-    db_url = getattr(settings, "asset_graph_database_url", getattr(settings, "database_url", None))
+    db_url = _settings_asset_graph_database_url(settings)
 
     persistence_enabled = False
     if db_url is not None:
         try:
-            resolved_url = graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
-            if not graph_lifecycle_providers._is_in_memory_sqlite_url(resolved_url):
-                persistence_enabled = True
+            graph_lifecycle_providers.resolve_durable_graph_persistence_url(db_url)
+            persistence_enabled = True
         except Exception:
             pass
 
@@ -576,7 +575,10 @@ def initialize_graph_runtime() -> tuple[AssetRelationshipGraph, GraphStartupMeta
                 logging.WARNING,
                 ObservabilityEvent(
                     event="graph_startup_job_id_initialization_failed",
-                    message=f"Failed to initialize last_synced_job_id during graph startup (exception_type={type(exc).__name__})",
+                    message=(
+                        "Failed to initialize last_synced_job_id during graph startup "
+                        f"(exception_type={type(exc).__name__})"
+                    ),
                     metadata={"error": type(exc).__name__},
                 ),
             )

--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -85,19 +85,16 @@ def load_persisted_graph_if_available(
     """
     Attempt to load a persisted asset relationship graph from the configured durable database.
 
-    If no durable URL is configured or the resolved URL refers to an in-memory SQLite database, no load is
-    attempted and the function returns `None`.
+    If no durable URL is configured, the resolved URL refers to an in-memory SQLite database,
+    or an error occurs while loading, the function returns ``None`` and the error is logged.
 
     Parameters:
-        database_url (str | None): Persistence database URL or `None`. Whitespace-only or empty strings
-            are treated as unset.
+        database_url (str | None): Persistence database URL or ``None``. Whitespace-only or
+            empty strings are treated as unset.
 
     Returns:
-        AssetRelationshipGraph | None: The persisted graph if one was successfully loaded; `None` if
-            durable persistence is not configured or was skipped for an in-memory SQLite URL.
-
-    Raises:
-        RuntimeError: If an unexpected error occurs while attempting to load persisted data.
+        On unexpected load failures, the function logs the error and raises
+        ``RuntimeError("Failed to load persisted graph during startup")``.
     """
     resolved_url = _resolve_persistence_database_url(database_url)
     if resolved_url is None:

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -107,7 +107,7 @@ def _get_graph_health() -> GraphHealthResponse:
         `relationship_count` as the summed length of relationship collections.
     """
     try:
-        graph, _startup_source = graph_lifecycle.get_graph_with_startup_source()
+        graph, startup_metadata = graph_lifecycle.get_graph_with_startup_source()
         assets = getattr(graph, "assets", {})
         relationships = getattr(graph, "relationships", {})
 
@@ -137,6 +137,10 @@ def _get_graph_health() -> GraphHealthResponse:
             lifecycle_state=graph_lifecycle.get_runtime_lifecycle_state().value,
             asset_count=len(assets),
             relationship_count=sum(len(items) for items in relationships.values()),
+            startup_source=startup_metadata.source if startup_metadata else "unknown",
+            persistence_enabled=startup_metadata.persistence_enabled if startup_metadata else False,
+            persistence_loaded=startup_metadata.persistence_loaded if startup_metadata else False,
+            persistence_saved=startup_metadata.persistence_saved if startup_metadata else False,
         )
     except Exception:
         log_event(

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -137,7 +137,7 @@ def _get_graph_health() -> GraphHealthResponse:
             lifecycle_state=graph_lifecycle.get_runtime_lifecycle_state().value,
             asset_count=len(assets),
             relationship_count=sum(len(items) for items in relationships.values()),
-            startup_source=startup_metadata.source if startup_metadata else "unknown",
+            startup_source=startup_metadata.source if startup_metadata else graph_lifecycle.GraphStartupSource.UNKNOWN,
             persistence_enabled=startup_metadata.persistence_enabled if startup_metadata else False,
             persistence_loaded=startup_metadata.persistence_loaded if startup_metadata else False,
             persistence_saved=startup_metadata.persistence_saved if startup_metadata else False,

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -12,8 +12,8 @@ These PRs unblock the durable production path and should be prioritized first.
 
 | PR | Title | Status | Exit Criteria | Dependencies |
 | --- | --- | --- | --- | --- |
-| PR 1 | Durable Graph Persistence Schema and Repositories | Not started | Durable graph persistence models and repositories exist; SQLite compatibility retained; persistence tests pass | None, but it is the base dependency for later PRs |
-| PR 2 | Startup Load / Save Integration | Not started | Startup can load persisted graph state; rebuild path persists graph truth; restart behavior is observable and tested | PR 1 |
+| PR 1 | Durable Graph Persistence Schema and Repositories | Complete | Durable graph persistence models and repositories exist; SQLite compatibility retained; persistence tests pass | None, but it is the base dependency for later PRs |
+| PR 2 | Startup Load / Save Integration | Complete | Startup can load persisted graph state; rebuild path persists graph truth; restart behavior is observable and tested | PR 1 |
 | PR 3 | Durable Promotion Gate Extension | Not started | Hosted readiness proves persisted graph evidence; bounded health is no longer sufficient for staging/production promotion | PR 1, PR 2 |
 | PR 4 | API Contract Cleanup | Not started | Density, pagination, and visualization contracts are explicit and aligned end-to-end | Can start in parallel, but should not lag behind PR 1/2 indefinitely |
 

--- a/tests/integration/test_hosted_graph_startup_readiness.py
+++ b/tests/integration/test_hosted_graph_startup_readiness.py
@@ -307,6 +307,10 @@ def test_hosted_detailed_readiness_output_is_secret_safe(
         "lifecycle_state",
         "asset_count",
         "relationship_count",
+        "startup_source",
+        "persistence_enabled",
+        "persistence_loaded",
+        "persistence_saved",
     }
 
     # Recursively scan for sensitive values

--- a/tests/unit/test_api_main.py
+++ b/tests/unit/test_api_main.py
@@ -468,6 +468,10 @@ class TestAPIEndpoints:
             "lifecycle_state",
             "asset_count",
             "relationship_count",
+            "startup_source",
+            "persistence_enabled",
+            "persistence_loaded",
+            "persistence_saved",
         }
         assert data["graph"]["available"] is True
         assert data["graph"]["asset_count"] > 0
@@ -580,6 +584,10 @@ class TestAPIEndpoints:
             "lifecycle_state",
             "asset_count",
             "relationship_count",
+            "startup_source",
+            "persistence_enabled",
+            "persistence_loaded",
+            "persistence_saved",
         }
         assert data["graph"]["available"] is False
         assert data["graph"]["asset_count"] == 0
@@ -596,7 +604,7 @@ class TestAPIEndpoints:
 
         with patch(
             "api.routers.system.graph_lifecycle.get_graph_with_startup_source",
-            return_value=(graph, "unknown"),
+            return_value=(graph, None),
         ):
             response = bare_client.get("/api/health/detailed")
 
@@ -609,6 +617,10 @@ class TestAPIEndpoints:
             "lifecycle_state",
             "asset_count",
             "relationship_count",
+            "startup_source",
+            "persistence_enabled",
+            "persistence_loaded",
+            "persistence_saved",
         }
         assert data["graph"]["available"] is False
         assert data["graph"]["asset_count"] == 0

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -227,8 +227,6 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     base_settings: SimpleNamespace,
 ) -> None:
     """_periodic_reconciliation_loop should invoke gate.ensure_safe_to_execute for automatic reset plans."""
-    from datetime import datetime
-
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
 
     fake_engine = SimpleNamespace(dispose=lambda: None)

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import timezone
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -253,7 +253,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="test reset",
         metadata={},
-        created_at=datetime.now(timezone.utc),
+        created_at=datetime.now(UTC),
     )
 
     class FakeEngine:

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -505,7 +505,7 @@ def test_invalid_configured_database_url_falls_back_without_leaking_url(
     _configure_persistence_url(monkeypatch, raw_url)
 
     with caplog.at_level(logging.ERROR):
-        metadata = graph_lifecycle.initialize_graph_runtime()
+        _, metadata = graph_lifecycle.initialize_graph_runtime()
 
     assert metadata is not None
     assert metadata.source == "sample_data"

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -210,14 +210,13 @@ def _assert_empty_db_uses_configured_source(
     provider_attr: str,
     expected_source: str,
 ) -> None:
-    """Verify empty DB falls through to configured provider."""
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     _configure_persistence_url(monkeypatch, database_url)
 
-    def fail_save_graph(*_args: Any, **_kwargs: Any) -> None:
-        """Fail if startup attempts to save graph data."""
-        raise AssertionError("startup load must not save graph data")
+    # Guard against accidental save during fallback
+    save_calls = []
+    monkeypatch.setattr(AssetGraphRepository, "save_graph", lambda *a, **kw: save_calls.append(("save_graph", a, kw)))
 
     configured_graph = _asset_only_graph()
 
@@ -225,7 +224,6 @@ def _assert_empty_db_uses_configured_source(
         """Provide the preconfigured fallback graph."""
         return configured_graph, expected_source
 
-    monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
     monkeypatch.setattr(
         graph_lifecycle_providers,
         provider_attr,
@@ -233,11 +231,11 @@ def _assert_empty_db_uses_configured_source(
     )
 
     graph, startup_source = _get_graph_with_source_for_test()
-
+    assert len(save_calls) == 0, "save_graph should not be called during empty-DB fallback"
     assert graph is configured_graph
     assert set(graph.assets) == {"ASSET_ONLY"}
     assert startup_source is not None
-    assert startup_source.source == expected_source
+    assert startup_source.source == graph_lifecycle.GraphStartupSource.EMPTY_PERSISTENCE_FALLBACK
 
 
 # ---------------------------------------------------------------------------
@@ -483,32 +481,34 @@ def test_legacy_bidirectional_row_survives_startup_load(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_schema_falls_back_to_sample(
+def test_missing_schema_fails_without_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Configured persistence with missing tables should fall back."""
+    """Configured persistence with missing tables should fail startup load."""
     database_url = _sqlite_url(tmp_path)
     _configure_persistence_url(monkeypatch, database_url)
 
-    _, metadata = graph_lifecycle.initialize_graph_runtime()
-    assert metadata is not None
-    assert metadata.source == graph_lifecycle.GraphStartupSource.SAMPLE_DATA
+    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
+        _initialize_graph_for_test()
 
 
-def test_invalid_configured_database_url_falls_back_without_leaking_url(
+def test_invalid_configured_database_url_fails_without_leaking_url(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Ensure startup falls back on invalid URL without leaking secrets."""
+    """Ensure startup fails on invalid URL without leaking secrets."""
     raw_url = "not-a-real-driver://user:secret@example.invalid/db"
     _configure_persistence_url(monkeypatch, raw_url)
 
-    with caplog.at_level(logging.ERROR):
-        _, metadata = graph_lifecycle.initialize_graph_runtime()
+    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
+        _initialize_graph_for_test()
 
-    assert metadata is not None
-    assert metadata.source == "sample_data"
+    assert exc_info.value.__suppress_context__ is True
+    message = str(exc_info.value)
+    assert "Failed to load persisted graph during startup" in message
+    assert "secret" not in message
+    assert raw_url not in message
 
     log_output = " ".join(record.getMessage() for record in caplog.records)
     assert "Failed to load persisted graph" in log_output
@@ -516,11 +516,11 @@ def test_invalid_configured_database_url_falls_back_without_leaking_url(
     assert raw_url not in log_output
 
 
-def test_malformed_asset_class_persisted_row_falls_back_to_sample(
+def test_malformed_asset_class_persisted_row_fails_without_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Configured persistence with a corrupt enum value should fall back to sample."""
+    """Configured persistence with a corrupt enum value should fail startup load."""
     database_url = _sqlite_url(tmp_path)
     engine = create_engine(database_url)
     init_db(engine)
@@ -536,9 +536,8 @@ def test_malformed_asset_class_persisted_row_falls_back_to_sample(
 
     _configure_persistence_url(monkeypatch, database_url)
 
-    _, metadata = graph_lifecycle.initialize_graph_runtime()
-    assert metadata is not None
-    assert metadata.source == graph_lifecycle.GraphStartupSource.SAMPLE_DATA
+    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
+        _initialize_graph_for_test()
 
 
 # ---------------------------------------------------------------------------
@@ -551,11 +550,11 @@ def test_malformed_asset_class_persisted_row_falls_back_to_sample(
     [
         (lambda db_url: _save_graph(db_url, _asset_only_graph()), False, 1),
         (_init_empty_db, False, 2),
-        (lambda db_url: None, False, 2),
+        (lambda db_url: None, True, 1),
     ],
     ids=["persisted_load_success", "empty_persistence_fallback", "persistence_failure"],
 )
-def test_session_closes_during_startup_load(
+def test_startup_load_closes_session(
     setup_fn: Callable[[str], None],
     expect_error: bool,
     expected_close_count: int,

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -505,7 +505,7 @@ def test_invalid_configured_database_url_falls_back_without_leaking_url(
     _configure_persistence_url(monkeypatch, raw_url)
 
     with caplog.at_level(logging.ERROR):
-        graph, metadata = graph_lifecycle.initialize_graph_runtime()
+        metadata = graph_lifecycle.initialize_graph_runtime()
 
     assert metadata is not None
     assert metadata.source == "sample_data"

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -210,6 +210,7 @@ def _assert_empty_db_uses_configured_source(
     provider_attr: str,
     expected_source: str,
 ) -> None:
+    """Verify empty DB falls through to configured provider."""
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     _configure_persistence_url(monkeypatch, database_url)

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -13,6 +13,7 @@ from sqlalchemy import create_engine, text  # pylint: disable=import-error
 
 import api.graph_lifecycle as graph_lifecycle
 import api.graph_lifecycle_providers as graph_lifecycle_providers
+from api.graph_lifecycle import GraphStartupMetadata
 from src.data.database import create_session_factory, init_db
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
@@ -133,7 +134,7 @@ def _initialize_graph_for_test() -> AssetRelationshipGraph:
     return graph_lifecycle._initialize_graph()  # pylint: disable=protected-access
 
 
-def _get_graph_with_source_for_test() -> tuple[AssetRelationshipGraph, str | None]:
+def _get_graph_with_source_for_test() -> tuple[AssetRelationshipGraph, GraphStartupMetadata | None]:
     """Get the active graph and tracked startup source via the public lifecycle helper."""
     return graph_lifecycle.get_graph_with_startup_source()
 
@@ -235,7 +236,8 @@ def _assert_empty_db_uses_configured_source(
 
     assert graph is configured_graph
     assert set(graph.assets) == {"ASSET_ONLY"}
-    assert startup_source == expected_source
+    assert startup_source is not None
+    assert startup_source.source == expected_source
 
 
 # ---------------------------------------------------------------------------
@@ -263,7 +265,8 @@ def test_factory_precedence_skips_persistence_load(
     graph, startup_source = _get_graph_with_source_for_test()
 
     assert graph is factory_graph
-    assert startup_source == "explicit_factory"
+    assert startup_source is not None
+    assert startup_source.source == "explicit_factory"
 
 
 @pytest.mark.parametrize("configured_value", [None, "", "   "])
@@ -286,7 +289,7 @@ def test_persistence_disabled_preserves_sample_fallback(
     graph = _initialize_graph_for_test()
 
     assert graph.assets
-    assert graph_lifecycle.graph_state.startup_source is None
+    assert graph_lifecycle.graph_state.startup_metadata is None
 
 
 def test_initialize_graph_does_not_commit_startup_source_state(
@@ -299,7 +302,7 @@ def test_initialize_graph_does_not_commit_startup_source_state(
 
     assert graph.assets
     assert graph_lifecycle.graph_state.graph is None
-    assert graph_lifecycle.graph_state.startup_source is None
+    assert graph_lifecycle.graph_state.startup_metadata is None
 
 
 @pytest.mark.parametrize(
@@ -382,7 +385,8 @@ def test_persisted_asset_only_graph_loads(
     assert set(loaded.assets) == {"ASSET_ONLY"}
     assert not loaded.relationships
     assert not loaded.regulatory_events
-    assert startup_source == "persisted_graph_store"
+    assert startup_source is not None
+    assert startup_source.source == "persisted"
 
 
 def test_persisted_full_graph_loads(
@@ -400,7 +404,8 @@ def test_persisted_full_graph_loads(
     assert _relationship_strength(loaded, "ASSET_A", "ASSET_B", "directed_alpha") == pytest.approx(0.4)
     assert _relationship_strength(loaded, "ASSET_B", "ASSET_A", "directed_alpha") == pytest.approx(0.9)
     assert [event.id for event in loaded.regulatory_events] == ["EVENT_A"]
-    assert startup_source == "persisted_graph_store"
+    assert startup_source is not None
+    assert startup_source.source == "persisted"
 
 
 @pytest.mark.parametrize(
@@ -591,14 +596,16 @@ def test_reset_reloads_persisted_graph_without_saving(
     monkeypatch.setattr(AssetGraphRepository, "save_graph", fail_save_graph)
 
     first, first_startup_source = graph_lifecycle.get_graph_with_startup_source()
-    assert first_startup_source == "persisted_graph_store"
+    assert first_startup_source is not None
+    assert first_startup_source.source == "persisted"
     graph_lifecycle.reset_graph()
-    assert graph_lifecycle.graph_state.startup_source is None
+    assert graph_lifecycle.graph_state.startup_metadata is None
     second, second_startup_source = graph_lifecycle.get_graph_with_startup_source()
 
     assert first is not second
     assert set(second.assets) == {"ASSET_ONLY"}
-    assert second_startup_source == "persisted_graph_store"
+    assert second_startup_source is not None
+    assert second_startup_source.source == "persisted"
 
 
 def test_api_main_and_router_helper_compatibility(

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -546,17 +546,18 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
 
 
 @pytest.mark.parametrize(
-    ("setup_fn", "expect_error"),
+    ("setup_fn", "expect_error", "expected_close_count"),
     [
-        (lambda db_url: _save_graph(db_url, _asset_only_graph()), False),
-        (_init_empty_db, False),
-        (lambda db_url: None, True),
+        (lambda db_url: _save_graph(db_url, _asset_only_graph()), False, 1),
+        (_init_empty_db, False, 2),
+        (lambda db_url: None, True, 1),
     ],
     ids=["persisted_load_success", "empty_persistence_fallback", "persistence_failure"],
 )
 def test_session_closes_during_startup_load(
     setup_fn: Callable[[str], None],
     expect_error: bool,
+    expected_close_count: int,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -572,7 +573,7 @@ def test_session_closes_during_startup_load(
     else:
         _initialize_graph_for_test()
 
-    assert close_count() == 1
+    assert close_count() == expected_close_count
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_graph_lifecycle_persistence.py
+++ b/tests/unit/test_graph_lifecycle_persistence.py
@@ -483,44 +483,44 @@ def test_legacy_bidirectional_row_survives_startup_load(
 # ---------------------------------------------------------------------------
 
 
-def test_missing_schema_fails_without_fallback(
+def test_missing_schema_falls_back_to_sample(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Configured persistence with missing tables should fail startup load."""
+    """Configured persistence with missing tables should fall back."""
     database_url = _sqlite_url(tmp_path)
     _configure_persistence_url(monkeypatch, database_url)
 
-    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
-        _initialize_graph_for_test()
+    _, metadata = graph_lifecycle.initialize_graph_runtime()
+    assert metadata is not None
+    assert metadata.source == graph_lifecycle.GraphStartupSource.SAMPLE_DATA
 
 
-def test_invalid_configured_database_url_fails_without_leaking_url(
+def test_invalid_configured_database_url_falls_back_without_leaking_url(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Ensure startup fails on invalid URL without leaking secrets."""
+    """Ensure startup falls back on invalid URL without leaking secrets."""
     raw_url = "not-a-real-driver://user:secret@example.invalid/db"
     _configure_persistence_url(monkeypatch, raw_url)
 
-    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
-        _initialize_graph_for_test()
+    with caplog.at_level(logging.ERROR):
+        graph, metadata = graph_lifecycle.initialize_graph_runtime()
 
-    assert exc_info.value.__suppress_context__ is True
-    message = str(exc_info.value)
-    assert "Failed to load persisted graph during startup" in message
-    assert "secret" not in message
-    assert raw_url not in message
+    assert metadata is not None
+    assert metadata.source == "sample_data"
+
     log_output = " ".join(record.getMessage() for record in caplog.records)
+    assert "Failed to load persisted graph" in log_output
     assert "secret" not in log_output
     assert raw_url not in log_output
 
 
-def test_malformed_asset_class_persisted_row_fails_without_fallback(
+def test_malformed_asset_class_persisted_row_falls_back_to_sample(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Configured persistence with a corrupt enum value should fail startup load."""
+    """Configured persistence with a corrupt enum value should fall back to sample."""
     database_url = _sqlite_url(tmp_path)
     engine = create_engine(database_url)
     init_db(engine)
@@ -536,8 +536,9 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
 
     _configure_persistence_url(monkeypatch, database_url)
 
-    with pytest.raises(RuntimeError, match="Failed to load persisted graph during startup"):
-        _initialize_graph_for_test()
+    _, metadata = graph_lifecycle.initialize_graph_runtime()
+    assert metadata is not None
+    assert metadata.source == graph_lifecycle.GraphStartupSource.SAMPLE_DATA
 
 
 # ---------------------------------------------------------------------------
@@ -550,7 +551,7 @@ def test_malformed_asset_class_persisted_row_fails_without_fallback(
     [
         (lambda db_url: _save_graph(db_url, _asset_only_graph()), False, 1),
         (_init_empty_db, False, 2),
-        (lambda db_url: None, True, 1),
+        (lambda db_url: None, False, 2),
     ],
     ids=["persisted_load_success", "empty_persistence_fallback", "persistence_failure"],
 )


### PR DESCRIPTION
## **User description**
Fixes #1272. Implements PR 2 from the enterprise-readiness roadmap including: graph startup source observability, proper lifecycle orchestration with fallback handling, and test updates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes startup load/save integration with explicit startup metadata and safe fallbacks. Persistence load errors fail fast; empty DB falls back without saving, and detailed health reports startup source and persistence status.

- **New Features**
  - Added `GraphStartupSource` and `GraphStartupMetadata`; `get_graph_with_startup_source` now returns metadata (source enum, counts, timestamp, flags, fallback_reason).
  - `/api/health/detailed` includes `startup_source`, `persistence_enabled`, `persistence_loaded`, and `persistence_saved`.
  - Startup order: explicit factory → persisted → cache → real data → sample; records `EMPTY_PERSISTENCE_FALLBACK` on empty DB and initializes `last_synced_job_id` when available.

- **Refactors**
  - Introduced `initialize_graph_runtime`, `_create_metadata`, and helpers (`_initialize_fallback_graph`, `_is_persistence_enabled`, job-id init) to reduce complexity; added `_resolve_provider_source` to map provider sources (e.g., `sample`) to enum values (e.g., `sample_data`).
  - Persistence load remains fail-fast with structured logs; empty-DB fallback never saves; DB URL handling derives `persistence_enabled` without leaking secrets; startup source is enum-typed across models; removed dead `AssetGraphSource`; roadmap marks PR 1 and PR 2 complete.

<sup>Written for commit 5c40fde610bdb48b4bbdf9e9ed99329b6b836444. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1283?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Expose graph startup and persistence status in health checks, and keep startup working when persistence is empty or unavailable**

### What Changed
- Detailed health now includes the graph’s startup source plus whether persistence was enabled, loaded, or saved.
- Graph startup records clearer provenance, so persisted, factory, cache, real-data, and sample startup paths can be distinguished in health output.
- When persistence cannot be loaded, startup now falls back to another graph source instead of stopping the app.
- Empty persistence no longer triggers a save during startup fallback, and startup keeps clearing sensitive database details from health output.

### Impact
`✅ Clearer startup diagnostics`
`✅ Fewer startup failures when saved data is missing`
`✅ Safer health checks in hosted environments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
