### PR TITLE
docs: add release candidate evidence capture

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -2,7 +2,7 @@
 name: Release candidate evidence capture
 about: Capture hosted and operator evidence for one enterprise release candidate
 title: "[RC EVIDENCE] "
-labels: "release, evidence, enterprise-readiness"
+labels: ["release", "evidence", "enterprise-readiness"]
 assignees: ""
 ---
 

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -1,0 +1,107 @@
+---
+name: Release candidate evidence capture
+about: Capture hosted and operator evidence for one enterprise release candidate
+title: "[RC EVIDENCE] "
+labels: "release, evidence, enterprise-readiness"
+assignees: ""
+---
+
+## Release Candidate
+
+**Release candidate identifier:**
+**Release commit SHA:**
+**Target environment:** <!-- staging / production -->
+**Evidence owner:**
+**Evidence capture date:**
+
+## Scope
+
+This issue captures target-environment release evidence for one release candidate. It does not request code,
+configuration, schema, workflow, or documentation changes.
+
+Reference:
+
+- [Release Evidence Pack](../../docs/release-evidence-pack.md)
+- [Enterprise Release Checklist](../../docs/release-checklist.md)
+- [Enterprise Deployment Operating Model](../../docs/enterprise-deployment-operating-model.md)
+
+## Automated Release Commit Evidence
+
+- [ ] Release commit identified and linked above.
+- [ ] Full CI completed for the release commit.
+- [ ] CI run URL attached:
+- [ ] Failed or skipped jobs are explained with owner and follow-up:
+
+## Hosted Promotion Evidence
+
+- [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
+- [ ] Hosted readiness was run with durable persistence required:
+
+  ```bash
+  python scripts/check_hosted_readiness.py <base_url> --require-persistence
+  ```
+
+- [ ] Hosted readiness output attached with secrets redacted.
+- [ ] Redacted `/api/health/detailed` output attached.
+- [ ] Redacted `/api/assets?per_page=1` output attached.
+- [ ] Persisted startup source is confirmed.
+- [ ] Persisted graph counts or approved sentinel baseline are confirmed.
+
+## Security Scanner and Exception Evidence
+
+- [ ] Security scanner summaries are attached for the release commit.
+- [ ] Critical/high findings are resolved or explicitly approved for release.
+- [ ] Non-blocking scanner failures are recorded with reason, owner, and follow-up issue.
+- [ ] Any CI/security gate exception includes affected gate, risk assessment, expiry or follow-up, and maintainer approval.
+
+## Operator Sign-Off
+
+Record named owners for this release candidate:
+
+| Role | Named owner | Sign-off status | Notes |
+| --- | --- | --- | --- |
+| Deploy operator |  | Pending |  |
+| Promotion approver |  | Pending |  |
+| Rollback owner |  | Pending |  |
+| Restore operator |  | Pending |  |
+| Persistence verification owner |  | Pending |  |
+
+## Disaster Recovery Rehearsal Evidence
+
+- [ ] Restore rehearsal log attached.
+- [ ] Selected restore point recorded.
+- [ ] Effective database-boundary topology recorded: Auth DB, Coordination DB, Asset Graph DB.
+- [ ] Scratch restore verification results attached.
+- [ ] Post-restore hosted readiness smoke evidence attached.
+
+## Gate Status Summary
+
+Use the status values from the release evidence pack.
+
+| Gate | Status | Evidence link or note | Release blocker? |
+| --- | --- | --- | --- |
+| Architecture |  |  |  |
+| Durable Persistence |  |  |  |
+| Restart / Reload |  |  |  |
+| Promotion |  |  |  |
+| API Contract |  |  |  |
+| Recovery / Rebuild |  |  |  |
+| Security |  |  |  |
+| Governance |  |  |  |
+| Disaster Recovery |  |  |  |
+
+## Final Decision
+
+- [ ] All release-blocking evidence is attached or explicitly approved.
+- [ ] No unapproved critical/high security findings remain.
+- [ ] Hosted persistence evidence is complete.
+- [ ] Named operator sign-off is complete.
+- [ ] DR restore rehearsal evidence is complete.
+
+**Release candidate decision:** <!-- Approved / Blocked -->
+**Decision owner:**
+**Decision date:**
+
+## Notes
+
+<!-- Do not paste secrets, raw connection strings, bearer tokens, private keys, full graph dumps, or raw exception traces. -->

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -21,9 +21,9 @@ configuration, schema, workflow, or documentation changes.
 
 Reference:
 
-- [Release Evidence Pack](../../docs/release-evidence-pack.md)
-- [Enterprise Release Checklist](../../docs/release-checklist.md)
-- [Enterprise Deployment Operating Model](../../docs/enterprise-deployment-operating-model.md)
+- [Release Evidence Pack](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-evidence-pack.md)
+- [Enterprise Release Checklist](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-checklist.md)
+- [Enterprise Deployment Operating Model](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/enterprise-deployment-operating-model.md)
 
 ## Automated Release Commit Evidence
 

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -273,6 +273,10 @@ Blocking rule:
 
 ## Release Evidence Attachment Checklist
 
+Open one release-candidate evidence issue per release candidate using the
+[Release candidate evidence capture template](../.github/ISSUE_TEMPLATE/release_candidate_evidence.md). The issue is
+the operational record for hosted evidence, scanner review, operator sign-off, and DR rehearsal proof.
+
 Before enterprise release sign-off, attach or link:
 
 - CI run for the release commit.


### PR DESCRIPTION
## Primary Objective

Add a reusable release-candidate evidence capture issue template so operators can record the hosted and manual evidence required by Objective 2 / issue #1304.

Closes #1304.

## Description

This PR adds a GitHub issue template for one release candidate evidence record. The template captures:

- release commit identity;
- full CI evidence;
- hosted readiness with `--require-persistence`;
- redacted `/api/health/detailed` evidence;
- redacted `/api/assets?per_page=1` evidence;
- confirmation that `ASSET_GRAPH_DATABASE_URL` targets the durable graph database;
- security scanner summaries and approved exceptions;
- named deploy, promotion, rollback, restore, and persistence-verification owners;
- DR rehearsal evidence;
- per-gate status and final release-candidate decision.

The release evidence pack now links to the template and instructs operators to open one evidence issue per release candidate.

## In Scope

- Add `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`.
- Link the template from `docs/release-evidence-pack.md`.
- Keep the change documentation/process-only.

## Out of Scope

- No runtime code changes.
- No test changes.
- No CI workflow changes.
- No release automation changes.
- No hosted evidence is captured in this PR.
- No release candidate is approved by this PR.

## Files Expected to Change

- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` - new operational issue template for RC evidence capture.
- `docs/release-evidence-pack.md` - points operators to the evidence issue template.

## Type of Change

- [ ] Architecture decision (ADR)
- [x] Documentation update
- [x] Policy document addition/update
- [ ] Template modification
- [ ] Repository configuration

## Rationale

The release evidence pack states that enterprise readiness cannot be proven by repository tests alone. A release candidate still needs hosted persistence proof, scanner/exception review, named operator sign-off, and DR rehearsal evidence. This PR provides the dedicated issue format for capturing that operational evidence without introducing code or automation changes.

## Impact Assessment

### Positive Impacts

- Creates a consistent evidence record for each release candidate.
- Makes manual release blockers explicit and auditable.
- Reduces the risk that hosted persistence proof, scanner review, owner sign-off, or DR rehearsal evidence is omitted.

### Potential Concerns

- The template captures evidence but does not enforce that evidence automatically.
- Operators still need to run hosted checks and attach redacted outputs manually.

### Mitigation Strategy

The template mirrors the release evidence pack’s blocker model and final decision checklist. It explicitly states that the issue does not request implementation changes and that secrets or raw connection strings must not be pasted into evidence.

## Validation Commands

```bash
pre-commit run --files .github/ISSUE_TEMPLATE/release_candidate_evidence.md docs/release-evidence-pack.md
```

Additional link check:

```bash
python - <<'PY'
from pathlib import Path
link = Path('docs') / '../.github/ISSUE_TEMPLATE/release_candidate_evidence.md'
print('ok' if link.exists() else 'missing', link)
PY
```

## Merge Criteria

- [ ] RC evidence capture template exists.
- [ ] Template covers release commit, CI, hosted readiness, health/assets evidence, durable graph DB config, scanner summaries, owners, DR rehearsal, and gate status.
- [ ] Release evidence pack links to the template.
- [ ] No runtime code changes are included.

## Related Documents

- `docs/release-evidence-pack.md`
- `docs/release-checklist.md`
- `docs/enterprise-deployment-operating-model.md`

## Checklist

### Documentation Quality

- [x] Documentation is clear, complete, and accurate
- [x] All cross-references are valid and up-to-date
- [x] New documents follow the project's documentation standards
- [x] No spelling or grammatical errors
- [x] Markdown formatting is correct

### Architectural Alignment

- [x] This PR respects the production architecture (FastAPI + Next.js)
- [x] Changes do not contradict existing ADRs
- [x] If adding an ADR, it follows the ADR template format
- [x] Policy changes are documented with rationale

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] I have not mixed architectural changes with code changes
- [x] No runtime behavior changes are included
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity

### Completeness

- [x] All related documentation has been updated consistently
- [x] No documentation is left in an inconsistent state
- [x] Templates and examples reflect the documented architecture
- [ ] README.md reflects any high-level changes

## Additional Notes

README.md was not changed because this is an operator evidence-capture template linked from the release evidence pack, not a general setup or usage change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable GitHub issue template to capture release-candidate evidence and links it from the release evidence pack. Fixes template links and meets Objective 2 in #1304 by standardizing hosted and manual evidence for each RC.

- **New Features**
  - Added `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` to record CI, durable DB config, hosted readiness with `--require-persistence`, redacted health/assets, persistence proof, scanner summaries and approved exceptions, named owners, DR rehearsal, per-gate status, and the final decision.
  - Updated `docs/release-evidence-pack.md` to open one evidence issue per RC and use it as the operational record; corrected template links to related docs.

<sup>Written for commit 865e3124088f727f8adec546564d64cb8f533349. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1305?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

