### PR TITLE
docs: add staging restore rehearsal evidence capture

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -78,11 +78,32 @@ Record named owners for this release candidate:
 
 ## Disaster Recovery Rehearsal Evidence
 
-- [ ] Restore rehearsal log attached.
-- [ ] Selected restore point recorded.
+- [ ] Restore rehearsal date recorded.
+- [ ] Restore operator recorded.
+- [ ] Source environment recorded.
+- [ ] Restore point timestamp or backup identifier recorded.
+- [ ] Scratch/non-production restore target recorded.
+- [ ] Backup/restore mechanism recorded: PITR / snapshot / logical dump / provider export / other.
 - [ ] Effective database-boundary topology recorded: Auth DB, Coordination DB, Asset Graph DB.
+- [ ] Auth/application DB boundary restore result recorded.
+- [ ] Coordination DB boundary restore result recorded, or shared-boundary fallback confirmed.
+- [ ] Asset graph DB boundary restore result recorded.
+- [ ] `DATABASE_URL` points to the restored app/auth boundary.
+- [ ] `ASSET_GRAPH_DATABASE_URL` points to the restored graph boundary, not the app/auth boundary.
+- [ ] `COORDINATION_DATABASE_URL` points to the restored coordination boundary when separated.
 - [ ] Scratch restore verification results attached.
-- [ ] Post-restore hosted readiness smoke evidence attached.
+- [ ] Post-restore hosted readiness with `--require-persistence` evidence attached.
+- [ ] Redacted post-restore `/api/health/detailed` evidence attached or summarized.
+- [ ] Redacted post-restore `/api/assets?per_page=1` or approved sentinel evidence attached or summarized.
+- [ ] Persisted graph startup source confirmed after restore.
+- [ ] Persisted graph counts or sentinel baseline checked after restore.
+- [ ] RPO target recorded.
+- [ ] Observed RPO recorded.
+- [ ] RTO target recorded.
+- [ ] Observed RTO recorded.
+- [ ] Target misses are classified as blocking or non-blocking with follow-up.
+- [ ] Restore rehearsal decision recorded: Passed / Failed / Blocked.
+- [ ] Follow-up issues are linked for unresolved ambiguity or failed steps.
 
 ## Gate Status Summary
 

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -267,6 +267,8 @@ Manual release attachment:
 - Effective database-boundary topology: Auth DB, Coordination DB, Asset Graph DB.
 - Scratch restore verification results.
 - Post-restore hosted readiness smoke output.
+- RPO/RTO observations and decision recorded using the
+  [restore rehearsal evidence record](runbooks/backup-restore-dr.md#restore-rehearsal-evidence-record).
 
 Blocking rule:
 

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -481,6 +481,7 @@ Auth DB boundary result:
 Coordination DB boundary result:
 Asset graph DB boundary result:
 Scratch restore verification results:
+Readiness requirement: hosted readiness run with --require-persistence
 Post-restore readiness result:
 Post-restore health evidence:
 Post-restore assets/sentinel evidence:

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -476,9 +476,11 @@ Source environment:
 Restore point:
 Restore target:
 Backup/restore mechanism:
+Effective database-boundary topology:
 Auth DB boundary result:
 Coordination DB boundary result:
 Asset graph DB boundary result:
+Scratch restore verification results:
 Post-restore readiness result:
 Post-restore health evidence:
 Post-restore assets/sentinel evidence:

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -458,4 +458,36 @@ A restore incident or rehearsal is complete only when:
 6. `/api/health/detailed` is healthy;
 7. lifecycle state reaches `READY`;
 8. graph functional smoke testing passes;
-9. the Incident Commander or designated promotion approver accepts closure.
+9. hosted readiness with `--require-persistence` passes for staging/production restore rehearsal evidence;
+10. RPO target, observed RPO, RTO target, and observed RTO are recorded;
+11. any RPO/RTO target miss is classified as blocking or non-blocking with a follow-up issue;
+12. the restore rehearsal evidence record is attached to the release-candidate evidence issue or incident record;
+13. the Incident Commander or designated promotion approver accepts closure.
+
+## Restore Rehearsal Evidence Record
+
+Use this structure in the release-candidate evidence issue or incident record. Do not include secrets, raw database URLs,
+database dump contents, bearer tokens, private keys, or unredacted logs.
+
+```text
+Restore rehearsal date:
+Restore operator:
+Source environment:
+Restore point:
+Restore target:
+Backup/restore mechanism:
+Auth DB boundary result:
+Coordination DB boundary result:
+Asset graph DB boundary result:
+Post-restore readiness result:
+Post-restore health evidence:
+Post-restore assets/sentinel evidence:
+Persisted graph startup source:
+Persisted graph counts or sentinel baseline:
+RPO target:
+Observed RPO:
+RTO target:
+Observed RTO:
+Decision: Passed / Failed / Blocked
+Follow-up issues:
+```

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -481,6 +481,7 @@ Auth DB boundary result:
 Coordination DB boundary result:
 Asset graph DB boundary result:
 Scratch restore verification results:
+Target miss classification (blocking/non-blocking):
 Readiness requirement: hosted readiness run with --require-persistence
 Post-restore readiness result:
 Post-restore health evidence:


### PR DESCRIPTION
## Primary Objective

Add the missing evidence-capture fields needed to record Objective 4 staging restore rehearsal results without changing runtime behavior.

Refs #1310.

## Description

Issue #1310 is primarily an operational restore rehearsal. This PR does not claim that the Supabase scratch restore has been performed. Instead, it closes the repository documentation gap needed to capture that rehearsal cleanly:

- the release-candidate evidence template now records restore point, restore target, boundary-by-boundary restore results, post-restore smoke evidence, RPO/RTO observations, decision, and follow-up issues;
- the DR runbook completion criteria now require hosted readiness with `--require-persistence`, RPO/RTO observations, target-miss classification, and an attached evidence record;
- the release evidence pack points the DR gate to the runbook’s restore rehearsal evidence record.

## In Scope

- Extend `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` with detailed DR rehearsal evidence fields.
- Update `docs/runbooks/backup-restore-dr.md` completion criteria for restore rehearsal evidence.
- Add a reusable restore rehearsal evidence record to the DR runbook.
- Link the release evidence pack DR gate to that evidence record.

## Out of Scope

- No runtime code changes.
- No database schema changes.
- No new backup architecture.
- No production restore execution.
- No staging restore execution in this PR.
- No secrets, connection strings, access tokens, private keys, database dumps, or unredacted logs.
- No claim that the DR gate is complete.

## Files Expected to Change

- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` - captures detailed staging restore rehearsal evidence.
- `docs/runbooks/backup-restore-dr.md` - clarifies completion criteria and evidence record format.
- `docs/release-evidence-pack.md` - links the DR gate to the evidence record.

## Type of Change

- [ ] Architecture decision (ADR)
- [x] Documentation update
- [x] Policy document addition/update
- [x] Template modification
- [ ] Repository configuration

## Rationale

The release evidence pack already marks DR as manual-evidence required. The runbook and RC evidence template had enough information for a general restore, but not enough structured fields to record the #1310 rehearsal outcome, especially RPO/RTO observations and boundary-by-boundary restore results.

## Impact Assessment

### Positive Impacts

- Operators have a precise evidence structure for staging restore rehearsal.
- Reviewers can distinguish “restore procedure documented” from “restore rehearsal artifact attached.”
- RPO/RTO target misses must be classified with follow-up instead of being buried in free-form notes.

### Potential Concerns

- This PR does not perform the actual Supabase scratch restore.
- Issue #1310 remains operationally incomplete until the rehearsal artifact and post-restore smoke evidence exist.

### Mitigation Strategy

The PR references #1310 but does not close it. The DR gate remains manual-evidence required until operators attach the actual restore rehearsal record and smoke evidence.

## Validation Commands

```bash
pre-commit run --files \
  .github/ISSUE_TEMPLATE/release_candidate_evidence.md \
  docs/runbooks/backup-restore-dr.md \
  docs/release-evidence-pack.md
```

Reference checks:

```bash
test -f .github/ISSUE_TEMPLATE/release_candidate_evidence.md
test -f docs/runbooks/backup-restore-dr.md
test -f docs/release-evidence-pack.md
test -f scripts/check_hosted_readiness.py
```

## Merge Criteria

- [ ] RC evidence template captures restore point, restore target, boundary results, post-restore smoke evidence, RPO/RTO observations, and decision.
- [ ] DR runbook completion criteria require RPO/RTO observations and attached evidence record.
- [ ] Release evidence pack links to the restore rehearsal evidence record.
- [ ] No runtime code changes are included.
- [ ] PR does not claim the restore rehearsal has been completed.

## Related Documents

- `docs/release-checklist.md`
- `docs/release-evidence-pack.md`
- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`
- `docs/staging-deployment-operating-baseline.md`
- `docs/enterprise-deployment-operating-model.md`
- `scripts/check_hosted_readiness.py`

## Checklist

### Documentation Quality

- [x] Documentation is clear, complete, and accurate
- [x] All cross-references are valid and up-to-date
- [x] New documents follow the project's documentation standards
- [x] No spelling or grammatical errors
- [x] Markdown formatting is correct

### Architectural Alignment

- [x] This PR respects the production architecture (FastAPI + Next.js)
- [x] Changes do not contradict existing ADRs
- [x] If adding an ADR, it follows the ADR template format
- [x] Policy changes are documented with rationale

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] I have not mixed architectural changes with code changes
- [x] No runtime behavior changes are included
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity

### Completeness

- [x] All related documentation has been updated consistently
- [x] No documentation is left in an inconsistent state
- [x] Templates and examples reflect the documented architecture
- [ ] README.md reflects any high-level changes

## Additional Notes

README.md was not changed because this is an operator evidence-capture refinement for DR rehearsal, not a general setup or usage change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds structured DR restore rehearsal evidence to the RC template and DR runbook, with a reusable evidence record, explicit DB URL checks, RPO/RTO with miss classification, and redaction rules. No runtime changes; enables clean capture of staging rehearsal results for #1310.

- **New Features**
  - Extend `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` with fields for date/operator/source env; restore point/target/mechanism; boundary results; URL wiring with `DATABASE_URL`, `ASSET_GRAPH_DATABASE_URL`, `COORDINATION_DATABASE_URL`; scratch verification; hosted readiness with `--require-persistence`; redacted health/assets evidence; persisted-graph source/counts; RPO/RTO; miss classification; decision; follow-ups.
  - Add a “Restore Rehearsal Evidence Record” to `docs/runbooks/backup-restore-dr.md` with a copy-paste template and a clear “no secrets/raw URLs/dumps/tokens/private keys/unredacted logs” rule; completion now requires readiness passing with `--require-persistence`, RPO/RTO recorded, miss classification, evidence record attached, and final approval.
  - Update `docs/release-evidence-pack.md` to link to the evidence record and require recorded RPO/RTO and a decision.

<sup>Written for commit 500cdd3abfc0a70e8bebb8602dcd1f9f6c38b545. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

