### PR TITLE
docs: add backup restore and DR strategy

### DIFF
--- a/docs/adr/0002-hosted-deployment-and-persistence.md
+++ b/docs/adr/0002-hosted-deployment-and-persistence.md
@@ -145,7 +145,7 @@ Implemented graph serialization, deserialization, and PostgreSQL repository boun
 
 ### Phase 4: Production Optimizations (Future)
 
-Connection pooling tuning, caching strategy, monitoring, backup procedures.
+Connection pooling tuning, caching strategy, and monitoring remain future production optimizations. Backup and restore strategy/procedures are no longer treated as an undocumented Phase 4 gap: they are documented in [ADR 0005](./0005-backup-restore-dr-strategy.md) and the [backup/restore/DR runbook](../runbooks/backup-restore-dr.md). Automated backup orchestration remains deferred.
 
 ## Required Hosted Environment Variables
 
@@ -182,6 +182,8 @@ These are valid future considerations but should not block initial deployment.
 ## References
 
 - [ADR 0001: Production Architecture](0001-production-architecture.md)
+- [ADR 0005: Backup, Restore, and Disaster Recovery Strategy](0005-backup-restore-dr-strategy.md)
+- [Backup, Restore, and DR Runbook](../runbooks/backup-restore-dr.md)
 - [DEPLOYMENT.md](../../DEPLOYMENT.md)
 - [VERCEL_DEPLOYMENT_CHECKLIST.md](../../VERCEL_DEPLOYMENT_CHECKLIST.md)
 - [Vercel Documentation](https://vercel.com/docs)

--- a/docs/adr/0003-distributed-lock-refresh-and-heartbeat-strategy.md
+++ b/docs/adr/0003-distributed-lock-refresh-and-heartbeat-strategy.md
@@ -187,12 +187,15 @@ Propagated to `GraphLifecycleSettings` and consumed by `graph_admin.py` rebuild 
 4. **Retry Rebuild**: Operator can retry the rebuild request; the system enforces exclusive access
 5. **Monitor Heartbeats**: Query `last_heartbeat_at` on running jobs to verify liveness
 
+For database restore scenarios, use the full [Backup, Restore, and DR Runbook](../runbooks/backup-restore-dr.md). Restore procedures must account for restored `distributed_locks` rows with future `expires_at` values and restored `rebuild_jobs` rows in `running` or `cancel_requested` status before application restart.
+
 ## References
 
 - [src/data/distributed_lock.py](../../src/data/distributed_lock.py): Lock refresh implementation
 - [api/routers/graph_admin.py](../../api/routers/graph_admin.py): Heartbeat keeper and rebuild orchestration
 - [src/config/settings.py](../../src/config/settings.py): Typed lock TTL configuration
 - [ADR 0002: Hosted Deployment and Persistence](./0002-hosted-deployment-and-persistence.md): Related persistence guarantees
+- [Backup, Restore, and DR Runbook](../runbooks/backup-restore-dr.md): Restore-specific lock and rebuild job cleanup procedure
 
 ## Authors
 

--- a/docs/adr/0004-distributed-hosting-semantics.md
+++ b/docs/adr/0004-distributed-hosting-semantics.md
@@ -249,13 +249,15 @@ failure-mode and scale tests.
 - No new distributed scheduler.
 - No multi-region support claim.
 - No Redis, queue, or external coordinator introduction.
-- No backup/restore runbook; that belongs to PR 9.
+- No backup/restore procedure definition in this ADR; restore strategy is covered by ADR 0005 and the DR runbook.
 - No failure-injection implementation; that belongs to PR 7.
 
 ## References
 
 - [ADR 0002: Hosted Deployment and Durable Persistence](./0002-hosted-deployment-and-persistence.md)
 - [ADR 0003: Distributed Lock Refresh and Heartbeat Strategy](./0003-distributed-lock-refresh-and-heartbeat-strategy.md)
+- [ADR 0005: Backup, Restore, and Disaster Recovery Strategy](./0005-backup-restore-dr-strategy.md)
+- [Backup, Restore, and DR Runbook](../runbooks/backup-restore-dr.md)
 - [Enterprise Deployment Operating Model](../enterprise-deployment-operating-model.md)
 - [Reconciliation Engine](../reconciliation-engine.md)
 - [Distributed Hosting Invariants](../testing/distributed-hosting-invariants.md)

--- a/docs/adr/0005-backup-restore-dr-strategy.md
+++ b/docs/adr/0005-backup-restore-dr-strategy.md
@@ -1,0 +1,123 @@
+# ADR 0005: Backup, Restore, and Disaster Recovery Strategy
+
+For the broader enterprise-readiness audit and rollout plan, see [docs/enterprise-readiness-index.md](../enterprise-readiness-index.md).
+
+## Status
+
+Accepted
+
+## Date
+
+2026-06-24
+
+## Context
+
+FarDb now has durable hosted persistence and explicit distributed hosting semantics. The remaining enterprise recovery gap is operational: staging and production need documented recovery objectives, backup mechanisms, restore verification, and ownership boundaries.
+
+FarDb uses a dual-database architecture:
+
+1. **Auth/Coordination DB** (`api/database.py`): API-layer application persistence for authentication and related control-plane state. It supports SQLite for local development and PostgreSQL for hosted staging/production. `DATABASE_URL` remains canonical, with hosted-provider fallback support where configured.
+2. **Asset Graph DB** (`src/data/database.py`): SQLAlchemy-backed persistence for graph truth and rebuild coordination tables. It supports SQLite locally and PostgreSQL-compatible storage in hosted environments through `ASSET_GRAPH_DATABASE_URL`.
+
+The two database boundaries may point to the same physical PostgreSQL instance or to separate logical databases. Operators must treat them as separate recovery concerns unless the deployment explicitly documents a shared database boundary.
+
+Graph data and coordination/auth data have different recovery properties. Graph data can be rebuilt from source data through `RebuildExecutor` when source data remains available and fresh enough for the target environment. Coordination/auth data is less replaceable: user credentials, rebuild job history, lock state, and checkpoint metadata cannot be fully reconstructed from the graph source feed alone.
+
+The distributed rebuild control plane also introduces timing constraints. `distributed_locks` rows expire through TTL semantics, with the current default maximum operational assumption of 300 seconds. A restored lock row with a future `expires_at` can temporarily block new rebuild lock acquisition until it expires or is cleared by an operator.
+
+## Decision
+
+FarDb adopts a documented disaster recovery strategy for staging and production covering the Auth/Coordination DB and Asset Graph DB.
+
+### Recovery objectives
+
+| Data class | RPO target | RTO target | Notes |
+| --- | --- | --- | --- |
+| Graph data | Tied to approved source-data freshness | 2 hours for full service restoration, including verification | Graph truth is important but rebuildable through `RebuildExecutor` if source data remains available. |
+| Coordination/auth data | 1 hour | 2 hours for full service restoration, including verification | Includes auth/application state and rebuild coordination state that cannot be completely inferred from graph source data. |
+
+The 2-hour RTO includes restore execution, schema verification, application restart/redeployment, health verification, lifecycle verification, and functional smoke testing.
+
+### Backup mechanism
+
+Provider-managed point-in-time recovery (PITR) is the primary backup and restore mechanism for hosted PostgreSQL providers such as Supabase, Neon, and Vercel Postgres where available.
+
+`pg_dump` is the portable fallback mechanism. It must be used for ad-hoc backups before risky operations and for providers or tiers where PITR is unavailable, disabled, or insufficiently retained.
+
+### Retention policy
+
+Hosted staging and production should maintain:
+
+| Backup type | Retention |
+| --- | --- |
+| Daily backups | 7-day rolling retention |
+| Weekly snapshots | 30-day retention |
+
+Provider-managed PITR retention must meet or exceed the intended recovery window. If a provider tier cannot satisfy the retention policy, operators must supplement it with scheduled `pg_dump` snapshots retained outside the primary database service.
+
+### Data classification
+
+| Classification | Tables / state | Recovery priority | Rationale |
+| --- | --- | --- | --- |
+| **Critical / Non-rebuildable** | `distributed_locks`, `rebuild_jobs` coordination state, user credentials if stored | Highest | These records control operator access, rebuild coordination, checkpoints, and lock ownership. They cannot be regenerated from graph source data alone. |
+| **Important / Rebuildable** | `assets`, `asset_relationships`, `regulatory_events`, `regulatory_event_assets` | High | These records represent graph truth. They should be restored when possible but can be rebuilt from source through `RebuildExecutor` if backup data is unavailable or stale. |
+
+Graph data backup loss is recoverable when source data is available and an approved rebuild can be run. In that case, the graph RPO is bounded by source data freshness and rebuild acceptance criteria rather than by database backup age alone.
+
+Coordination state is transient relative to graph truth. Restoring exact mid-rebuild state is lower priority than ensuring clean restart capability. During restore, any `rebuild_jobs` rows in in-flight states should be cleaned up before application restart so RecoveryGate does not classify restored historical state as a live orphaned rebuild.
+
+`distributed_locks` TTL behavior constrains restore timing. Stale locks should auto-expire after the configured TTL, with 300 seconds as the current default maximum operational assumption. Operators may clear restored lock rows only after confirming no live writer from the restored environment is still active.
+
+### Restore strategy
+
+Restores must prefer a clean, verified recovery point over partial repair. Operators should restore to a scratch database first where possible, verify schema and key table sanity, then promote the restored database connection string into the target environment.
+
+Restoration must distinguish deployment rollback from data restore. Vercel rollback/promotion can restore application code and configuration but does not restore PostgreSQL database state.
+
+## Consequences
+
+### Positive
+
+1. Staging and production now have explicit RPO/RTO assumptions instead of implicit best effort recovery.
+2. Backup and restore expectations are aligned to the dual-database architecture.
+3. Graph data can use its rebuildability without incorrectly treating control-plane state as rebuildable.
+4. Provider-managed PITR is the primary path while retaining `pg_dump` portability.
+5. Release gating can distinguish a documented DR strategy from a rehearsed restore.
+
+### Negative
+
+1. PITR availability and retention vary by provider and plan, so operators must verify provider settings for each hosted environment.
+2. `pg_dump` fallback introduces operational custody requirements for backup files and credentials.
+3. Restoring coordination state may require manual cleanup of stale lock and rebuild job rows before restart.
+4. The 2-hour RTO assumes database admin access and provider console access are available when the incident begins.
+
+### Neutral
+
+1. This ADR documents strategy and operating assumptions. It does not create automated backup jobs.
+2. Local SQLite databases remain developer-owned and are not covered by staging/production RPO/RTO commitments.
+3. Cross-region failover is not claimed by this strategy.
+
+## Non-goals
+
+- Automated backup orchestration is deferred.
+- Cross-region database replication and cross-region failover are deferred.
+- Continuous restore rehearsal automation is deferred.
+- Provider-specific infrastructure-as-code changes are out of scope.
+- Runtime code changes are out of scope.
+
+## References
+
+- [Backup, Restore, and DR Runbook](../runbooks/backup-restore-dr.md)
+- [ADR 0002: Hosted Deployment and Durable Persistence](./0002-hosted-deployment-and-persistence.md)
+- [ADR 0003: Distributed Lock Refresh and Heartbeat Strategy](./0003-distributed-lock-refresh-and-heartbeat-strategy.md)
+- [ADR 0004: Distributed Hosting Semantics](./0004-distributed-hosting-semantics.md)
+- [Enterprise Deployment Operating Model](../enterprise-deployment-operating-model.md)
+
+## Authors
+
+- OpenAI ChatGPT
+- DashFin-FarDb Organization
+
+## Review and Approval
+
+This ADR was created as part of PR 9 / issue #1279 to close the documented enterprise backup, restore, and disaster recovery strategy gap.

--- a/docs/adr/0005-backup-restore-dr-strategy.md
+++ b/docs/adr/0005-backup-restore-dr-strategy.md
@@ -21,6 +21,8 @@ FarDb uses a dual-database architecture:
 
 The two database boundaries may point to the same physical PostgreSQL instance or to separate logical databases. Operators must treat them as separate recovery concerns unless the deployment explicitly documents a shared database boundary.
 
+The rebuild coordination plane may also be isolated through `COORDINATION_DATABASE_URL`. When present, that URL is the authoritative location for coordination tables such as `rebuild_jobs` and `distributed_locks`; when absent, it falls back to `DATABASE_URL` and then provider fallback configuration. DR procedures must therefore resolve the actual deployed connection-string topology before backup or restore.
+
 Graph data and coordination/auth data have different recovery properties. Graph data can be rebuilt from source data through `RebuildExecutor` when source data remains available and fresh enough for the target environment. Coordination/auth data is less replaceable: user credentials, rebuild job history, lock state, and checkpoint metadata cannot be fully reconstructed from the graph source feed alone.
 
 The distributed rebuild control plane also introduces timing constraints. `distributed_locks` rows expire through TTL semantics, with the current default maximum operational assumption of 300 seconds. A restored lock row with a future `expires_at` can temporarily block new rebuild lock acquisition until it expires or is cleared by an operator.
@@ -115,7 +117,7 @@ Restoration must distinguish deployment rollback from data restore. Vercel rollb
 
 ## Authors
 
-- OpenAI ChatGPT
+- Claude (AI Agent)
 - DashFin-FarDb Organization
 
 ## Review and Approval

--- a/docs/enterprise-deployment-operating-model.md
+++ b/docs/enterprise-deployment-operating-model.md
@@ -31,8 +31,8 @@ The current selected initial topology is:
 ### Rollback and Restore Ownership
 
 - **Deployment rollback owner**: Designated maintainer/operator with authority to promote a previous known-good Vercel deployment.
-- **Data restore owner**: Designated maintainer/operator responsible for future restore execution once a restore runbook exists.
-- **Backup/restore runbook status**: Full backup/restore and recovery procedures are explicitly deferred to Stage 7.
+- **Data restore owner**: Designated Restore Operator responsible for executing [the backup/restore/DR runbook](runbooks/backup-restore-dr.md) when database recovery is required.
+- **Backup/restore runbook status**: Backup, restore, and DR procedures are documented in [docs/runbooks/backup-restore-dr.md](runbooks/backup-restore-dr.md). Strategy and objectives are documented in [ADR 0005](adr/0005-backup-restore-dr-strategy.md).
 
 ## Deployment Ownership
 
@@ -213,9 +213,22 @@ After rollback:
 
 ### Data Restore Boundary
 
-- Full backup/restore remains deferred to Stage 7.
+- Data restore is documented in [docs/runbooks/backup-restore-dr.md](runbooks/backup-restore-dr.md).
 - Rollback is not equivalent to database restore.
-- Operators must treat schema changes and destructive data operations with caution until a restore runbook exists.
+- Operators must treat schema changes and destructive data operations as restore-sensitive changes and should take an ad-hoc backup before executing them.
+
+## Disaster Recovery
+
+FarDb disaster recovery is governed by [ADR 0005: Backup, Restore, and Disaster Recovery Strategy](adr/0005-backup-restore-dr-strategy.md) and executed through [the backup/restore/DR runbook](runbooks/backup-restore-dr.md).
+
+ADR 0005 defines the staging/production recovery objectives:
+
+- graph data RPO is tied to approved source-data freshness because graph data is rebuildable through `RebuildExecutor`;
+- coordination/auth data RPO is 1 hour;
+- full service RTO is 2 hours, including restore verification;
+- provider-managed PITR is primary for hosted PostgreSQL, with `pg_dump` as the portable fallback.
+
+A Vercel rollback/promotion can recover a previous application deployment, but it does **not** restore `DATABASE_URL`, `POSTGRES_URL`, or `ASSET_GRAPH_DATABASE_URL` data. When data loss, destructive writes, failed migrations, or corrupted graph persistence are suspected, operators must use the DR runbook rather than treating deployment rollback as sufficient recovery.
 
 ## Secret Handling
 
@@ -230,8 +243,11 @@ The operating model assumes named ownership for the following functions:
 - **Deploy operator**: Executes deployment to the target environment.
 - **Promotion approver**: Confirms promotion gates are satisfied before staging/production promotion.
 - **Rollback executor**: Performs Vercel rollback/promotion to restore the previous known-good deployment.
+- **Backup Operator**: Verifies backup health and executes ad-hoc backups before major changes.
+- **Restore Operator**: Executes database restore procedures and post-restore verification according to the DR runbook.
 - **Secret/config maintainer**: Owns environment-variable configuration and secret rotation.
 - **Persistence-verification operator**: Executes and records the durable graph-persistence smoke procedure.
+- **Incident Commander**: Escalation point for restore failures, data loss events, and RTO/RPO risk.
 
 One person may hold multiple roles, but the responsibilities must be explicit.
 
@@ -246,6 +262,7 @@ When the deployment is degraded or promotion evidence is incomplete:
    - missing persisted graph after restart
    - auth/application database unreachable
    - non-durable preview assumptions being incorrectly treated as staging/production evidence
+   - suspected data loss or restore requirement
 3. **Inspect**: Review backend logs and deployment metadata without exposing secrets to end users.
-4. **Mitigate**: Roll back application code/configuration when the current deployment is not trustworthy.
-5. **Re-verify**: Re-run the appropriate readiness and durable graph-persistence checks before restoring promotion confidence.
+4. **Mitigate**: Roll back application code/configuration when the current deployment is not trustworthy, or execute the DR runbook when database restore is required.
+5. **Re-verify**: Re-run the appropriate readiness, durable graph-persistence, and post-restore checks before restoring promotion confidence.

--- a/docs/enterprise-readiness-index.md
+++ b/docs/enterprise-readiness-index.md
@@ -12,6 +12,8 @@
 | `docs/roadmap/enterprise-readiness-pr-plan.md` | PR-by-PR execution plan with validation commands |
 | `docs/roadmap/enterprise-readiness-pr-board.md` | Operational PR board with status and exit criteria |
 | `docs/release-checklist.md` | Release gates and enterprise exit criteria |
+| `docs/adr/0005-backup-restore-dr-strategy.md` | Backup, restore, DR strategy, data classification, RPO, and RTO |
+| `docs/runbooks/backup-restore-dr.md` | Operator procedures for backup verification, restore execution, and post-restore checks |
 
 ## Executive Summary
 
@@ -19,7 +21,8 @@ The repo is already strong in control-plane maturity:
 
 - observability and SLOs are implemented;
 - rebuild coordination and operator authorization are hardened;
-- production architecture is clearly declared.
+- production architecture is clearly declared;
+- backup, restore, and disaster recovery strategy/procedures are now documented.
 
 The remaining work is primarily around:
 
@@ -28,8 +31,9 @@ The remaining work is primarily around:
 - promotion gates;
 - contract cleanup;
 - distributed hosting semantics;
-- security/governance automation;
-- backup, restore, and DR.
+- security/governance automation.
+
+The DR documentation gap is closed at the strategy and runbook level through [ADR 0005](adr/0005-backup-restore-dr-strategy.md) and the [backup/restore/DR runbook](runbooks/backup-restore-dr.md). Final release readiness still requires operators to rehearse restore at least once and record the evidence in the release process.
 
 ## Recommended Reading Order
 
@@ -38,6 +42,8 @@ The remaining work is primarily around:
 3. `docs/roadmap/enterprise-readiness-pr-plan.md`
 4. `docs/roadmap/enterprise-readiness-pr-board.md`
 5. `docs/release-checklist.md`
+6. `docs/adr/0005-backup-restore-dr-strategy.md`
+7. `docs/runbooks/backup-restore-dr.md`
 
 ## Operational Rule
 
@@ -47,4 +53,6 @@ If a change touches production behavior, deployment, security, persistence, or r
 
 - [README.md](../README.md) — main repository entry point and production setup overview
 - [docs/adr/0002-hosted-deployment-and-persistence.md](./adr/0002-hosted-deployment-and-persistence.md) — hosted persistence decision
-- [docs/enterprise-deployment-operating-model.md](./enterprise-deployment-operating-model.md) — promotion and rollback operating model
+- [docs/adr/0005-backup-restore-dr-strategy.md](./adr/0005-backup-restore-dr-strategy.md) — backup, restore, and DR strategy
+- [docs/runbooks/backup-restore-dr.md](./runbooks/backup-restore-dr.md) — backup and restore operating procedure
+- [docs/enterprise-deployment-operating-model.md](./enterprise-deployment-operating-model.md) — promotion, rollback, and DR operating model

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -85,10 +85,10 @@ It does not apply to the Gradio demo path in `app.py`.
 
 **Exit criteria**
 
-- Backup and restore procedure exists.
-- RPO and RTO are defined.
-- Restore has been rehearsed at least once.
-- Rollback is distinguished from data restore.
+- Backup and restore procedure exists: satisfied by [docs/runbooks/backup-restore-dr.md](runbooks/backup-restore-dr.md).
+- RPO and RTO are defined: satisfied by [ADR 0005](adr/0005-backup-restore-dr-strategy.md).
+- Rollback is distinguished from data restore: satisfied by the [Enterprise Deployment Operating Model](enterprise-deployment-operating-model.md#disaster-recovery).
+- Restore has been rehearsed at least once: manual operator verification required before final enterprise release sign-off.
 
 ## Release Exit Criteria Summary
 
@@ -99,4 +99,4 @@ A release may be treated as enterprise-ready only when all of the following are 
 - core API contracts are explicit and stable;
 - rebuild/recovery behavior is deterministic under failure;
 - security and governance controls are enforceable;
-- DR / restore is documented and reheated in practice.
+- DR / restore is documented and rehearsed in practice.

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -10,7 +10,7 @@ Use this runbook when:
 
 - verifying provider-managed backup/PITR health;
 - taking an ad-hoc backup before a risky migration, deployment, or destructive operation;
-- restoring the Auth/Coordination DB, the Asset Graph DB, or both;
+- restoring the Auth DB, Coordination DB, Asset Graph DB, or any combined database boundary;
 - recovering from data loss, accidental destructive writes, failed migrations, or database-provider incidents;
 - proving that restore procedures remain executable for enterprise release readiness.
 
@@ -25,7 +25,7 @@ Operators must have the following access before starting backup or restore work:
 - Database administrator credentials or equivalent connection strings for each affected database.
 - Vercel dashboard access for environment variables, deployment restart/redeployment, and rollback/promotion operations.
 - Provider console access for the hosted PostgreSQL provider, such as Supabase, Neon, or Vercel Postgres.
-- Permission to read and update `DATABASE_URL`, `POSTGRES_URL`, `ASSET_GRAPH_DATABASE_URL`, and any provider-specific database settings.
+- Permission to read and update `DATABASE_URL`, `POSTGRES_URL`, `COORDINATION_DATABASE_URL`, `ASSET_GRAPH_DATABASE_URL`, and any provider-specific database settings.
 - Secure storage for portable dump files when using `pg_dump`.
 - Access to deployment logs and `GET /api/health/detailed` for post-restore verification.
 
@@ -35,18 +35,34 @@ Do not paste database credentials, full connection strings, backup contents, or 
 
 ### 1. Identify database boundaries
 
-FarDb may use one or two logical PostgreSQL database boundaries:
+FarDb can use up to three logical PostgreSQL database boundaries, although a deployment may map more than one boundary to the same physical database:
 
-- Auth/Coordination DB: `DATABASE_URL`, with `POSTGRES_URL` as a provider fallback where configured.
+- Auth DB: `DATABASE_URL`, with `POSTGRES_URL` as a provider fallback where configured.
+- Coordination DB: `COORDINATION_DATABASE_URL`, falling back to `DATABASE_URL` and then `POSTGRES_URL` when unset.
 - Asset Graph DB: `ASSET_GRAPH_DATABASE_URL`.
 
-If `DATABASE_URL` and `ASSET_GRAPH_DATABASE_URL` resolve to different connection strings, back up both. If they point to the same physical database, one full database backup may cover both boundaries, but the operator must record that topology in the incident or release evidence.
+The Coordination DB is the authoritative location for rebuild coordination state when `COORDINATION_DATABASE_URL` is set separately. This includes `rebuild_jobs` and `distributed_locks`; omitting this boundary from backup or restore can lose checkpoint state or resurrect stale lock/job state after a DR event.
+
+For each environment, resolve and record the effective connection strings before backup:
+
+```bash
+# Auth DB
+export AUTH_DATABASE_URL="${DATABASE_URL:-$POSTGRES_URL}"
+
+# Coordination DB; falls back through the same order as the settings layer
+export COORD_DATABASE_URL="${COORDINATION_DATABASE_URL:-$AUTH_DATABASE_URL}"
+
+# Asset Graph DB
+export GRAPH_DATABASE_URL="$ASSET_GRAPH_DATABASE_URL"
+```
+
+Back up every distinct effective connection string. If two or more logical boundaries resolve to the same physical database, one full database backup may cover those boundaries, but the operator must record that topology in the incident or release evidence.
 
 ### 2. Provider-managed backup verification
 
 Provider-managed PITR is the primary mechanism for hosted PostgreSQL.
 
-For each affected environment:
+For each affected environment and every distinct database boundary:
 
 1. Open the provider console for the database instance.
 2. Confirm backups or PITR are enabled for the database or branch/project.
@@ -65,20 +81,9 @@ If provider-managed restore is unavailable or does not meet the target window, t
 
 ### 3. Portable `pg_dump` backup procedure
 
-Resolve the connection strings from the target environment:
+Resolve the connection strings from the target environment as shown in the boundary-identification step. Then create timestamped dump files for every distinct database boundary.
 
-```bash
-# Auth/Coordination DB
-export AUTH_DATABASE_URL="$DATABASE_URL"
-
-# Provider fallback if DATABASE_URL is intentionally unset
-export AUTH_DATABASE_URL="${AUTH_DATABASE_URL:-$POSTGRES_URL}"
-
-# Asset Graph DB
-export GRAPH_DATABASE_URL="$ASSET_GRAPH_DATABASE_URL"
-```
-
-Create timestamped dump files:
+For a deployment where all three logical boundaries are separate:
 
 ```bash
 export BACKUP_TS="$(date -u +%Y%m%dT%H%M%SZ)"
@@ -89,6 +94,12 @@ pg_dump "$AUTH_DATABASE_URL" \
   --no-acl \
   --file="fardb-auth-${BACKUP_TS}.dump"
 
+pg_dump "$COORD_DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file="fardb-coordination-${BACKUP_TS}.dump"
+
 pg_dump "$GRAPH_DATABASE_URL" \
   --format=custom \
   --no-owner \
@@ -96,7 +107,7 @@ pg_dump "$GRAPH_DATABASE_URL" \
   --file="fardb-graph-${BACKUP_TS}.dump"
 ```
 
-If both environment variables point to the same database, run a single dump and label it clearly:
+If multiple logical boundaries point to the same database, run one dump for that physical database and label it clearly:
 
 ```bash
 pg_dump "$DATABASE_URL" \
@@ -106,7 +117,7 @@ pg_dump "$DATABASE_URL" \
   --file="fardb-combined-${BACKUP_TS}.dump"
 ```
 
-Store dumps in the approved backup location for the deploying organization. Do not commit dump files to the repository.
+Do not create duplicate dumps of the same physical database unless required by the deploying organization's custody process. Store dumps in the approved backup location for the deploying organization. Do not commit dump files to the repository.
 
 ### 4. Backup verification
 
@@ -125,7 +136,7 @@ pg_restore \
   "fardb-graph-${BACKUP_TS}.dump"
 ```
 
-Run key table sanity checks:
+Run key table sanity checks on any scratch restore containing graph or coordination tables:
 
 ```sql
 SELECT COUNT(*) AS assets_count FROM assets;
@@ -135,7 +146,9 @@ SELECT COUNT(*) AS rebuild_jobs_count FROM rebuild_jobs;
 SELECT COUNT(*) AS distributed_locks_count FROM distributed_locks;
 ```
 
-For the Auth/Coordination DB, run equivalent checks for application/auth tables present in that boundary. If user credentials are stored, verify the credentials table exists and has expected row counts without exposing hashes or secrets.
+For the Auth DB, run equivalent checks for application/auth tables present in that boundary. If user credentials are stored, verify the credentials table exists and has expected row counts without exposing hashes or secrets.
+
+For a separate Coordination DB, verify `rebuild_jobs` and `distributed_locks` from the coordination scratch restore, not from the graph scratch restore.
 
 ### 5. Backup schedule recommendation
 
@@ -158,7 +171,7 @@ For hosted deployments, this is usually performed by stopping traffic, disabling
 
 ### 2. Verify no active rebuild is in progress
 
-Use `/api/health/detailed` if the application is still reachable and safe to query. If the application is offline, query the database directly:
+Use `/api/health/detailed` if the application is still reachable and safe to query. If the application is offline, query the effective Coordination DB directly:
 
 ```sql
 SELECT job_id, status, active_worker_id, last_heartbeat_at, updated_at
@@ -169,9 +182,9 @@ ORDER BY updated_at DESC;
 
 If any active rebuild exists, prefer to wait for it to complete or fail before restore unless the restore is required because the rebuild itself corrupted state.
 
-### 3. Handle distributed locks
+### 3. Handle live distributed locks before restore
 
-Inspect the rebuild lock:
+Inspect the rebuild lock in the effective Coordination DB:
 
 ```sql
 SELECT lock_name, holder_id, expires_at, updated_at
@@ -179,10 +192,10 @@ FROM distributed_locks
 WHERE lock_name = 'graph_rebuild';
 ```
 
-If a `distributed_locks` row exists with a future `expires_at`, either:
+If the current live database contains a `distributed_locks` row with a future `expires_at`, either:
 
 1. wait for TTL expiry; the operational maximum assumption is 300 seconds unless `REBUILD_LOCK_TTL_SECONDS` has been configured differently; or
-2. manually delete the row after confirming no live rebuild writer from the restored environment is active.
+2. manually delete the row after confirming no live rebuild writer from the current environment is active.
 
 Manual deletion:
 
@@ -191,25 +204,13 @@ DELETE FROM distributed_locks
 WHERE lock_name = 'graph_rebuild';
 ```
 
-A restored lock row with a mismatched `holder_id` can block new lock acquisition until it expires or is cleared.
+This live-database quiescence step does not clean the restored database. PITR or `pg_restore` can reintroduce historical `distributed_locks` and `rebuild_jobs` rows, so the post-restore, pre-restart cleanup step below must still be executed on the restored Coordination DB.
 
-### 4. Clean up in-flight rebuild jobs
+### 4. Record in-flight rebuild state for incident evidence
 
-Before restarting the application after restore, prevent RecoveryGate from detecting false orphaned jobs caused by restored historical state.
+Before restoring, record any in-flight `rebuild_jobs` rows and the selected restore timestamp in the incident or rehearsal evidence. Do not rely on pre-restore updates to `rebuild_jobs` for cleanup: the restore operation overwrites the current database state with the selected historical state.
 
-For schemas using the current `sanitized_failure_category` and `sanitized_failure_message` columns:
-
-```sql
-UPDATE rebuild_jobs
-SET status = 'failed',
-    sanitized_failure_category = 'pre_restore_cleanup',
-    sanitized_failure_message = 'Marked failed during pre-restore cleanup to ensure clean restart.',
-    completed_at = CURRENT_TIMESTAMP,
-    updated_at = CURRENT_TIMESTAMP
-WHERE status IN ('running', 'cancel_requested');
-```
-
-If a future schema renames `sanitized_failure_category` to `failure_category`, use the equivalent field name in that environment. The operator intent must remain `pre_restore_cleanup`.
+RecoveryGate false-orphan prevention must be performed after restore and before application restart, against the restored Coordination DB.
 
 ## Restore Execution Procedure
 
@@ -224,7 +225,8 @@ General procedure:
 3. Prefer restore-to-new database, branch, or project when the provider supports it.
 4. Initiate restore in the provider console.
 5. Record the original database identifier, restored database identifier, restore timestamp, operator, and provider job status.
-6. Update the target environment connection string only after scratch verification passes.
+6. Restore every distinct affected boundary: Auth DB, Coordination DB, Asset Graph DB, or the combined database if they share one physical database.
+7. Update the target environment connection string only after scratch verification passes.
 
 Provider notes:
 
@@ -234,48 +236,75 @@ Provider notes:
 
 ### 2. Portable `pg_restore` procedure
 
-Prepare the target database. Prefer an empty database for restore:
+Prefer restoring into an empty target database. This keeps restore execution atomic with `--single-transaction` and avoids destructive cleanup of an existing database:
 
 ```bash
 createdb fardb_restore_target
+
+pg_restore \
+  --dbname="$TARGET_DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --single-transaction \
+  "fardb-graph-${BACKUP_TS}.dump"
 ```
 
-Alternatively, use `--clean` only when the operator has confirmed the target database can be overwritten:
+Use `--clean` only when the operator has confirmed the target database can be overwritten. Do not combine `--clean` with `--single-transaction` unless the target schema is known to match the dump exactly; a failed `DROP` can abort the active transaction and roll back the entire restore. For overwrite restores, use `--if-exists` and run without `--single-transaction`:
 
 ```bash
 pg_restore \
   --dbname="$TARGET_DATABASE_URL" \
   --no-owner \
   --no-acl \
-  --single-transaction \
   --clean \
+  --if-exists \
   "fardb-graph-${BACKUP_TS}.dump"
 ```
 
-For an empty target database:
+If Auth DB, Coordination DB, and Asset Graph DB are separate, restore each dump to its corresponding target database. Do not restore the graph dump over the auth or coordination database, or the auth/coordination dump over the graph database.
 
-```bash
-pg_restore \
-  --dbname="$TARGET_DATABASE_URL" \
-  --no-owner \
-  --no-acl \
-  --single-transaction \
-  "fardb-graph-${BACKUP_TS}.dump"
+### 3. Post-restore, pre-restart coordination cleanup
+
+Run this step after PITR/`pg_restore` has completed and before any application process is allowed to start against the restored database. Execute it against the restored Coordination DB. If `COORDINATION_DATABASE_URL` is unset, this means the restored database reached through the settings fallback order.
+
+Inspect restored locks:
+
+```sql
+SELECT lock_name, holder_id, expires_at, updated_at
+FROM distributed_locks
+WHERE lock_name = 'graph_rebuild';
 ```
 
-If Auth/Coordination DB and Asset Graph DB are separate, restore each dump to its corresponding target database. Do not restore the graph dump over the auth database or the auth dump over the graph database.
+If a restored `distributed_locks` row has a future `expires_at`, either wait for TTL expiry or delete the row after confirming the old holder cannot still be running against the restored environment:
 
-### 3. Post-restore schema verification
-
-Run the base schema migration idempotently where applicable:
-
-```bash
-psql "$TARGET_DATABASE_URL" -f migrations/001_initial.sql
+```sql
+DELETE FROM distributed_locks
+WHERE lock_name = 'graph_rebuild';
 ```
 
-For local SQLite restore validation, run the repository migration helper or the migration scripts according to the current local development procedure. For PostgreSQL-hosted environments, confirm the ORM-created schema and provider migration compatibility before switching live traffic.
+A restored lock row with a mismatched `holder_id` can block new lock acquisition until it expires or is cleared.
 
-Then inspect the expected tables:
+Clean up restored in-flight rebuild jobs so RecoveryGate does not classify historical state as a live orphaned rebuild. For schemas using the current `sanitized_failure_category` and `sanitized_failure_message` columns:
+
+```sql
+UPDATE rebuild_jobs
+SET status = 'failed',
+    sanitized_failure_category = 'pre_restore_cleanup',
+    sanitized_failure_message = 'Marked failed after restore and before restart to ensure clean RecoveryGate evaluation.',
+    completed_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE status IN ('running', 'cancel_requested');
+```
+
+If a future schema renames `sanitized_failure_category` to `failure_category`, use the equivalent field name in that environment. The operator intent must remain `pre_restore_cleanup`.
+
+### 4. Post-restore schema verification
+
+For hosted PostgreSQL restores, the restored schema should come from PITR or the `pg_restore` dump. Do not run `migrations/001_initial.sql` through `psql`; the repository SQL migration files are SQLite-oriented, and a full PostgreSQL restore already contains schema and data.
+
+If the restore point predates repository compatibility migrations, use the repository's PostgreSQL-compatible initialization path against the restored database before restarting live traffic. The current code path is `src.data.database.init_db(engine)`, which calls SQLAlchemy `Base.metadata.create_all(engine)` and the PostgreSQL compatibility migration helper for rebuild heartbeat/checkpoint columns. For local SQLite validation only, use `src.data.migrations.apply_migrations()`.
+
+Inspect the expected tables:
 
 ```sql
 SELECT table_name
@@ -292,7 +321,7 @@ WHERE table_schema = 'public'
 ORDER BY table_name;
 ```
 
-### 4. Rollback guidance for failed restore
+### 5. Rollback guidance for failed restore
 
 If restore fails mid-way, do not attempt partial manual recovery inside the failed target database. Drop or abandon the failed target, create a new empty target, and re-run restore from the same backup or provider restore point.
 
@@ -322,19 +351,19 @@ LEFT JOIN assets target_asset ON target_asset.id = ar.target_asset_id
 WHERE source_asset.id IS NULL OR target_asset.id IS NULL;
 ```
 
-Run regulatory event orphan checks:
+Run regulatory event orphan checks. The current schema has both a primary event asset on `regulatory_events.asset_id` and related assets through the `regulatory_event_assets` join table, so verify both relationships:
 
 ```sql
-SELECT COUNT(*) AS orphaned_regulatory_events
+SELECT COUNT(*) AS orphaned_primary_regulatory_events
 FROM regulatory_events re
-LEFT JOIN assets asset ON asset.id = re.asset_id
-WHERE asset.id IS NULL;
+LEFT JOIN assets primary_asset ON primary_asset.id = re.asset_id
+WHERE primary_asset.id IS NULL;
 
 SELECT COUNT(*) AS orphaned_regulatory_event_assets
 FROM regulatory_event_assets rea
 LEFT JOIN regulatory_events re ON re.id = rea.event_id
-LEFT JOIN assets asset ON asset.id = rea.asset_id
-WHERE re.id IS NULL OR asset.id IS NULL;
+LEFT JOIN assets related_asset ON related_asset.id = rea.asset_id
+WHERE re.id IS NULL OR related_asset.id IS NULL;
 ```
 
 Expected results:
@@ -356,7 +385,6 @@ curl -fsS "$BASE_URL/api/health/detailed"
 Expected result:
 
 - `/api/health/detailed` returns a healthy status.
-- The graph lifecycle state reaches `READY`.
 - In staging and production, startup evidence confirms the graph loaded from persisted durable graph truth, not fallback sample/cache generation.
 
 Where the hosted readiness checker is available, run:
@@ -367,19 +395,23 @@ python scripts/check_hosted_readiness.py "$BASE_URL" --require-persistence
 
 ### 3. Functional smoke test
 
-Trigger a graph read path and verify a valid response:
+Trigger an existing graph-read path and verify a valid response. The canonical lightweight read endpoint is the paginated assets endpoint:
 
 ```bash
-curl -fsS "$BASE_URL/api/graph/"
+curl -fsS "$BASE_URL/api/assets?per_page=1"
 ```
 
-If the graph endpoint path differs in the deployed API version, use the canonical graph-read endpoint for that deployment. The smoke test must prove that the API can read restored graph state from the running service.
+Expected result:
+
+- The response is valid JSON.
+- The response includes the paginated assets contract (`items`, `total`, `page`, `per_page`, `has_more`).
+- `total` matches the restored baseline or the approved post-rebuild baseline.
 
 Optional additional checks when an approved sentinel baseline exists:
 
 ```bash
-curl -fsS "$BASE_URL/api/assets"
 curl -fsS "$BASE_URL/api/relationships"
+curl -fsS "$BASE_URL/api/visualization"
 ```
 
 Confirm expected sentinel assets and directed relationship strengths are present.
@@ -391,7 +423,7 @@ The deploying organization must assign named owners for the following roles befo
 | Role | Responsibility | Required access |
 | --- | --- | --- |
 | **Backup Operator** | Verifies provider-managed backup health, confirms retention windows, and executes ad-hoc backups before major changes. | Provider console read access, database read/backup access, secure backup storage access. |
-| **Restore Operator** | Executes restore procedures, runs pre-restore cleanup, performs post-restore verification, and updates database connection strings when approved. | Database admin access, provider console restore access, Vercel environment/deployment access. |
+| **Restore Operator** | Executes restore procedures, runs post-restore/pre-restart cleanup, performs post-restore verification, and updates database connection strings when approved. | Database admin access, provider console restore access, Vercel environment/deployment access. |
 | **Incident Commander** | Owns escalation, coordinates restore decisions, accepts residual risk, and decides whether RTO breach or data loss must be declared. | Incident-management authority and access to the responsible engineering/operator contacts. |
 
 One person may hold multiple roles, but the active role for each incident must be explicit in the incident record.
@@ -405,19 +437,21 @@ Escalate to the Incident Commander if:
 - provider-managed PITR is unavailable when it was assumed available;
 - restored coordination state suggests split-brain or unsafe rebuild ownership.
 
-Contact and paging information is organization-specific and must be filled by the deploying team:
+Contact and paging routing for the DashFin-FarDb deployment:
 
-- Backup Operator contact: `TODO(deploying-team)`
-- Restore Operator contact: `TODO(deploying-team)`
-- Incident Commander contact: `TODO(deploying-team)`
-- Paging/escalation channel: `TODO(deploying-team)`
+- Backup Operator contact: DashFin-FarDb Operations / designated backup owner.
+- Restore Operator contact: DashFin-FarDb Operations / designated database restore owner.
+- Incident Commander contact: DashFin-FarDb Operations / designated production incident lead.
+- Paging/escalation channel: DashFin-FarDb production incident channel and provider emergency-support channel for the active hosted database provider.
+
+Private personal contact details, phone numbers, and provider account identifiers must remain in the deploying organization's private incident-management system, not in this public repository.
 
 ## Completion Criteria
 
 A restore incident or rehearsal is complete only when:
 
 1. the selected database restore point is documented;
-2. stale lock and in-flight rebuild job state have been resolved;
+2. stale lock and in-flight rebuild job state have been resolved on the restored Coordination DB;
 3. schema verification passes;
 4. graph integrity checks pass;
 5. the application has restarted successfully;

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -1,0 +1,427 @@
+# Backup, Restore, and Disaster Recovery Runbook
+
+For strategy, recovery objectives, and data classification, see [ADR 0005: Backup, Restore, and Disaster Recovery Strategy](../adr/0005-backup-restore-dr-strategy.md).
+
+## Preamble
+
+This runbook defines operator procedures for backing up, restoring, and verifying FarDb staging and production databases.
+
+Use this runbook when:
+
+- verifying provider-managed backup/PITR health;
+- taking an ad-hoc backup before a risky migration, deployment, or destructive operation;
+- restoring the Auth/Coordination DB, the Asset Graph DB, or both;
+- recovering from data loss, accidental destructive writes, failed migrations, or database-provider incidents;
+- proving that restore procedures remain executable for enterprise release readiness.
+
+The intended audience is operators with database, hosting, and deployment authority. It is not an end-user support document.
+
+This runbook distinguishes application rollback from data restore. Vercel rollback/promotion restores application code and configuration only; it does not restore database state.
+
+## Prerequisites
+
+Operators must have the following access before starting backup or restore work:
+
+- Database administrator credentials or equivalent connection strings for each affected database.
+- Vercel dashboard access for environment variables, deployment restart/redeployment, and rollback/promotion operations.
+- Provider console access for the hosted PostgreSQL provider, such as Supabase, Neon, or Vercel Postgres.
+- Permission to read and update `DATABASE_URL`, `POSTGRES_URL`, `ASSET_GRAPH_DATABASE_URL`, and any provider-specific database settings.
+- Secure storage for portable dump files when using `pg_dump`.
+- Access to deployment logs and `GET /api/health/detailed` for post-restore verification.
+
+Do not paste database credentials, full connection strings, backup contents, or raw exception traces into public issues, PR comments, or support channels.
+
+## Backup Procedures
+
+### 1. Identify database boundaries
+
+FarDb may use one or two logical PostgreSQL database boundaries:
+
+- Auth/Coordination DB: `DATABASE_URL`, with `POSTGRES_URL` as a provider fallback where configured.
+- Asset Graph DB: `ASSET_GRAPH_DATABASE_URL`.
+
+If `DATABASE_URL` and `ASSET_GRAPH_DATABASE_URL` resolve to different connection strings, back up both. If they point to the same physical database, one full database backup may cover both boundaries, but the operator must record that topology in the incident or release evidence.
+
+### 2. Provider-managed backup verification
+
+Provider-managed PITR is the primary mechanism for hosted PostgreSQL.
+
+For each affected environment:
+
+1. Open the provider console for the database instance.
+2. Confirm backups or PITR are enabled for the database or branch/project.
+3. Confirm the available restore window meets the retention policy in ADR 0005.
+4. Identify the latest available restore point and the earliest available restore point.
+5. Confirm whether restore creates a new database/branch/project or overwrites the existing instance.
+6. Record provider, environment, database boundary, restore window, and timestamp of verification.
+
+Provider-specific expectations:
+
+- **Supabase**: verify point-in-time recovery or scheduled backups in the project database backup settings. Confirm the project tier retention window.
+- **Neon**: verify history/restore capability for the relevant branch and identify the timestamp range available for branch restore.
+- **Vercel Postgres**: verify backup/restore capability in the storage dashboard and confirm the plan-specific retention behavior.
+
+If provider-managed restore is unavailable or does not meet the target window, take a portable backup with `pg_dump`.
+
+### 3. Portable `pg_dump` backup procedure
+
+Resolve the connection strings from the target environment:
+
+```bash
+# Auth/Coordination DB
+export AUTH_DATABASE_URL="$DATABASE_URL"
+
+# Provider fallback if DATABASE_URL is intentionally unset
+export AUTH_DATABASE_URL="${AUTH_DATABASE_URL:-$POSTGRES_URL}"
+
+# Asset Graph DB
+export GRAPH_DATABASE_URL="$ASSET_GRAPH_DATABASE_URL"
+```
+
+Create timestamped dump files:
+
+```bash
+export BACKUP_TS="$(date -u +%Y%m%dT%H%M%SZ)"
+
+pg_dump "$AUTH_DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file="fardb-auth-${BACKUP_TS}.dump"
+
+pg_dump "$GRAPH_DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file="fardb-graph-${BACKUP_TS}.dump"
+```
+
+If both environment variables point to the same database, run a single dump and label it clearly:
+
+```bash
+pg_dump "$DATABASE_URL" \
+  --format=custom \
+  --no-owner \
+  --no-acl \
+  --file="fardb-combined-${BACKUP_TS}.dump"
+```
+
+Store dumps in the approved backup location for the deploying organization. Do not commit dump files to the repository.
+
+### 4. Backup verification
+
+A backup is not considered valid until it has been restored to a scratch database and inspected.
+
+Prepare a scratch database, then restore:
+
+```bash
+createdb fardb_restore_scratch
+
+pg_restore \
+  --dbname="postgresql://USER:PASSWORD@HOST:PORT/fardb_restore_scratch" \
+  --no-owner \
+  --no-acl \
+  --single-transaction \
+  "fardb-graph-${BACKUP_TS}.dump"
+```
+
+Run key table sanity checks:
+
+```sql
+SELECT COUNT(*) AS assets_count FROM assets;
+SELECT COUNT(*) AS relationships_count FROM asset_relationships;
+SELECT COUNT(*) AS regulatory_events_count FROM regulatory_events;
+SELECT COUNT(*) AS rebuild_jobs_count FROM rebuild_jobs;
+SELECT COUNT(*) AS distributed_locks_count FROM distributed_locks;
+```
+
+For the Auth/Coordination DB, run equivalent checks for application/auth tables present in that boundary. If user credentials are stored, verify the credentials table exists and has expected row counts without exposing hashes or secrets.
+
+### 5. Backup schedule recommendation
+
+ADR 0005 defines the retention policy:
+
+- daily full backups with 7-day rolling retention;
+- weekly snapshots retained for 30 days.
+
+Operators should align provider PITR retention and portable `pg_dump` snapshots to that policy. Take an ad-hoc `pg_dump` before major migrations, destructive maintenance, or production restore rehearsal.
+
+## Pre-Restore Quiescence Procedure
+
+The goal of quiescence is to prevent new writes or rebuild synchronization while restore is being prepared.
+
+### 1. Stop application graph mutation
+
+Call `begin_shutdown()` from the application lifecycle boundary to transition the graph lifecycle state to `SHUTTING_DOWN` and then `STOPPED`. This prevents `synchronize_runtime_graph()` from accepting new runtime graph data while the restore is in progress.
+
+For hosted deployments, this is usually performed by stopping traffic, disabling the affected deployment, or entering the administrative shutdown path that invokes `begin_shutdown()` before database restore. Where direct invocation is not available in the hosted environment, use deployment controls to prevent requests from reaching the backend during restore.
+
+### 2. Verify no active rebuild is in progress
+
+Use `/api/health/detailed` if the application is still reachable and safe to query. If the application is offline, query the database directly:
+
+```sql
+SELECT job_id, status, active_worker_id, last_heartbeat_at, updated_at
+FROM rebuild_jobs
+WHERE status IN ('running', 'cancel_requested')
+ORDER BY updated_at DESC;
+```
+
+If any active rebuild exists, prefer to wait for it to complete or fail before restore unless the restore is required because the rebuild itself corrupted state.
+
+### 3. Handle distributed locks
+
+Inspect the rebuild lock:
+
+```sql
+SELECT lock_name, holder_id, expires_at, updated_at
+FROM distributed_locks
+WHERE lock_name = 'graph_rebuild';
+```
+
+If a `distributed_locks` row exists with a future `expires_at`, either:
+
+1. wait for TTL expiry; the operational maximum assumption is 300 seconds unless `REBUILD_LOCK_TTL_SECONDS` has been configured differently; or
+2. manually delete the row after confirming no live rebuild writer from the restored environment is active.
+
+Manual deletion:
+
+```sql
+DELETE FROM distributed_locks
+WHERE lock_name = 'graph_rebuild';
+```
+
+A restored lock row with a mismatched `holder_id` can block new lock acquisition until it expires or is cleared.
+
+### 4. Clean up in-flight rebuild jobs
+
+Before restarting the application after restore, prevent RecoveryGate from detecting false orphaned jobs caused by restored historical state.
+
+For schemas using the current `sanitized_failure_category` and `sanitized_failure_message` columns:
+
+```sql
+UPDATE rebuild_jobs
+SET status = 'failed',
+    sanitized_failure_category = 'pre_restore_cleanup',
+    sanitized_failure_message = 'Marked failed during pre-restore cleanup to ensure clean restart.',
+    completed_at = CURRENT_TIMESTAMP,
+    updated_at = CURRENT_TIMESTAMP
+WHERE status IN ('running', 'cancel_requested');
+```
+
+If a future schema renames `sanitized_failure_category` to `failure_category`, use the equivalent field name in that environment. The operator intent must remain `pre_restore_cleanup`.
+
+## Restore Execution Procedure
+
+### 1. Provider-managed PITR restore
+
+Use provider-managed PITR when available.
+
+General procedure:
+
+1. Identify the target restore timestamp in UTC.
+2. Confirm the timestamp is inside the provider restore window.
+3. Prefer restore-to-new database, branch, or project when the provider supports it.
+4. Initiate restore in the provider console.
+5. Record the original database identifier, restored database identifier, restore timestamp, operator, and provider job status.
+6. Update the target environment connection string only after scratch verification passes.
+
+Provider notes:
+
+- **Supabase**: initiate restore from the project backup/PITR surface. Prefer restore to a new project or safe restore target where available, then verify before switching application configuration.
+- **Neon**: restore by creating a new branch at the chosen timestamp or using the provider's restore flow. Verify the branch before promoting it.
+- **Vercel Postgres**: use the storage dashboard restore flow available for the attached database. Confirm whether restore is in-place or creates a separate restored instance before proceeding.
+
+### 2. Portable `pg_restore` procedure
+
+Prepare the target database. Prefer an empty database for restore:
+
+```bash
+createdb fardb_restore_target
+```
+
+Alternatively, use `--clean` only when the operator has confirmed the target database can be overwritten:
+
+```bash
+pg_restore \
+  --dbname="$TARGET_DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --single-transaction \
+  --clean \
+  "fardb-graph-${BACKUP_TS}.dump"
+```
+
+For an empty target database:
+
+```bash
+pg_restore \
+  --dbname="$TARGET_DATABASE_URL" \
+  --no-owner \
+  --no-acl \
+  --single-transaction \
+  "fardb-graph-${BACKUP_TS}.dump"
+```
+
+If Auth/Coordination DB and Asset Graph DB are separate, restore each dump to its corresponding target database. Do not restore the graph dump over the auth database or the auth dump over the graph database.
+
+### 3. Post-restore schema verification
+
+Run the base schema migration idempotently where applicable:
+
+```bash
+psql "$TARGET_DATABASE_URL" -f migrations/001_initial.sql
+```
+
+For local SQLite restore validation, run the repository migration helper or the migration scripts according to the current local development procedure. For PostgreSQL-hosted environments, confirm the ORM-created schema and provider migration compatibility before switching live traffic.
+
+Then inspect the expected tables:
+
+```sql
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN (
+    'assets',
+    'asset_relationships',
+    'regulatory_events',
+    'regulatory_event_assets',
+    'rebuild_jobs',
+    'distributed_locks'
+  )
+ORDER BY table_name;
+```
+
+### 4. Rollback guidance for failed restore
+
+If restore fails mid-way, do not attempt partial manual recovery inside the failed target database. Drop or abandon the failed target, create a new empty target, and re-run restore from the same backup or provider restore point.
+
+If two restore attempts fail, escalate to the Incident Commander.
+
+## Post-Restore Verification Procedure
+
+### 1. Data integrity checks
+
+Run row-count checks:
+
+```sql
+SELECT COUNT(*) AS assets_count FROM assets;
+SELECT COUNT(*) AS relationships_count FROM asset_relationships;
+SELECT COUNT(*) AS regulatory_events_count FROM regulatory_events;
+SELECT COUNT(*) AS regulatory_event_assets_count FROM regulatory_event_assets;
+SELECT COUNT(*) AS running_rebuild_jobs_count FROM rebuild_jobs WHERE status = 'running';
+```
+
+Run foreign-key/orphan checks for graph relationships:
+
+```sql
+SELECT COUNT(*) AS orphaned_relationships
+FROM asset_relationships ar
+LEFT JOIN assets source_asset ON source_asset.id = ar.source_asset_id
+LEFT JOIN assets target_asset ON target_asset.id = ar.target_asset_id
+WHERE source_asset.id IS NULL OR target_asset.id IS NULL;
+```
+
+Run regulatory event orphan checks:
+
+```sql
+SELECT COUNT(*) AS orphaned_regulatory_events
+FROM regulatory_events re
+LEFT JOIN assets asset ON asset.id = re.asset_id
+WHERE asset.id IS NULL;
+
+SELECT COUNT(*) AS orphaned_regulatory_event_assets
+FROM regulatory_event_assets rea
+LEFT JOIN regulatory_events re ON re.id = rea.event_id
+LEFT JOIN assets asset ON asset.id = rea.asset_id
+WHERE re.id IS NULL OR asset.id IS NULL;
+```
+
+Expected results:
+
+- `running_rebuild_jobs_count` is `0`.
+- orphan counts are `0`.
+- `assets_count` and `relationships_count` match the selected backup/scratch restore baseline or the approved restored source-data baseline.
+
+### 2. Application restart and health verification
+
+Restart the backend process or trigger a new Vercel deployment after updating database connection strings.
+
+Verify health:
+
+```bash
+curl -fsS "$BASE_URL/api/health/detailed"
+```
+
+Expected result:
+
+- `/api/health/detailed` returns a healthy status.
+- The graph lifecycle state reaches `READY`.
+- In staging and production, startup evidence confirms the graph loaded from persisted durable graph truth, not fallback sample/cache generation.
+
+Where the hosted readiness checker is available, run:
+
+```bash
+python scripts/check_hosted_readiness.py "$BASE_URL" --require-persistence
+```
+
+### 3. Functional smoke test
+
+Trigger a graph read path and verify a valid response:
+
+```bash
+curl -fsS "$BASE_URL/api/graph/"
+```
+
+If the graph endpoint path differs in the deployed API version, use the canonical graph-read endpoint for that deployment. The smoke test must prove that the API can read restored graph state from the running service.
+
+Optional additional checks when an approved sentinel baseline exists:
+
+```bash
+curl -fsS "$BASE_URL/api/assets"
+curl -fsS "$BASE_URL/api/relationships"
+```
+
+Confirm expected sentinel assets and directed relationship strengths are present.
+
+## Operator Ownership
+
+The deploying organization must assign named owners for the following roles before treating staging or production as enterprise-ready.
+
+| Role | Responsibility | Required access |
+| --- | --- | --- |
+| **Backup Operator** | Verifies provider-managed backup health, confirms retention windows, and executes ad-hoc backups before major changes. | Provider console read access, database read/backup access, secure backup storage access. |
+| **Restore Operator** | Executes restore procedures, runs pre-restore cleanup, performs post-restore verification, and updates database connection strings when approved. | Database admin access, provider console restore access, Vercel environment/deployment access. |
+| **Incident Commander** | Owns escalation, coordinates restore decisions, accepts residual risk, and decides whether RTO breach or data loss must be declared. | Incident-management authority and access to the responsible engineering/operator contacts. |
+
+One person may hold multiple roles, but the active role for each incident must be explicit in the incident record.
+
+Escalate to the Incident Commander if:
+
+- restore fails after two attempts;
+- data integrity checks fail after restore;
+- the 2-hour RTO threshold is at risk of being exceeded;
+- the selected restore point implies data loss beyond the documented RPO;
+- provider-managed PITR is unavailable when it was assumed available;
+- restored coordination state suggests split-brain or unsafe rebuild ownership.
+
+Contact and paging information is organization-specific and must be filled by the deploying team:
+
+- Backup Operator contact: `TODO(deploying-team)`
+- Restore Operator contact: `TODO(deploying-team)`
+- Incident Commander contact: `TODO(deploying-team)`
+- Paging/escalation channel: `TODO(deploying-team)`
+
+## Completion Criteria
+
+A restore incident or rehearsal is complete only when:
+
+1. the selected database restore point is documented;
+2. stale lock and in-flight rebuild job state have been resolved;
+3. schema verification passes;
+4. graph integrity checks pass;
+5. the application has restarted successfully;
+6. `/api/health/detailed` is healthy;
+7. lifecycle state reaches `READY`;
+8. graph functional smoke testing passes;
+9. the Incident Commander or designated promotion approver accepts closure.


### PR DESCRIPTION
## Summary

Implements PR 9 / issue #1279 documentation scope for backup, restore, and disaster recovery.

Adds:

- `docs/adr/0005-backup-restore-dr-strategy.md`
  - DR strategy, dual-database architecture, RPO/RTO, backup mechanisms, retention, data classification, and non-goals.
- `docs/runbooks/backup-restore-dr.md`
  - operator runbook covering backup verification, `pg_dump`, pre-restore quiescence, lock/job cleanup, restore execution, post-restore verification, ownership, and escalation.

Updates:

- `docs/enterprise-deployment-operating-model.md`
  - DR section, restore ownership, Backup Operator / Restore Operator / Incident Commander roles, and rollback-vs-restore boundary.
- `docs/release-checklist.md`
  - Gate 9 marks documented procedure, RPO/RTO, and rollback/data-restore distinction as satisfied, leaving restore rehearsal as manual verification.
- `docs/enterprise-readiness-index.md`
  - removes DR from remaining work and links ADR 0005 + runbook.
- `docs/adr/0002-hosted-deployment-and-persistence.md`
  - notes backup/restore is now documented in ADR 0005 and the runbook.
- `docs/adr/0003-distributed-lock-refresh-and-heartbeat-strategy.md`
  - links restore scenarios to the full DR runbook.
- `docs/adr/0004-distributed-hosting-semantics.md`
  - replaces the stale "belongs to PR 9" note with ADR 0005/runbook references.

## Validation

- Documentation-only change.
- Compared branch against `main`: 8 files changed, no code changes.
- Restore rehearsal remains a manual operator gate per the release checklist.

Closes #1279
