### PR TITLE
PR 3 — Durable Promotion Gate Extension

### DIFF
--- a/.github/workflows/hosted-readiness.yml
+++ b/.github/workflows/hosted-readiness.yml
@@ -12,6 +12,11 @@ name: Hosted readiness smoke check
         required: false
         default: "10"
         type: string
+      require_persistence:
+        description: "Prove persisted graph load rather than fallback generation."
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -25,6 +30,7 @@ jobs:
     env:
       HOSTED_READINESS_BASE_URL: ${{ inputs.base_url || secrets.HOSTED_READINESS_BASE_URL }}
       HOSTED_READINESS_TIMEOUT: ${{ inputs.timeout }}
+      HOSTED_READINESS_REQUIRE_PERSISTENCE: ${{ inputs.require_persistence }}
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -41,4 +47,8 @@ jobs:
           mask_value="${mask_value//$'\r'/%0D}"
           mask_value="${mask_value//$'\n'/%0A}"
           printf '::add-mask::%s\n' "$mask_value"
-          python scripts/check_hosted_readiness.py "$HOSTED_READINESS_BASE_URL" --timeout "$HOSTED_READINESS_TIMEOUT"
+          cmd=(python scripts/check_hosted_readiness.py "$HOSTED_READINESS_BASE_URL" --timeout "$HOSTED_READINESS_TIMEOUT")
+          if [ "${HOSTED_READINESS_REQUIRE_PERSISTENCE}" = "true" ]; then
+            cmd+=(--require-persistence)
+          fi
+          "${cmd[@]}"

--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ For the full enterprise-readiness package, see [docs/enterprise-readiness-index.
 ### Hosted Readiness Smoke Check
 
 You can verify a hosted deployment's liveness and readiness endpoints:
+
 ```bash
 python scripts/check_hosted_readiness.py <base_url> [--timeout SECONDS] [--require-persistence]
 ```
+
 The `--require-persistence` option enforces that the deployment has successfully loaded its asset graph from the configured database (meaning `persistence_enabled` is true, `persistence_loaded` is true, and the startup source is `"persisted"`). This persistence verification is a mandatory gate for staging and production promotions.
 
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ See [DEPLOYMENT.md](DEPLOYMENT.md) for detailed deployment instructions and Verc
 
 For the full enterprise-readiness package, see [docs/enterprise-readiness-index.md](./docs/enterprise-readiness-index.md).
 
+### Hosted Readiness Smoke Check
+
+You can verify a hosted deployment's liveness and readiness endpoints:
+```bash
+python scripts/check_hosted_readiness.py <base_url> [--timeout SECONDS] [--require-persistence]
+```
+The `--require-persistence` option enforces that the deployment has successfully loaded its asset graph from the configured database (meaning `persistence_enabled` is true, `persistence_loaded` is true, and the startup source is `"persisted"`). This persistence verification is a mandatory gate for staging and production promotions.
+
+
 ### Troubleshooting
 
 #### Frontend shows "Failed to load data"

--- a/docs/adr/0002-hosted-deployment-and-persistence.md
+++ b/docs/adr/0002-hosted-deployment-and-persistence.md
@@ -4,7 +4,7 @@ For the broader enterprise-readiness audit and rollout plan, see [docs/enterpris
 
 ## Status
 
-Accepted — implementation pending
+Implemented
 
 ## Date
 
@@ -135,13 +135,13 @@ should implement connection pooling (Phase 4) before significant traffic.
 Vercel Postgres may expose `POSTGRES_*` variables rather than `DATABASE_URL`. Phase 1 adds
 explicit settings-layer support for `POSTGRES_URL` as a fallback when `DATABASE_URL` is not set.
 
-### Phase 2: Enhanced Health Checks
+### Phase 2: Enhanced Health Checks & Durable Promotion Gate (Completed)
 
-Add `/api/health/detailed` endpoint with database connectivity, graph status, and environment validation.
+Added `/api/health/detailed` endpoint with database connectivity, graph status, and environment validation. Extended `scripts/check_hosted_readiness.py` and the GitHub Actions workflow with a `--require-persistence` parameter to verify that the graph was loaded successfully from the durable storage boundary during deployment promotion.
 
-### Phase 3: Graph Persistence (Deferred)
+### Phase 3: Graph Persistence (Completed)
 
-Design PostgreSQL schema for assets/relationships and implement graph serialization/deserialization.
+Implemented graph serialization, deserialization, and PostgreSQL repository boundary support. Verified durability of graph state across application restart cycles.
 
 ### Phase 4: Production Optimizations (Future)
 

--- a/docs/enterprise-deployment-operating-model.md
+++ b/docs/enterprise-deployment-operating-model.md
@@ -111,16 +111,21 @@ Recommended diagnostic evidence, when an approved sentinel baseline exists:
 
 ## Verification and Smoke Testing
 
-`GET /api/health/detailed` is a bounded readiness signal only. It confirms in-memory graph availability and auth/application database reachability. It does **not** prove the graph was loaded from `ASSET_GRAPH_DATABASE_URL`.
+`GET /api/health/detailed` is a bounded readiness signal only. It confirms in-memory graph availability and auth/application database reachability. It does **not** prove the graph was loaded from `ASSET_GRAPH_DATABASE_URL` unless verified via the persistence-gate check.
 
 For staging and production deployment acceptance, operators must run this durable graph-persistence smoke procedure:
 
 1. Confirm `ASSET_GRAPH_DATABASE_URL` is set in the target environment.
 2. Trigger a controlled authenticated graph rebuild/persist operation through `POST /api/graph/rebuild`, or use an approved persisted baseline.
 3. Restart or redeploy the backend.
-4. Verify startup logs contain `Graph startup source: persisted_graph_store`.
-5. Call `GET /api/health/detailed` and confirm:
-   - `status` is `healthy`
+4. Run the hosted readiness checker with `--require-persistence` configured:
+   ```bash
+   python scripts/check_hosted_readiness.py <base_url> --require-persistence
+   ```
+5. Confirm the checker exits successfully (exit code 0), verifying that:
+   - `/api/health/detailed` `status` is `healthy`
+   - `graph.persistence_loaded` is `true`
+   - `graph.startup_source` is `"persisted"`
    - graph counts match the expected persisted baseline
    - auth/application database is reachable
 6. If an approved sentinel baseline exists, call `GET /api/assets` and confirm known sentinel asset IDs are present.

--- a/docs/enterprise-deployment-operating-model.md
+++ b/docs/enterprise-deployment-operating-model.md
@@ -119,9 +119,11 @@ For staging and production deployment acceptance, operators must run this durabl
 2. Trigger a controlled authenticated graph rebuild/persist operation through `POST /api/graph/rebuild`, or use an approved persisted baseline.
 3. Restart or redeploy the backend.
 4. Run the hosted readiness checker with `--require-persistence` configured:
+
    ```bash
    python scripts/check_hosted_readiness.py <base_url> --require-persistence
    ```
+
 5. Confirm the checker exits successfully (exit code 0), verifying that:
    - `/api/health/detailed` `status` is `healthy`
    - `graph.persistence_loaded` is `true`

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -14,7 +14,7 @@ These PRs unblock the durable production path and should be prioritized first.
 | --- | --- | --- | --- | --- |
 | PR 1 | Durable Graph Persistence Schema and Repositories | Complete | Durable graph persistence models and repositories exist; SQLite compatibility retained; persistence tests pass | None, but it is the base dependency for later PRs |
 | PR 2 | Startup Load / Save Integration | Complete | Startup can load persisted graph state; rebuild path persists graph truth; restart behavior is observable and tested | PR 1 |
-| PR 3 | Durable Promotion Gate Extension | Not started | Hosted readiness proves persisted graph evidence; bounded health is no longer sufficient for staging/production promotion | PR 1, PR 2 |
+| PR 3 | Durable Promotion Gate Extension | Complete | Hosted readiness proves persisted graph evidence; bounded health is no longer sufficient for staging/production promotion | PR 1, PR 2 |
 | PR 4 | API Contract Cleanup | Not started | Density, pagination, and visualization contracts are explicit and aligned end-to-end | Can start in parallel, but should not lag behind PR 1/2 indefinitely |
 
 ## Next

--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -67,7 +67,7 @@ def _resolves_to_internal_address(hostname: str) -> bool:
     except OSError:
         return False
 
-    return any(_is_internal_ip_address(result[4][0]) for result in address_info)
+    return any(_is_internal_ip_address(str(result[4][0])) for result in address_info)
 
 
 def _validate_scheme_and_host(parsed: ParseResult) -> str | None:
@@ -301,7 +301,29 @@ def _record_detailed_shape_failures(payload: dict[str, Any], failures: list[str]
         failures.append("/api/health/detailed database field is not an object")
 
 
-def check_detailed_readiness(base_url: str, timeout: float) -> list[str]:
+def _record_persistence_gate_failures(payload: dict[str, Any], failures: list[str]) -> None:
+    """Record failures when the durable graph-persistence gate is not satisfied."""
+    if payload.get("graph_persistence_configured") is not True:
+        failures.append("/api/health/detailed graph_persistence_configured is not true")
+
+    graph = payload.get("graph")
+    if isinstance(graph, dict):
+        if graph.get("persistence_enabled") is not True:
+            failures.append("/api/health/detailed graph.persistence_enabled is not true")
+        if graph.get("persistence_loaded") is not True:
+            failures.append("/api/health/detailed graph.persistence_loaded is not true")
+        actual_source = graph.get("startup_source")
+        if actual_source != "persisted":
+            failures.append(f'/api/health/detailed graph.startup_source is "{actual_source}", expected "persisted"')
+    else:
+        failures.append("/api/health/detailed graph persistence verification skipped due to invalid graph shape")
+
+
+def check_detailed_readiness(
+    base_url: str,
+    timeout: float,
+    require_persistence: bool = False,
+) -> list[str]:
     """Return detailed readiness check failures."""
     failures: list[str] = []
     url = _build_url(base_url, "/api/health/detailed")
@@ -314,6 +336,9 @@ def check_detailed_readiness(base_url: str, timeout: float) -> list[str]:
     _record_top_level_contract_failures(payload, failures)
     _record_forbidden_field_failures(payload, failures)
     _record_detailed_shape_failures(payload, failures)
+
+    if require_persistence:
+        _record_persistence_gate_failures(payload, failures)
 
     return failures
 
@@ -347,7 +372,7 @@ def _report_failures(failures: list[str]) -> int:
     return CHECK_FAILED
 
 
-def run_checks(base_url: str, timeout: float) -> int:
+def run_checks(base_url: str, timeout: float, require_persistence: bool = False) -> int:
     """Run hosted readiness checks and return a process exit code."""
     liveness_failures = _run_named_check("Liveness", base_url, timeout, check_liveness)
     if liveness_failures is None:
@@ -357,7 +382,7 @@ def run_checks(base_url: str, timeout: float) -> int:
         "Detailed readiness",
         base_url,
         timeout,
-        check_detailed_readiness,
+        lambda url, t: check_detailed_readiness(url, t, require_persistence),
     )
     if readiness_failures is None:
         return CHECK_FAILED
@@ -370,6 +395,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Smoke-check hosted API health/readiness endpoints.")
     parser.add_argument("base_url", help="Base URL of the hosted deployment, e.g. https://example.vercel.app")
     parser.add_argument("--timeout", type=float, default=5.0, help="Request timeout in seconds.")
+    parser.add_argument(
+        "--require-persistence",
+        action="store_true",
+        help="Prove persisted graph load rather than fallback generation.",
+    )
     return parser.parse_args(argv)
 
 
@@ -386,7 +416,7 @@ def main(argv: list[str] | None = None) -> int:
         print(base_url_error, file=sys.stderr)
         return USAGE_ERROR
 
-    return run_checks(args.base_url, args.timeout)
+    return run_checks(args.base_url, args.timeout, args.require_persistence)
 
 
 if __name__ == "__main__":

--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -284,6 +284,24 @@ def _readiness_status_label(value: Any) -> str:
     return "unknown"
 
 
+def _startup_source_label(value: Any) -> str:
+    """Return a bounded startup source label for operator output."""
+    valid_sources = {
+        "persisted",
+        "real_data",
+        "sample_data",
+        "empty_persistence_fallback",
+        "rebuild",
+        "failed",
+        "cache",
+        "explicit_factory",
+        "unknown",
+    }
+    if value in valid_sources:
+        return str(value)
+    return "unknown"
+
+
 def _record_detailed_shape_failures(payload: dict[str, Any], failures: list[str]) -> None:
     """Record detailed-readiness status and object-shape failures."""
     readiness_status = payload.get("status")
@@ -313,10 +331,12 @@ def _record_persistence_gate_failures(payload: dict[str, Any], failures: list[st
         if graph.get("persistence_loaded") is not True:
             failures.append("/api/health/detailed graph.persistence_loaded is not true")
         actual_source = graph.get("startup_source")
-        if actual_source != "persisted":
-            failures.append(f'/api/health/detailed graph.startup_source is "{actual_source}", expected "persisted"')
-    else:
-        failures.append("/api/health/detailed graph persistence verification skipped due to invalid graph shape")
+        if actual_source is None:
+            failures.append("/api/health/detailed graph.startup_source field is missing")
+        else:
+            source_label = _startup_source_label(actual_source)
+            if source_label != "persisted":
+                failures.append(f'/api/health/detailed graph.startup_source is "{source_label}", expected "persisted"')
 
 
 def check_detailed_readiness(

--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -297,8 +297,8 @@ def _startup_source_label(value: Any) -> str:
         "explicit_factory",
         "unknown",
     }
-    if value in valid_sources:
-        return str(value)
+    if isinstance(value, str) and value in valid_sources:
+        return value
     return "unknown"
 
 

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -222,7 +222,10 @@ class TestHostedReadinessWorkflowEnvironment:
     """Verify the workflow environment configuration."""
 
     def test_environment_variables_configured(self, hosted_readiness_workflow):
-        """Job must define HOSTED_READINESS_BASE_URL, HOSTED_READINESS_TIMEOUT, and HOSTED_READINESS_REQUIRE_PERSISTENCE env vars."""
+        """
+        Job must define HOSTED_READINESS_BASE_URL, HOSTED_READINESS_TIMEOUT,
+        and HOSTED_READINESS_REQUIRE_PERSISTENCE env vars.
+        """
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         assert "env" in job, "The 'hosted-readiness' job must define 'env' section"
         env = job.get("env", {})
@@ -379,7 +382,10 @@ class TestHostedReadinessWorkflowSteps:
         ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
 
     def test_script_invocation_uses_require_persistence_env_var(self, hosted_readiness_steps):
-        """The script invocation must conditionally append --require-persistence using $HOSTED_READINESS_REQUIRE_PERSISTENCE."""
+        """
+        The script invocation must conditionally append --require-persistence
+        using $HOSTED_READINESS_REQUIRE_PERSISTENCE.
+        """
         run_check_step = next(
             (s for s in hosted_readiness_steps if "Run hosted readiness smoke check" in s.get("name", "")),
             None,

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -18,13 +18,13 @@ import re
 from pathlib import Path
 
 import pytest
-import yaml
+import yaml  # type: ignore[import-untyped]
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HOSTED_READINESS_WORKFLOW_PATH = REPO_ROOT / ".github/workflows/hosted-readiness.yml"
 
 TRUSTED_GITHUB_REFERENCES_PATTERN = re.compile(
-    r"\b(?:inputs\.base_url|inputs\.timeout|secrets\.HOSTED_READINESS_BASE_URL)\b"
+    r"\b(?:inputs\.base_url|inputs\.timeout|inputs\.require_persistence|secrets\.HOSTED_READINESS_BASE_URL)\b"
 )
 
 PROVIDER_SECRET_NAMES = (
@@ -207,18 +207,30 @@ class TestHostedReadinessWorkflowInputs:
         assert "default" in timeout_input, "timeout input must have a 'default' value"
         assert isinstance(timeout_input["default"], str), "timeout input default must be a string"
 
+    def test_require_persistence_input_configuration(self, hosted_readiness_workflow):
+        """require_persistence input must exist and be a boolean default false."""
+        inputs = hosted_readiness_workflow["on"]["workflow_dispatch"]["inputs"]
+        assert "require_persistence" in inputs, "workflow_dispatch inputs must include 'require_persistence'"
+        input_cfg = inputs["require_persistence"]
+        assert "description" in input_cfg, "require_persistence input must have a 'description'"
+        assert input_cfg.get("default") is False, "require_persistence default must be false"
+        assert input_cfg.get("type") == "boolean", "require_persistence type must be boolean"
+
 
 @pytest.mark.integration
 class TestHostedReadinessWorkflowEnvironment:
     """Verify the workflow environment configuration."""
 
     def test_environment_variables_configured(self, hosted_readiness_workflow):
-        """Job must define HOSTED_READINESS_BASE_URL and HOSTED_READINESS_TIMEOUT env vars."""
+        """Job must define HOSTED_READINESS_BASE_URL, HOSTED_READINESS_TIMEOUT, and HOSTED_READINESS_REQUIRE_PERSISTENCE env vars."""
         job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
         assert "env" in job, "The 'hosted-readiness' job must define 'env' section"
         env = job.get("env", {})
         assert "HOSTED_READINESS_BASE_URL" in env, "Job must define HOSTED_READINESS_BASE_URL env var"
         assert "HOSTED_READINESS_TIMEOUT" in env, "Job must define HOSTED_READINESS_TIMEOUT env var"
+        assert (
+            "HOSTED_READINESS_REQUIRE_PERSISTENCE" in env
+        ), "Job must define HOSTED_READINESS_REQUIRE_PERSISTENCE env var"
 
     def test_base_url_comes_from_input_or_secret(self, hosted_readiness_workflow):
         """Base URL must come from inputs.base_url or secrets.HOSTED_READINESS_BASE_URL."""
@@ -236,6 +248,14 @@ class TestHostedReadinessWorkflowEnvironment:
         assert (
             env.get("HOSTED_READINESS_TIMEOUT") == "${{ inputs.timeout }}"
         ), "HOSTED_READINESS_TIMEOUT must use inputs.timeout"
+
+    def test_require_persistence_comes_from_input(self, hosted_readiness_workflow):
+        """Require persistence must come from inputs.require_persistence."""
+        job = hosted_readiness_workflow["jobs"]["hosted-readiness"]
+        env = job.get("env", {})
+        assert (
+            env.get("HOSTED_READINESS_REQUIRE_PERSISTENCE") == "${{ inputs.require_persistence }}"
+        ), "HOSTED_READINESS_REQUIRE_PERSISTENCE must use inputs.require_persistence"
 
 
 @pytest.mark.integration
@@ -357,6 +377,19 @@ class TestHostedReadinessWorkflowSteps:
         assert (
             "$HOSTED_READINESS_TIMEOUT" in run_script or "${HOSTED_READINESS_TIMEOUT}" in run_script
         ), "Script invocation must use $HOSTED_READINESS_TIMEOUT env var"
+
+    def test_script_invocation_uses_require_persistence_env_var(self, hosted_readiness_steps):
+        """The script invocation must conditionally append --require-persistence using $HOSTED_READINESS_REQUIRE_PERSISTENCE."""
+        run_check_step = next(
+            (s for s in hosted_readiness_steps if "Run hosted readiness smoke check" in s.get("name", "")),
+            None,
+        )
+        assert run_check_step is not None
+        run_script = run_check_step.get("run", "")
+        assert "--require-persistence" in run_script, "Script invocation must check/reference --require-persistence"
+        assert (
+            "HOSTED_READINESS_REQUIRE_PERSISTENCE" in run_script
+        ), "Script invocation must check HOSTED_READINESS_REQUIRE_PERSISTENCE"
 
 
 @pytest.mark.integration

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -527,6 +527,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 1: graph_persistence_configured is false
     def fake_get_json_no_config(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning unconfigured persistence payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph_persistence_configured"] = False
         return 200, payload
@@ -537,6 +538,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 2: persistence_enabled is false
     def fake_get_json_not_enabled(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning disabled graph persistence payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"]["persistence_enabled"] = False
         return 200, payload
@@ -547,6 +549,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 3: persistence_loaded is false
     def fake_get_json_not_loaded(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning unloaded graph persistence payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"]["persistence_loaded"] = False
         return 200, payload
@@ -557,6 +560,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 4: startup_source is not persisted
     def fake_get_json_wrong_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning incorrect startup source payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"]["startup_source"] = "sample_data"
         return 200, payload
@@ -567,6 +571,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 5: startup_source is None (missing field)
     def fake_get_json_missing_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning missing startup source payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"]["startup_source"] = None
         return 200, payload
@@ -577,6 +582,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 6: startup_source has unsafe values
     def fake_get_json_unsafe_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning unsafe startup source payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"]["startup_source"] = "untrusted_input\nwith_control_chars"
         return 200, payload
@@ -587,6 +593,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 7: graph is not a dict (should not append redundant persistence-gate failure message)
     def fake_get_json_non_dict_graph(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning non-dictionary graph payload."""
         payload = _healthy_detailed_payload_with_persistence()
         payload["graph"] = "not_a_dict"
         return 200, payload
@@ -602,6 +609,7 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
 
     # Case 8: graph is missing entirely from payload keys (should not double-fail or crash)
     def fake_get_json_missing_graph(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Mock JSON fetch returning payload with missing graph key."""
         payload = _healthy_detailed_payload_with_persistence()
         payload.pop("graph")
         return 200, payload

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -561,6 +561,41 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
     failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
     assert '/api/health/detailed graph.startup_source is "sample_data", expected "persisted"' in failures
 
+    # Case 5: startup_source is None (missing field)
+    def fake_get_json_missing_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"]["startup_source"] = None
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_missing_source)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert "/api/health/detailed graph.startup_source field is missing" in failures
+
+    # Case 6: startup_source has unsafe values
+    def fake_get_json_unsafe_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"]["startup_source"] = "untrusted_input\nwith_control_chars"
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_unsafe_source)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert '/api/health/detailed graph.startup_source is "unknown", expected "persisted"' in failures
+
+    # Case 7: graph is not a dict (should not append redundant persistence-gate failure message)
+    def fake_get_json_non_dict_graph(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"] = "not_a_dict"
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_non_dict_graph)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    # The shape check should catch it:
+    assert "/api/health/detailed graph field is not an object" in failures
+    # But there should NOT be a redundant generic verification error:
+    assert not any("skipped" in f for f in failures)
+    assert not any("graph_persistence_configured" in f for f in failures)
+    assert not any("persistence_enabled" in f for f in failures)
+
 
 def test_parse_args_handles_require_persistence() -> None:
     """CLI argument parser correctly extracts the require-persistence flag."""

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -318,7 +318,11 @@ def test_run_checks_reports_detailed_readiness_runtime_context(
         """Return an empty liveness failure list."""
         return []
 
-    def fake_check_detailed_readiness(base_url: str, timeout: float, *args: Any, **kwargs: Any) -> list[str]:
+    def fake_check_detailed_readiness(
+        base_url: str,
+        timeout: float,
+        require_persistence: bool = False,
+    ) -> list[str]:
         """Raise a fake detailed readiness runtime error."""
         raise RuntimeError("/api/health/detailed request failed")
 
@@ -593,6 +597,20 @@ def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytes
     assert "/api/health/detailed graph field is not an object" in failures
     # But there should NOT be a redundant generic verification error:
     assert not any("skipped" in f for f in failures)
+    assert not any("graph_persistence_configured" in f for f in failures)
+    assert not any("persistence_enabled" in f for f in failures)
+
+    # Case 8: graph is missing entirely from payload keys (should not double-fail or crash)
+    def fake_get_json_missing_graph(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload.pop("graph")
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_missing_graph)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    # Contract check should catch it:
+    assert any("graph" in f for f in failures)
+    # But no double failures or extra errors:
     assert not any("graph_persistence_configured" in f for f in failures)
     assert not any("persistence_enabled" in f for f in failures)
 

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -34,6 +34,24 @@ def _healthy_detailed_payload() -> dict[str, Any]:
     }
 
 
+def _healthy_detailed_payload_with_persistence() -> dict[str, Any]:
+    """Return a healthy detailed-readiness payload with active persistence for tests."""
+    return {
+        "status": "healthy",
+        "graph_persistence_configured": True,
+        "graph": {
+            "available": True,
+            "asset_count": 19,
+            "relationship_count": 57,
+            "persistence_enabled": True,
+            "persistence_loaded": True,
+            "persistence_saved": False,
+            "startup_source": "persisted",
+        },
+        "database": {"configured": True, "type": "postgresql", "reachable": True},
+    }
+
+
 def _url_with_credentials(path: str) -> str:
     """Build a credentialed URL without a hard-coded credential literal."""
     return "https://" + "user" + ":" + "secret" + f"@example.com{path}"
@@ -300,7 +318,7 @@ def test_run_checks_reports_detailed_readiness_runtime_context(
         """Return an empty liveness failure list."""
         return []
 
-    def fake_check_detailed_readiness(base_url: str, timeout: float) -> list[str]:
+    def fake_check_detailed_readiness(base_url: str, timeout: float, *args: Any, **kwargs: Any) -> list[str]:
         """Raise a fake detailed readiness runtime error."""
         raise RuntimeError("/api/health/detailed request failed")
 
@@ -484,3 +502,72 @@ def test_main_rejects_hostname_that_resolves_to_internal_address(monkeypatch: py
     monkeypatch.setattr(script.socket, "getaddrinfo", fake_getaddrinfo)
 
     assert script.main(["https://metadata.example.com"]) == script.USAGE_ERROR
+
+
+def test_detailed_readiness_with_require_persistence_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detailed readiness check accepts a persistent payload when require_persistence is True."""
+    script = _load_script()
+
+    def fake_get_json(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Return a fake successful detailed readiness response with persistence."""
+        return 200, _healthy_detailed_payload_with_persistence()
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json)
+
+    assert script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True) == []
+
+
+def test_detailed_readiness_with_require_persistence_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Detailed readiness check rejects non-persistent or misconfigured payloads when require_persistence is True."""
+    script = _load_script()
+
+    # Case 1: graph_persistence_configured is false
+    def fake_get_json_no_config(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph_persistence_configured"] = False
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_no_config)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert "/api/health/detailed graph_persistence_configured is not true" in failures
+
+    # Case 2: persistence_enabled is false
+    def fake_get_json_not_enabled(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"]["persistence_enabled"] = False
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_not_enabled)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert "/api/health/detailed graph.persistence_enabled is not true" in failures
+
+    # Case 3: persistence_loaded is false
+    def fake_get_json_not_loaded(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"]["persistence_loaded"] = False
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_not_loaded)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert "/api/health/detailed graph.persistence_loaded is not true" in failures
+
+    # Case 4: startup_source is not persisted
+    def fake_get_json_wrong_source(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        payload = _healthy_detailed_payload_with_persistence()
+        payload["graph"]["startup_source"] = "sample_data"
+        return 200, payload
+
+    monkeypatch.setattr(script, "_get_json", fake_get_json_wrong_source)
+    failures = script.check_detailed_readiness("https://example.com", 5.0, require_persistence=True)
+    assert '/api/health/detailed graph.startup_source is "sample_data", expected "persisted"' in failures
+
+
+def test_parse_args_handles_require_persistence() -> None:
+    """CLI argument parser correctly extracts the require-persistence flag."""
+    script = _load_script()
+
+    args = script.parse_args(["https://example.com", "--require-persistence"])
+    assert args.require_persistence is True
+
+    args_default = script.parse_args(["https://example.com"])
+    assert args_default.require_persistence is False


### PR DESCRIPTION
## **User description**
### Primary Objective
Require durable graph evidence for staging/production promotion.

### In Scope
- Extend `scripts/check_hosted_readiness.py` with `--require-persistence` parameter to verify the persistence state fields (`persistence_enabled`, `persistence_loaded`, `startup_source`, and `graph_persistence_configured`) on the detailed health endpoint.
- Add `require_persistence` input to `hosted-readiness.yml` GitHub Actions workflow and conditionally append the flag.
- Document the new smoke check verification process in `README.md` and `docs/enterprise-deployment-operating-model.md`.
- Mark Phase 2 health checks/promotion gates and Phase 3 graph persistence as completed/implemented in `docs/adr/0002-hosted-deployment-and-persistence.md`.

### Out of Scope
- Graph schema changes.
- Startup lifecycle changes.
- API contract refactors.
- Restore tooling.

### Files Expected to Change
- `scripts/check_hosted_readiness.py`
- `.github/workflows/hosted-readiness.yml`
- `tests/unit/test_check_hosted_readiness.py`
- `tests/integration/test_hosted_readiness_workflow.py`
- `README.md`
- `docs/adr/0002-hosted-deployment-and-persistence.md`
- `docs/enterprise-deployment-operating-model.md`
- `docs/roadmap/enterprise-readiness-pr-board.md`

### Validation Commands
- `pytest tests/unit/test_check_hosted_readiness.py -v`
- `pytest tests/integration/test_hosted_readiness_workflow.py -v`

### Merge Criteria
- All unit and integration tests must pass cleanly.
- Pre-commit formatting and static type checking (`black`, `flake8`, `mypy`) must pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a durable promotion gate to hosted readiness and hardens startup-source handling and internal IP detection. Staging/production promotion now requires proof of a persisted graph load and safe, bounded readiness signals.

- **New Features**
  - `scripts/check_hosted_readiness.py`: added `--require-persistence` to verify `graph_persistence_configured`, `graph.persistence_enabled`, `graph.persistence_loaded`, and `graph.startup_source: "persisted"`; bounds `startup_source` values with clear missing-value reporting; fixes internal host IP detection.
  - GitHub Actions: `hosted-readiness.yml` adds `require_persistence` (boolean, default false), maps to `HOSTED_READINESS_REQUIRE_PERSISTENCE`, and conditionally appends the flag.
  - Docs: README and operating model document the new gate; ADR marks Phase 2/3 Implemented; roadmap marks PR 3 Complete.
  - Tests: unit and integration tests cover persistence-gate checks, unsafe/missing `startup_source`, non-dict/missing `graph`, and verify workflow wiring for the env var and conditional flag.

- **Migration**
  - CLI: `python scripts/check_hosted_readiness.py <base_url> --require-persistence`.
  - Workflow: set `require_persistence: true` for staging/production runs.

<sup>Written for commit 17afb29b4fe2c2c3a041845584d83891a8191f50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1286?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add an optional persistence gate to hosted readiness checks**

### What Changed
- The hosted readiness check can now require proof that the graph was loaded from persistent storage before promotion succeeds.
- When this gate is enabled, the check now verifies that persistence is configured, persistence is enabled, the graph was loaded, and startup came from persisted data.
- The hosted readiness workflow now includes a `require_persistence` option and passes it through to the smoke check.
- The README and deployment guidance now document the new promotion step and when to use it.

### Impact
`✅ Safer staging promotions`
`✅ Fewer production deploys from non-persisted startup state`
`✅ Clearer readiness checks for durable graph deployments`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
