### PR TITLE
docs: add staging deployment operating baseline

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -34,7 +34,15 @@ Reference:
 
 ## Hosted Promotion Evidence
 
+- [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
+- [ ] Staging Vercel backend/API project/deployment mapping is recorded, if this is staging evidence.
+- [ ] Staging database provider name is recorded.
+- [ ] Staging app/auth database boundary label is recorded.
+- [ ] Staging asset graph database boundary label is recorded.
+- [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.
+- [ ] Preview evidence is labelled `durable` or `non-durable`, if preview evidence is attached.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
+- [ ] `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or an approved exception is attached.
 - [ ] Hosted readiness was run with durable persistence required:
 
   ```bash

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -36,7 +36,7 @@ Reference:
 
 - [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
 - [ ] Staging Vercel backend/API project/deployment mapping is recorded, if this is staging evidence.
-- [ ] Staging database provider name is recorded.
+- [ ] Staging database provider is recorded as Supabase.
 - [ ] Staging app/auth database boundary label is recorded.
 - [ ] Staging asset graph database boundary label is recorded.
 - [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -41,6 +41,7 @@ Reference:
 - [ ] Staging app/auth database boundary label is recorded.
 - [ ] Staging asset graph database boundary label is recorded.
 - [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.
+- [ ] `COORDINATION_DATABASE_URL` is configured when coordination is separated, or shared-boundary fallback is documented.
 - [ ] Preview evidence is labelled `durable` or `non-durable`, if preview evidence is attached.
 - [ ] `DATABASE_URL` is configured for the target durable app/auth database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -35,7 +35,6 @@ Reference:
 ## Hosted Promotion Evidence
 
 - [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
-- [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
 - [ ] Staging Vercel backend/API project/deployment mapping is recorded, if this is staging evidence.
 - [ ] Staging database provider name is recorded.
 - [ ] Staging app/auth database boundary label is recorded.

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -45,7 +45,6 @@ Reference:
 - [ ] `DATABASE_URL` is configured for the target durable app/auth database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or an approved exception is attached.
-- [ ] `COORDINATION_DATABASE_URL` is configured if coordination is separated, or fallback is documented.
 - [ ] Hosted readiness was run with durable persistence required:
 
   ```bash

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -41,8 +41,10 @@ Reference:
 - [ ] Staging asset graph database boundary label is recorded.
 - [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.
 - [ ] Preview evidence is labelled `durable` or `non-durable`, if preview evidence is attached.
+- [ ] `DATABASE_URL` is configured for the target database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or an approved exception is attached.
+- [ ] `COORDINATION_DATABASE_URL` is configured if coordination is separated, or fallback is documented.
 - [ ] Hosted readiness was run with durable persistence required:
 
   ```bash

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -35,13 +35,14 @@ Reference:
 ## Hosted Promotion Evidence
 
 - [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
+- [ ] Staging Vercel frontend project/deployment mapping is recorded, if this is staging evidence.
 - [ ] Staging Vercel backend/API project/deployment mapping is recorded, if this is staging evidence.
-- [ ] Staging database provider is recorded as Supabase.
+- [ ] Staging database provider name is recorded.
 - [ ] Staging app/auth database boundary label is recorded.
 - [ ] Staging asset graph database boundary label is recorded.
 - [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.
 - [ ] Preview evidence is labelled `durable` or `non-durable`, if preview evidence is attached.
-- [ ] `DATABASE_URL` is configured for the target database.
+- [ ] `DATABASE_URL` is configured for the target durable app/auth database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or an approved exception is attached.
 - [ ] `COORDINATION_DATABASE_URL` is configured if coordination is separated, or fallback is documented.

--- a/docs/enterprise-deployment-operating-model.md
+++ b/docs/enterprise-deployment-operating-model.md
@@ -7,6 +7,9 @@ promoted, verified, rolled back, and operated across environments. It distinguis
 between basic service readiness and the stronger durable graph-persistence verification
 required for staging and production promotion.
 
+For staging-specific provider boundaries, Vercel environment mapping, preview durability labelling, and promotion
+evidence capture, see the [Staging Deployment Operating Baseline](staging-deployment-operating-baseline.md).
+
 For current rebuild/recovery/persistence state-machine semantics, ownership rules, and exception paths, see the canonical [State Machine and Operating Authority](governance/state-machine-and-operating-authority.md).
 
 ## Operating Topology
@@ -27,7 +30,7 @@ The current selected initial topology is:
 
 - **Local**: Developer-owned runtime for development and testing. SQLite is allowed.
 - **Preview**: May be durable or non-durable. If non-durable, the deployment must be labeled accordingly and must not be treated as proof of production persistence behavior.
-- **Staging**: Durable pre-production verification environment. Must use the same persistence boundary class expected for production.
+- **Staging**: Durable pre-production verification environment. Must use the same persistence boundary class expected for production. The staging provider, Vercel project/deployment mapping, database boundaries, variable-presence checks, preview durability label, and promotion evidence are governed by the [Staging Deployment Operating Baseline](staging-deployment-operating-baseline.md).
 - **Production**: Durable authoritative environment.
 
 ### Rollback and Restore Ownership

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -49,6 +49,7 @@ gates, see the [Release Evidence Pack](release-evidence-pack.md).
 - Hosted readiness proves more than bounded health; it must prove durable graph evidence for staging and production.
 - Promotion requires an explicit durable graph-persistence smoke procedure.
 - A basic health check alone is not accepted as production proof.
+- Staging promotion follows the [Staging Deployment Operating Baseline](staging-deployment-operating-baseline.md).
 
 ### 5. API Contract Gate
 

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -136,6 +136,8 @@ Manual release attachment:
 
 - Staging/prod smoke output with secrets redacted.
 - Expected persisted graph counts or approved sentinel baseline evidence.
+- For staging, attach the provider, boundary, Vercel mapping, and preview durability evidence required by the
+  [Staging Deployment Operating Baseline](staging-deployment-operating-baseline.md).
 
 Blocking rule:
 

--- a/docs/staging-deployment-operating-baseline.md
+++ b/docs/staging-deployment-operating-baseline.md
@@ -123,19 +123,20 @@ link the following evidence:
 - [ ] Hosted readiness with durable persistence required:
 
   ```bash
-  python scripts/check_hosted_readiness.py <staging_base_url> --require-persistence
+  STAGING_BASE_URL="https://staging.example.com"
+  python scripts/check_hosted_readiness.py "$STAGING_BASE_URL" --require-persistence
   ```
 
 - [ ] Redacted bounded health output:
 
   ```bash
-  curl -fsS "<staging_base_url>/api/health/detailed"
+  curl -fsS "$STAGING_BASE_URL/api/health/detailed"
   ```
 
 - [ ] Redacted bounded asset smoke output or approved sentinel evidence:
 
   ```bash
-  curl -fsS "<staging_base_url>/api/assets?per_page=1"
+  curl -fsS "$STAGING_BASE_URL/api/assets?per_page=1"
   ```
 
 - [ ] Evidence confirms `graph.persistence_loaded == true`.

--- a/docs/staging-deployment-operating-baseline.md
+++ b/docs/staging-deployment-operating-baseline.md
@@ -19,9 +19,9 @@ Staging uses the existing hosted topology:
 
 - Vercel-hosted Next.js frontend.
 - Vercel serverless FastAPI backend using `api.main:app`.
-- PostgreSQL-compatible app/auth database exposed through `DATABASE_URL`.
-- PostgreSQL-compatible durable graph database exposed through `ASSET_GRAPH_DATABASE_URL`.
-- Optional PostgreSQL-compatible coordination database exposed through `COORDINATION_DATABASE_URL` when separated.
+- Supabase PostgreSQL app/auth database exposed through `DATABASE_URL`.
+- Supabase PostgreSQL durable graph database exposed through `ASSET_GRAPH_DATABASE_URL`.
+- Optional Supabase PostgreSQL coordination database exposed through `COORDINATION_DATABASE_URL` when separated.
 - Vercel environment variables for secret and configuration injection.
 
 No new hosting architecture, queue, scheduler, database abstraction, or persistence rewrite is introduced by this
@@ -29,12 +29,13 @@ baseline.
 
 ## Current Provider Record
 
-The repository does not commit the concrete staging database vendor, database instance names, Vercel project IDs, or
-environment-variable values. Those values are operator-controlled and must be captured as redacted release evidence.
+The staging database provider is **Supabase**. The repository does not commit concrete Supabase project IDs, database
+instance names, Vercel project IDs, or environment-variable values. Those values are operator-controlled and must be
+captured as redacted release evidence.
 
 Before staging promotion, the release-candidate evidence issue must record:
 
-- staging database provider name;
+- staging database provider name: Supabase;
 - app/auth database boundary label;
 - asset graph database boundary label;
 - coordination database boundary label, or explicit statement that coordination shares the app/auth boundary;
@@ -67,13 +68,13 @@ durable, use PostgreSQL-compatible durable boundaries, and are approved as promo
 
 ## Staging Database Boundaries
 
-Staging must use durable PostgreSQL-compatible boundaries. SQLite is not accepted as staging durable persistence.
+Staging must use Supabase PostgreSQL durable boundaries. SQLite is not accepted as staging durable persistence.
 
 | Boundary | Environment variable | Required staging behavior | Evidence required |
 | --- | --- | --- | --- |
-| App/auth database | `DATABASE_URL` | Exists and points to a PostgreSQL-compatible durable app/auth database. | Redacted provider/project label and variable-presence confirmation. |
-| Asset graph database | `ASSET_GRAPH_DATABASE_URL` | Exists and points to the authoritative durable graph database. Must be distinct from `DATABASE_URL` unless an exception is approved. | Redacted provider/project label, distinctness confirmation, and hosted persistence smoke evidence. |
-| Coordination database | `COORDINATION_DATABASE_URL` | Exists when rebuild lock/job coordination is separated. If absent, coordination fallback boundary is documented. | Redacted provider/project label or explicit shared-boundary statement. |
+| App/auth database | `DATABASE_URL` | Exists and points to a Supabase PostgreSQL durable app/auth database. | Redacted Supabase project/database label and variable-presence confirmation. |
+| Asset graph database | `ASSET_GRAPH_DATABASE_URL` | Exists and points to the authoritative Supabase PostgreSQL durable graph database. Must be distinct from `DATABASE_URL` unless an exception is approved. | Redacted Supabase project/database label, distinctness confirmation, and hosted persistence smoke evidence. |
+| Coordination database | `COORDINATION_DATABASE_URL` | Exists when rebuild lock/job coordination is separated. If absent, coordination fallback boundary is documented. | Redacted Supabase project/database label or explicit shared-boundary statement. |
 
 Shared boundaries are allowed only when intentional and documented. If coordination shares the app/auth database, the
 release evidence must say so explicitly.
@@ -111,7 +112,8 @@ link the following evidence:
 
 - [ ] Release commit SHA and full CI run.
 - [ ] Staging Vercel project/deployment mapping for frontend and backend/API traffic.
-- [ ] Staging database provider name and redacted app/auth, graph, and coordination boundary labels.
+- [ ] Staging database provider recorded as Supabase.
+- [ ] Redacted Supabase app/auth, graph, and coordination boundary labels.
 - [ ] Confirmation that `DATABASE_URL` exists in staging.
 - [ ] Confirmation that `ASSET_GRAPH_DATABASE_URL` exists in staging.
 - [ ] Confirmation that `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or approved exception details.

--- a/docs/staging-deployment-operating-baseline.md
+++ b/docs/staging-deployment-operating-baseline.md
@@ -1,0 +1,171 @@
+# Staging Deployment Operating Baseline
+
+**Status:** Active
+**Issue:** #1306
+**Scope:** Staging operating baseline for the FastAPI + Next.js production architecture.
+
+## Purpose
+
+This baseline makes staging deployment operations auditable without introducing new hosting architecture. It records the
+required provider boundaries, Vercel environment mapping, environment-variable expectations, preview durability labels,
+and staging promotion evidence path.
+
+This document does not contain secret values, raw connection strings, access tokens, provider credentials, or full
+deployment logs.
+
+## Baseline Decision
+
+Staging uses the existing hosted topology:
+
+- Vercel-hosted Next.js frontend.
+- Vercel serverless FastAPI backend using `api.main:app`.
+- PostgreSQL-compatible app/auth database exposed through `DATABASE_URL`.
+- PostgreSQL-compatible durable graph database exposed through `ASSET_GRAPH_DATABASE_URL`.
+- Optional PostgreSQL-compatible coordination database exposed through `COORDINATION_DATABASE_URL` when separated.
+- Vercel environment variables for secret and configuration injection.
+
+No new hosting architecture, queue, scheduler, database abstraction, or persistence rewrite is introduced by this
+baseline.
+
+## Current Provider Record
+
+The repository does not commit the concrete staging database vendor, database instance names, Vercel project IDs, or
+environment-variable values. Those values are operator-controlled and must be captured as redacted release evidence.
+
+Before staging promotion, the release-candidate evidence issue must record:
+
+- staging database provider name;
+- app/auth database boundary label;
+- asset graph database boundary label;
+- coordination database boundary label, or explicit statement that coordination shares the app/auth boundary;
+- confirmation that `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, unless an approved exception is
+  recorded;
+- Vercel project name or deployment URL used for staging frontend traffic;
+- Vercel project name or deployment URL used for staging backend/API traffic.
+
+If any of these records are missing, staging promotion is blocked.
+
+## Vercel Environment Mapping
+
+The selected deployment platform is Vercel. The repository is configured for a monorepo deployment in
+[`vercel.json`](../vercel.json):
+
+- requests under `/api/*` route to `api/main.py`;
+- all other requests route to the Next.js frontend under `frontend/`;
+- `app.py` is excluded from the Vercel build and remains non-production.
+
+Operators must record the following mapping for each release candidate:
+
+| Environment | Required mapping | Evidence location |
+| --- | --- | --- |
+| Preview | Preview deployment URL and durability label: `durable` or `non-durable`. | Release-candidate evidence issue. |
+| Staging | Vercel project name or deployment URL used for staging frontend and backend/API traffic. | Release-candidate evidence issue. |
+| Production | Production project/domain if already known; otherwise explicitly deferred. | Release-candidate evidence issue or production cutover record. |
+
+Preview deployments must not be treated as staging or production durable proof unless they are explicitly labelled
+durable, use PostgreSQL-compatible durable boundaries, and are approved as promotion evidence.
+
+## Staging Database Boundaries
+
+Staging must use durable PostgreSQL-compatible boundaries. SQLite is not accepted as staging durable persistence.
+
+| Boundary | Environment variable | Required staging behavior | Evidence required |
+| --- | --- | --- | --- |
+| App/auth database | `DATABASE_URL` | Exists and points to a PostgreSQL-compatible durable app/auth database. | Redacted provider/project label and variable-presence confirmation. |
+| Asset graph database | `ASSET_GRAPH_DATABASE_URL` | Exists and points to the authoritative durable graph database. Must be distinct from `DATABASE_URL` unless an exception is approved. | Redacted provider/project label, distinctness confirmation, and hosted persistence smoke evidence. |
+| Coordination database | `COORDINATION_DATABASE_URL` | Exists when rebuild lock/job coordination is separated. If absent, coordination fallback boundary is documented. | Redacted provider/project label or explicit shared-boundary statement. |
+
+Shared boundaries are allowed only when intentional and documented. If coordination shares the app/auth database, the
+release evidence must say so explicitly.
+
+## Required Variable Verification
+
+Before staging promotion, the Secret/config maintainer must confirm:
+
+- `DATABASE_URL` is configured for staging.
+- `ASSET_GRAPH_DATABASE_URL` is configured for staging.
+- `ASSET_GRAPH_DATABASE_URL` does not point to the same boundary as `DATABASE_URL`, unless an approved exception exists.
+- `COORDINATION_DATABASE_URL` is configured if coordination is separated.
+- If `COORDINATION_DATABASE_URL` is absent, the fallback boundary is documented.
+- `SECRET_KEY`, `ADMIN_USERNAME`, and `ADMIN_PASSWORD` are configured through Vercel environment variables.
+- No raw secret values are committed or pasted into issues, PRs, logs, or evidence records.
+
+Record only variable presence, provider labels, project labels, redacted URLs, and reviewer sign-off.
+
+## Preview Durability Labels
+
+Every preview deployment used during release evidence capture must be labelled:
+
+- `durable`: the preview uses PostgreSQL-compatible app/auth and graph persistence boundaries suitable for the evidence
+  being claimed;
+- `non-durable`: the preview may use local, SQLite, in-memory, generated, or otherwise non-authoritative persistence.
+
+Non-durable preview evidence can prove build/deployment shape and bounded health only. It cannot substitute for staging
+or production durable graph evidence.
+
+## Staging Promotion Checklist
+
+Open one release-candidate evidence issue using the
+[Release candidate evidence capture template](../.github/ISSUE_TEMPLATE/release_candidate_evidence.md), then attach or
+link the following evidence:
+
+- [ ] Release commit SHA and full CI run.
+- [ ] Staging Vercel project/deployment mapping for frontend and backend/API traffic.
+- [ ] Staging database provider name and redacted app/auth, graph, and coordination boundary labels.
+- [ ] Confirmation that `DATABASE_URL` exists in staging.
+- [ ] Confirmation that `ASSET_GRAPH_DATABASE_URL` exists in staging.
+- [ ] Confirmation that `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or approved exception details.
+- [ ] Confirmation that `COORDINATION_DATABASE_URL` exists when coordination is separated, or documented fallback when
+      absent.
+- [ ] Preview durability label for any preview evidence used.
+- [ ] Hosted readiness with durable persistence required:
+
+  ```bash
+  python scripts/check_hosted_readiness.py <staging_base_url> --require-persistence
+  ```
+
+- [ ] Redacted bounded health output:
+
+  ```bash
+  curl -fsS "<staging_base_url>/api/health/detailed"
+  ```
+
+- [ ] Redacted bounded asset smoke output or approved sentinel evidence:
+
+  ```bash
+  curl -fsS "<staging_base_url>/api/assets?per_page=1"
+  ```
+
+- [ ] Evidence confirms `graph.persistence_loaded == true`.
+- [ ] Evidence confirms `graph.startup_source == "persisted"`.
+- [ ] Named deploy, promotion, rollback, restore, and persistence-verification owners are recorded.
+- [ ] Security scanner summaries and approved exceptions are attached.
+- [ ] DR restore rehearsal evidence is attached or explicitly marked as pending when the release is not final enterprise
+      sign-off.
+
+Repository CI success is not hosted durable graph proof. `/api/health/detailed` alone is not hosted durable graph proof.
+
+## Promotion Decision Rule
+
+Staging promotion is blocked when any of the following are true:
+
+- staging provider or boundary records are missing;
+- `DATABASE_URL` or `ASSET_GRAPH_DATABASE_URL` is not configured;
+- `ASSET_GRAPH_DATABASE_URL` shares the `DATABASE_URL` boundary without an approved exception;
+- preview evidence is not clearly labelled durable or non-durable;
+- hosted readiness was not run with `--require-persistence`;
+- redacted `/api/health/detailed` and `/api/assets?per_page=1` evidence is missing;
+- persisted startup evidence does not show `graph.persistence_loaded == true` and `graph.startup_source == "persisted"`;
+- named operator ownership is missing;
+- unapproved critical/high security findings or undocumented gate exceptions remain.
+
+The promotion approver owns the final gate decision and must link the release-candidate evidence issue from the
+promotion record.
+
+## Related Documents
+
+- [Enterprise Deployment Operating Model](enterprise-deployment-operating-model.md)
+- [Release Evidence Pack](release-evidence-pack.md)
+- [Enterprise Release Checklist](release-checklist.md)
+- [Release candidate evidence capture template](../.github/ISSUE_TEMPLATE/release_candidate_evidence.md)
+- [State Machine and Operating Authority](governance/state-machine-and-operating-authority.md)


### PR DESCRIPTION
## Primary Objective

Make staging deployment operations repeatable and auditable by documenting provider-boundary evidence, Vercel environment mapping requirements, preview durability labels, and staging promotion evidence capture.

Closes #1306.

## Description

This PR adds `docs/staging-deployment-operating-baseline.md`, a staging-specific operating baseline for the existing FastAPI + Next.js on Vercel topology.

The baseline does not introduce a new architecture. It documents what operators must record before staging promotion:

- staging database provider name;
- app/auth, asset graph, and optional coordination database boundaries;
- `DATABASE_URL`, `ASSET_GRAPH_DATABASE_URL`, and `COORDINATION_DATABASE_URL` expectations;
- `ASSET_GRAPH_DATABASE_URL` distinctness from `DATABASE_URL`;
- Vercel frontend/backend project or deployment mapping;
- preview durability labelling;
- hosted readiness and redacted smoke evidence;
- named operator ownership.

The concrete provider, project names, deployment URLs, and variable-presence confirmations are intentionally captured in the release-candidate evidence issue, not committed to the repository. Missing provider or boundary records block staging promotion.

## In Scope

- Add a staging deployment operating baseline.
- Link the baseline from the enterprise deployment operating model, release checklist, and release evidence pack.
- Extend the RC evidence issue template with staging provider, Vercel mapping, boundary, distinctness, and preview durability fields.
- Document staging smoke commands and promotion decision rules.

## Out of Scope

- No new hosting architecture.
- No database provider decision in code.
- No runtime persistence rewrite.
- No production cutover.
- No secret values, raw connection strings, access tokens, provider credentials, or raw logs.
- No CI workflow changes.
- No runtime code changes.

## Files Expected to Change

- `docs/staging-deployment-operating-baseline.md` - new staging-specific operating baseline and checklist.
- `docs/enterprise-deployment-operating-model.md` - links staging operations to the new baseline.
- `docs/release-evidence-pack.md` - requires staging provider/boundary/mapping evidence in promotion evidence.
- `docs/release-checklist.md` - links the Promotion Gate to the staging baseline.
- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` - captures staging-specific evidence fields.

## Type of Change

- [ ] Architecture decision (ADR)
- [x] Documentation update
- [x] Policy document addition/update
- [x] Template modification
- [x] Repository configuration

## Rationale

The operating model already defines the hosted topology, but staging promotion needs an auditable provider/boundary and evidence checklist. This PR turns staging from an implicit deployment concept into an operator-verifiable baseline without exposing secrets or changing runtime behavior.

## Impact Assessment

### Positive Impacts

- Operators can identify exactly what staging evidence must be captured before promotion.
- Preview evidence must be labelled durable or non-durable.
- Missing provider, boundary, Vercel mapping, hosted persistence proof, or owner sign-off blocks staging promotion explicitly.
- The RC evidence template now has fields for staging baseline evidence.

### Potential Concerns

- The repository still does not commit concrete provider instance names or secret-bearing configuration.
- Operators must complete the provider/project/boundary evidence in the RC evidence issue.

### Mitigation Strategy

The baseline makes missing provider and boundary records a promotion blocker. It records non-secret evidence requirements in docs and routes environment-specific details through the RC evidence issue.

## Validation Commands

```bash
pre-commit run --files \
  docs/staging-deployment-operating-baseline.md \
  docs/enterprise-deployment-operating-model.md \
  docs/release-evidence-pack.md \
  docs/release-checklist.md \
  .github/ISSUE_TEMPLATE/release_candidate_evidence.md
```

Reference checks:

```bash
test -f docs/staging-deployment-operating-baseline.md
test -f docs/enterprise-deployment-operating-model.md
test -f docs/release-evidence-pack.md
test -f docs/release-checklist.md
test -f .github/ISSUE_TEMPLATE/release_candidate_evidence.md
test -f scripts/check_hosted_readiness.py
test -f vercel.json
```

## Merge Criteria

- [ ] Staging provider and database boundary evidence requirements are documented without secrets.
- [ ] `DATABASE_URL`, `ASSET_GRAPH_DATABASE_URL`, and optional `COORDINATION_DATABASE_URL` expectations are documented.
- [ ] `ASSET_GRAPH_DATABASE_URL` distinctness from `DATABASE_URL` is explicit.
- [ ] Preview durability labelling rules are documented.
- [ ] Vercel project/environment mapping evidence requirements are documented.
- [ ] Staging promotion checklist links to the release evidence pack and RC evidence template.
- [ ] Smoke validation commands are documented and tied to promotion criteria.
- [ ] No runtime code changes are included.

## Related Documents

- `docs/enterprise-deployment-operating-model.md`
- `docs/release-evidence-pack.md`
- `docs/release-checklist.md`
- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`
- `scripts/check_hosted_readiness.py`

## Checklist

### Documentation Quality

- [x] Documentation is clear, complete, and accurate
- [x] All cross-references are valid and up-to-date
- [x] New documents follow the project's documentation standards
- [x] No spelling or grammatical errors
- [x] Markdown formatting is correct

### Architectural Alignment

- [x] This PR respects the production architecture (FastAPI + Next.js)
- [x] Changes do not contradict existing ADRs
- [x] If adding an ADR, it follows the ADR template format
- [x] Policy changes are documented with rationale

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] I have not mixed architectural changes with code changes
- [x] No runtime behavior changes are included
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity

### Completeness

- [x] All related documentation has been updated consistently
- [x] No documentation is left in an inconsistent state
- [x] Templates and examples reflect the documented architecture
- [ ] README.md reflects any high-level changes

## Additional Notes

README.md was not changed because this is staging operator evidence documentation, not a general setup or user-facing usage change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a staging deployment operating baseline for the FastAPI + Next.js stack on Vercel to make promotions repeatable and auditable. Sets Supabase as the staging database and requires Vercel mapping, env var checks, preview durability labels, and durable readiness/persisted-startup evidence (closes #1306).

- **New Features**
  - Added `docs/staging-deployment-operating-baseline.md` covering: Supabase as the staging provider; Vercel mapping and monorepo routing in `vercel.json` (`/api/*` -> `api.main:app`, Next.js frontend; `app.py` excluded); env var rules (`DATABASE_URL`, `ASSET_GRAPH_DATABASE_URL` distinct from `DATABASE_URL`, optional `COORDINATION_DATABASE_URL` with fallback); preview durability labels; hosted readiness and persisted-startup checks; redacted smoke evidence; operator ownership.
  - Linked the baseline from `docs/enterprise-deployment-operating-model.md`, `docs/release-checklist.md`, and `docs/release-evidence-pack.md`.
  - Expanded `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` to capture staging provider, frontend/backend Vercel mapping, database boundaries, `ASSET_GRAPH_DATABASE_URL` distinctness or approved exception, `COORDINATION_DATABASE_URL` or documented fallback, preview durability label, and durable readiness evidence.

- **Bug Fixes**
  - Removed a duplicate coordination evidence item in the baseline to avoid redundant checks.

<sup>Written for commit 9c52f01d137d63e55c7b4c821a90ace9e1c93527. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

