### PR TITLE
feat: Unify ReconciliationPlan consumption in RecoveryGate

### DIFF
--- a/PULL_REQUEST_DESCRIPTION.md
+++ b/PULL_REQUEST_DESCRIPTION.md
@@ -82,9 +82,9 @@ The main safety objective is to remove split-brain recovery decision paths where
 - `tests/unit/test_recovery_gate.py`
   - Adds plan-consumption, reset, cancellation, TTL, and lock-reacquisition regression coverage.
 - `tests/unit/test_reconciliation_loop.py`
-  - Adds dedicated periodic reconciliation-loop unit coverage.
+  - Introduces dedicated periodic reconciliation-loop unit coverage.
 - `tests/unit/test_app_factory.py`
-  - Adds background task TTL propagation/capping coverage and fixes the loop test trace wrapper to return an awaitable.
+  - Covers background task TTL propagation/capping and fixes the loop test trace wrapper to return an awaitable.
 - `tests/unit/test_recovery_gate_startup.py`
   - Updates startup recovery-gate expectations to preserve fail-closed defaults and automatic-recovery explicitness.
 - `tests/integration/test_recovery_gate_integration.py`

--- a/PULL_REQUEST_DESCRIPTION.md
+++ b/PULL_REQUEST_DESCRIPTION.md
@@ -1,64 +1,77 @@
-# PR: Phase 1.3.a - Trace Context Model and Propagation
+# PR: Convergence of Reconciliation Plan Consumption into RecoveryGate
 
-## Architectural Alignment
+## Primary seam / decision
 
-- **Backend**: FastAPI (production path)
-- **Frontend**: Next.js (production path)
-- **Gradio**: non-production (demo/testing only)
+Converge control-plane reconciliation loop and execution engine decisions into `RecoveryGate` as the single execution boundary for plan consumption, state mutation, and safety checks.
 
-This PR implements thread-safe and async-safe trace context variables (`trace_id`, `span_id`, `parent_span_id`) inside `src/observability/context.py` using standard `contextvars.ContextVar`. These changes align with our structured logging and observability design, preparing the application for deep operational span tracing.
+## Why this seam now
 
-## Primary Objective
-
-Establish trace context management variables (`trace_id`, `span_id`, `parent_span_id`) and helper primitives in a single, isolated, thread-safe, and async-safe file change to `src/observability/context.py`.
+Compliance with the Enterprise Readiness Index and Release Checklist (`docs/enterprise-readiness-index.md`), specifically the directive that durable persistence is the gating dependency. Unifying `ReconciliationPlan` consumption inside `RecoveryGate` eliminates dual-path execution logic where the background loop and the gate separately made safety and reset decisions, preventing split-brain mutations.
 
 ## Triage Data (Project Mandate)
 
-- **Upstream Source**: Calls to context getters (`get_trace_id`, `get_span_id`, `get_parent_span_id`, and `get_request_context`) will be initiated by logging and middleware components. The callers assume these operations are $O(1)$ and thread/async safe.
-- **Downstream Impact**: The return values are merged into logging payloads and event schemas. Adding these fields to `get_request_context` will automatically propagate them to all structured logs, but will not affect performance or cause memory leaks, as context variables are garbage collected when the request/task context terminates.
-- **Failure Mode**: Since `ContextVar` operations are thread-safe and isolated to current asynchronous chains, failures in context mutation do not leak state across requests or threads. If invalid/missing IDs are set, they are returned as `None`, ensuring structured logging does not fail.
+- **Upstream Source**: The FastAPI application startup lifespan (`_perform_startup_reconciliation`) and the periodic reconciliation background loop (`periodic_reconciliation_loop`) invoke `RecoveryGate.ensure_safe_to_execute()` or `RecoveryGate.consume_reconciliation_plan()`. The callers assume that these methods will safely assess the current distributed lock state, DB rebuild job records, and determine whether the worker can proceed with execution without causing conflict or split-brain conditions.
+- **Downstream Impact**: A block propagates as an `ExecutionBlockedError` back up to the caller, preventing the startup of the fastapi server or the execution of subsequent loop cycles. No database transaction resources or lock leaks can occur, because reacquired locks are deterministically released inside `finally` blocks (using the `lock_was_reacquired` flag), preventing starvation of other workers.
+- **Failure Mode**: If a database transaction fails during a state mutation (e.g., in `_perform_reset_recovery`), `RecoveryGate` intercepts the error, rollback occurs via the database context manager, and `ExecutionBlockedError` is raised. The system remains in a clean state, holding the lock or releasing it appropriately depending on whether the lock was reacquired.
 
-## Scope
+## In scope
 
-### In Scope
+- Refactored `RecoveryGate` constructor to store `enable_automatic_recovery` and `record_drift_metric`.
+- Implemented `consume_reconciliation_plan()` as the sole component mapping safety states and triggering bounded state resets.
+- Refactored `ensure_safe_to_execute()` to delegate evaluation and consumption to `consume_reconciliation_plan()`.
+- Refactored `reconciliation_loop.py` to remove duplicate engine instantiations and local reset execution blocks, delegating plan consumption fully to `RecoveryGate`.
+- Configured lock TTL seconds propagation in `app_factory.py` from settings.
+- Added comprehensive unit tests in `test_recovery_gate.py`, `test_app_factory.py`, and created `test_reconciliation_loop.py` to test plan consumption, reacquired lock release, and error backoff.
 
-- **Context Variables**: Defined `_trace_id_ctx`, `_span_id_ctx`, and `_parent_span_id_ctx` in `src/observability/context.py`.
-- **Getters & Setters**: Implemented `get_trace_id()`, `get_span_id()`, `get_parent_span_id()`, `set_trace_context(trace_id, span_id, parent_span_id)`, and `reset_trace_context(tokens)`.
-- **Structured Logging Hook**: Updated `get_request_context()` to include the new trace variables in the returned dictionary.
+## Out of scope
 
-### Out of Scope
+- Changing graph persistence or SQLite persistence semantics.
+- Hosted readiness check probes.
+- Auth model redesign or unrelated frontend visualizer updates.
 
-- **Middleware Refactoring**: Modifying `api/middleware/correlation.py` is deferred to a separate PR.
-- **Startup & Rebuild Integration**: Instrumenting startup Lifespan or Reconciliation Engine loops with tracing spans is deferred.
+## Backward compatibility contract
 
-### Files Expected to Change
+- The public `RecoveryGate.ensure_safe_to_execute()` and `RecoveryGate.evaluate_state()` methods remain fully backward compatible.
+- The `ExecutionBlockedError` exceptions continue to expose `action` and `inconsistency_type` string properties and format messages containing `(action=..., inconsistency=...)` tags to maintain exact behavior expected by the startup routing/APIs and pre-existing test assertions.
 
-- `src/observability/context.py`
+## Behavior intentionally preserved
 
-## Validation Commands
+- RecoveryGate defaults: `enable_automatic_recovery` defaults to `False` to preserve fail-closed startup/admin behavior when callers do not pass this parameter explicitly.
+- Automatic recovery in background: The periodic background loop continues to initialize `RecoveryGate` with `enable_automatic_recovery=True` to allow automatic recovery from orphaned RUNNING states.
+
+## Known issues intentionally deferred
+
+- None.
+
+## Files expected to change
+
+- `src/logic/recovery_gate.py`
+- `src/logic/reconciliation_loop.py`
+- `api/app_factory.py`
+- `tests/unit/test_recovery_gate.py`
+- `tests/unit/test_reconciliation_loop.py`
+- `tests/unit/test_app_factory.py`
+- `tests/unit/test_recovery_gate_startup.py`
+- `tests/integration/test_recovery_gate_integration.py`
+
+## Validation commands
 
 ```bash
-# Verify existing context and correlation tests pass
-pytest tests/unit/api/observability/test_context.py -v
-pytest tests/unit/api/middleware/test_correlation.py -v
+# Focused unit and integration tests
+pytest tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py tests/unit/test_recovery_gate_startup.py tests/integration/test_recovery_gate_integration.py -v
+
+# Style/lint checks
+pre-commit run --files api/app_factory.py src/logic/reconciliation_loop.py src/logic/recovery_gate.py tests/integration/test_recovery_gate_integration.py tests/unit/test_app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_recovery_gate_startup.py tests/unit/test_reconciliation_loop.py
 ```
 
-## Merge Criteria
+## Merge criteria
 
-- [x] Scope is tightly aligned to the Primary Objective
-- [x] Validation commands pass locally or in CI
-- [x] Changes align with production architecture (FastAPI + Next.js)
+- [x] PR implements one decision only (Converge Plan Consumption)
+- [x] No unrelated cleanup has been folded in
+- [x] Compatibility surface is preserved or explicitly documented
+- [x] Production architecture assumptions remain accurate (`FastAPI + Next.js`)
+- [x] Gradio/demo paths are not treated as production architecture
+- [x] Runtime dependency source of truth remains `requirements.txt`
+- [x] Any deferred issues are explicitly recorded
 
-## Checklist
-
-### Scope Compliance
-
-- [x] This PR makes one primary decision only (Trace Context Model)
-- [x] I have explicitly listed what is out of scope
-- [x] I have verified the base branch is `main`
-- [x] I have checked this PR against the production architecture
-
-### Testing Best Practices
-
-- [x] Tests verify observable behavior (isolation and retrieval)
-- [x] Tests properly clean up resources (using finally blocks for resetting contexts)
+AI-Generated: true

--- a/PULL_REQUEST_DESCRIPTION.md
+++ b/PULL_REQUEST_DESCRIPTION.md
@@ -1,77 +1,175 @@
-# PR: Convergence of Reconciliation Plan Consumption into RecoveryGate
+# PR: Unify ReconciliationPlan Consumption in RecoveryGate
 
-## Primary seam / decision
+## Architectural Alignment
 
-Converge control-plane reconciliation loop and execution engine decisions into `RecoveryGate` as the single execution boundary for plan consumption, state mutation, and safety checks.
+- Backend: FastAPI production path. This PR changes startup/background recovery control-plane behavior used by the FastAPI application lifecycle.
+- Frontend: Next.js production path is unaffected.
+- Gradio: non-production demo/testing path is unaffected.
 
-## Why this seam now
+This PR does not change the declared production architecture. It keeps the work in the FastAPI backend and Python recovery/control-plane code, consistent with `.github/AUTOMATION_SCOPE_POLICY.md` and `docs/adr/0001-production-architecture.md`.
 
-Compliance with the Enterprise Readiness Index and Release Checklist (`docs/enterprise-readiness-index.md`), specifically the directive that durable persistence is the gating dependency. Unifying `ReconciliationPlan` consumption inside `RecoveryGate` eliminates dual-path execution logic where the background loop and the gate separately made safety and reset decisions, preventing split-brain mutations.
+## Primary Objective
 
-## Triage Data (Project Mandate)
+Make `RecoveryGate` the single execution boundary that consumes `ReconciliationPlan` objects and decides whether execution may proceed, must wait, must alert/block, or may perform bounded reset recovery.
 
-- **Upstream Source**: The FastAPI application startup lifespan (`_perform_startup_reconciliation`) and the periodic reconciliation background loop (`periodic_reconciliation_loop`) invoke `RecoveryGate.ensure_safe_to_execute()` or `RecoveryGate.consume_reconciliation_plan()`. The callers assume that these methods will safely assess the current distributed lock state, DB rebuild job records, and determine whether the worker can proceed with execution without causing conflict or split-brain conditions.
-- **Downstream Impact**: A block propagates as an `ExecutionBlockedError` back up to the caller, preventing the startup of the fastapi server or the execution of subsequent loop cycles. No database transaction resources or lock leaks can occur, because reacquired locks are deterministically released inside `finally` blocks (using the `lock_was_reacquired` flag), preventing starvation of other workers.
-- **Failure Mode**: If a database transaction fails during a state mutation (e.g., in `_perform_reset_recovery`), `RecoveryGate` intercepts the error, rollback occurs via the database context manager, and `ExecutionBlockedError` is raised. The system remains in a clean state, holding the lock or releasing it appropriately depending on whether the lock was reacquired.
+The main safety objective is to remove split-brain recovery decision paths where the periodic reconciliation loop generated/interpreted a plan and then asked `RecoveryGate` to independently re-plan before mutating state.
 
-## In scope
+## Scope
 
-- Refactored `RecoveryGate` constructor to store `enable_automatic_recovery` and `record_drift_metric`.
-- Implemented `consume_reconciliation_plan()` as the sole component mapping safety states and triggering bounded state resets.
-- Refactored `ensure_safe_to_execute()` to delegate evaluation and consumption to `consume_reconciliation_plan()`.
-- Refactored `reconciliation_loop.py` to remove duplicate engine instantiations and local reset execution blocks, delegating plan consumption fully to `RecoveryGate`.
-- Configured lock TTL seconds propagation in `app_factory.py` from settings.
-- Added comprehensive unit tests in `test_recovery_gate.py`, `test_app_factory.py`, and created `test_reconciliation_loop.py` to test plan consumption, reacquired lock release, and error backoff.
+### In Scope
 
-## Out of scope
+- Add `RecoveryGate.consume_reconciliation_plan(plan, cancellation_event=None)` as the canonical plan-consumption method.
+- Refactor `RecoveryGate.ensure_safe_to_execute()` to generate one plan and delegate consumption to `consume_reconciliation_plan()`.
+- Add explicit `RecoveryGate` constructor options:
+  - `enable_automatic_recovery`
+  - `record_drift_metric`
+- Ensure `get_reconciliation_plan()` constructs `ReconciliationEngine` with the same automatic-recovery and drift-metric configuration that the consuming gate will enforce.
+- Refactor `src/logic/reconciliation_loop.py` so the periodic loop:
+  - creates session/lock dependencies,
+  - constructs a `RecoveryGate`,
+  - asks that gate for one plan,
+  - consumes that same plan once,
+  - does not independently inspect or execute `ActionType.RESET_STATE`.
+- Preserve startup fail-closed behavior:
+  - `RecoveryGate.enable_automatic_recovery` defaults to `False`.
+  - startup reconciliation passes `enable_automatic_recovery=False`.
+  - periodic reconciliation passes `enable_automatic_recovery=True`.
+- Propagate `settings.rebuild_lock_ttl_seconds` from `api/app_factory.py` into `periodic_reconciliation_loop()`.
+- Enforce the distributed-lock TTL safety ceiling for reconciliation recovery:
+  - app-factory background task wiring bounds configured TTL to `1..300`.
+  - reconciliation-loop lock construction bounds TTL to `1..300`.
+  - `RecoveryGate.lock_ttl_seconds` bounds TTL to `1..300`.
+- Preserve the plan drift type when lock reacquisition times out instead of hard-coding `orphaned_running`.
+- Treat expected `ExecutionBlockedError` safety blocks in the periodic loop as non-transient blocked states, not infrastructure failures that trigger exponential backoff.
+- Release only locks reacquired by `RecoveryGate`, and continue logging release failures without crashing the reconciliation loop.
+- Add/extend tests for:
+  - plan consumption paths,
+  - wait/alert/evaluation-failed/deferred reset non-mutation behavior,
+  - automatic reset delegation,
+  - post-reset re-evaluation,
+  - cancellation before reset mutation,
+  - reacquired-lock release,
+  - lock release failure logging,
+  - configured and bounded lock TTL propagation,
+  - no duplicate plan generation in the periodic loop,
+  - drift metric forwarding,
+  - runtime-not-ready skip behavior,
+  - expected blocked states not entering transient-error backoff.
 
-- Changing graph persistence or SQLite persistence semantics.
-- Hosted readiness check probes.
-- Auth model redesign or unrelated frontend visualizer updates.
+### Out of Scope
 
-## Backward compatibility contract
+- Graph persistence semantics.
+- SQLite persistence compatibility changes.
+- Rebuild job schema changes.
+- Hosted readiness probes or deployment smoke-check behavior.
+- Auth model changes.
+- API response contract cleanup outside reconciliation/recovery behavior.
+- Frontend/Next.js visualizer changes.
+- Gradio/demo behavior changes.
+- New schedulers, workers, or background executors.
+- Dependency changes.
 
-- The public `RecoveryGate.ensure_safe_to_execute()` and `RecoveryGate.evaluate_state()` methods remain fully backward compatible.
-- The `ExecutionBlockedError` exceptions continue to expose `action` and `inconsistency_type` string properties and format messages containing `(action=..., inconsistency=...)` tags to maintain exact behavior expected by the startup routing/APIs and pre-existing test assertions.
-
-## Behavior intentionally preserved
-
-- RecoveryGate defaults: `enable_automatic_recovery` defaults to `False` to preserve fail-closed startup/admin behavior when callers do not pass this parameter explicitly.
-- Automatic recovery in background: The periodic background loop continues to initialize `RecoveryGate` with `enable_automatic_recovery=True` to allow automatic recovery from orphaned RUNNING states.
-
-## Known issues intentionally deferred
-
-- None.
-
-## Files expected to change
+### Files Expected to Change
 
 - `src/logic/recovery_gate.py`
+  - Adds explicit plan consumption, automatic-recovery configuration, TTL bounding, reset authorization checks, post-reset re-evaluation, and drift-aware lock reacquisition errors.
 - `src/logic/reconciliation_loop.py`
+  - Removes duplicate plan interpretation from the loop, delegates consumption to `RecoveryGate`, bounds lock TTL, releases reacquired locks, and treats expected recovery-gate blocks as non-transient.
 - `api/app_factory.py`
+  - Passes bounded `rebuild_lock_ttl_seconds` into the periodic reconciliation loop.
+- `tests/conftest.py`
+  - Adds shared `make_reconciliation_plan` test fixture used by recovery-gate and reconciliation-loop tests.
 - `tests/unit/test_recovery_gate.py`
+  - Adds plan-consumption, reset, cancellation, TTL, and lock-reacquisition regression coverage.
 - `tests/unit/test_reconciliation_loop.py`
+  - Adds dedicated periodic reconciliation-loop unit coverage.
 - `tests/unit/test_app_factory.py`
+  - Adds background task TTL propagation/capping coverage and fixes the loop test trace wrapper to return an awaitable.
 - `tests/unit/test_recovery_gate_startup.py`
+  - Updates startup recovery-gate expectations to preserve fail-closed defaults and automatic-recovery explicitness.
 - `tests/integration/test_recovery_gate_integration.py`
+  - Adjusts integration coverage to match explicit automatic-recovery construction.
+- `PULL_REQUEST_DESCRIPTION.md`
+  - Keeps the checked-in PR description aligned with the live GitHub PR body and repo guardrails.
 
-## Validation commands
+## Behavior and Compatibility Notes
+
+- `RecoveryGate.ensure_safe_to_execute()` remains public and backward-compatible for existing callers.
+- `RecoveryGate.evaluate_state()` remains public and backward-compatible.
+- `ExecutionBlockedError` continues exposing `action` and `inconsistency_type`.
+- Block messages continue including `(action=..., inconsistency=...)` tags where compatibility-sensitive callers/tests expect them.
+- Startup remains conservative: automatic reset recovery is not enabled by default.
+- Periodic reconciliation remains the only automatic recovery path in this PR and only runs once the runtime lifecycle is `READY`.
+- Bounded reset recovery still requires:
+  - automatic or immediate execution mode,
+  - `RESET_REQUIRED` safety state,
+  - no cancellation signal,
+  - a valid or successfully reacquired distributed lock,
+  - stale/orphaned active rebuild state before mutation.
+
+## Review Feedback Addressed
+
+- Capped configured reconciliation lock TTL values before they reach `DistributedLock` or stale-heartbeat comparisons.
+- Fixed the test trace wrapper that previously returned a synchronous result where the loop expected an awaitable.
+- Preserved plan drift type for lock reacquisition timeout errors.
+- Added a module-level `pytestmark = pytest.mark.unit` to the new reconciliation-loop unit tests.
+- Reduced duplicated wait/alert block handling in `RecoveryGate`.
+- Bundled repeated reconciliation-loop test dependencies to reduce test fixture argument count.
+- Added regression coverage for expected blocked states so they do not trigger transient-error backoff.
+
+## Delayed, Deferred, or Not Acted On
+
+- No in-scope implementation items are intentionally deferred.
+- CodeScene-style duplication findings in tests may still reappear depending on the analyzer threshold; this PR reduced the highest-signal duplication/argument-count issues without obscuring scenario-specific test intent.
+- Existing repository/default-branch vulnerability notices are not addressed here because this PR does not change dependencies.
+- Full-file `tests/unit/test_app_factory.py` was not used as final validation because the existing lifespan/background-task teardown path timed out locally under the managed sandbox. The three app-factory tests affected by this PR were run directly and passed.
+- Review threads were not manually resolved through GitHub by this change; they are expected to be re-evaluated by reviewers/bots after the pushed commits.
+
+## Validation Commands
+
+Executed successfully:
 
 ```bash
-# Focused unit and integration tests
-pytest tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py tests/unit/test_recovery_gate_startup.py tests/integration/test_recovery_gate_integration.py -v
-
-# Style/lint checks
-pre-commit run --files api/app_factory.py src/logic/reconciliation_loop.py src/logic/recovery_gate.py tests/integration/test_recovery_gate_integration.py tests/unit/test_app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_recovery_gate_startup.py tests/unit/test_reconciliation_loop.py
+pytest tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py -q
+pytest tests/unit/test_app_factory.py::test_periodic_reconciliation_loop_triggers_recovery tests/unit/test_app_factory.py::test_start_background_tasks_propagates_rebuild_lock_ttl_seconds tests/unit/test_app_factory.py::test_start_background_tasks_caps_rebuild_lock_ttl_seconds -q
+pre-commit run --files api/app_factory.py src/logic/reconciliation_loop.py src/logic/recovery_gate.py tests/unit/test_app_factory.py tests/unit/test_reconciliation_loop.py tests/unit/test_recovery_gate.py
 ```
 
-## Merge criteria
+Additional syntax/format checks were also run during implementation:
 
-- [x] PR implements one decision only (Converge Plan Consumption)
-- [x] No unrelated cleanup has been folded in
-- [x] Compatibility surface is preserved or explicitly documented
-- [x] Production architecture assumptions remain accurate (`FastAPI + Next.js`)
-- [x] Gradio/demo paths are not treated as production architecture
-- [x] Runtime dependency source of truth remains `requirements.txt`
-- [x] Any deferred issues are explicitly recorded
+```bash
+python -m compileall src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
+python -m black --workers 1 src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
+python -m flake8 --jobs=1 src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
+```
 
-AI-Generated: true
+## Merge Criteria
+
+- [x] Scope is tightly aligned to the Primary Objective.
+- [x] This PR makes one primary decision only: converge `ReconciliationPlan` consumption into `RecoveryGate`.
+- [x] In-scope and out-of-scope boundaries are explicitly documented.
+- [x] Changes align with production architecture (`FastAPI` backend + `Next.js` frontend).
+- [x] Gradio/demo paths are not treated as production architecture.
+- [x] Runtime dependency source of truth remains unchanged.
+- [x] Compatibility surface is preserved or explicitly documented.
+- [x] Focused validation commands pass locally.
+- [x] Review-feedback fixes are documented.
+- [x] Deferred or not-acted-on items are explicitly recorded.
+
+## Checklist
+
+### Scope Compliance
+
+- [x] This PR makes one primary decision only.
+- [x] I have explicitly listed what is out of scope.
+- [x] This is not a docs/policy/architecture-only PR.
+- [x] I have verified the branch, base branch, and referenced issue/PR context.
+- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend).
+- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`.
+
+### Testing Best Practices
+
+- [x] Tests verify observable behavior such as raised actions, state decisions, function calls, and interval/backoff effects.
+- [x] Tests avoid coupling to exact log message strings.
+- [x] New tests do not add fixed timing sleeps for assertions.
+- [x] Recovery/control-plane tests use mocks or existing fixtures to avoid leaking database/lock resources.

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -340,6 +340,7 @@ def _start_background_tasks(
 
         recon_url = _resolve_startup_reconciliation_url(settings)
         coord_url = getattr(settings, "coordination_database_url", None) or recon_url
+        lock_ttl_seconds = max(1, min(int(getattr(settings, "rebuild_lock_ttl_seconds", 300)), 300))
 
         recon_task = asyncio.create_task(
             periodic_reconciliation_loop(
@@ -353,7 +354,7 @@ def _start_background_tasks(
                 ),
                 run_with_trace_fn=_run_with_generated_trace,
                 cancel_event=None,
-                lock_ttl_seconds=getattr(settings, "rebuild_lock_ttl_seconds", 300),
+                lock_ttl_seconds=lock_ttl_seconds,
             )
         )
 

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -336,11 +336,12 @@ def _start_background_tasks(
         sync_task = asyncio.create_task(_graph_synchronization_loop(interval_seconds=interval))
 
         recon_interval = getattr(settings, "reconciliation_interval_seconds", interval)
+        from src.data.distributed_lock import MAX_TTL
         from src.logic.reconciliation_loop import periodic_reconciliation_loop
 
         recon_url = _resolve_startup_reconciliation_url(settings)
         coord_url = getattr(settings, "coordination_database_url", None) or recon_url
-        lock_ttl_seconds = max(1, min(int(getattr(settings, "rebuild_lock_ttl_seconds", 300)), 300))
+        lock_ttl_seconds = max(1, min(int(getattr(settings, "rebuild_lock_ttl_seconds", MAX_TTL)), MAX_TTL))
 
         recon_task = asyncio.create_task(
             periodic_reconciliation_loop(

--- a/api/app_factory.py
+++ b/api/app_factory.py
@@ -135,6 +135,7 @@ def _execute_recovery_gate(engine: Any, coord_engine: Any, cancellation_event: t
         increment_recovery_trigger=increment_recovery_trigger,
         runtime_has_active_executor=False,
         lock_ttl_seconds=int(_STARTUP_RECONCILIATION_LOCK_TTL_SECONDS),
+        enable_automatic_recovery=False,
     )
 
     try:
@@ -352,6 +353,7 @@ def _start_background_tasks(
                 ),
                 run_with_trace_fn=_run_with_generated_trace,
                 cancel_event=None,
+                lock_ttl_seconds=getattr(settings, "rebuild_lock_ttl_seconds", 300),
             )
         )
 

--- a/src/logic/reconciliation_loop.py
+++ b/src/logic/reconciliation_loop.py
@@ -6,18 +6,17 @@ import threading
 from collections.abc import Callable
 from typing import Any
 
+from src.data.distributed_lock import MAX_TTL
 from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.recovery_gate import ExecutionBlockedError
 from src.observability.facade import ObservabilityEvent, log_event
 
 logger = logging.getLogger(__name__)
 
-_MAX_RECONCILIATION_LOCK_TTL_SECONDS = 300
-
 
 def _bound_lock_ttl(lock_ttl: int) -> int:
     """Return a lock TTL within the distributed-lock safety bounds."""
-    return max(1, min(int(lock_ttl), _MAX_RECONCILIATION_LOCK_TTL_SECONDS))
+    return max(1, min(int(lock_ttl), MAX_TTL))
 
 
 def _check_cancellation(cancel_event: threading.Event | None) -> None:

--- a/src/logic/reconciliation_loop.py
+++ b/src/logic/reconciliation_loop.py
@@ -7,9 +7,17 @@ from collections.abc import Callable
 from typing import Any
 
 from src.logic.reconciliation_engine import RebuildCancelledError
+from src.logic.recovery_gate import ExecutionBlockedError
 from src.observability.facade import ObservabilityEvent, log_event
 
 logger = logging.getLogger(__name__)
+
+_MAX_RECONCILIATION_LOCK_TTL_SECONDS = 300
+
+
+def _bound_lock_ttl(lock_ttl: int) -> int:
+    """Return a lock TTL within the distributed-lock safety bounds."""
+    return max(1, min(int(lock_ttl), _MAX_RECONCILIATION_LOCK_TTL_SECONDS))
 
 
 def _check_cancellation(cancel_event: threading.Event | None) -> None:
@@ -27,13 +35,14 @@ def _create_reconciliation_dependencies(
     from src.data.database import create_session_factory
     from src.data.distributed_lock import DistributedLock
 
+    bounded_lock_ttl = _bound_lock_ttl(lock_ttl)
     session_factory = create_session_factory(engine)
     coord_session_factory = create_session_factory(coord_engine) if coord_engine is not engine else session_factory
 
     lock = DistributedLock(
         coordination_session_factory=coord_session_factory,
         lock_name="graph_rebuild",
-        ttl_seconds=lock_ttl,
+        ttl_seconds=bounded_lock_ttl,
     )
 
     return session_factory, lock
@@ -49,20 +58,21 @@ def _run_sync_reconciliation(
     import time
 
     from api.metrics import RECONCILIATION_DURATION, increment_recovery_trigger, record_drift_metric
-    from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
+    from src.logic.recovery_gate import RecoveryGate
 
     start_time = time.perf_counter()
 
     _check_cancellation(cancel_event)
 
-    session_factory, lock = _create_reconciliation_dependencies(engine, coord_engine, lock_ttl)
+    bounded_lock_ttl = _bound_lock_ttl(lock_ttl)
+    session_factory, lock = _create_reconciliation_dependencies(engine, coord_engine, bounded_lock_ttl)
 
     gate = RecoveryGate(
         session_factory=session_factory,
         lock=lock,
         increment_recovery_trigger=increment_recovery_trigger,
         runtime_has_active_executor=False,
-        lock_ttl_seconds=lock_ttl,
+        lock_ttl_seconds=bounded_lock_ttl,
         enable_automatic_recovery=True,
         record_drift_metric=record_drift_metric,
     )
@@ -206,6 +216,20 @@ async def periodic_reconciliation_loop(
                     ),
                 )
                 return
+            except ExecutionBlockedError as exc:
+                log_event(
+                    logger,
+                    logging.INFO,
+                    ObservabilityEvent(
+                        event="reconciliation_loop_blocked_state",
+                        message=f"Periodic reconciliation blocked by recovery gate: {exc}",
+                        metadata={
+                            "action": exc.action,
+                            "inconsistency": exc.inconsistency_type,
+                        },
+                    ),
+                )
+                is_in_error_state, current_interval = _handle_reconciliation_success(is_in_error_state, base_interval)
             except Exception as exc:
                 is_in_error_state, current_interval = _handle_reconciliation_error(
                     exc, is_in_error_state, current_interval, max_interval

--- a/src/logic/reconciliation_loop.py
+++ b/src/logic/reconciliation_loop.py
@@ -22,13 +22,10 @@ def _create_reconciliation_dependencies(
     engine: Any,
     coord_engine: Any,
     lock_ttl: int,
-    record_drift_metric: Callable,
-) -> tuple[Any, Any, Any]:
-    """Initialize and return coordination engine, locks, and evaluators."""
+) -> tuple[Any, Any]:
+    """Initialize and return session factory and distributed lock."""
     from src.data.database import create_session_factory
     from src.data.distributed_lock import DistributedLock
-    from src.logic.rebuild_drift_evaluator import RebuildDriftEvaluator
-    from src.logic.reconciliation_engine import ReconciliationEngine
 
     session_factory = create_session_factory(engine)
     coord_session_factory = create_session_factory(coord_engine) if coord_engine is not engine else session_factory
@@ -39,36 +36,7 @@ def _create_reconciliation_dependencies(
         ttl_seconds=lock_ttl,
     )
 
-    evaluator = RebuildDriftEvaluator(
-        session_factory=session_factory,
-        lock=lock,
-        runtime_has_active_executor=False,
-        lock_ttl_seconds=lock_ttl,
-    )
-
-    engine_inst = ReconciliationEngine(
-        evaluator=evaluator,
-        enable_automatic_execution=True,
-        record_drift_metric=record_drift_metric,
-    )
-
-    return session_factory, lock, engine_inst
-
-
-def _execute_plan_if_needed(
-    gate: Any,
-    plan: Any,
-    cancel_event: threading.Event | None,
-) -> None:
-    """Execute the plan using RecoveryGate if an automatic reset is required."""
-    if not _should_execute_automatic_reset(plan):
-        return
-
-    try:
-        gate.ensure_safe_to_execute(cancellation_event=cancel_event)
-    finally:
-        if getattr(gate, "lock_was_reacquired", False):
-            gate.lock.release()
+    return session_factory, lock
 
 
 def _run_sync_reconciliation(
@@ -87,9 +55,7 @@ def _run_sync_reconciliation(
 
     _check_cancellation(cancel_event)
 
-    session_factory, lock, engine_inst = _create_reconciliation_dependencies(
-        engine, coord_engine, lock_ttl, record_drift_metric
-    )
+    session_factory, lock = _create_reconciliation_dependencies(engine, coord_engine, lock_ttl)
 
     gate = RecoveryGate(
         session_factory=session_factory,
@@ -97,12 +63,14 @@ def _run_sync_reconciliation(
         increment_recovery_trigger=increment_recovery_trigger,
         runtime_has_active_executor=False,
         lock_ttl_seconds=lock_ttl,
+        enable_automatic_recovery=True,
+        record_drift_metric=record_drift_metric,
     )
 
     try:
         _check_cancellation(cancel_event)
-        plan = engine_inst.generate_reconciliation_plan()
-        _execute_plan_if_needed(gate, plan, cancel_event)
+        plan = gate.get_reconciliation_plan()
+        gate.consume_reconciliation_plan(plan, cancellation_event=cancel_event)
     except RebuildCancelledError:
         log_event(
             logger,
@@ -124,6 +92,19 @@ def _run_sync_reconciliation(
         )
         raise
     finally:
+        if getattr(gate, "lock_was_reacquired", False):
+            try:
+                gate.lock.release()
+            except Exception as release_exc:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    ObservabilityEvent(
+                        event="reconciliation_loop_lock_release_failed",
+                        message=f"Failed to release distributed rebuild lock: {type(release_exc).__name__}",
+                        metadata={"error": type(release_exc).__name__},
+                    ),
+                )
         RECONCILIATION_DURATION.observe(time.perf_counter() - start_time)
 
 
@@ -294,13 +275,6 @@ def _handle_reconciliation_error(
         )
         is_in_error_state = True
     return is_in_error_state, _next_backoff_interval(current_interval, max_interval)
-
-
-def _should_execute_automatic_reset(plan: Any) -> bool:
-    """Check if the plan requires automatic reset."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode
-
-    return ActionType.RESET_STATE in plan.actions and plan.execution_mode == ExecutionMode.AUTOMATIC
 
 
 def _next_backoff_interval(current_interval: float, max_interval: float) -> float:

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -244,11 +244,11 @@ class RecoveryGate:
 
     def _should_execute_reset(self, plan: ReconciliationPlan) -> bool:
         """Return True when a reset plan is authorized for immediate mutation."""
-        return (
-            ActionType.RESET_STATE in plan.actions
-            and plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
-            and plan.safety_state == ExecutionSafety.RESET_REQUIRED
-        )
+        if ActionType.RESET_STATE not in plan.actions or plan.safety_state != ExecutionSafety.RESET_REQUIRED:
+            return False
+        if plan.execution_mode == ExecutionMode.IMMEDIATE:
+            return True
+        return plan.execution_mode == ExecutionMode.AUTOMATIC and self.enable_automatic_recovery
 
     def _handle_reset_action(
         self,
@@ -449,25 +449,31 @@ class RecoveryGate:
         if self.lock.check_state() == LockState.VALID:
             return
 
-        if not self.lock_was_reacquired:
-            try:
-                self.lock.acquire(max_retries=30)
-                self.lock_was_reacquired = True
-            except LockAcquisitionTimeout as lat_exc:
-                log_event(
-                    logger,
-                    logging.ERROR,
-                    ObservabilityEvent(
-                        event="recovery_gate_lock_reacquisition_failed",
-                        message="Timeout acquiring distributed lock for reset recovery",
-                        metadata={"error": "LockAcquisitionTimeout"},
-                    ),
-                )
-                raise ExecutionBlockedError(
-                    f"Timeout acquiring distributed lock for reset recovery: {lat_exc}",
-                    action="wait",
-                    inconsistency_type=drift_type,
-                ) from lat_exc
+        try:
+            self.lock.acquire(max_retries=30)
+            self.lock_was_reacquired = True
+        except LockAcquisitionTimeout as lat_exc:
+            log_event(
+                logger,
+                logging.ERROR,
+                ObservabilityEvent(
+                    event="recovery_gate_lock_reacquisition_failed",
+                    message="Timeout acquiring distributed lock for reset recovery",
+                    metadata={"error": "LockAcquisitionTimeout"},
+                ),
+            )
+            raise ExecutionBlockedError(
+                f"Timeout acquiring distributed lock for reset recovery: {lat_exc}",
+                action="wait",
+                inconsistency_type=drift_type,
+            ) from lat_exc
+
+        if self.lock.check_state() != LockState.VALID:
+            raise ExecutionBlockedError(
+                "Cannot perform reset recovery without valid lock after reacquisition",
+                action="wait",
+                inconsistency_type=drift_type,
+            )
 
     def _is_heartbeat_stale(self, active_job: Any) -> bool:
         """Determine if active rebuild job heartbeat is stale."""

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -463,14 +463,14 @@ class RecoveryGate:
                 ),
             )
             raise ExecutionBlockedError(
-                f"Timeout acquiring distributed lock for reset recovery: {lat_exc}",
+                f"Timeout acquiring distributed lock for reset recovery: {lat_exc} (action=wait, inconsistency={drift_type})",
                 action="wait",
                 inconsistency_type=drift_type,
             ) from lat_exc
 
         if self.lock.check_state() != LockState.VALID:
             raise ExecutionBlockedError(
-                "Cannot perform reset recovery without valid lock after reacquisition",
+                f"Cannot perform reset recovery without valid lock after reacquisition (action=wait, inconsistency={drift_type})",
                 action="wait",
                 inconsistency_type=drift_type,
             )

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -6,6 +6,7 @@ import logging
 import threading
 from collections.abc import Callable
 from datetime import UTC, datetime
+from typing import Any
 
 from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy.orm import Session
@@ -217,122 +218,118 @@ class RecoveryGate:
         plan = self.get_reconciliation_plan()
         return self._map_plan_to_action(plan)
 
-    def consume_reconciliation_plan(
+    def _raise_safety_block(self, plan: ReconciliationPlan, action: str) -> None:
+        """Log and raise ExecutionBlockedError for unsafe safety states."""
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="recovery_gate_execution_blocked_final",
+                message=(
+                    f"Execution blocked by recovery gate safety state: "
+                    f"safety_state={plan.safety_state.value}, inconsistency={plan.drift_type}"
+                ),
+                metadata={
+                    "action": action,
+                    "inconsistency": plan.drift_type,
+                    "safety_state": plan.safety_state.value,
+                },
+            ),
+        )
+        raise ExecutionBlockedError(
+            f"Execution blocked due to safety state: {plan.safety_state.value} (action={action}, inconsistency={plan.drift_type})",
+            action=action,
+            inconsistency_type=plan.drift_type,
+        )
+
+    def _handle_reset_action(
         self,
         plan: ReconciliationPlan,
         cancellation_event: threading.Event | None = None,
-    ) -> None:
-        """Consume a ReconciliationPlan and enforce recovery or execution blocking rules."""
-        if plan.safety_state in (
-            ExecutionSafety.EVALUATION_FAILED,
-            ExecutionSafety.OBSERVABILITY_FAILURE,
-            ExecutionSafety.UNSAFE_SPLIT_BRAIN,
-            ExecutionSafety.INTEGRITY_COMPROMISED,
+    ) -> bool:
+        """Handle reset actions. Returns True if reset was executed, False otherwise."""
+        if ActionType.RESET_STATE not in plan.actions:
+            return False
+
+        if (
+            plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
+            and plan.safety_state == ExecutionSafety.RESET_REQUIRED
         ):
-            action = self._map_plan_to_action(plan)
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="recovery_gate_execution_blocked_final",
-                    message=(
-                        f"Execution blocked by recovery gate safety state: "
-                        f"safety_state={plan.safety_state.value}, inconsistency={plan.drift_type}"
-                    ),
-                    metadata={
-                        "action": action,
-                        "inconsistency": plan.drift_type,
-                        "safety_state": plan.safety_state.value,
-                    },
+            from src.logic.reconciliation_engine import RebuildCancelledError
+
+            if cancellation_event and cancellation_event.is_set():
+                raise RebuildCancelledError("Rebuild cancelled via API request")
+
+            self._execute_reset_path(plan, cancellation_event)
+
+            if cancellation_event and cancellation_event.is_set():
+                raise RebuildCancelledError("Rebuild cancelled via API request")
+            return True
+
+        action = "wait" if plan.execution_mode == ExecutionMode.DEFERRED else "alert_only"
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="recovery_gate_execution_blocked_final",
+                message=(
+                    f"Execution blocked for non-automatic reset plan: "
+                    f"action={action}, inconsistency={plan.drift_type}"
                 ),
-            )
-            raise ExecutionBlockedError(
-                f"Execution blocked due to safety state: {plan.safety_state.value} (action={action}, inconsistency={plan.drift_type})",
-                action=action,
-                inconsistency_type=plan.drift_type,
-            )
+                metadata={
+                    "action": action,
+                    "inconsistency": plan.drift_type,
+                },
+            ),
+        )
+        raise ExecutionBlockedError(
+            f"Execution blocked: reset required but mode={plan.execution_mode.value} (action={action}, inconsistency={plan.drift_type})",
+            action=action,
+            inconsistency_type=plan.drift_type,
+        )
 
-        if ActionType.RESET_STATE in plan.actions:
-            if (
-                plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
-                and plan.safety_state == ExecutionSafety.RESET_REQUIRED
-            ):
-                from src.logic.reconciliation_engine import RebuildCancelledError
+    def _raise_wait_block(self, plan: ReconciliationPlan) -> None:
+        """Log and raise ExecutionBlockedError for WAIT action."""
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="recovery_gate_execution_blocked_final",
+                message=f"Execution blocked by recovery gate: action=wait, inconsistency={plan.drift_type}",
+                metadata={
+                    "action": "wait",
+                    "inconsistency": plan.drift_type,
+                },
+            ),
+        )
+        raise ExecutionBlockedError(
+            f"Execution blocked: waiting for convergence. Reason: {plan.reason} (action=wait, inconsistency={plan.drift_type})",
+            action="wait",
+            inconsistency_type=plan.drift_type,
+        )
 
-                if cancellation_event and cancellation_event.is_set():
-                    raise RebuildCancelledError("Rebuild cancelled via API request")
+    def _raise_alert_block(self, plan: ReconciliationPlan) -> None:
+        """Log and raise ExecutionBlockedError for ALERT_ONLY action."""
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="recovery_gate_execution_blocked_final",
+                message=f"Execution blocked by recovery gate: action=alert_only, inconsistency={plan.drift_type}",
+                metadata={
+                    "action": "alert_only",
+                    "inconsistency": plan.drift_type,
+                },
+            ),
+        )
+        raise ExecutionBlockedError(
+            f"Execution blocked: alert only. Reason: {plan.reason} (action=alert_only, inconsistency={plan.drift_type})",
+            action="alert_only",
+            inconsistency_type=plan.drift_type,
+        )
 
-                self._execute_reset_path(plan, cancellation_event)
-
-                if cancellation_event and cancellation_event.is_set():
-                    raise RebuildCancelledError("Rebuild cancelled via API request")
-                return
-            else:
-                action = "wait" if plan.execution_mode == ExecutionMode.DEFERRED else "alert_only"
-                log_event(
-                    logger,
-                    logging.WARNING,
-                    ObservabilityEvent(
-                        event="recovery_gate_execution_blocked_final",
-                        message=(
-                            f"Execution blocked for non-automatic reset plan: "
-                            f"action={action}, inconsistency={plan.drift_type}"
-                        ),
-                        metadata={
-                            "action": action,
-                            "inconsistency": plan.drift_type,
-                        },
-                    ),
-                )
-                raise ExecutionBlockedError(
-                    f"Execution blocked: reset required but mode={plan.execution_mode.value} (action={action}, inconsistency={plan.drift_type})",
-                    action=action,
-                    inconsistency_type=plan.drift_type,
-                )
-
-        if ActionType.WAIT_FOR_CONVERGENCE in plan.actions or plan.safety_state == ExecutionSafety.WAIT_REQUIRED:
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="recovery_gate_execution_blocked_final",
-                    message=f"Execution blocked by recovery gate: action=wait, inconsistency={plan.drift_type}",
-                    metadata={
-                        "action": "wait",
-                        "inconsistency": plan.drift_type,
-                    },
-                ),
-            )
-            raise ExecutionBlockedError(
-                f"Execution blocked: waiting for convergence. Reason: {plan.reason} (action=wait, inconsistency={plan.drift_type})",
-                action="wait",
-                inconsistency_type=plan.drift_type,
-            )
-
-        if ActionType.ALERT_ONLY in plan.actions:
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="recovery_gate_execution_blocked_final",
-                    message=f"Execution blocked by recovery gate: action=alert_only, inconsistency={plan.drift_type}",
-                    metadata={
-                        "action": "alert_only",
-                        "inconsistency": plan.drift_type,
-                    },
-                ),
-            )
-            raise ExecutionBlockedError(
-                f"Execution blocked: alert only. Reason: {plan.reason} (action=alert_only, inconsistency={plan.drift_type})",
-                action="alert_only",
-                inconsistency_type=plan.drift_type,
-            )
-
-        if ActionType.NOOP in plan.actions and plan.safety_state == ExecutionSafety.CONVERGED:
-            # allow execution
-            return
-
-        # Fallback
+    def _handle_fallback_block(self, plan: ReconciliationPlan) -> None:
+        """Handle fallback block logic."""
         action = self._map_plan_to_action(plan)
         if action != "resume":
             log_event(
@@ -355,6 +352,37 @@ class RecoveryGate:
                 action=action,
                 inconsistency_type=plan.drift_type,
             )
+
+    def consume_reconciliation_plan(
+        self,
+        plan: ReconciliationPlan,
+        cancellation_event: threading.Event | None = None,
+    ) -> None:
+        """Consume a ReconciliationPlan and enforce recovery or execution blocking rules."""
+        if plan.safety_state in (
+            ExecutionSafety.EVALUATION_FAILED,
+            ExecutionSafety.OBSERVABILITY_FAILURE,
+            ExecutionSafety.UNSAFE_SPLIT_BRAIN,
+            ExecutionSafety.INTEGRITY_COMPROMISED,
+        ):
+            action = self._map_plan_to_action(plan)
+            self._raise_safety_block(plan, action)
+
+        if self._handle_reset_action(plan, cancellation_event):
+            return
+
+        if ActionType.WAIT_FOR_CONVERGENCE in plan.actions or plan.safety_state == ExecutionSafety.WAIT_REQUIRED:
+            self._raise_wait_block(plan)
+
+        if ActionType.ALERT_ONLY in plan.actions:
+            self._raise_alert_block(plan)
+
+        if ActionType.NOOP in plan.actions and plan.safety_state == ExecutionSafety.CONVERGED:
+            # allow execution
+            return
+
+        # Fallback
+        self._handle_fallback_block(plan)
 
     def ensure_safe_to_execute(self, cancellation_event: threading.Event | None = None) -> None:
         """Enforce execution blocking rules and perform recovery actions."""
@@ -425,46 +453,32 @@ class RecoveryGate:
             raise ExecutionBlockedError(f"Reset recovery failed: {type(exc).__name__}") from exc
 
     def _ensure_lock_for_reset(self) -> None:
-        """Ensure the distributed lock is held before resetting recovery."""
-        lock_state = self.lock.check_state()
-        if lock_state == LockState.VALID:
+        """Acquire lock if not already held or reacquired."""
+        if self.lock.check_state() == LockState.VALID:
             return
 
-        log_event(
-            logger,
-            logging.WARNING,
-            ObservabilityEvent(
-                event="recovery_gate_lock_reacquisition_attempt",
-                message=f"Lock state is {lock_state.value} before RESET recovery, attempting reacquisition...",
-                metadata={"lock_state": lock_state.value},
-            ),
-        )
-        try:
-            self.lock.acquire()
-        except LockAcquisitionTimeout as exc:
-            msg = f"Cannot perform RESET recovery without valid lock (state={lock_state.value})"
-            log_event(
-                logger,
-                logging.ERROR,
-                ObservabilityEvent(
-                    event="recovery_gate_lock_reacquisition_failed",
-                    message=f"{ExecutionBlockedError.__name__}: {msg}",
-                    metadata={"error": ExecutionBlockedError.__name__, "details": msg},
-                ),
-            )
-            raise ExecutionBlockedError(msg) from exc
-        self.lock_was_reacquired = True
-        log_event(
-            logger,
-            logging.INFO,
-            ObservabilityEvent(
-                event="recovery_gate_lock_reacquired",
-                message="Successfully reacquired lock for RESET recovery",
-            ),
-        )
+        if not self.lock_was_reacquired:
+            try:
+                self.lock.acquire(max_retries=30)
+                self.lock_was_reacquired = True
+            except LockAcquisitionTimeout as lat_exc:
+                log_event(
+                    logger,
+                    logging.ERROR,
+                    ObservabilityEvent(
+                        event="recovery_gate_lock_reacquisition_failed",
+                        message="Timeout acquiring distributed lock for reset recovery",
+                        metadata={"error": "LockAcquisitionTimeout"},
+                    ),
+                )
+                raise ExecutionBlockedError(
+                    f"Timeout acquiring distributed lock for reset recovery: {lat_exc}",
+                    action="wait",
+                    inconsistency_type="orphaned_running",
+                ) from lat_exc
 
-    def _is_heartbeat_stale(self, active_job) -> bool:
-        """Check if an active job's heartbeat is stale."""
+    def _is_heartbeat_stale(self, active_job: Any) -> bool:
+        """Determine if active rebuild job heartbeat is stale."""
         if not active_job.last_heartbeat_at:
             return True
         heartbeat_time = active_job.last_heartbeat_at
@@ -472,6 +486,28 @@ class RecoveryGate:
             heartbeat_time = heartbeat_time.replace(tzinfo=UTC)
         age = (datetime.now(UTC) - heartbeat_time).total_seconds()
         return age >= self.lock_ttl_seconds
+
+    def _reset_active_job(self, active_job: Any, repo: AssetGraphRepository, session: Any) -> None:
+        """Mark active job as failed and commit."""
+        current_worker = self.lock.holder_id
+        if active_job.active_worker_id != current_worker and not self._is_heartbeat_stale(active_job):
+            raise ExecutionBlockedError(
+                f"Cannot reset job {active_job.job_id}: active worker "
+                f"{active_job.active_worker_id} has fresh heartbeat",
+                action="unsafe",
+                inconsistency_type="orphaned_running",
+            )
+
+        repo.mark_rebuild_job_failed(
+            active_job.job_id,
+            execution_id=active_job.execution_id,
+            details=RebuildFailureDetails(
+                failure_category="recovery_reset",
+                failure_message="Recovered from orphaned state by RecoveryGate",
+                duration_ms=0,
+            ),
+        )
+        session.commit()
 
     def _perform_reset_recovery(self, cancellation_event: threading.Event | None = None) -> None:
         """Reset an orphaned RUNNING rebuild job so a new execution can proceed."""
@@ -496,25 +532,8 @@ class RecoveryGate:
                 if cancellation_event and cancellation_event.is_set():
                     return
 
-                current_worker = self.lock.holder_id
-                if active_job.active_worker_id != current_worker and not self._is_heartbeat_stale(active_job):
-                    raise ExecutionBlockedError(
-                        f"Cannot reset job {active_job.job_id}: active worker "
-                        f"{active_job.active_worker_id} has fresh heartbeat",
-                        action="unsafe",
-                        inconsistency_type="orphaned_running",
-                    )
+                self._reset_active_job(active_job, repo, session)
 
-                repo.mark_rebuild_job_failed(
-                    active_job.job_id,
-                    execution_id=active_job.execution_id,
-                    details=RebuildFailureDetails(
-                        failure_category="recovery_reset",
-                        failure_message="Recovered from orphaned state by RecoveryGate",
-                        duration_ms=0,
-                    ),
-                )
-                session.commit()
                 log_event(
                     logger,
                     logging.WARNING,

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -321,8 +321,8 @@ class RecoveryGate:
         """Log and raise ExecutionBlockedError for ALERT_ONLY action."""
         self._raise_action_block(plan, "alert_only", "alert only")
 
-    def _handle_fallback_block(self, plan: ReconciliationPlan) -> None:
-        """Handle fallback block logic."""
+    def _handle_unknown_plan_block(self, plan: ReconciliationPlan) -> None:
+        """Block unrecognized plan combinations without mutating state."""
         action = self._map_plan_to_action(plan)
         if action != "resume":
             log_event(
@@ -331,7 +331,7 @@ class RecoveryGate:
                 ObservabilityEvent(
                     event="recovery_gate_execution_blocked_final",
                     message=(
-                        f"Execution blocked by recovery gate fallback: "
+                        f"Execution blocked by recovery gate for unrecognized plan: "
                         f"action={action}, inconsistency={plan.drift_type}"
                     ),
                     metadata={
@@ -341,7 +341,7 @@ class RecoveryGate:
                 ),
             )
             raise ExecutionBlockedError(
-                f"Execution blocked: fallback block. (action={action}, inconsistency={plan.drift_type})",
+                f"Execution blocked: unrecognized plan. (action={action}, inconsistency={plan.drift_type})",
                 action=action,
                 inconsistency_type=plan.drift_type,
             )
@@ -374,8 +374,7 @@ class RecoveryGate:
             # allow execution
             return
 
-        # Fallback
-        self._handle_fallback_block(plan)
+        self._handle_unknown_plan_block(plan)
 
     def ensure_safe_to_execute(self, cancellation_event: threading.Event | None = None) -> None:
         """Enforce execution blocking rules and perform recovery actions."""

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -347,18 +347,30 @@ class RecoveryGate:
             inconsistency_type=plan.drift_type,
         )
 
+    def _is_terminal_safety_plan(self, plan: ReconciliationPlan) -> bool:
+        """Return True when the plan safety state must block immediately."""
+        return plan.safety_state in (
+            ExecutionSafety.EVALUATION_FAILED,
+            ExecutionSafety.OBSERVABILITY_FAILURE,
+            ExecutionSafety.UNSAFE_SPLIT_BRAIN,
+            ExecutionSafety.INTEGRITY_COMPROMISED,
+        )
+
+    def _is_wait_plan(self, plan: ReconciliationPlan) -> bool:
+        """Return True when the plan requires waiting for convergence."""
+        return ActionType.WAIT_FOR_CONVERGENCE in plan.actions or plan.safety_state == ExecutionSafety.WAIT_REQUIRED
+
+    def _is_converged_noop_plan(self, plan: ReconciliationPlan) -> bool:
+        """Return True when the plan explicitly allows execution."""
+        return ActionType.NOOP in plan.actions and plan.safety_state == ExecutionSafety.CONVERGED
+
     def consume_reconciliation_plan(
         self,
         plan: ReconciliationPlan,
         cancellation_event: threading.Event | None = None,
     ) -> None:
         """Consume a ReconciliationPlan and enforce recovery or execution blocking rules."""
-        if plan.safety_state in (
-            ExecutionSafety.EVALUATION_FAILED,
-            ExecutionSafety.OBSERVABILITY_FAILURE,
-            ExecutionSafety.UNSAFE_SPLIT_BRAIN,
-            ExecutionSafety.INTEGRITY_COMPROMISED,
-        ):
+        if self._is_terminal_safety_plan(plan):
             action = self._map_plan_to_action(plan)
             if action == "resume":
                 action = "unsafe"
@@ -367,13 +379,13 @@ class RecoveryGate:
         if self._handle_reset_action(plan, cancellation_event):
             return
 
-        if ActionType.WAIT_FOR_CONVERGENCE in plan.actions or plan.safety_state == ExecutionSafety.WAIT_REQUIRED:
+        if self._is_wait_plan(plan):
             self._raise_wait_block(plan)
 
         if ActionType.ALERT_ONLY in plan.actions:
             self._raise_alert_block(plan)
 
-        if ActionType.NOOP in plan.actions and plan.safety_state == ExecutionSafety.CONVERGED:
+        if self._is_converged_noop_plan(plan):
             # allow execution
             return
 

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -452,7 +452,6 @@ class RecoveryGate:
 
         try:
             self.lock.acquire(max_retries=30)
-            self.lock_was_reacquired = True
         except LockAcquisitionTimeout as lat_exc:
             log_event(
                 logger,
@@ -475,6 +474,7 @@ class RecoveryGate:
                 action="wait",
                 inconsistency_type=drift_type,
             )
+        self.lock_was_reacquired = True
 
     def _is_heartbeat_stale(self, active_job: Any) -> bool:
         """Determine if active rebuild job heartbeat is stale."""

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -54,6 +54,8 @@ class RecoveryGate:
         increment_recovery_trigger: Callable[[str], None] | None = None,
         runtime_has_active_executor: bool = False,
         lock_ttl_seconds: int = 300,
+        enable_automatic_recovery: bool = False,
+        record_drift_metric: Callable[[str, str, str], None] | None = None,
     ) -> None:
         """Initialize RecoveryGate."""
         self.session_factory = session_factory
@@ -61,6 +63,8 @@ class RecoveryGate:
         self.increment_recovery_trigger = increment_recovery_trigger or (lambda _: None)
         self.runtime_has_active_executor = runtime_has_active_executor
         self.lock_ttl_seconds = lock_ttl_seconds
+        self.enable_automatic_recovery = enable_automatic_recovery
+        self.record_drift_metric = record_drift_metric or (lambda _t, _s, _e: None)
         self.lock_was_reacquired = False
 
     def _create_unsafe_plan_from_error(
@@ -155,7 +159,11 @@ class RecoveryGate:
                     runtime_has_active_executor=self.runtime_has_active_executor,
                     lock_ttl_seconds=self.lock_ttl_seconds,
                 )
-                engine = ReconciliationEngine(evaluator=evaluator)
+                engine = ReconciliationEngine(
+                    evaluator=evaluator,
+                    enable_automatic_execution=self.enable_automatic_recovery,
+                    record_drift_metric=self.record_drift_metric,
+                )
                 plan = engine.generate_reconciliation_plan()
             except ValueError as exc:
                 return self._create_unsafe_plan_from_error(exc, "active rebuild state query failed")
@@ -209,21 +217,133 @@ class RecoveryGate:
         plan = self.get_reconciliation_plan()
         return self._map_plan_to_action(plan)
 
-    def ensure_safe_to_execute(self, cancellation_event: threading.Event | None = None) -> None:
-        """Enforce execution blocking rules and perform recovery actions."""
-        self.lock_was_reacquired = False
-        plan = self.get_reconciliation_plan()
-        action = self._map_plan_to_action(plan)
-
-        if action == "reset":
-            self._execute_reset_path(plan, cancellation_event)
-        elif action != "resume":
+    def consume_reconciliation_plan(
+        self,
+        plan: ReconciliationPlan,
+        cancellation_event: threading.Event | None = None,
+    ) -> None:
+        """Consume a ReconciliationPlan and enforce recovery or execution blocking rules."""
+        if plan.safety_state in (
+            ExecutionSafety.EVALUATION_FAILED,
+            ExecutionSafety.OBSERVABILITY_FAILURE,
+            ExecutionSafety.UNSAFE_SPLIT_BRAIN,
+            ExecutionSafety.INTEGRITY_COMPROMISED,
+        ):
+            action = self._map_plan_to_action(plan)
             log_event(
                 logger,
                 logging.WARNING,
                 ObservabilityEvent(
                     event="recovery_gate_execution_blocked_final",
-                    message=f"Execution blocked by recovery gate: action={action}, inconsistency={plan.drift_type}",
+                    message=(
+                        f"Execution blocked by recovery gate safety state: "
+                        f"safety_state={plan.safety_state.value}, inconsistency={plan.drift_type}"
+                    ),
+                    metadata={
+                        "action": action,
+                        "inconsistency": plan.drift_type,
+                        "safety_state": plan.safety_state.value,
+                    },
+                ),
+            )
+            raise ExecutionBlockedError(
+                f"Execution blocked due to safety state: {plan.safety_state.value} (action={action}, inconsistency={plan.drift_type})",
+                action=action,
+                inconsistency_type=plan.drift_type,
+            )
+
+        if ActionType.RESET_STATE in plan.actions:
+            if (
+                plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
+                and plan.safety_state == ExecutionSafety.RESET_REQUIRED
+            ):
+                from src.logic.reconciliation_engine import RebuildCancelledError
+
+                if cancellation_event and cancellation_event.is_set():
+                    raise RebuildCancelledError("Rebuild cancelled via API request")
+
+                self._execute_reset_path(plan, cancellation_event)
+
+                if cancellation_event and cancellation_event.is_set():
+                    raise RebuildCancelledError("Rebuild cancelled via API request")
+                return
+            else:
+                action = "wait" if plan.execution_mode == ExecutionMode.DEFERRED else "alert_only"
+                log_event(
+                    logger,
+                    logging.WARNING,
+                    ObservabilityEvent(
+                        event="recovery_gate_execution_blocked_final",
+                        message=(
+                            f"Execution blocked for non-automatic reset plan: "
+                            f"action={action}, inconsistency={plan.drift_type}"
+                        ),
+                        metadata={
+                            "action": action,
+                            "inconsistency": plan.drift_type,
+                        },
+                    ),
+                )
+                raise ExecutionBlockedError(
+                    f"Execution blocked: reset required but mode={plan.execution_mode.value} (action={action}, inconsistency={plan.drift_type})",
+                    action=action,
+                    inconsistency_type=plan.drift_type,
+                )
+
+        if ActionType.WAIT_FOR_CONVERGENCE in plan.actions or plan.safety_state == ExecutionSafety.WAIT_REQUIRED:
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="recovery_gate_execution_blocked_final",
+                    message=f"Execution blocked by recovery gate: action=wait, inconsistency={plan.drift_type}",
+                    metadata={
+                        "action": "wait",
+                        "inconsistency": plan.drift_type,
+                    },
+                ),
+            )
+            raise ExecutionBlockedError(
+                f"Execution blocked: waiting for convergence. Reason: {plan.reason} (action=wait, inconsistency={plan.drift_type})",
+                action="wait",
+                inconsistency_type=plan.drift_type,
+            )
+
+        if ActionType.ALERT_ONLY in plan.actions:
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="recovery_gate_execution_blocked_final",
+                    message=f"Execution blocked by recovery gate: action=alert_only, inconsistency={plan.drift_type}",
+                    metadata={
+                        "action": "alert_only",
+                        "inconsistency": plan.drift_type,
+                    },
+                ),
+            )
+            raise ExecutionBlockedError(
+                f"Execution blocked: alert only. Reason: {plan.reason} (action=alert_only, inconsistency={plan.drift_type})",
+                action="alert_only",
+                inconsistency_type=plan.drift_type,
+            )
+
+        if ActionType.NOOP in plan.actions and plan.safety_state == ExecutionSafety.CONVERGED:
+            # allow execution
+            return
+
+        # Fallback
+        action = self._map_plan_to_action(plan)
+        if action != "resume":
+            log_event(
+                logger,
+                logging.WARNING,
+                ObservabilityEvent(
+                    event="recovery_gate_execution_blocked_final",
+                    message=(
+                        f"Execution blocked by recovery gate fallback: "
+                        f"action={action}, inconsistency={plan.drift_type}"
+                    ),
                     metadata={
                         "action": action,
                         "inconsistency": plan.drift_type,
@@ -231,10 +351,16 @@ class RecoveryGate:
                 ),
             )
             raise ExecutionBlockedError(
-                f"Execution blocked: action={action}, inconsistency={plan.drift_type}",
+                f"Execution blocked: fallback block. (action={action}, inconsistency={plan.drift_type})",
                 action=action,
                 inconsistency_type=plan.drift_type,
             )
+
+    def ensure_safe_to_execute(self, cancellation_event: threading.Event | None = None) -> None:
+        """Enforce execution blocking rules and perform recovery actions."""
+        self.lock_was_reacquired = False
+        plan = self.get_reconciliation_plan()
+        self.consume_reconciliation_plan(plan, cancellation_event)
 
     def _execute_reset_path(self, plan: ReconciliationPlan, cancellation_event: threading.Event | None) -> None:
         """Handle the reset recovery path."""

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -360,6 +360,8 @@ class RecoveryGate:
             ExecutionSafety.INTEGRITY_COMPROMISED,
         ):
             action = self._map_plan_to_action(plan)
+            if action == "resume":
+                action = "unsafe"
             self._raise_safety_block(plan, action)
 
         if self._handle_reset_action(plan, cancellation_event):

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -492,11 +492,12 @@ class RecoveryGate:
         """Mark active job as failed and commit."""
         current_worker = self.lock.holder_id
         if active_job.active_worker_id != current_worker and not self._is_heartbeat_stale(active_job):
+            inconsistency = InconsistencyType.STALE_OWNERSHIP.value
             raise ExecutionBlockedError(
                 f"Cannot reset job {active_job.job_id}: active worker "
-                f"{active_job.active_worker_id} has fresh heartbeat",
+                f"{active_job.active_worker_id} has fresh heartbeat (action=unsafe, inconsistency={inconsistency})",
                 action="unsafe",
-                inconsistency_type=InconsistencyType.STALE_OWNERSHIP.value,
+                inconsistency_type=inconsistency,
             )
 
         repo.mark_rebuild_job_failed(

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -11,7 +11,7 @@ from typing import Any
 from sqlalchemy import exc as sqlalchemy_exc
 from sqlalchemy.orm import Session
 
-from src.data.distributed_lock import DistributedLock, LockAcquisitionTimeout, LockState
+from src.data.distributed_lock import MAX_TTL, DistributedLock, LockAcquisitionTimeout, LockState
 from src.data.repository import AssetGraphRepository, RebuildFailureDetails
 from src.logic.rebuild_drift_evaluator import RebuildDriftEvaluator
 from src.logic.rebuild_failure_detection import InconsistencyType
@@ -63,7 +63,7 @@ class RecoveryGate:
         self.lock = lock
         self.increment_recovery_trigger = increment_recovery_trigger or (lambda _: None)
         self.runtime_has_active_executor = runtime_has_active_executor
-        self.lock_ttl_seconds = lock_ttl_seconds
+        self.lock_ttl_seconds = max(1, min(int(lock_ttl_seconds), MAX_TTL))
         self.enable_automatic_recovery = enable_automatic_recovery
         self.record_drift_metric = record_drift_metric or (lambda _t, _s, _e: None)
         self.lock_was_reacquired = False
@@ -242,6 +242,14 @@ class RecoveryGate:
             inconsistency_type=plan.drift_type,
         )
 
+    def _should_execute_reset(self, plan: ReconciliationPlan) -> bool:
+        """Return True when a reset plan is authorized for immediate mutation."""
+        return (
+            ActionType.RESET_STATE in plan.actions
+            and plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
+            and plan.safety_state == ExecutionSafety.RESET_REQUIRED
+        )
+
     def _handle_reset_action(
         self,
         plan: ReconciliationPlan,
@@ -251,10 +259,7 @@ class RecoveryGate:
         if ActionType.RESET_STATE not in plan.actions:
             return False
 
-        if (
-            plan.execution_mode in (ExecutionMode.AUTOMATIC, ExecutionMode.IMMEDIATE)
-            and plan.safety_state == ExecutionSafety.RESET_REQUIRED
-        ):
+        if self._should_execute_reset(plan):
             from src.logic.reconciliation_engine import RebuildCancelledError
 
             if cancellation_event and cancellation_event.is_set():
@@ -288,45 +293,33 @@ class RecoveryGate:
             inconsistency_type=plan.drift_type,
         )
 
-    def _raise_wait_block(self, plan: ReconciliationPlan) -> None:
-        """Log and raise ExecutionBlockedError for WAIT action."""
+    def _raise_action_block(self, plan: ReconciliationPlan, action: str, reason_prefix: str) -> None:
+        """Log and raise ExecutionBlockedError for a terminal block action."""
         log_event(
             logger,
             logging.WARNING,
             ObservabilityEvent(
                 event="recovery_gate_execution_blocked_final",
-                message=f"Execution blocked by recovery gate: action=wait, inconsistency={plan.drift_type}",
+                message=f"Execution blocked by recovery gate: action={action}, inconsistency={plan.drift_type}",
                 metadata={
-                    "action": "wait",
+                    "action": action,
                     "inconsistency": plan.drift_type,
                 },
             ),
         )
         raise ExecutionBlockedError(
-            f"Execution blocked: waiting for convergence. Reason: {plan.reason} (action=wait, inconsistency={plan.drift_type})",
-            action="wait",
+            f"Execution blocked: {reason_prefix}. Reason: {plan.reason} (action={action}, inconsistency={plan.drift_type})",
+            action=action,
             inconsistency_type=plan.drift_type,
         )
 
+    def _raise_wait_block(self, plan: ReconciliationPlan) -> None:
+        """Log and raise ExecutionBlockedError for WAIT action."""
+        self._raise_action_block(plan, "wait", "waiting for convergence")
+
     def _raise_alert_block(self, plan: ReconciliationPlan) -> None:
         """Log and raise ExecutionBlockedError for ALERT_ONLY action."""
-        log_event(
-            logger,
-            logging.WARNING,
-            ObservabilityEvent(
-                event="recovery_gate_execution_blocked_final",
-                message=f"Execution blocked by recovery gate: action=alert_only, inconsistency={plan.drift_type}",
-                metadata={
-                    "action": "alert_only",
-                    "inconsistency": plan.drift_type,
-                },
-            ),
-        )
-        raise ExecutionBlockedError(
-            f"Execution blocked: alert only. Reason: {plan.reason} (action=alert_only, inconsistency={plan.drift_type})",
-            action="alert_only",
-            inconsistency_type=plan.drift_type,
-        )
+        self._raise_action_block(plan, "alert_only", "alert only")
 
     def _handle_fallback_block(self, plan: ReconciliationPlan) -> None:
         """Handle fallback block logic."""
@@ -405,7 +398,7 @@ class RecoveryGate:
             ),
         )
         try:
-            self._perform_reset_recovery(cancellation_event=cancellation_event)
+            self._perform_reset_recovery(cancellation_event=cancellation_event, drift_type=plan.drift_type)
 
             if cancellation_event and cancellation_event.is_set():
                 return
@@ -452,7 +445,7 @@ class RecoveryGate:
             )
             raise ExecutionBlockedError(f"Reset recovery failed: {type(exc).__name__}") from exc
 
-    def _ensure_lock_for_reset(self) -> None:
+    def _ensure_lock_for_reset(self, drift_type: str) -> None:
         """Acquire lock if not already held or reacquired."""
         if self.lock.check_state() == LockState.VALID:
             return
@@ -474,7 +467,7 @@ class RecoveryGate:
                 raise ExecutionBlockedError(
                     f"Timeout acquiring distributed lock for reset recovery: {lat_exc}",
                     action="wait",
-                    inconsistency_type="orphaned_running",
+                    inconsistency_type=drift_type,
                 ) from lat_exc
 
     def _is_heartbeat_stale(self, active_job: Any) -> bool:
@@ -509,14 +502,18 @@ class RecoveryGate:
         )
         session.commit()
 
-    def _perform_reset_recovery(self, cancellation_event: threading.Event | None = None) -> None:
+    def _perform_reset_recovery(
+        self,
+        cancellation_event: threading.Event | None = None,
+        drift_type: str = InconsistencyType.ORPHANED_RUNNING.value,
+    ) -> None:
         """Reset an orphaned RUNNING rebuild job so a new execution can proceed."""
         from src.data.db_models import RebuildJobStatus
 
         if cancellation_event and cancellation_event.is_set():
             return
 
-        self._ensure_lock_for_reset()
+        self._ensure_lock_for_reset(drift_type)
 
         if cancellation_event and cancellation_event.is_set():
             return

--- a/src/logic/recovery_gate.py
+++ b/src/logic/recovery_gate.py
@@ -323,28 +323,29 @@ class RecoveryGate:
 
     def _handle_unknown_plan_block(self, plan: ReconciliationPlan) -> None:
         """Block unrecognized plan combinations without mutating state."""
-        action = self._map_plan_to_action(plan)
-        if action != "resume":
-            log_event(
-                logger,
-                logging.WARNING,
-                ObservabilityEvent(
-                    event="recovery_gate_execution_blocked_final",
-                    message=(
-                        f"Execution blocked by recovery gate for unrecognized plan: "
-                        f"action={action}, inconsistency={plan.drift_type}"
-                    ),
-                    metadata={
-                        "action": action,
-                        "inconsistency": plan.drift_type,
-                    },
+        mapped_action = self._map_plan_to_action(plan)
+        action = "unsafe" if mapped_action == "resume" else mapped_action
+        log_event(
+            logger,
+            logging.WARNING,
+            ObservabilityEvent(
+                event="recovery_gate_execution_blocked_final",
+                message=(
+                    f"Execution blocked by recovery gate for unrecognized plan: "
+                    f"action={action}, inconsistency={plan.drift_type}"
                 ),
-            )
-            raise ExecutionBlockedError(
-                f"Execution blocked: unrecognized plan. (action={action}, inconsistency={plan.drift_type})",
-                action=action,
-                inconsistency_type=plan.drift_type,
-            )
+                metadata={
+                    "action": action,
+                    "inconsistency": plan.drift_type,
+                    "mapped_action": mapped_action,
+                },
+            ),
+        )
+        raise ExecutionBlockedError(
+            f"Execution blocked: unrecognized plan. (action={action}, inconsistency={plan.drift_type})",
+            action=action,
+            inconsistency_type=plan.drift_type,
+        )
 
     def consume_reconciliation_plan(
         self,
@@ -493,7 +494,7 @@ class RecoveryGate:
                 f"Cannot reset job {active_job.job_id}: active worker "
                 f"{active_job.active_worker_id} has fresh heartbeat",
                 action="unsafe",
-                inconsistency_type="orphaned_running",
+                inconsistency_type=InconsistencyType.STALE_OWNERSHIP.value,
             )
 
         repo.mark_rebuild_job_failed(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,10 +12,7 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
 if TYPE_CHECKING:
-    from src.logic.reconciliation_engine import (
-        ReconciliationPlan,
-        Severity,
-    )
+    from src.logic.reconciliation_engine import ReconciliationPlan
 
 # Ensure a clean SQLite database for the authentication layer before any modules import it.
 _db_path = Path(__file__).resolve().parent / "test_auth.db"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,6 @@ from sqlalchemy import event
 from sqlalchemy.engine import Engine
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
     from src.logic.reconciliation_engine import (
         ActionType,
         ExecutionMode,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,22 @@ from __future__ import annotations
 import importlib.util
 import os
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Callable
 
 import pytest
 from sqlalchemy import event
 from sqlalchemy.engine import Engine
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+    from src.logic.reconciliation_engine import (
+        ActionType,
+        ExecutionMode,
+        ExecutionSafety,
+        ReconciliationPlan,
+        Severity,
+    )
 
 # Ensure a clean SQLite database for the authentication layer before any modules import it.
 _db_path = Path(__file__).resolve().parent / "test_auth.db"
@@ -324,7 +335,7 @@ def mock_rebuild_job():
 
 
 @pytest.fixture
-def make_reconciliation_plan():
+def make_reconciliation_plan() -> Callable[..., ReconciliationPlan]:
     """Return a factory function to create ReconciliationPlan instances for testing."""
     from datetime import UTC, datetime
 
@@ -337,16 +348,16 @@ def make_reconciliation_plan():
     )
 
     def _make(
-        drift_type="none",
-        severity=Severity.NONE,
-        actions=(ActionType.NOOP,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.CONVERGED,
-        reason="Graph is healthy",
-        metadata=None,
-        created_at=None,
-    ):
+        drift_type: str = "none",
+        severity: Severity = Severity.NONE,
+        actions: tuple[ActionType, ...] = (ActionType.NOOP,),
+        target_state: str = "healthy",
+        execution_mode: ExecutionMode = ExecutionMode.AUTOMATIC,
+        safety_state: ExecutionSafety = ExecutionSafety.CONVERGED,
+        reason: str = "Graph is healthy",
+        metadata: dict[str, str | int | float | bool | None] | None = None,
+        created_at: datetime | None = None,
+    ) -> ReconciliationPlan:
         if metadata is None:
             metadata = {}
         if created_at is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from sqlalchemy.engine import Engine
 
 if TYPE_CHECKING:
     from src.logic.reconciliation_engine import (
-        ActionType,
         ExecutionMode,
         ExecutionSafety,
         ReconciliationPlan,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -321,3 +321,46 @@ def mock_rebuild_job():
         return job
 
     return _make_job
+
+
+@pytest.fixture
+def make_reconciliation_plan():
+    """Return a factory function to create ReconciliationPlan instances for testing."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import (
+        ActionType,
+        ExecutionMode,
+        ExecutionSafety,
+        ReconciliationPlan,
+        Severity,
+    )
+
+    def _make(
+        drift_type="none",
+        severity=Severity.NONE,
+        actions=(ActionType.NOOP,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.CONVERGED,
+        reason="Graph is healthy",
+        metadata=None,
+        created_at=None,
+    ):
+        if metadata is None:
+            metadata = {}
+        if created_at is None:
+            created_at = datetime.now(UTC)
+        return ReconciliationPlan(
+            drift_type=drift_type,
+            severity=severity,
+            actions=actions,
+            target_state=target_state,
+            execution_mode=execution_mode,
+            safety_state=safety_state,
+            reason=reason,
+            metadata=metadata,
+            created_at=created_at,
+        )
+
+    return _make

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from sqlalchemy.engine import Engine
 
 if TYPE_CHECKING:
     from src.logic.reconciliation_engine import (
-        ExecutionSafety,
         ReconciliationPlan,
         Severity,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,6 @@ from sqlalchemy.engine import Engine
 
 if TYPE_CHECKING:
     from src.logic.reconciliation_engine import (
-        ExecutionMode,
         ExecutionSafety,
         ReconciliationPlan,
         Severity,

--- a/tests/integration/test_recovery_gate_integration.py
+++ b/tests/integration/test_recovery_gate_integration.py
@@ -53,7 +53,7 @@ def session_factory(sqlite_engine):
 
 
 def test_recovery_gate_passes_with_clean_db(session_factory):
-    """RecoveryGate allows execution when there are no running rebuild jobs.
+    """The RecoveryGate allows execution when there are no running rebuild jobs.
 
     The lock is pre-acquired so that the gate sees a VALID lock state and returns
     RESUME (clean state, no inconsistency detected).
@@ -81,7 +81,7 @@ def test_recovery_gate_passes_with_clean_db(session_factory):
 
 
 def test_recovery_gate_resets_orphaned_running_job(session_factory):
-    """RecoveryGate performs RESET recovery for an orphaned RUNNING job.
+    """The RecoveryGate performs RESET recovery for an orphaned RUNNING job.
 
     Scenario: A RUNNING job exists in the DB with an EXPIRED distributed lock
     (simulating a crashed worker whose lock TTL passed).  The gate detects
@@ -125,6 +125,7 @@ def test_recovery_gate_resets_orphaned_running_job(session_factory):
         lock=lock,
         runtime_has_active_executor=False,
         lock_ttl_seconds=_LOCK_TTL,
+        enable_automatic_recovery=True,
     )
 
     # Gate should detect ORPHANED_RUNNING → perform RESET → allow execution.
@@ -141,7 +142,7 @@ def test_recovery_gate_resets_orphaned_running_job(session_factory):
 
 
 def test_recovery_gate_blocks_on_lost_lock_state(session_factory):
-    """RecoveryGate raises ExecutionBlockedError when the lock state is LOST.
+    """The RecoveryGate raises ExecutionBlockedError when the lock state is LOST.
 
     A LOST state indicates DB connectivity failure.  The gate must block
     execution without attempting any state mutation.

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -267,7 +267,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     monkeypatch.setattr("src.logic.reconciliation_engine.ReconciliationEngine", FakeEngine)
 
     # Mock RecoveryGate
-    ensure_safe_called = []
+    consume_plan_called = []
 
     class FakeGate:
         """Mock RecoveryGate."""
@@ -275,9 +275,13 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
         def __init__(self, **kwargs):
             self.lock_was_reacquired = False
 
-        def ensure_safe_to_execute(self, cancellation_event=None):
-            """Track that ensure_safe_to_execute was called."""
-            ensure_safe_called.append(True)
+        def get_reconciliation_plan(self):
+            """Return mock plan."""
+            return mock_plan
+
+        def consume_reconciliation_plan(self, plan, cancellation_event=None):
+            """Track plan consumption call."""
+            consume_plan_called.append(True)
 
     monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", FakeGate)
 
@@ -322,7 +326,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
             lock_ttl_seconds=300,
         )
 
-    assert ensure_safe_called == [True]
+    assert consume_plan_called == [True]
 
 
 @pytest.mark.asyncio
@@ -553,3 +557,34 @@ def test_generate_startup_trace_ids_format() -> None:
     # Span ID should be 16 hex chars
     assert len(span_id) == 16
     assert all(c in "0123456789abcdef" for c in span_id)
+
+
+def test_start_background_tasks_propagates_rebuild_lock_ttl_seconds(monkeypatch) -> None:
+    """_start_background_tasks should propagate settings.rebuild_lock_ttl_seconds to periodic_reconciliation_loop."""
+    from types import SimpleNamespace
+
+    settings = SimpleNamespace(
+        database_url="sqlite:///:memory:",
+        coordination_database_url="sqlite:///:memory:",
+        graph_sync_interval_seconds=60.0,
+        reconciliation_interval_seconds=30.0,
+        rebuild_lock_ttl_seconds=120,
+    )
+
+    recon_loop_mock = MagicMock()
+    monkeypatch.setattr("src.logic.reconciliation_loop.periodic_reconciliation_loop", recon_loop_mock)
+    monkeypatch.setattr("api.app_factory.init_rebuild_executor", lambda s: None)
+    monkeypatch.setattr("api.app_factory._graph_synchronization_loop", lambda interval_seconds: None)
+    monkeypatch.setattr("api.app_factory._slo_evaluation_loop", lambda: None)
+    monkeypatch.setattr("api.app_factory._resolve_startup_reconciliation_url", lambda s: "sqlite:///:memory:")
+
+    create_task_mock = MagicMock()
+    monkeypatch.setattr("api.app_factory.asyncio.create_task", create_task_mock)
+
+    from api.app_factory import _start_background_tasks
+
+    _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
+
+    recon_loop_mock.assert_called_once()
+    kwargs = recon_loop_mock.call_args[1]
+    assert kwargs["lock_ttl_seconds"] == 120

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -226,7 +226,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     base_settings: SimpleNamespace,
     make_reconciliation_plan,
 ) -> None:
-    """_periodic_reconciliation_loop should invoke gate.ensure_safe_to_execute for automatic reset plans."""
+    """periodic_reconciliation_loop should retrieve and consume automatic reset reconciliation plans."""
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     fake_engine = SimpleNamespace(dispose=lambda: None)
@@ -594,3 +594,28 @@ def test_start_background_tasks_caps_rebuild_lock_ttl_seconds(monkeypatch) -> No
     _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
 
     assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == 300
+
+
+def test_start_background_tasks_floors_rebuild_lock_ttl_seconds(monkeypatch) -> None:
+    """_start_background_tasks should floor periodic reconciliation lock TTL at one second."""
+    settings = SimpleNamespace(
+        database_url="sqlite:///:memory:",
+        coordination_database_url="sqlite:///:memory:",
+        graph_sync_interval_seconds=60.0,
+        reconciliation_interval_seconds=30.0,
+        rebuild_lock_ttl_seconds=0,
+    )
+
+    recon_loop_mock = MagicMock()
+    monkeypatch.setattr("src.logic.reconciliation_loop.periodic_reconciliation_loop", recon_loop_mock)
+    monkeypatch.setattr("api.app_factory.init_rebuild_executor", lambda s: None)
+    monkeypatch.setattr("api.app_factory._graph_synchronization_loop", lambda interval_seconds: None)
+    monkeypatch.setattr("api.app_factory._slo_evaluation_loop", lambda: None)
+    monkeypatch.setattr("api.app_factory._resolve_startup_reconciliation_url", lambda s: "sqlite:///:memory:")
+    monkeypatch.setattr("api.app_factory.asyncio.create_task", MagicMock())
+
+    from api.app_factory import _start_background_tasks
+
+    _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
+
+    assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == 1

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -270,11 +270,11 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     # We want sleep to yield once then raise CancelledError to terminate the loop cleanly
     sleep_calls = 0
 
+    original_sleep = asyncio.sleep
+
     async def mock_sleep(seconds: float):
         """Mock sleep to yield once then raise CancelledError."""
-        f: asyncio.Future[None] = asyncio.Future()
-        f.set_result(None)
-        await f
+        await original_sleep(0)
         nonlocal sleep_calls
         sleep_calls += 1
         if sleep_calls > 1:
@@ -291,11 +291,16 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     with pytest.raises(asyncio.CancelledError):
         from src.logic.reconciliation_loop import periodic_reconciliation_loop
 
+        async def fake_run_with_trace(fn, **kwargs):
+            """Run the traced callable and return an awaitable result."""
+            await original_sleep(0)
+            return fn()
+
         await periodic_reconciliation_loop(
             interval_seconds=0.1,
             database_url=base_settings.database_url,
             is_shutdown_fn=lambda: False,
-            run_with_trace_fn=lambda fn, **kwargs: fn(),
+            run_with_trace_fn=fake_run_with_trace,
             coordination_database_url=base_settings.database_url,
             cancel_event=None,
             lock_ttl_seconds=300,
@@ -563,3 +568,29 @@ def test_start_background_tasks_propagates_rebuild_lock_ttl_seconds(monkeypatch)
     recon_loop_mock.assert_called_once()
     kwargs = recon_loop_mock.call_args[1]
     assert kwargs["lock_ttl_seconds"] == 120
+
+
+def test_start_background_tasks_caps_rebuild_lock_ttl_seconds(monkeypatch) -> None:
+    """_start_background_tasks should cap periodic reconciliation lock TTL at the distributed-lock limit."""
+    settings = SimpleNamespace(
+        database_url="sqlite:///:memory:",
+        coordination_database_url="sqlite:///:memory:",
+        graph_sync_interval_seconds=60.0,
+        reconciliation_interval_seconds=30.0,
+        rebuild_lock_ttl_seconds=450,
+    )
+
+    recon_loop_mock = MagicMock()
+    monkeypatch.setattr("src.logic.reconciliation_loop.periodic_reconciliation_loop", recon_loop_mock)
+    monkeypatch.setattr("api.app_factory.init_rebuild_executor", lambda s: None)
+    monkeypatch.setattr("api.app_factory._graph_synchronization_loop", lambda interval_seconds: None)
+    monkeypatch.setattr("api.app_factory._slo_evaluation_loop", lambda: None)
+    monkeypatch.setattr("api.app_factory._resolve_startup_reconciliation_url", lambda s: "sqlite:///:memory:")
+
+    monkeypatch.setattr("api.app_factory.asyncio.create_task", MagicMock())
+
+    from api.app_factory import _start_background_tasks
+
+    _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
+
+    assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == 300

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import MagicMock
@@ -225,9 +224,10 @@ def test_startup_reconciliation_lock_release_behavior(
 async def test_periodic_reconciliation_loop_triggers_recovery(
     monkeypatch: pytest.MonkeyPatch,
     base_settings: SimpleNamespace,
+    make_reconciliation_plan,
 ) -> None:
     """_periodic_reconciliation_loop should invoke gate.ensure_safe_to_execute for automatic reset plans."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     fake_engine = SimpleNamespace(dispose=lambda: None)
     fake_lock = SimpleNamespace(lock_name="graph_rebuild", release=MagicMock())
@@ -241,8 +241,7 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     monkeypatch.setattr("src.logic.rebuild_drift_evaluator.RebuildDriftEvaluator", MagicMock())
 
     # Mock ReconciliationEngine to return a reset plan with automatic execution mode
-
-    mock_plan = ReconciliationPlan(
+    mock_plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.CRITICAL,
         actions=(ActionType.RESET_STATE,),
@@ -250,49 +249,32 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="test reset",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
-    class FakeEngine:
-        """Mock ReconciliationEngine."""
-
-        def __init__(self, *args, **kwargs):
-            """Accept arguments."""
-
-        def generate_reconciliation_plan(self):
-            """Return a mock reconciliation plan."""
-            return mock_plan
-
-    monkeypatch.setattr("src.logic.reconciliation_engine.ReconciliationEngine", FakeEngine)
+    fake_engine_inst = MagicMock()
+    fake_engine_inst.generate_reconciliation_plan.return_value = mock_plan
+    monkeypatch.setattr(
+        "src.logic.reconciliation_engine.ReconciliationEngine", MagicMock(return_value=fake_engine_inst)
+    )
 
     # Mock RecoveryGate
     consume_plan_called = []
-
-    class FakeGate:
-        """Mock RecoveryGate."""
-
-        def __init__(self, **kwargs):
-            self.lock_was_reacquired = False
-
-        def get_reconciliation_plan(self):
-            """Return mock plan."""
-            return mock_plan
-
-        def consume_reconciliation_plan(self, plan, cancellation_event=None):
-            """Track plan consumption call."""
-            consume_plan_called.append(True)
-
-    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", FakeGate)
+    fake_gate = MagicMock()
+    fake_gate.lock_was_reacquired = False
+    fake_gate.get_reconciliation_plan.return_value = mock_plan
+    fake_gate.consume_reconciliation_plan.side_effect = (
+        lambda plan, cancellation_event=None: consume_plan_called.append(True)
+    )
+    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", MagicMock(return_value=fake_gate))
 
     # We want sleep to yield once then raise CancelledError to terminate the loop cleanly
     sleep_calls = 0
 
     async def mock_sleep(seconds: float):
         """Mock sleep to yield once then raise CancelledError."""
-        future: asyncio.Future[None] = asyncio.Future()
-        future.set_result(None)
-        await future  # use async feature
+        f: asyncio.Future[None] = asyncio.Future()
+        f.set_result(None)
+        await f
         nonlocal sleep_calls
         sleep_calls += 1
         if sleep_calls > 1:
@@ -309,18 +291,11 @@ async def test_periodic_reconciliation_loop_triggers_recovery(
     with pytest.raises(asyncio.CancelledError):
         from src.logic.reconciliation_loop import periodic_reconciliation_loop
 
-        async def fake_run_with_trace(fn, **kwargs):
-            """Mock run_with_trace function."""
-            future: asyncio.Future[None] = asyncio.Future()
-            future.set_result(None)
-            await future
-            return fn()
-
         await periodic_reconciliation_loop(
             interval_seconds=0.1,
             database_url=base_settings.database_url,
             is_shutdown_fn=lambda: False,
-            run_with_trace_fn=fake_run_with_trace,
+            run_with_trace_fn=lambda fn, **kwargs: fn(),
             coordination_database_url=base_settings.database_url,
             cancel_event=None,
             lock_ttl_seconds=300,

--- a/tests/unit/test_app_factory.py
+++ b/tests/unit/test_app_factory.py
@@ -539,16 +539,14 @@ def test_generate_startup_trace_ids_format() -> None:
     assert all(c in "0123456789abcdef" for c in span_id)
 
 
-def test_start_background_tasks_propagates_rebuild_lock_ttl_seconds(monkeypatch) -> None:
-    """_start_background_tasks should propagate settings.rebuild_lock_ttl_seconds to periodic_reconciliation_loop."""
-    from types import SimpleNamespace
-
+def _assert_start_background_tasks_lock_ttl(monkeypatch, configured_ttl: int, expected_ttl: int) -> None:
+    """Assert periodic reconciliation receives the bounded rebuild lock TTL."""
     settings = SimpleNamespace(
         database_url="sqlite:///:memory:",
         coordination_database_url="sqlite:///:memory:",
         graph_sync_interval_seconds=60.0,
         reconciliation_interval_seconds=30.0,
-        rebuild_lock_ttl_seconds=120,
+        rebuild_lock_ttl_seconds=configured_ttl,
     )
 
     recon_loop_mock = MagicMock()
@@ -566,56 +564,19 @@ def test_start_background_tasks_propagates_rebuild_lock_ttl_seconds(monkeypatch)
     _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
 
     recon_loop_mock.assert_called_once()
-    kwargs = recon_loop_mock.call_args[1]
-    assert kwargs["lock_ttl_seconds"] == 120
+    assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == expected_ttl
+
+
+def test_start_background_tasks_propagates_rebuild_lock_ttl_seconds(monkeypatch) -> None:
+    """_start_background_tasks should propagate settings.rebuild_lock_ttl_seconds to periodic_reconciliation_loop."""
+    _assert_start_background_tasks_lock_ttl(monkeypatch, configured_ttl=120, expected_ttl=120)
 
 
 def test_start_background_tasks_caps_rebuild_lock_ttl_seconds(monkeypatch) -> None:
     """_start_background_tasks should cap periodic reconciliation lock TTL at the distributed-lock limit."""
-    settings = SimpleNamespace(
-        database_url="sqlite:///:memory:",
-        coordination_database_url="sqlite:///:memory:",
-        graph_sync_interval_seconds=60.0,
-        reconciliation_interval_seconds=30.0,
-        rebuild_lock_ttl_seconds=450,
-    )
-
-    recon_loop_mock = MagicMock()
-    monkeypatch.setattr("src.logic.reconciliation_loop.periodic_reconciliation_loop", recon_loop_mock)
-    monkeypatch.setattr("api.app_factory.init_rebuild_executor", lambda s: None)
-    monkeypatch.setattr("api.app_factory._graph_synchronization_loop", lambda interval_seconds: None)
-    monkeypatch.setattr("api.app_factory._slo_evaluation_loop", lambda: None)
-    monkeypatch.setattr("api.app_factory._resolve_startup_reconciliation_url", lambda s: "sqlite:///:memory:")
-
-    monkeypatch.setattr("api.app_factory.asyncio.create_task", MagicMock())
-
-    from api.app_factory import _start_background_tasks
-
-    _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
-
-    assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == 300
+    _assert_start_background_tasks_lock_ttl(monkeypatch, configured_ttl=450, expected_ttl=300)
 
 
 def test_start_background_tasks_floors_rebuild_lock_ttl_seconds(monkeypatch) -> None:
     """_start_background_tasks should floor periodic reconciliation lock TTL at one second."""
-    settings = SimpleNamespace(
-        database_url="sqlite:///:memory:",
-        coordination_database_url="sqlite:///:memory:",
-        graph_sync_interval_seconds=60.0,
-        reconciliation_interval_seconds=30.0,
-        rebuild_lock_ttl_seconds=0,
-    )
-
-    recon_loop_mock = MagicMock()
-    monkeypatch.setattr("src.logic.reconciliation_loop.periodic_reconciliation_loop", recon_loop_mock)
-    monkeypatch.setattr("api.app_factory.init_rebuild_executor", lambda s: None)
-    monkeypatch.setattr("api.app_factory._graph_synchronization_loop", lambda interval_seconds: None)
-    monkeypatch.setattr("api.app_factory._slo_evaluation_loop", lambda: None)
-    monkeypatch.setattr("api.app_factory._resolve_startup_reconciliation_url", lambda s: "sqlite:///:memory:")
-    monkeypatch.setattr("api.app_factory.asyncio.create_task", MagicMock())
-
-    from api.app_factory import _start_background_tasks
-
-    _start_background_tasks(has_persistence=True, settings=cast(Any, settings))
-
-    assert recon_loop_mock.call_args[1]["lock_ttl_seconds"] == 1
+    _assert_start_background_tasks_lock_ttl(monkeypatch, configured_ttl=0, expected_ttl=1)

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -284,7 +284,7 @@ async def test_periodic_reconciliation_loop_skips_when_not_ready(monkeypatch):
         interval_seconds=0.01,
         database_url="sqlite://",
         is_shutdown_fn=mock_is_shutdown,
-        run_with_trace_fn=lambda fn, **kwargs: fn(),
+        run_with_trace_fn=lambda fn, **kwargs: asyncio.to_thread(fn),
     )
 
     # The iteration should not be called

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -320,7 +320,7 @@ async def test_periodic_reconciliation_loop_runs_iteration_when_ready(monkeypatc
         interval_seconds=0.001,
         database_url="sqlite://",
         is_shutdown_fn=mock_is_shutdown,
-        run_with_trace_fn=lambda fn, **kwargs: fn(),
+        run_with_trace_fn=lambda fn, **kwargs: asyncio.to_thread(fn),
     )
 
     # The iteration should be called

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -436,7 +436,7 @@ async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(mo
         interval_seconds=2.0,
         database_url="sqlite://",
         is_shutdown_fn=mock_is_shutdown,
-        run_with_trace_fn=lambda fn, **kwargs: fn(),
+        run_with_trace_fn=lambda fn, **kwargs: asyncio.to_thread(fn),
     )
 
     assert iter_calls == 2

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -375,7 +375,7 @@ async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
         interval_seconds=2.0,
         database_url="sqlite://",
         is_shutdown_fn=mock_is_shutdown,
-        run_with_trace_fn=lambda fn, **kwargs: fn(),
+        run_with_trace_fn=lambda fn, **kwargs: asyncio.to_thread(fn),
     )
 
     # Assert loop ran twice

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -1,5 +1,6 @@
 """Unit tests for the background reconciliation loop."""
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -323,6 +324,7 @@ async def test_periodic_reconciliation_loop_runs_iteration_when_ready(monkeypatc
 @pytest.mark.asyncio
 async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
     """Verify loop backs off on error and resets on success."""
+    original_sleep = asyncio.sleep
     lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.READY)
     monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
 
@@ -336,6 +338,7 @@ async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
 
     async def mock_perform_reconciliation_iteration(*args, **kwargs):
         nonlocal iter_calls
+        await original_sleep(0)
         iter_calls += 1
         if iter_calls == 1:
             raise RuntimeError("Database error")
@@ -357,6 +360,7 @@ async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
     sleep_durations = []
 
     async def mock_sleep(seconds):
+        await original_sleep(0)
         sleep_durations.append(seconds)
 
     monkeypatch.setattr("asyncio.sleep", mock_sleep)
@@ -376,14 +380,15 @@ async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
     # 2. 4.xxxx (backed off after first iter failed)
     # 3. 2.0 (reset after second iter succeeded)
     assert len(sleep_durations) == 3
-    assert sleep_durations[0] == 2.0
+    assert sleep_durations[0] == pytest.approx(2.0)
     assert sleep_durations[1] > 2.0
-    assert sleep_durations[2] == 2.0
+    assert sleep_durations[2] == pytest.approx(2.0)
 
 
 @pytest.mark.asyncio
 async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(monkeypatch):
     """Verify expected recovery gate blocks do not trigger transient-error backoff."""
+    original_sleep = asyncio.sleep
     lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.READY)
     monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
 
@@ -396,6 +401,7 @@ async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(mo
 
     async def mock_perform_reconciliation_iteration(*args, **kwargs):
         nonlocal iter_calls
+        await original_sleep(0)
         iter_calls += 1
         if iter_calls == 1:
             raise ExecutionBlockedError("blocked", action="wait", inconsistency_type="wait_for_convergence")
@@ -415,6 +421,7 @@ async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(mo
     sleep_durations = []
 
     async def mock_sleep(seconds):
+        await original_sleep(0)
         sleep_durations.append(seconds)
 
     monkeypatch.setattr("asyncio.sleep", mock_sleep)
@@ -427,4 +434,4 @@ async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(mo
     )
 
     assert iter_calls == 2
-    assert sleep_durations == [2.0, 2.0, 2.0]
+    assert sleep_durations == pytest.approx([2.0, 2.0, 2.0])

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -1,6 +1,5 @@
 """Unit tests for the background reconciliation loop."""
 
-from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,7 +9,6 @@ from src.logic.reconciliation_engine import (
     ActionType,
     ExecutionMode,
     ExecutionSafety,
-    ReconciliationPlan,
     Severity,
 )
 from src.logic.reconciliation_loop import (
@@ -72,9 +70,11 @@ def test_create_reconciliation_dependencies(monkeypatch):
     )
 
 
-def test_run_sync_reconciliation_success(monkeypatch, mock_db_engines, mock_session_factory, mock_lock):
+def test_run_sync_reconciliation_success(
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
+):
     """Verify single-pass plan consumption under normal execution."""
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="none",
         severity=Severity.HIGH,
         actions=(ActionType.NOOP,),
@@ -82,8 +82,6 @@ def test_run_sync_reconciliation_success(monkeypatch, mock_db_engines, mock_sess
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.CONVERGED,
         reason="Healthy",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     # Mock gate methods
@@ -118,10 +116,10 @@ def test_run_sync_reconciliation_success(monkeypatch, mock_db_engines, mock_sess
 
 
 def test_run_sync_reconciliation_releases_reacquired_lock(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
 ):
     """Verify that a reacquired lock is released in the finally block."""
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -129,8 +127,6 @@ def test_run_sync_reconciliation_releases_reacquired_lock(
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Orphaned running",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     gate_mock = MagicMock()
@@ -158,10 +154,10 @@ def test_run_sync_reconciliation_releases_reacquired_lock(
 
 
 def test_run_sync_reconciliation_lock_release_failure_is_caught(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
 ):
     """Verify that lock release exceptions are handled and do not propagate."""
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -169,8 +165,6 @@ def test_run_sync_reconciliation_lock_release_failure_is_caught(
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Orphaned running",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     gate_mock = MagicMock()
@@ -207,10 +201,10 @@ def test_run_sync_reconciliation_lock_release_failure_is_caught(
 
 
 def test_run_sync_reconciliation_blocked_error_propagates(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
 ):
     """Verify that ExecutionBlockedError propagates out of the sync loop."""
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="lock_lost",
         severity=Severity.CRITICAL,
         actions=(ActionType.ALERT_ONLY,),
@@ -218,8 +212,6 @@ def test_run_sync_reconciliation_blocked_error_propagates(
         execution_mode=ExecutionMode.MANUAL,
         safety_state=ExecutionSafety.UNSAFE_SPLIT_BRAIN,
         reason="Lock lost",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     gate_mock = MagicMock()

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -1,0 +1,370 @@
+"""Unit tests for the background reconciliation loop."""
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from api.app_factory import GraphRuntimeLifecycleState
+from src.logic.reconciliation_engine import (
+    ActionType,
+    ExecutionMode,
+    ExecutionSafety,
+    ReconciliationPlan,
+    Severity,
+)
+from src.logic.reconciliation_loop import (
+    _create_reconciliation_dependencies,
+    _run_sync_reconciliation,
+    periodic_reconciliation_loop,
+)
+from src.logic.recovery_gate import ExecutionBlockedError
+
+
+@pytest.fixture
+def mock_db_engines():
+    """Return mock db engines."""
+    return MagicMock(), MagicMock()
+
+
+@pytest.fixture
+def mock_session_factory():
+    """Return mock session factory."""
+    factory = MagicMock()
+    factory.return_value.__enter__.return_value = MagicMock()
+    return factory
+
+
+@pytest.fixture
+def mock_lock():
+    """Return mock lock."""
+    lock = MagicMock()
+    lock.holder_id = "test-worker"
+    return lock
+
+
+def test_create_reconciliation_dependencies(monkeypatch):
+    """Verify that lock_ttl propagates to create_session_factory and DistributedLock."""
+    mock_session_factory_val = MagicMock()
+    mock_lock_val = MagicMock()
+
+    create_session_factory_mock = MagicMock(return_value=mock_session_factory_val)
+    distributed_lock_mock = MagicMock(return_value=mock_lock_val)
+
+    monkeypatch.setattr("src.data.database.create_session_factory", create_session_factory_mock)
+    monkeypatch.setattr("src.data.distributed_lock.DistributedLock", distributed_lock_mock)
+
+    engine = MagicMock()
+    coord_engine = MagicMock()
+    lock_ttl = 450
+
+    sf, lock = _create_reconciliation_dependencies(engine, coord_engine, lock_ttl)
+
+    assert sf == mock_session_factory_val
+    assert lock == mock_lock_val
+
+    # create_session_factory should be called twice (once for engine, once for coord_engine)
+    assert create_session_factory_mock.call_count == 2
+    distributed_lock_mock.assert_called_once_with(
+        coordination_session_factory=mock_session_factory_val,
+        lock_name="graph_rebuild",
+        ttl_seconds=lock_ttl,
+    )
+
+
+def test_run_sync_reconciliation_success(monkeypatch, mock_db_engines, mock_session_factory, mock_lock):
+    """Verify single-pass plan consumption under normal execution."""
+    plan = ReconciliationPlan(
+        drift_type="none",
+        severity=Severity.HIGH,
+        actions=(ActionType.NOOP,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.CONVERGED,
+        reason="Healthy",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    # Mock gate methods
+    gate_mock = MagicMock()
+    gate_mock.get_reconciliation_plan.return_value = plan
+    gate_mock.lock_was_reacquired = False
+
+    # We mock RecoveryGate constructor to return our gate_mock
+    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
+
+    # Mock dependencies setup
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._create_reconciliation_dependencies",
+        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+    )
+
+    # Also mock metrics to avoid actual prometheus interactions
+    mock_duration = MagicMock()
+    monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", mock_duration)
+
+    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+
+    # Gate should query the plan and consume it
+    gate_mock.get_reconciliation_plan.assert_called_once()
+    gate_mock.consume_reconciliation_plan.assert_called_once_with(plan, cancellation_event=None)
+
+    # Metrics should observe duration
+    mock_duration.observe.assert_called_once()
+
+    # Lock release should not be called since lock_was_reacquired is False
+    mock_lock.release.assert_not_called()
+
+
+def test_run_sync_reconciliation_releases_reacquired_lock(
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+):
+    """Verify that a reacquired lock is released in the finally block."""
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Orphaned running",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    gate_mock = MagicMock()
+    gate_mock.get_reconciliation_plan.return_value = plan
+    # Simulate that lock was reacquired during reset execution
+    gate_mock.lock_was_reacquired = False
+    gate_mock.lock = mock_lock
+
+    def _consume_and_mark_reacquired(*args, **kwargs):
+        gate_mock.lock_was_reacquired = True
+
+    gate_mock.consume_reconciliation_plan.side_effect = _consume_and_mark_reacquired
+
+    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._create_reconciliation_dependencies",
+        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+    )
+    monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
+
+    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+
+    # Release must be called since lock_was_reacquired is True
+    mock_lock.release.assert_called_once()
+
+
+def test_run_sync_reconciliation_lock_release_failure_is_caught(
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+):
+    """Verify that lock release exceptions are handled and do not propagate."""
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Orphaned running",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    gate_mock = MagicMock()
+    gate_mock.get_reconciliation_plan.return_value = plan
+    gate_mock.lock_was_reacquired = False
+    gate_mock.lock = mock_lock
+
+    def _consume_and_mark_reacquired(*args, **kwargs):
+        gate_mock.lock_was_reacquired = True
+
+    gate_mock.consume_reconciliation_plan.side_effect = _consume_and_mark_reacquired
+    # Mock release to fail
+    mock_lock.release.side_effect = RuntimeError("Release failed")
+
+    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._create_reconciliation_dependencies",
+        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+    )
+    monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
+
+    # We mock log_event to assert that the release failure is logged
+    mock_log_event = MagicMock()
+    monkeypatch.setattr("src.logic.reconciliation_loop.log_event", mock_log_event)
+
+    # Should not raise RuntimeError
+    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+
+    mock_lock.release.assert_called_once()
+
+    # Assert it logged the event reconciliation_loop_lock_release_failed
+    log_calls = [call[0][2] for call in mock_log_event.call_args_list]
+    assert any(ev.event == "reconciliation_loop_lock_release_failed" for ev in log_calls)
+
+
+def test_run_sync_reconciliation_blocked_error_propagates(
+    monkeypatch, mock_db_engines, mock_session_factory, mock_lock
+):
+    """Verify that ExecutionBlockedError propagates out of the sync loop."""
+    plan = ReconciliationPlan(
+        drift_type="lock_lost",
+        severity=Severity.CRITICAL,
+        actions=(ActionType.ALERT_ONLY,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.MANUAL,
+        safety_state=ExecutionSafety.UNSAFE_SPLIT_BRAIN,
+        reason="Lock lost",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    gate_mock = MagicMock()
+    gate_mock.get_reconciliation_plan.return_value = plan
+    gate_mock.consume_reconciliation_plan.side_effect = ExecutionBlockedError("Blocked", action="alert_only")
+    gate_mock.lock_was_reacquired = False
+
+    monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._create_reconciliation_dependencies",
+        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+    )
+    monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
+
+    with pytest.raises(ExecutionBlockedError):
+        _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+
+
+@pytest.mark.asyncio
+async def test_periodic_reconciliation_loop_skips_when_not_ready(monkeypatch):
+    """Verify loop skips iteration when runtime lifecycle state is not READY."""
+    lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.INITIALIZING)
+    monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
+
+    # Mock DB engines setup
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._setup_engines", lambda url, coord_url: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr("src.logic.reconciliation_loop._dispose_engines", lambda e, ce: None)
+
+    # Mock iteration call
+    iter_mock = MagicMock()
+    monkeypatch.setattr("src.logic.reconciliation_loop._perform_reconciliation_iteration", iter_mock)
+
+    # Stop the loop after 1 iteration
+    shutdown_calls = 0
+
+    def mock_is_shutdown():
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+        return shutdown_calls > 1
+
+    await periodic_reconciliation_loop(
+        interval_seconds=0.01,
+        database_url="sqlite://",
+        is_shutdown_fn=mock_is_shutdown,
+        run_with_trace_fn=lambda fn, **kwargs: fn(),
+    )
+
+    # The iteration should not be called
+    iter_mock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_periodic_reconciliation_loop_runs_iteration_when_ready(monkeypatch):
+    """Verify loop executes iteration when runtime lifecycle state is READY."""
+    lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.READY)
+    monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
+
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._setup_engines", lambda url, coord_url: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr("src.logic.reconciliation_loop._dispose_engines", lambda e, ce: None)
+
+    from unittest.mock import AsyncMock
+
+    # Mock iteration call (async)
+    iter_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr("src.logic.reconciliation_loop._perform_reconciliation_iteration", iter_mock)
+
+    # Stop the loop after 1 iteration
+    shutdown_calls = 0
+
+    def mock_is_shutdown():
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+        return shutdown_calls > 1
+
+    await periodic_reconciliation_loop(
+        interval_seconds=0.001,
+        database_url="sqlite://",
+        is_shutdown_fn=mock_is_shutdown,
+        run_with_trace_fn=lambda fn, **kwargs: fn(),
+    )
+
+    # The iteration should be called
+    iter_mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
+    """Verify loop backs off on error and resets on success."""
+    lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.READY)
+    monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
+
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._setup_engines", lambda url, coord_url: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr("src.logic.reconciliation_loop._dispose_engines", lambda e, ce: None)
+
+    # First iteration fails with exception, second succeeds
+    iter_calls = 0
+
+    async def mock_perform_reconciliation_iteration(*args, **kwargs):
+        nonlocal iter_calls
+        iter_calls += 1
+        if iter_calls == 1:
+            raise RuntimeError("Database error")
+        return None
+
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._perform_reconciliation_iteration", mock_perform_reconciliation_iteration
+    )
+
+    # Let the loop execute twice, then shutdown
+    shutdown_calls = 0
+
+    def mock_is_shutdown():
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+        return shutdown_calls > 2
+
+    # Capture sleep duration to verify backoff is applied
+    sleep_durations = []
+
+    async def mock_sleep(seconds):
+        sleep_durations.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", mock_sleep)
+
+    await periodic_reconciliation_loop(
+        interval_seconds=2.0,
+        database_url="sqlite://",
+        is_shutdown_fn=mock_is_shutdown,
+        run_with_trace_fn=lambda fn, **kwargs: fn(),
+    )
+
+    # Assert loop ran twice
+    assert iter_calls == 2
+
+    # The sleep durations should be exactly 3:
+    # 1. 2.0 (initial)
+    # 2. 4.xxxx (backed off after first iter failed)
+    # 3. 2.0 (reset after second iter succeeded)
+    assert len(sleep_durations) == 3
+    assert sleep_durations[0] == 2.0
+    assert sleep_durations[1] > 2.0
+    assert sleep_durations[2] == 2.0

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -1,5 +1,6 @@
 """Unit tests for the background reconciliation loop."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,6 +18,8 @@ from src.logic.reconciliation_loop import (
     periodic_reconciliation_loop,
 )
 from src.logic.recovery_gate import ExecutionBlockedError
+
+pytestmark = pytest.mark.unit
 
 
 @pytest.fixture
@@ -41,8 +44,18 @@ def mock_lock():
     return lock
 
 
+@pytest.fixture
+def reconciliation_loop_context(mock_db_engines, mock_session_factory, mock_lock):
+    """Return bundled loop dependencies for tests."""
+    return SimpleNamespace(
+        db_engines=mock_db_engines,
+        session_factory=mock_session_factory,
+        lock=mock_lock,
+    )
+
+
 def test_create_reconciliation_dependencies(monkeypatch):
-    """Verify that lock_ttl propagates to create_session_factory and DistributedLock."""
+    """Verify lock_ttl is bounded before constructing DistributedLock."""
     mock_session_factory_val = MagicMock()
     mock_lock_val = MagicMock()
 
@@ -66,13 +79,11 @@ def test_create_reconciliation_dependencies(monkeypatch):
     distributed_lock_mock.assert_called_once_with(
         coordination_session_factory=mock_session_factory_val,
         lock_name="graph_rebuild",
-        ttl_seconds=lock_ttl,
+        ttl_seconds=300,
     )
 
 
-def test_run_sync_reconciliation_success(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
-):
+def test_run_sync_reconciliation_success(monkeypatch, reconciliation_loop_context, make_reconciliation_plan):
     """Verify single-pass plan consumption under normal execution."""
     plan = make_reconciliation_plan(
         drift_type="none",
@@ -95,14 +106,16 @@ def test_run_sync_reconciliation_success(
     # Mock dependencies setup
     monkeypatch.setattr(
         "src.logic.reconciliation_loop._create_reconciliation_dependencies",
-        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+        lambda *args, **kwargs: (reconciliation_loop_context.session_factory, reconciliation_loop_context.lock),
     )
 
     # Also mock metrics to avoid actual prometheus interactions
     mock_duration = MagicMock()
     monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", mock_duration)
 
-    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+    _run_sync_reconciliation(
+        reconciliation_loop_context.db_engines[0], reconciliation_loop_context.db_engines[1], None, 450
+    )
 
     # Gate should query the plan and consume it
     gate_mock.get_reconciliation_plan.assert_called_once()
@@ -112,11 +125,11 @@ def test_run_sync_reconciliation_success(
     mock_duration.observe.assert_called_once()
 
     # Lock release should not be called since lock_was_reacquired is False
-    mock_lock.release.assert_not_called()
+    reconciliation_loop_context.lock.release.assert_not_called()
 
 
 def test_run_sync_reconciliation_releases_reacquired_lock(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
+    monkeypatch, reconciliation_loop_context, make_reconciliation_plan
 ):
     """Verify that a reacquired lock is released in the finally block."""
     plan = make_reconciliation_plan(
@@ -133,7 +146,7 @@ def test_run_sync_reconciliation_releases_reacquired_lock(
     gate_mock.get_reconciliation_plan.return_value = plan
     # Simulate that lock was reacquired during reset execution
     gate_mock.lock_was_reacquired = False
-    gate_mock.lock = mock_lock
+    gate_mock.lock = reconciliation_loop_context.lock
 
     def _consume_and_mark_reacquired(*args, **kwargs):
         gate_mock.lock_was_reacquired = True
@@ -143,18 +156,20 @@ def test_run_sync_reconciliation_releases_reacquired_lock(
     monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
     monkeypatch.setattr(
         "src.logic.reconciliation_loop._create_reconciliation_dependencies",
-        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+        lambda *args, **kwargs: (reconciliation_loop_context.session_factory, reconciliation_loop_context.lock),
     )
     monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
 
-    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+    _run_sync_reconciliation(
+        reconciliation_loop_context.db_engines[0], reconciliation_loop_context.db_engines[1], None, 300
+    )
 
     # Release must be called since lock_was_reacquired is True
-    mock_lock.release.assert_called_once()
+    reconciliation_loop_context.lock.release.assert_called_once()
 
 
 def test_run_sync_reconciliation_lock_release_failure_is_caught(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
+    monkeypatch, reconciliation_loop_context, make_reconciliation_plan
 ):
     """Verify that lock release exceptions are handled and do not propagate."""
     plan = make_reconciliation_plan(
@@ -170,19 +185,19 @@ def test_run_sync_reconciliation_lock_release_failure_is_caught(
     gate_mock = MagicMock()
     gate_mock.get_reconciliation_plan.return_value = plan
     gate_mock.lock_was_reacquired = False
-    gate_mock.lock = mock_lock
+    gate_mock.lock = reconciliation_loop_context.lock
 
     def _consume_and_mark_reacquired(*args, **kwargs):
         gate_mock.lock_was_reacquired = True
 
     gate_mock.consume_reconciliation_plan.side_effect = _consume_and_mark_reacquired
     # Mock release to fail
-    mock_lock.release.side_effect = RuntimeError("Release failed")
+    reconciliation_loop_context.lock.release.side_effect = RuntimeError("Release failed")
 
     monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
     monkeypatch.setattr(
         "src.logic.reconciliation_loop._create_reconciliation_dependencies",
-        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+        lambda *args, **kwargs: (reconciliation_loop_context.session_factory, reconciliation_loop_context.lock),
     )
     monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
 
@@ -191,9 +206,11 @@ def test_run_sync_reconciliation_lock_release_failure_is_caught(
     monkeypatch.setattr("src.logic.reconciliation_loop.log_event", mock_log_event)
 
     # Should not raise RuntimeError
-    _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+    _run_sync_reconciliation(
+        reconciliation_loop_context.db_engines[0], reconciliation_loop_context.db_engines[1], None, 300
+    )
 
-    mock_lock.release.assert_called_once()
+    reconciliation_loop_context.lock.release.assert_called_once()
 
     # Assert it logged the event reconciliation_loop_lock_release_failed
     log_calls = [call[0][2] for call in mock_log_event.call_args_list]
@@ -201,7 +218,7 @@ def test_run_sync_reconciliation_lock_release_failure_is_caught(
 
 
 def test_run_sync_reconciliation_blocked_error_propagates(
-    monkeypatch, mock_db_engines, mock_session_factory, mock_lock, make_reconciliation_plan
+    monkeypatch, reconciliation_loop_context, make_reconciliation_plan
 ):
     """Verify that ExecutionBlockedError propagates out of the sync loop."""
     plan = make_reconciliation_plan(
@@ -222,12 +239,14 @@ def test_run_sync_reconciliation_blocked_error_propagates(
     monkeypatch.setattr("src.logic.recovery_gate.RecoveryGate", lambda **kwargs: gate_mock)
     monkeypatch.setattr(
         "src.logic.reconciliation_loop._create_reconciliation_dependencies",
-        lambda *args, **kwargs: (mock_session_factory, mock_lock),
+        lambda *args, **kwargs: (reconciliation_loop_context.session_factory, reconciliation_loop_context.lock),
     )
     monkeypatch.setattr("api.metrics.RECONCILIATION_DURATION", MagicMock())
 
     with pytest.raises(ExecutionBlockedError):
-        _run_sync_reconciliation(mock_db_engines[0], mock_db_engines[1], None, 300)
+        _run_sync_reconciliation(
+            reconciliation_loop_context.db_engines[0], reconciliation_loop_context.db_engines[1], None, 300
+        )
 
 
 @pytest.mark.asyncio
@@ -360,3 +379,52 @@ async def test_periodic_reconciliation_loop_backoff_on_error(monkeypatch):
     assert sleep_durations[0] == 2.0
     assert sleep_durations[1] > 2.0
     assert sleep_durations[2] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_periodic_reconciliation_loop_does_not_backoff_on_blocked_state(monkeypatch):
+    """Verify expected recovery gate blocks do not trigger transient-error backoff."""
+    lifecycle_mock = MagicMock(return_value=GraphRuntimeLifecycleState.READY)
+    monkeypatch.setattr("api.app_factory.get_runtime_lifecycle_state", lifecycle_mock)
+
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._setup_engines", lambda url, coord_url: (MagicMock(), MagicMock())
+    )
+    monkeypatch.setattr("src.logic.reconciliation_loop._dispose_engines", lambda e, ce: None)
+
+    iter_calls = 0
+
+    async def mock_perform_reconciliation_iteration(*args, **kwargs):
+        nonlocal iter_calls
+        iter_calls += 1
+        if iter_calls == 1:
+            raise ExecutionBlockedError("blocked", action="wait", inconsistency_type="wait_for_convergence")
+        return None
+
+    monkeypatch.setattr(
+        "src.logic.reconciliation_loop._perform_reconciliation_iteration", mock_perform_reconciliation_iteration
+    )
+
+    shutdown_calls = 0
+
+    def mock_is_shutdown():
+        nonlocal shutdown_calls
+        shutdown_calls += 1
+        return shutdown_calls > 2
+
+    sleep_durations = []
+
+    async def mock_sleep(seconds):
+        sleep_durations.append(seconds)
+
+    monkeypatch.setattr("asyncio.sleep", mock_sleep)
+
+    await periodic_reconciliation_loop(
+        interval_seconds=2.0,
+        database_url="sqlite://",
+        is_shutdown_fn=mock_is_shutdown,
+        run_with_trace_fn=lambda fn, **kwargs: fn(),
+    )
+
+    assert iter_calls == 2
+    assert sleep_durations == [2.0, 2.0, 2.0]

--- a/tests/unit/test_reconciliation_loop.py
+++ b/tests/unit/test_reconciliation_loop.py
@@ -57,28 +57,34 @@ def reconciliation_loop_context(mock_db_engines, mock_session_factory, mock_lock
 
 def test_create_reconciliation_dependencies(monkeypatch):
     """Verify lock_ttl is bounded before constructing DistributedLock."""
-    mock_session_factory_val = MagicMock()
+    engine_session_factory = MagicMock(name="engine_session_factory")
+    coord_session_factory = MagicMock(name="coord_session_factory")
     mock_lock_val = MagicMock()
 
-    create_session_factory_mock = MagicMock(return_value=mock_session_factory_val)
+    engine = MagicMock()
+    coord_engine = MagicMock()
+    factory_by_engine = {
+        engine: engine_session_factory,
+        coord_engine: coord_session_factory,
+    }
+
+    create_session_factory_mock = MagicMock(side_effect=lambda db_engine: factory_by_engine[db_engine])
     distributed_lock_mock = MagicMock(return_value=mock_lock_val)
 
     monkeypatch.setattr("src.data.database.create_session_factory", create_session_factory_mock)
     monkeypatch.setattr("src.data.distributed_lock.DistributedLock", distributed_lock_mock)
 
-    engine = MagicMock()
-    coord_engine = MagicMock()
     lock_ttl = 450
 
     sf, lock = _create_reconciliation_dependencies(engine, coord_engine, lock_ttl)
 
-    assert sf == mock_session_factory_val
+    assert sf == engine_session_factory
     assert lock == mock_lock_val
 
     # create_session_factory should be called twice (once for engine, once for coord_engine)
     assert create_session_factory_mock.call_count == 2
     distributed_lock_mock.assert_called_once_with(
-        coordination_session_factory=mock_session_factory_val,
+        coordination_session_factory=coord_session_factory,
         lock_name="graph_rebuild",
         ttl_seconds=300,
     )

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -286,6 +286,13 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
     gate.consume_reconciliation_plan(plan)
 
 
+def test_recovery_gate_caps_lock_ttl_seconds(mock_session_factory, mock_lock):
+    """The recovery gate should cap lock TTL at the distributed-lock maximum."""
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, lock_ttl_seconds=450)
+
+    assert gate.lock_ttl_seconds == 300
+
+
 def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Wait plans must raise ExecutionBlockedError and not mutate state."""
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
@@ -465,3 +472,31 @@ def test_consume_reset_respects_cancellation_before_mutation(mock_session_factor
         gate.consume_reconciliation_plan(plan, cancellation_event=cancel_event)
 
     mock_perform_reset.assert_not_called()
+
+
+def test_reset_lock_reacquisition_timeout_uses_plan_drift_type(
+    mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
+):
+    """Lock reacquisition timeout should preserve the plan drift type in the block error."""
+    from src.data.distributed_lock import LockAcquisitionTimeout, LockState
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = make_reconciliation_plan(
+        drift_type="crash_suspicion",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Crash suspected",
+    )
+    mock_lock.check_state.return_value = LockState.EXPIRED
+    mock_lock.acquire.side_effect = LockAcquisitionTimeout("timeout")
+    monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: None)
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+
+    assert exc_info.value.action == "wait"
+    assert exc_info.value.inconsistency_type == "crash_suspicion"

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -286,6 +286,28 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
     gate.consume_reconciliation_plan(plan)
 
 
+def test_consume_unknown_noop_plan_blocks_fail_closed(mock_session_factory, mock_lock, make_reconciliation_plan):
+    """NOOP only allows execution when paired with CONVERGED safety."""
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = make_reconciliation_plan(
+        drift_type="manual_investigation",
+        severity=Severity.HIGH,
+        actions=(ActionType.NOOP,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.MANUAL,
+        safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
+        reason="Malformed plan should fail closed",
+    )
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+
+    assert exc_info.value.action == "unsafe"
+    assert exc_info.value.inconsistency_type == "manual_investigation"
+
+
 def test_recovery_gate_caps_lock_ttl_seconds(mock_session_factory, mock_lock):
     """The recovery gate should cap lock TTL at the distributed-lock maximum."""
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, lock_ttl_seconds=450)
@@ -577,3 +599,43 @@ def test_reset_lock_reacquisition_requires_valid_lock_after_acquire(
     assert exc_info.value.action == "wait"
     assert exc_info.value.inconsistency_type == "crash_suspicion"
     mock_lock.acquire.assert_called_once_with(max_retries=30)
+
+
+def test_reset_blocks_fresh_remote_owner_as_stale_ownership(
+    mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
+):
+    """A fresh heartbeat from a different worker should block as stale ownership, not orphaned running."""
+    from datetime import UTC, datetime
+
+    from src.data.db_models import RebuildJobStatus
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
+    plan = make_reconciliation_plan(
+        drift_type="stale_ownership",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Ownership mismatch with fresh heartbeat",
+    )
+
+    class FreshRemoteJob:
+        status = RebuildJobStatus.RUNNING
+        job_id = "job-1"
+        execution_id = "exec-1"
+        active_worker_id = "remote-worker"
+        last_heartbeat_at = datetime.now(UTC)
+
+    mock_lock.holder_id = "current-worker"
+    repo = MagicMock()
+    repo.get_active_rebuild_state.return_value = FreshRemoteJob()
+    monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository", lambda _session: repo)
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+
+    assert exc_info.value.action == "unsafe"
+    assert exc_info.value.inconsistency_type == "stale_ownership"
+    repo.mark_rebuild_job_failed.assert_not_called()

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -542,6 +542,8 @@ def test_reset_lock_reacquisition_requires_valid_lock_after_acquire(
     mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
 ):
     """Reset recovery must block if reacquisition does not produce a valid lock state."""
+    from src.data.distributed_lock import LockState
+
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
     plan = _make_reset_required_plan(
         make_reconciliation_plan,

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -219,6 +219,7 @@ def test_recovery_gate_error_message_includes_decision_reason(mock_session_facto
         session_factory=mock_session_factory,
         lock=mock_lock,
         runtime_has_active_executor=False,
+        enable_automatic_recovery=True,
     )
 
     from src.data.db_models import RebuildJobStatus
@@ -265,3 +266,231 @@ def test_recovery_gate_orphaned_with_new_lock_owner_returns_reset(mock_session_f
         "src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: DummyJob()
     )
     assert gate.evaluate_state() == RecoveryAction.RESET
+
+
+def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock):
+    """Converged plan should allow execution without raising errors."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="none",
+        severity=Severity.NONE,
+        actions=(ActionType.NOOP,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.CONVERGED,
+        reason="Graph is healthy",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+    # Should not raise any exception
+    gate.consume_reconciliation_plan(plan)
+
+
+def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+    """Wait plans must raise ExecutionBlockedError and not mutate state."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="wait_for_convergence",
+        severity=Severity.MEDIUM,
+        actions=(ActionType.WAIT_FOR_CONVERGENCE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.WAIT_REQUIRED,
+        reason="Waiting for active build",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+    assert exc_info.value.action == "wait"
+    assert exc_info.value.inconsistency_type == "wait_for_convergence"
+
+
+def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+    """Alert-only plans must raise ExecutionBlockedError with alert_only action."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="stale_ownership",
+        severity=Severity.HIGH,
+        actions=(ActionType.ALERT_ONLY,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.MANUAL,
+        safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
+        reason="Stale ownership detected",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+    assert exc_info.value.action == "alert_only"
+    assert exc_info.value.inconsistency_type == "stale_ownership"
+
+
+def test_consume_evaluation_failed_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+    """Evaluation failed plans must raise ExecutionBlockedError without mutating."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="evaluation_failed",
+        severity=Severity.CRITICAL,
+        actions=(ActionType.ALERT_ONLY,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.MANUAL,
+        safety_state=ExecutionSafety.EVALUATION_FAILED,
+        reason="State query failed",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+    assert exc_info.value.action == "alert_only"
+    assert exc_info.value.inconsistency_type == "evaluation_failed"
+
+
+def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_lock):
+    """Deferred reset plans must block with 'wait' action and not execute reset."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.DEFERRED,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Orphaned job reset deferred",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    # Mock _execute_reset_path to assert it is never called
+    gate._execute_reset_path = MagicMock()
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+    assert exc_info.value.action == "wait"
+    assert exc_info.value.inconsistency_type == "orphaned_running"
+    gate._execute_reset_path.assert_not_called()
+
+
+def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, mock_lock):
+    """Automatic reset plans must trigger the reset execution pathway."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Auto-reset orphaned job",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    # Mock _execute_reset_path so we don't hit the DB/lock layer in this test
+    gate._execute_reset_path = MagicMock()
+
+    gate.consume_reconciliation_plan(plan)
+    gate._execute_reset_path.assert_called_once_with(plan, None)
+
+
+def test_consume_reset_plan_rechecks_state_after_reset(mock_session_factory, mock_lock, monkeypatch):
+    """Reset path must recheck plan post-reset and block if still unsafe."""
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Auto-reset orphaned job",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    # Mock get_active_rebuild_state to do nothing and succeed
+    monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: None)
+
+    # Mock get_reconciliation_plan to return a non-resume plan after reset
+    unsafe_plan = ReconciliationPlan(
+        drift_type="lock_lost",
+        severity=Severity.CRITICAL,
+        actions=(ActionType.ALERT_ONLY,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.MANUAL,
+        safety_state=ExecutionSafety.UNSAFE_SPLIT_BRAIN,
+        reason="Lock lost post-reset",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    def mock_get_reconciliation_plan(increment_metric=True):
+        return unsafe_plan
+
+    gate.get_reconciliation_plan = mock_get_reconciliation_plan
+
+    with pytest.raises(ExecutionBlockedError, match="Reset recovery completed but state still unsafe"):
+        gate.consume_reconciliation_plan(plan)
+
+
+def test_consume_reset_respects_cancellation_before_mutation(mock_session_factory, mock_lock):
+    """Cancellation event set before or during reset should abort execution without mutation."""
+    import threading
+    from datetime import UTC, datetime
+
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    plan = ReconciliationPlan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Auto-reset orphaned job",
+        metadata={},
+        created_at=datetime.now(UTC),
+    )
+
+    cancel_event = threading.Event()
+    cancel_event.set()
+
+    mock_perform_reset = MagicMock()
+    gate._perform_reset_recovery = mock_perform_reset
+
+    from src.logic.reconciliation_engine import RebuildCancelledError
+
+    # Execute plan with cancelled event
+    with pytest.raises(RebuildCancelledError, match="Rebuild cancelled via API request"):
+        gate.consume_reconciliation_plan(plan, cancellation_event=cancel_event)
+
+    mock_perform_reset.assert_not_called()

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -1,5 +1,6 @@
 """Tests for the RecoveryGate component."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -48,6 +49,28 @@ def _make_reset_required_plan(
         target_state="healthy",
         execution_mode=execution_mode,
         safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason=reason,
+    )
+
+
+def _make_plan(
+    make_reconciliation_plan,
+    *,
+    drift_type,
+    severity,
+    actions,
+    execution_mode,
+    safety_state,
+    reason,
+):
+    """Return a reconciliation plan with the common healthy target state."""
+    return make_reconciliation_plan(
+        drift_type=drift_type,
+        severity=severity,
+        actions=actions,
+        target_state="healthy",
+        execution_mode=execution_mode,
+        safety_state=safety_state,
         reason=reason,
     )
 
@@ -298,11 +321,11 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
+    plan = _make_plan(
+        make_reconciliation_plan,
         drift_type="none",
         severity=Severity.NONE,
         actions=(ActionType.NOOP,),
-        target_state="healthy",
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.CONVERGED,
         reason="Graph is healthy",
@@ -311,26 +334,99 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
     gate.consume_reconciliation_plan(plan)
 
 
-def test_consume_unknown_noop_plan_blocks_fail_closed(mock_session_factory, mock_lock, make_reconciliation_plan):
-    """NOOP only allows execution when paired with CONVERGED safety."""
+def test_consume_blocking_plans_fail_closed(mock_session_factory, mock_lock, make_reconciliation_plan):
+    """Blocking plans must raise with the expected action and avoid reset mutation."""
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
-        drift_type="manual_investigation",
-        severity=Severity.HIGH,
-        actions=(ActionType.NOOP,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.MANUAL,
-        safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
-        reason="Malformed plan should fail closed",
-    )
+    cases = [
+        (
+            "unknown_noop",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
+            _make_plan(
+                make_reconciliation_plan,
+                drift_type="manual_investigation",
+                severity=Severity.HIGH,
+                actions=(ActionType.NOOP,),
+                execution_mode=ExecutionMode.MANUAL,
+                safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
+                reason="Malformed plan should fail closed",
+            ),
+            "unsafe",
+            "manual_investigation",
+        ),
+        (
+            "wait_required",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
+            _make_plan(
+                make_reconciliation_plan,
+                drift_type="wait_for_convergence",
+                severity=Severity.MEDIUM,
+                actions=(ActionType.WAIT_FOR_CONVERGENCE,),
+                execution_mode=ExecutionMode.AUTOMATIC,
+                safety_state=ExecutionSafety.WAIT_REQUIRED,
+                reason="Waiting for active build",
+            ),
+            "wait",
+            "wait_for_convergence",
+        ),
+        (
+            "alert_only",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
+            _make_plan(
+                make_reconciliation_plan,
+                drift_type="stale_ownership",
+                severity=Severity.HIGH,
+                actions=(ActionType.ALERT_ONLY,),
+                execution_mode=ExecutionMode.MANUAL,
+                safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
+                reason="Stale ownership detected",
+            ),
+            "alert_only",
+            "stale_ownership",
+        ),
+        (
+            "evaluation_failed",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
+            _make_plan(
+                make_reconciliation_plan,
+                drift_type="evaluation_failed",
+                severity=Severity.CRITICAL,
+                actions=(ActionType.ALERT_ONLY,),
+                execution_mode=ExecutionMode.MANUAL,
+                safety_state=ExecutionSafety.EVALUATION_FAILED,
+                reason="State query failed",
+            ),
+            "alert_only",
+            "evaluation_failed",
+        ),
+        (
+            "deferred_reset",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
+            _make_reset_required_plan(
+                make_reconciliation_plan,
+                execution_mode=ExecutionMode.DEFERRED,
+                reason="Orphaned job reset deferred",
+            ),
+            "wait",
+            "orphaned_running",
+        ),
+        (
+            "automatic_reset_disabled",
+            RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False),
+            _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job"),
+            "alert_only",
+            "orphaned_running",
+        ),
+    ]
 
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
+    for name, gate, plan, expected_action, expected_inconsistency in cases:
+        gate._execute_reset_path = MagicMock()
+        with pytest.raises(ExecutionBlockedError) as exc_info:
+            gate.consume_reconciliation_plan(plan)
 
-    assert exc_info.value.action == "unsafe"
-    assert exc_info.value.inconsistency_type == "manual_investigation"
+        assert exc_info.value.action == expected_action, name
+        assert exc_info.value.inconsistency_type == expected_inconsistency, name
+        gate._execute_reset_path.assert_not_called()
 
 
 def test_recovery_gate_caps_lock_ttl_seconds(mock_session_factory, mock_lock):
@@ -338,89 +434,6 @@ def test_recovery_gate_caps_lock_ttl_seconds(mock_session_factory, mock_lock):
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, lock_ttl_seconds=450)
 
     assert gate.lock_ttl_seconds == 300
-
-
-def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
-    """Wait plans must raise ExecutionBlockedError and not mutate state."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
-        drift_type="wait_for_convergence",
-        severity=Severity.MEDIUM,
-        actions=(ActionType.WAIT_FOR_CONVERGENCE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.WAIT_REQUIRED,
-        reason="Waiting for active build",
-    )
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
-    assert exc_info.value.action == "wait"
-    assert exc_info.value.inconsistency_type == "wait_for_convergence"
-
-
-def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
-    """Alert-only plans must raise ExecutionBlockedError with alert_only action."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
-        drift_type="stale_ownership",
-        severity=Severity.HIGH,
-        actions=(ActionType.ALERT_ONLY,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.MANUAL,
-        safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
-        reason="Stale ownership detected",
-    )
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
-    assert exc_info.value.action == "alert_only"
-    assert exc_info.value.inconsistency_type == "stale_ownership"
-
-
-def test_consume_evaluation_failed_plan_blocks_without_mutation(
-    mock_session_factory, mock_lock, make_reconciliation_plan
-):
-    """Evaluation failed plans must raise ExecutionBlockedError without mutating."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
-        drift_type="evaluation_failed",
-        severity=Severity.CRITICAL,
-        actions=(ActionType.ALERT_ONLY,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.MANUAL,
-        safety_state=ExecutionSafety.EVALUATION_FAILED,
-        reason="State query failed",
-    )
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
-    assert exc_info.value.action == "alert_only"
-    assert exc_info.value.inconsistency_type == "evaluation_failed"
-
-
-def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_lock, make_reconciliation_plan):
-    """Deferred reset plans must block with 'wait' action and not execute reset."""
-    from src.logic.reconciliation_engine import ExecutionMode
-
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = _make_reset_required_plan(
-        make_reconciliation_plan,
-        execution_mode=ExecutionMode.DEFERRED,
-        reason="Orphaned job reset deferred",
-    )
-
-    # Mock _execute_reset_path to assert it is never called
-    gate._execute_reset_path = MagicMock()
-
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
-    assert exc_info.value.action == "wait"
-    assert exc_info.value.inconsistency_type == "orphaned_running"
-    gate._execute_reset_path.assert_not_called()
 
 
 def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, mock_lock, make_reconciliation_plan):
@@ -433,22 +446,6 @@ def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, moc
 
     gate.consume_reconciliation_plan(plan)
     gate._execute_reset_path.assert_called_once_with(plan, None)
-
-
-def test_consume_automatic_reset_plan_blocks_when_automatic_recovery_disabled(
-    mock_session_factory, mock_lock, make_reconciliation_plan
-):
-    """Automatic reset plans must not mutate when the gate is configured fail-closed."""
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False)
-    plan = _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job")
-    gate._execute_reset_path = MagicMock()
-
-    with pytest.raises(ExecutionBlockedError) as exc_info:
-        gate.consume_reconciliation_plan(plan)
-
-    assert exc_info.value.action == "alert_only"
-    assert exc_info.value.inconsistency_type == "orphaned_running"
-    gate._execute_reset_path.assert_not_called()
 
 
 def test_consume_immediate_reset_plan_calls_reset_path_when_automatic_recovery_disabled(
@@ -584,16 +581,17 @@ def test_reset_blocks_fresh_remote_owner_as_stale_ownership(
         reason="Ownership mismatch with fresh heartbeat",
     )
 
-    class FreshRemoteJob:
-        status = RebuildJobStatus.RUNNING
-        job_id = "job-1"
-        execution_id = "exec-1"
-        active_worker_id = "remote-worker"
-        last_heartbeat_at = datetime.now(UTC)
+    fresh_remote_job = SimpleNamespace(
+        status=RebuildJobStatus.RUNNING,
+        job_id="job-1",
+        execution_id="exec-1",
+        active_worker_id="remote-worker",
+        last_heartbeat_at=datetime.now(UTC),
+    )
 
     mock_lock.holder_id = "current-worker"
     repo = MagicMock()
-    repo.get_active_rebuild_state.return_value = FreshRemoteJob()
+    repo.get_active_rebuild_state.return_value = fresh_remote_job
     monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository", lambda _session: repo)
 
     with pytest.raises(ExecutionBlockedError) as exc_info:

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -268,14 +268,12 @@ def test_recovery_gate_orphaned_with_new_lock_owner_returns_reset(mock_session_f
     assert gate.evaluate_state() == RecoveryAction.RESET
 
 
-def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock):
+def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Converged plan should allow execution without raising errors."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="none",
         severity=Severity.NONE,
         actions=(ActionType.NOOP,),
@@ -283,21 +281,17 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.CONVERGED,
         reason="Graph is healthy",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
     # Should not raise any exception
     gate.consume_reconciliation_plan(plan)
 
 
-def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Wait plans must raise ExecutionBlockedError and not mutate state."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="wait_for_convergence",
         severity=Severity.MEDIUM,
         actions=(ActionType.WAIT_FOR_CONVERGENCE,),
@@ -305,8 +299,6 @@ def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lo
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.WAIT_REQUIRED,
         reason="Waiting for active build",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
     with pytest.raises(ExecutionBlockedError) as exc_info:
         gate.consume_reconciliation_plan(plan)
@@ -314,14 +306,12 @@ def test_consume_wait_plan_blocks_without_mutation(mock_session_factory, mock_lo
     assert exc_info.value.inconsistency_type == "wait_for_convergence"
 
 
-def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Alert-only plans must raise ExecutionBlockedError with alert_only action."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="stale_ownership",
         severity=Severity.HIGH,
         actions=(ActionType.ALERT_ONLY,),
@@ -329,8 +319,6 @@ def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, m
         execution_mode=ExecutionMode.MANUAL,
         safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
         reason="Stale ownership detected",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
     with pytest.raises(ExecutionBlockedError) as exc_info:
         gate.consume_reconciliation_plan(plan)
@@ -338,14 +326,14 @@ def test_consume_alert_only_plan_blocks_without_mutation(mock_session_factory, m
     assert exc_info.value.inconsistency_type == "stale_ownership"
 
 
-def test_consume_evaluation_failed_plan_blocks_without_mutation(mock_session_factory, mock_lock):
+def test_consume_evaluation_failed_plan_blocks_without_mutation(
+    mock_session_factory, mock_lock, make_reconciliation_plan
+):
     """Evaluation failed plans must raise ExecutionBlockedError without mutating."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="evaluation_failed",
         severity=Severity.CRITICAL,
         actions=(ActionType.ALERT_ONLY,),
@@ -353,8 +341,6 @@ def test_consume_evaluation_failed_plan_blocks_without_mutation(mock_session_fac
         execution_mode=ExecutionMode.MANUAL,
         safety_state=ExecutionSafety.EVALUATION_FAILED,
         reason="State query failed",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
     with pytest.raises(ExecutionBlockedError) as exc_info:
         gate.consume_reconciliation_plan(plan)
@@ -362,14 +348,12 @@ def test_consume_evaluation_failed_plan_blocks_without_mutation(mock_session_fac
     assert exc_info.value.inconsistency_type == "evaluation_failed"
 
 
-def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_lock):
+def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Deferred reset plans must block with 'wait' action and not execute reset."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -377,8 +361,6 @@ def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_
         execution_mode=ExecutionMode.DEFERRED,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Orphaned job reset deferred",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     # Mock _execute_reset_path to assert it is never called
@@ -391,14 +373,12 @@ def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_
     gate._execute_reset_path.assert_not_called()
 
 
-def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, mock_lock):
+def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Automatic reset plans must trigger the reset execution pathway."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -406,8 +386,6 @@ def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, moc
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Auto-reset orphaned job",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     # Mock _execute_reset_path so we don't hit the DB/lock layer in this test
@@ -417,14 +395,14 @@ def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, moc
     gate._execute_reset_path.assert_called_once_with(plan, None)
 
 
-def test_consume_reset_plan_rechecks_state_after_reset(mock_session_factory, mock_lock, monkeypatch):
+def test_consume_reset_plan_rechecks_state_after_reset(
+    mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
+):
     """Reset path must recheck plan post-reset and block if still unsafe."""
-    from datetime import UTC, datetime
-
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -432,15 +410,13 @@ def test_consume_reset_plan_rechecks_state_after_reset(mock_session_factory, moc
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Auto-reset orphaned job",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     # Mock get_active_rebuild_state to do nothing and succeed
     monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: None)
 
     # Mock get_reconciliation_plan to return a non-resume plan after reset
-    unsafe_plan = ReconciliationPlan(
+    unsafe_plan = make_reconciliation_plan(
         drift_type="lock_lost",
         severity=Severity.CRITICAL,
         actions=(ActionType.ALERT_ONLY,),
@@ -448,8 +424,6 @@ def test_consume_reset_plan_rechecks_state_after_reset(mock_session_factory, moc
         execution_mode=ExecutionMode.MANUAL,
         safety_state=ExecutionSafety.UNSAFE_SPLIT_BRAIN,
         reason="Lock lost post-reset",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     def mock_get_reconciliation_plan(increment_metric=True):
@@ -461,15 +435,14 @@ def test_consume_reset_plan_rechecks_state_after_reset(mock_session_factory, moc
         gate.consume_reconciliation_plan(plan)
 
 
-def test_consume_reset_respects_cancellation_before_mutation(mock_session_factory, mock_lock):
+def test_consume_reset_respects_cancellation_before_mutation(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Cancellation event set before or during reset should abort execution without mutation."""
     import threading
-    from datetime import UTC, datetime
 
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, ReconciliationPlan, Severity
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = ReconciliationPlan(
+    plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
         actions=(ActionType.RESET_STATE,),
@@ -477,8 +450,6 @@ def test_consume_reset_respects_cancellation_before_mutation(mock_session_factor
         execution_mode=ExecutionMode.AUTOMATIC,
         safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Auto-reset orphaned job",
-        metadata={},
-        created_at=datetime.now(UTC),
     )
 
     cancel_event = threading.Event()

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -27,6 +27,31 @@ def mock_lock():
     return lock
 
 
+def _make_reset_required_plan(
+    make_reconciliation_plan,
+    *,
+    drift_type="orphaned_running",
+    execution_mode=None,
+    reason=None,
+):
+    """Return a reset-required reconciliation plan for recovery-gate boundary tests."""
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    if execution_mode is None:
+        execution_mode = ExecutionMode.AUTOMATIC
+    if reason is None:
+        reason = f"Reset required for {drift_type}"
+    return make_reconciliation_plan(
+        drift_type=drift_type,
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=execution_mode,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason=reason,
+    )
+
+
 def test_recovery_gate_waits_on_unknown_lock_with_no_active_job(mock_session_factory, mock_lock):
     """Test that RecoveryGate returns WAIT (allowing startup) when lock is UNKNOWN and no active job exists.
 
@@ -379,16 +404,12 @@ def test_consume_evaluation_failed_plan_blocks_without_mutation(
 
 def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Deferred reset plans must block with 'wait' action and not execute reset."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+    from src.logic.reconciliation_engine import ExecutionMode
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
+    plan = _make_reset_required_plan(
+        make_reconciliation_plan,
         execution_mode=ExecutionMode.DEFERRED,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Orphaned job reset deferred",
     )
 
@@ -404,18 +425,8 @@ def test_consume_deferred_reset_plan_does_not_mutate(mock_session_factory, mock_
 
 def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, mock_lock, make_reconciliation_plan):
     """Automatic reset plans must trigger the reset execution pathway."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
-        reason="Auto-reset orphaned job",
-    )
+    plan = _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job")
 
     # Mock _execute_reset_path so we don't hit the DB/lock layer in this test
     gate._execute_reset_path = MagicMock()
@@ -428,18 +439,8 @@ def test_consume_automatic_reset_plan_blocks_when_automatic_recovery_disabled(
     mock_session_factory, mock_lock, make_reconciliation_plan
 ):
     """Automatic reset plans must not mutate when the gate is configured fail-closed."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
-        reason="Auto-reset orphaned job",
-    )
+    plan = _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job")
     gate._execute_reset_path = MagicMock()
 
     with pytest.raises(ExecutionBlockedError) as exc_info:
@@ -454,16 +455,12 @@ def test_consume_immediate_reset_plan_calls_reset_path_when_automatic_recovery_d
     mock_session_factory, mock_lock, make_reconciliation_plan
 ):
     """Immediate reset plans remain explicitly authorized even when automatic recovery is disabled."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+    from src.logic.reconciliation_engine import ExecutionMode
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
+    plan = _make_reset_required_plan(
+        make_reconciliation_plan,
         execution_mode=ExecutionMode.IMMEDIATE,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Immediate reset orphaned job",
     )
     gate._execute_reset_path = MagicMock()
@@ -480,15 +477,7 @@ def test_consume_reset_plan_rechecks_state_after_reset(
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
-        reason="Auto-reset orphaned job",
-    )
+    plan = _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job")
 
     # Mock get_active_rebuild_state to do nothing and succeed
     monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: None)
@@ -517,18 +506,8 @@ def test_consume_reset_respects_cancellation_before_mutation(mock_session_factor
     """Cancellation event set before or during reset should abort execution without mutation."""
     import threading
 
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
-        drift_type="orphaned_running",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
-        reason="Auto-reset orphaned job",
-    )
+    plan = _make_reset_required_plan(make_reconciliation_plan, reason="Auto-reset orphaned job")
 
     cancel_event = threading.Event()
     cancel_event.set()
@@ -550,16 +529,11 @@ def test_reset_lock_reacquisition_timeout_uses_plan_drift_type(
 ):
     """Lock reacquisition timeout should preserve the plan drift type in the block error."""
     from src.data.distributed_lock import LockAcquisitionTimeout, LockState
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
+    plan = _make_reset_required_plan(
+        make_reconciliation_plan,
         drift_type="crash_suspicion",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Crash suspected",
     )
     mock_lock.check_state.return_value = LockState.EXPIRED
@@ -577,16 +551,10 @@ def test_reset_lock_reacquisition_requires_valid_lock_after_acquire(
     mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
 ):
     """Reset recovery must block if reacquisition does not produce a valid lock state."""
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
-
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
+    plan = _make_reset_required_plan(
+        make_reconciliation_plan,
         drift_type="crash_suspicion",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Crash suspected",
     )
     mock_lock.check_state.side_effect = [LockState.EXPIRED, LockState.EXPIRED]
@@ -608,16 +576,11 @@ def test_reset_blocks_fresh_remote_owner_as_stale_ownership(
     from datetime import UTC, datetime
 
     from src.data.db_models import RebuildJobStatus
-    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
-    plan = make_reconciliation_plan(
+    plan = _make_reset_required_plan(
+        make_reconciliation_plan,
         drift_type="stale_ownership",
-        severity=Severity.HIGH,
-        actions=(ActionType.RESET_STATE,),
-        target_state="healthy",
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.RESET_REQUIRED,
         reason="Ownership mismatch with fresh heartbeat",
     )
 

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -384,7 +384,7 @@ def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, moc
     """Automatic reset plans must trigger the reset execution pathway."""
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
     plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
@@ -402,13 +402,62 @@ def test_consume_automatic_reset_plan_calls_reset_path(mock_session_factory, moc
     gate._execute_reset_path.assert_called_once_with(plan, None)
 
 
+def test_consume_automatic_reset_plan_blocks_when_automatic_recovery_disabled(
+    mock_session_factory, mock_lock, make_reconciliation_plan
+):
+    """Automatic reset plans must not mutate when the gate is configured fail-closed."""
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False)
+    plan = make_reconciliation_plan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Auto-reset orphaned job",
+    )
+    gate._execute_reset_path = MagicMock()
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+
+    assert exc_info.value.action == "alert_only"
+    assert exc_info.value.inconsistency_type == "orphaned_running"
+    gate._execute_reset_path.assert_not_called()
+
+
+def test_consume_immediate_reset_plan_calls_reset_path_when_automatic_recovery_disabled(
+    mock_session_factory, mock_lock, make_reconciliation_plan
+):
+    """Immediate reset plans remain explicitly authorized even when automatic recovery is disabled."""
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=False)
+    plan = make_reconciliation_plan(
+        drift_type="orphaned_running",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.IMMEDIATE,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Immediate reset orphaned job",
+    )
+    gate._execute_reset_path = MagicMock()
+
+    gate.consume_reconciliation_plan(plan)
+
+    gate._execute_reset_path.assert_called_once_with(plan, None)
+
+
 def test_consume_reset_plan_rechecks_state_after_reset(
     mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
 ):
     """Reset path must recheck plan post-reset and block if still unsafe."""
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
     plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
@@ -448,7 +497,7 @@ def test_consume_reset_respects_cancellation_before_mutation(mock_session_factor
 
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
     plan = make_reconciliation_plan(
         drift_type="orphaned_running",
         severity=Severity.HIGH,
@@ -481,7 +530,7 @@ def test_reset_lock_reacquisition_timeout_uses_plan_drift_type(
     from src.data.distributed_lock import LockAcquisitionTimeout, LockState
     from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
 
-    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
     plan = make_reconciliation_plan(
         drift_type="crash_suspicion",
         severity=Severity.HIGH,
@@ -500,3 +549,31 @@ def test_reset_lock_reacquisition_timeout_uses_plan_drift_type(
 
     assert exc_info.value.action == "wait"
     assert exc_info.value.inconsistency_type == "crash_suspicion"
+
+
+def test_reset_lock_reacquisition_requires_valid_lock_after_acquire(
+    mock_session_factory, mock_lock, monkeypatch, make_reconciliation_plan
+):
+    """Reset recovery must block if reacquisition does not produce a valid lock state."""
+    from src.logic.reconciliation_engine import ActionType, ExecutionMode, ExecutionSafety, Severity
+
+    gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock, enable_automatic_recovery=True)
+    plan = make_reconciliation_plan(
+        drift_type="crash_suspicion",
+        severity=Severity.HIGH,
+        actions=(ActionType.RESET_STATE,),
+        target_state="healthy",
+        execution_mode=ExecutionMode.AUTOMATIC,
+        safety_state=ExecutionSafety.RESET_REQUIRED,
+        reason="Crash suspected",
+    )
+    mock_lock.check_state.side_effect = [LockState.EXPIRED, LockState.EXPIRED]
+    mock_lock.acquire.return_value = True
+    monkeypatch.setattr("src.logic.recovery_gate.AssetGraphRepository.get_active_rebuild_state", lambda self: None)
+
+    with pytest.raises(ExecutionBlockedError) as exc_info:
+        gate.consume_reconciliation_plan(plan)
+
+    assert exc_info.value.action == "wait"
+    assert exc_info.value.inconsistency_type == "crash_suspicion"
+    mock_lock.acquire.assert_called_once_with(max_retries=30)

--- a/tests/unit/test_recovery_gate.py
+++ b/tests/unit/test_recovery_gate.py
@@ -53,26 +53,10 @@ def _make_reset_required_plan(
     )
 
 
-def _make_plan(
-    make_reconciliation_plan,
-    *,
-    drift_type,
-    severity,
-    actions,
-    execution_mode,
-    safety_state,
-    reason,
-):
+def _make_plan(make_reconciliation_plan, overrides):
     """Return a reconciliation plan with the common healthy target state."""
-    return make_reconciliation_plan(
-        drift_type=drift_type,
-        severity=severity,
-        actions=actions,
-        target_state="healthy",
-        execution_mode=execution_mode,
-        safety_state=safety_state,
-        reason=reason,
-    )
+    defaults = {"target_state": "healthy"}
+    return make_reconciliation_plan(**{**defaults, **overrides})
 
 
 def test_recovery_gate_waits_on_unknown_lock_with_no_active_job(mock_session_factory, mock_lock):
@@ -323,12 +307,14 @@ def test_consume_converged_plan_allows_execution(mock_session_factory, mock_lock
     gate = RecoveryGate(session_factory=mock_session_factory, lock=mock_lock)
     plan = _make_plan(
         make_reconciliation_plan,
-        drift_type="none",
-        severity=Severity.NONE,
-        actions=(ActionType.NOOP,),
-        execution_mode=ExecutionMode.AUTOMATIC,
-        safety_state=ExecutionSafety.CONVERGED,
-        reason="Graph is healthy",
+        {
+            "drift_type": "none",
+            "severity": Severity.NONE,
+            "actions": (ActionType.NOOP,),
+            "execution_mode": ExecutionMode.AUTOMATIC,
+            "safety_state": ExecutionSafety.CONVERGED,
+            "reason": "Graph is healthy",
+        },
     )
     # Should not raise any exception
     gate.consume_reconciliation_plan(plan)
@@ -344,12 +330,14 @@ def test_consume_blocking_plans_fail_closed(mock_session_factory, mock_lock, mak
             RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
             _make_plan(
                 make_reconciliation_plan,
-                drift_type="manual_investigation",
-                severity=Severity.HIGH,
-                actions=(ActionType.NOOP,),
-                execution_mode=ExecutionMode.MANUAL,
-                safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
-                reason="Malformed plan should fail closed",
+                {
+                    "drift_type": "manual_investigation",
+                    "severity": Severity.HIGH,
+                    "actions": (ActionType.NOOP,),
+                    "execution_mode": ExecutionMode.MANUAL,
+                    "safety_state": ExecutionSafety.MANUAL_INVESTIGATION,
+                    "reason": "Malformed plan should fail closed",
+                },
             ),
             "unsafe",
             "manual_investigation",
@@ -359,12 +347,14 @@ def test_consume_blocking_plans_fail_closed(mock_session_factory, mock_lock, mak
             RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
             _make_plan(
                 make_reconciliation_plan,
-                drift_type="wait_for_convergence",
-                severity=Severity.MEDIUM,
-                actions=(ActionType.WAIT_FOR_CONVERGENCE,),
-                execution_mode=ExecutionMode.AUTOMATIC,
-                safety_state=ExecutionSafety.WAIT_REQUIRED,
-                reason="Waiting for active build",
+                {
+                    "drift_type": "wait_for_convergence",
+                    "severity": Severity.MEDIUM,
+                    "actions": (ActionType.WAIT_FOR_CONVERGENCE,),
+                    "execution_mode": ExecutionMode.AUTOMATIC,
+                    "safety_state": ExecutionSafety.WAIT_REQUIRED,
+                    "reason": "Waiting for active build",
+                },
             ),
             "wait",
             "wait_for_convergence",
@@ -374,12 +364,14 @@ def test_consume_blocking_plans_fail_closed(mock_session_factory, mock_lock, mak
             RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
             _make_plan(
                 make_reconciliation_plan,
-                drift_type="stale_ownership",
-                severity=Severity.HIGH,
-                actions=(ActionType.ALERT_ONLY,),
-                execution_mode=ExecutionMode.MANUAL,
-                safety_state=ExecutionSafety.MANUAL_INVESTIGATION,
-                reason="Stale ownership detected",
+                {
+                    "drift_type": "stale_ownership",
+                    "severity": Severity.HIGH,
+                    "actions": (ActionType.ALERT_ONLY,),
+                    "execution_mode": ExecutionMode.MANUAL,
+                    "safety_state": ExecutionSafety.MANUAL_INVESTIGATION,
+                    "reason": "Stale ownership detected",
+                },
             ),
             "alert_only",
             "stale_ownership",
@@ -389,12 +381,14 @@ def test_consume_blocking_plans_fail_closed(mock_session_factory, mock_lock, mak
             RecoveryGate(session_factory=mock_session_factory, lock=mock_lock),
             _make_plan(
                 make_reconciliation_plan,
-                drift_type="evaluation_failed",
-                severity=Severity.CRITICAL,
-                actions=(ActionType.ALERT_ONLY,),
-                execution_mode=ExecutionMode.MANUAL,
-                safety_state=ExecutionSafety.EVALUATION_FAILED,
-                reason="State query failed",
+                {
+                    "drift_type": "evaluation_failed",
+                    "severity": Severity.CRITICAL,
+                    "actions": (ActionType.ALERT_ONLY,),
+                    "execution_mode": ExecutionMode.MANUAL,
+                    "safety_state": ExecutionSafety.EVALUATION_FAILED,
+                    "reason": "State query failed",
+                },
             ),
             "alert_only",
             "evaluation_failed",
@@ -564,6 +558,7 @@ def test_reset_lock_reacquisition_requires_valid_lock_after_acquire(
     assert exc_info.value.action == "wait"
     assert exc_info.value.inconsistency_type == "crash_suspicion"
     mock_lock.acquire.assert_called_once_with(max_retries=30)
+    assert gate.lock_was_reacquired is False
 
 
 def test_reset_blocks_fresh_remote_owner_as_stale_ownership(

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -31,6 +31,49 @@ def mock_lock():
     return lock
 
 
+def _make_orphaned_job(job_id: str) -> RebuildJobORM:
+    """Return a stale running rebuild job for startup fail-closed tests."""
+    from datetime import datetime
+
+    return RebuildJobORM(
+        job_id=job_id,
+        requested_by="previous-worker",
+        status=RebuildJobStatus.RUNNING,
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        active_worker_id="dead-worker",
+        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),
+    )
+
+
+def _assert_startup_orphan_blocks(
+    mock_session_factory,
+    mock_lock,
+    mock_repo,
+    *,
+    expect_lock_was_reacquired: bool | None = None,
+) -> RecoveryGate:
+    """Assert startup blocks reset-required orphaned state without mutating recovery state."""
+    with patch("src.logic.recovery_gate.AssetGraphRepository", return_value=mock_repo):
+        gate = RecoveryGate(
+            session_factory=mock_session_factory,
+            lock=mock_lock,
+            runtime_has_active_executor=False,
+            lock_ttl_seconds=300,
+        )
+
+        with pytest.raises(ExecutionBlockedError) as exc_info:
+            gate.ensure_safe_to_execute()
+
+        assert exc_info.value.action == "wait"
+        assert exc_info.value.inconsistency_type == "orphaned_running"
+        mock_repo.mark_rebuild_job_failed.assert_not_called()
+        mock_lock.acquire.assert_not_called()
+        if expect_lock_was_reacquired is not None:
+            assert gate.lock_was_reacquired is expect_lock_was_reacquired
+        return gate
+
+
 def test_startup_reconciliation_passes_with_consistent_state(mock_session_factory, mock_lock):
     """Test that startup reconciliation passes when state is consistent."""
     # Setup: No active job in DB
@@ -85,39 +128,11 @@ def test_gate_waits_on_unknown_lock_with_no_active_job(mock_session_factory, moc
 
 def test_startup_reconciliation_blocks_orphaned_job_fail_closed(mock_session_factory, mock_lock):
     """Startup reconciliation must not perform automatic RESET recovery for orphaned jobs."""
-    from datetime import datetime
-
-    # Setup: Orphaned RUNNING job in DB
-    orphaned_job = RebuildJobORM(
-        job_id="orphaned-job-1",
-        requested_by="previous-worker",
-        status=RebuildJobStatus.RUNNING,
-        created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC),
-        active_worker_id="dead-worker",
-        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),  # Very stale
-    )
-
     mock_repo = MagicMock()
-    # Calls: 1) initial eval, 2) inside _perform_reset_recovery, 3) re-eval after RESET
-    mock_repo.get_active_rebuild_state.side_effect = [orphaned_job, orphaned_job, None]
+    mock_repo.get_active_rebuild_state.return_value = _make_orphaned_job("orphaned-job-1")
     mock_repo.mark_rebuild_job_failed = MagicMock()
 
-    with patch("src.logic.recovery_gate.AssetGraphRepository", return_value=mock_repo):
-        gate = RecoveryGate(
-            session_factory=mock_session_factory,
-            lock=mock_lock,
-            runtime_has_active_executor=False,
-            lock_ttl_seconds=300,
-        )
-
-        with pytest.raises(ExecutionBlockedError) as exc_info:
-            gate.ensure_safe_to_execute()
-
-        assert exc_info.value.action == "wait"
-        assert exc_info.value.inconsistency_type == "orphaned_running"
-        mock_repo.mark_rebuild_job_failed.assert_not_called()
-        mock_lock.acquire.assert_not_called()
+    _assert_startup_orphan_blocks(mock_session_factory, mock_lock, mock_repo)
 
 
 def test_startup_reconciliation_blocks_on_lost_lock_state(mock_session_factory, mock_lock):
@@ -212,38 +227,15 @@ def test_startup_reconciliation_blocks_on_fresh_remote_heartbeat(mock_session_fa
 
 def test_startup_reconciliation_blocks_expired_orphan_without_reacquiring_lock(mock_session_factory, mock_lock):
     """Startup reconciliation must stay fail-closed even when an orphaned job has an expired lock."""
-    from datetime import datetime
-
-    # Setup: Orphaned job + expired lock
-    orphaned_job = RebuildJobORM(
-        job_id="orphaned-job-2",
-        requested_by="previous-worker",
-        status=RebuildJobStatus.RUNNING,
-        created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC),
-        active_worker_id="dead-worker",
-        last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),
-    )
-
     mock_lock.check_state.return_value = LockState.EXPIRED
 
     mock_repo = MagicMock()
-    mock_repo.get_active_rebuild_state.return_value = orphaned_job
+    mock_repo.get_active_rebuild_state.return_value = _make_orphaned_job("orphaned-job-2")
     mock_repo.mark_rebuild_job_failed = MagicMock()
 
-    with patch("src.logic.recovery_gate.AssetGraphRepository", return_value=mock_repo):
-        gate = RecoveryGate(
-            session_factory=mock_session_factory,
-            lock=mock_lock,
-            runtime_has_active_executor=False,
-            lock_ttl_seconds=300,
-        )
-
-        with pytest.raises(ExecutionBlockedError) as exc_info:
-            gate.ensure_safe_to_execute()
-
-        assert exc_info.value.action == "wait"
-        assert exc_info.value.inconsistency_type == "orphaned_running"
-        mock_lock.acquire.assert_not_called()
-        assert gate.lock_was_reacquired is False
-        mock_repo.mark_rebuild_job_failed.assert_not_called()
+    _assert_startup_orphan_blocks(
+        mock_session_factory,
+        mock_lock,
+        mock_repo,
+        expect_lock_was_reacquired=False,
+    )

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -117,6 +117,7 @@ def test_startup_reconciliation_blocks_orphaned_job_fail_closed(mock_session_fac
         assert exc_info.value.action == "wait"
         assert exc_info.value.inconsistency_type == "orphaned_running"
         mock_repo.mark_rebuild_job_failed.assert_not_called()
+        mock_lock.acquire.assert_not_called()
 
 
 def test_startup_reconciliation_blocks_on_lost_lock_state(mock_session_factory, mock_lock):

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -228,8 +228,8 @@ def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factor
     )
 
     # First check: EXPIRED (initial eval), second check (during RESET): EXPIRED,
-    # third check (re-eval after RESET): VALID
-    mock_lock.check_state.side_effect = [LockState.EXPIRED, LockState.EXPIRED, LockState.VALID]
+    # third check (post-acquire verification): VALID, fourth check (re-eval after RESET): VALID
+    mock_lock.check_state.side_effect = [LockState.EXPIRED, LockState.EXPIRED, LockState.VALID, LockState.VALID]
     mock_lock.acquire.return_value = True
 
     mock_repo = MagicMock()

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -83,8 +83,8 @@ def test_gate_waits_on_unknown_lock_with_no_active_job(mock_session_factory, moc
         assert exc_info.value.inconsistency_type == "none"
 
 
-def test_startup_reconciliation_performs_reset_for_orphaned_job(mock_session_factory, mock_lock):
-    """Test that startup reconciliation performs RESET recovery for orphaned job."""
+def test_startup_reconciliation_blocks_orphaned_job_fail_closed(mock_session_factory, mock_lock):
+    """Startup reconciliation must not perform automatic RESET recovery for orphaned jobs."""
     from datetime import datetime
 
     # Setup: Orphaned RUNNING job in DB
@@ -109,17 +109,14 @@ def test_startup_reconciliation_performs_reset_for_orphaned_job(mock_session_fac
             lock=mock_lock,
             runtime_has_active_executor=False,
             lock_ttl_seconds=300,
-            enable_automatic_recovery=True,
         )
 
-        # Should perform RESET recovery and allow execution
-        gate.ensure_safe_to_execute()
+        with pytest.raises(ExecutionBlockedError) as exc_info:
+            gate.ensure_safe_to_execute()
 
-        # Verify RESET was performed
-        mock_repo.mark_rebuild_job_failed.assert_called_once()
-        call_args = mock_repo.mark_rebuild_job_failed.call_args
-        assert call_args[0][0] == "orphaned-job-1"
-        assert call_args[1]["details"].failure_category == "recovery_reset"
+        assert exc_info.value.action == "wait"
+        assert exc_info.value.inconsistency_type == "orphaned_running"
+        mock_repo.mark_rebuild_job_failed.assert_not_called()
 
 
 def test_startup_reconciliation_blocks_on_lost_lock_state(mock_session_factory, mock_lock):
@@ -212,8 +209,8 @@ def test_startup_reconciliation_blocks_on_fresh_remote_heartbeat(mock_session_fa
             gate.ensure_safe_to_execute()
 
 
-def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factory, mock_lock):
-    """Test that startup reconciliation reacquires lock if expired before RESET."""
+def test_startup_reconciliation_blocks_expired_orphan_without_reacquiring_lock(mock_session_factory, mock_lock):
+    """Startup reconciliation must stay fail-closed even when an orphaned job has an expired lock."""
     from datetime import datetime
 
     # Setup: Orphaned job + expired lock
@@ -227,14 +224,10 @@ def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factor
         last_heartbeat_at=datetime(2020, 1, 1, tzinfo=UTC),
     )
 
-    # First check: EXPIRED (initial eval), second check (during RESET): EXPIRED,
-    # third check (post-acquire verification): VALID, fourth check (re-eval after RESET): VALID
-    mock_lock.check_state.side_effect = [LockState.EXPIRED, LockState.EXPIRED, LockState.VALID, LockState.VALID]
-    mock_lock.acquire.return_value = True
+    mock_lock.check_state.return_value = LockState.EXPIRED
 
     mock_repo = MagicMock()
-    # Calls: 1) initial eval, 2) inside _perform_reset_recovery, 3) re-eval after RESET
-    mock_repo.get_active_rebuild_state.side_effect = [orphaned_job, orphaned_job, None]
+    mock_repo.get_active_rebuild_state.return_value = orphaned_job
     mock_repo.mark_rebuild_job_failed = MagicMock()
 
     with patch("src.logic.recovery_gate.AssetGraphRepository", return_value=mock_repo):
@@ -243,14 +236,13 @@ def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factor
             lock=mock_lock,
             runtime_has_active_executor=False,
             lock_ttl_seconds=300,
-            enable_automatic_recovery=True,
         )
 
-        # Should reacquire lock and perform RESET
-        gate.ensure_safe_to_execute()
+        with pytest.raises(ExecutionBlockedError) as exc_info:
+            gate.ensure_safe_to_execute()
 
-        # Verify lock was reacquired
-        mock_lock.acquire.assert_called_once()
-        assert gate.lock_was_reacquired is True
-        # Verify RESET was performed
-        mock_repo.mark_rebuild_job_failed.assert_called_once()
+        assert exc_info.value.action == "wait"
+        assert exc_info.value.inconsistency_type == "orphaned_running"
+        mock_lock.acquire.assert_not_called()
+        assert gate.lock_was_reacquired is False
+        mock_repo.mark_rebuild_job_failed.assert_not_called()

--- a/tests/unit/test_recovery_gate_startup.py
+++ b/tests/unit/test_recovery_gate_startup.py
@@ -109,6 +109,7 @@ def test_startup_reconciliation_performs_reset_for_orphaned_job(mock_session_fac
             lock=mock_lock,
             runtime_has_active_executor=False,
             lock_ttl_seconds=300,
+            enable_automatic_recovery=True,
         )
 
         # Should perform RESET recovery and allow execution
@@ -242,6 +243,7 @@ def test_startup_reconciliation_reacquires_lock_before_reset(mock_session_factor
             lock=mock_lock,
             runtime_has_active_executor=False,
             lock_ttl_seconds=300,
+            enable_automatic_recovery=True,
         )
 
         # Should reacquire lock and perform RESET


### PR DESCRIPTION
# PR: Unify ReconciliationPlan Consumption in RecoveryGate

## Architectural Alignment

- Backend: FastAPI production path. This PR changes startup/background recovery control-plane behavior used by the FastAPI application lifecycle.
- Frontend: Next.js production path is unaffected.
- Gradio: non-production demo/testing path is unaffected.

This PR does not change the declared production architecture. It keeps the work in the FastAPI backend and Python recovery/control-plane code, consistent with `.github/AUTOMATION_SCOPE_POLICY.md` and `docs/adr/0001-production-architecture.md`.

## Primary Objective

Make `RecoveryGate` the single execution boundary that consumes `ReconciliationPlan` objects and decides whether execution may proceed, must wait, must alert/block, or may perform bounded reset recovery.

The main safety objective is to remove split-brain recovery decision paths where the periodic reconciliation loop generated/interpreted a plan and then asked `RecoveryGate` to independently re-plan before mutating state.

## Scope

### In Scope

- Add `RecoveryGate.consume_reconciliation_plan(plan, cancellation_event=None)` as the canonical plan-consumption method.
- Refactor `RecoveryGate.ensure_safe_to_execute()` to generate one plan and delegate consumption to `consume_reconciliation_plan()`.
- Add explicit `RecoveryGate` constructor options:
  - `enable_automatic_recovery`
  - `record_drift_metric`
- Ensure `get_reconciliation_plan()` constructs `ReconciliationEngine` with the same automatic-recovery and drift-metric configuration that the consuming gate will enforce.
- Refactor `src/logic/reconciliation_loop.py` so the periodic loop:
  - creates session/lock dependencies,
  - constructs a `RecoveryGate`,
  - asks that gate for one plan,
  - consumes that same plan once,
  - does not independently inspect or execute `ActionType.RESET_STATE`.
- Preserve startup fail-closed behavior:
  - `RecoveryGate.enable_automatic_recovery` defaults to `False`.
  - startup reconciliation passes `enable_automatic_recovery=False`.
  - periodic reconciliation passes `enable_automatic_recovery=True`.
- Propagate `settings.rebuild_lock_ttl_seconds` from `api/app_factory.py` into `periodic_reconciliation_loop()`.
- Enforce the distributed-lock TTL safety ceiling for reconciliation recovery:
  - app-factory background task wiring bounds configured TTL to `1..300`.
  - reconciliation-loop lock construction bounds TTL to `1..300`.
  - `RecoveryGate.lock_ttl_seconds` bounds TTL to `1..300`.
- Preserve the plan drift type when lock reacquisition times out instead of hard-coding `orphaned_running`.
- Treat expected `ExecutionBlockedError` safety blocks in the periodic loop as non-transient blocked states, not infrastructure failures that trigger exponential backoff.
- Release only locks reacquired by `RecoveryGate`, and continue logging release failures without crashing the reconciliation loop.
- Add/extend tests for:
  - plan consumption paths,
  - wait/alert/evaluation-failed/deferred reset non-mutation behavior,
  - automatic reset delegation,
  - post-reset re-evaluation,
  - cancellation before reset mutation,
  - reacquired-lock release,
  - lock release failure logging,
  - configured and bounded lock TTL propagation,
  - no duplicate plan generation in the periodic loop,
  - drift metric forwarding,
  - runtime-not-ready skip behavior,
  - expected blocked states not entering transient-error backoff.

### Out of Scope

- Graph persistence semantics.
- SQLite persistence compatibility changes.
- Rebuild job schema changes.
- Hosted readiness probes or deployment smoke-check behavior.
- Auth model changes.
- API response contract cleanup outside reconciliation/recovery behavior.
- Frontend/Next.js visualizer changes.
- Gradio/demo behavior changes.
- New schedulers, workers, or background executors.
- Dependency changes.

### Files Expected to Change

- `src/logic/recovery_gate.py`
  - Adds explicit plan consumption, automatic-recovery configuration, TTL bounding, reset authorization checks, post-reset re-evaluation, and drift-aware lock reacquisition errors.
- `src/logic/reconciliation_loop.py`
  - Removes duplicate plan interpretation from the loop, delegates consumption to `RecoveryGate`, bounds lock TTL, releases reacquired locks, and treats expected recovery-gate blocks as non-transient.
- `api/app_factory.py`
  - Passes bounded `rebuild_lock_ttl_seconds` into the periodic reconciliation loop.
- `tests/conftest.py`
  - Adds shared `make_reconciliation_plan` test fixture used by recovery-gate and reconciliation-loop tests.
- `tests/unit/test_recovery_gate.py`
  - Adds plan-consumption, reset, cancellation, TTL, and lock-reacquisition regression coverage.
- `tests/unit/test_reconciliation_loop.py`
  - Adds dedicated periodic reconciliation-loop unit coverage.
- `tests/unit/test_app_factory.py`
  - Adds background task TTL propagation/capping coverage and fixes the loop test trace wrapper to return an awaitable.
- `tests/unit/test_recovery_gate_startup.py`
  - Updates startup recovery-gate expectations to preserve fail-closed defaults and automatic-recovery explicitness.
- `tests/integration/test_recovery_gate_integration.py`
  - Adjusts integration coverage to match explicit automatic-recovery construction.
- `PULL_REQUEST_DESCRIPTION.md`
  - Keeps the checked-in PR description aligned with the live GitHub PR body and repo guardrails.

## Behavior and Compatibility Notes

- `RecoveryGate.ensure_safe_to_execute()` remains public and backward-compatible for existing callers.
- `RecoveryGate.evaluate_state()` remains public and backward-compatible.
- `ExecutionBlockedError` continues exposing `action` and `inconsistency_type`.
- Block messages continue including `(action=..., inconsistency=...)` tags where compatibility-sensitive callers/tests expect them.
- Startup remains conservative: automatic reset recovery is not enabled by default.
- Periodic reconciliation remains the only automatic recovery path in this PR and only runs once the runtime lifecycle is `READY`.
- Bounded reset recovery still requires:
  - automatic or immediate execution mode,
  - `RESET_REQUIRED` safety state,
  - no cancellation signal,
  - a valid or successfully reacquired distributed lock,
  - stale/orphaned active rebuild state before mutation.

## Review Feedback Addressed

- Capped configured reconciliation lock TTL values before they reach `DistributedLock` or stale-heartbeat comparisons.
- Fixed the test trace wrapper that previously returned a synchronous result where the loop expected an awaitable.
- Preserved plan drift type for lock reacquisition timeout errors.
- Added a module-level `pytestmark = pytest.mark.unit` to the new reconciliation-loop unit tests.
- Reduced duplicated wait/alert block handling in `RecoveryGate`.
- Bundled repeated reconciliation-loop test dependencies to reduce test fixture argument count.
- Added regression coverage for expected blocked states so they do not trigger transient-error backoff.

## Delayed, Deferred, or Not Acted On

- No in-scope implementation items are intentionally deferred.
- CodeScene-style duplication findings in tests may still reappear depending on the analyzer threshold; this PR reduced the highest-signal duplication/argument-count issues without obscuring scenario-specific test intent.
- Existing repository/default-branch vulnerability notices are not addressed here because this PR does not change dependencies.
- Full-file `tests/unit/test_app_factory.py` was not used as final validation because the existing lifespan/background-task teardown path timed out locally under the managed sandbox. The three app-factory tests affected by this PR were run directly and passed.
- Review threads were not manually resolved through GitHub by this change; they are expected to be re-evaluated by reviewers/bots after the pushed commits.

## Validation Commands

Executed successfully:

```bash
pytest tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py -q
pytest tests/unit/test_app_factory.py::test_periodic_reconciliation_loop_triggers_recovery tests/unit/test_app_factory.py::test_start_background_tasks_propagates_rebuild_lock_ttl_seconds tests/unit/test_app_factory.py::test_start_background_tasks_caps_rebuild_lock_ttl_seconds -q
pre-commit run --files api/app_factory.py src/logic/reconciliation_loop.py src/logic/recovery_gate.py tests/unit/test_app_factory.py tests/unit/test_reconciliation_loop.py tests/unit/test_recovery_gate.py
```

Additional syntax/format checks were also run during implementation:

```bash
python -m compileall src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
python -m black --workers 1 src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
python -m flake8 --jobs=1 src/logic/recovery_gate.py src/logic/reconciliation_loop.py api/app_factory.py tests/unit/test_recovery_gate.py tests/unit/test_reconciliation_loop.py tests/unit/test_app_factory.py
```

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective.
- [x] This PR makes one primary decision only: converge `ReconciliationPlan` consumption into `RecoveryGate`.
- [x] In-scope and out-of-scope boundaries are explicitly documented.
- [x] Changes align with production architecture (`FastAPI` backend + `Next.js` frontend).
- [x] Gradio/demo paths are not treated as production architecture.
- [x] Runtime dependency source of truth remains unchanged.
- [x] Compatibility surface is preserved or explicitly documented.
- [x] Focused validation commands pass locally.
- [x] Review-feedback fixes are documented.
- [x] Deferred or not-acted-on items are explicitly recorded.

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only.
- [x] I have explicitly listed what is out of scope.
- [x] This is not a docs/policy/architecture-only PR.
- [x] I have verified the branch, base branch, and referenced issue/PR context.
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend).
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`.

### Testing Best Practices

- [x] Tests verify observable behavior such as raised actions, state decisions, function calls, and interval/backoff effects.
- [x] Tests avoid coupling to exact log message strings.
- [x] New tests do not add fixed timing sleeps for assertions.
- [x] Recovery/control-plane tests use mocks or existing fixtures to avoid leaking database/lock resources.
