### PR TITLE
docs: add operational drill and scale-validation pack

### DIFF
--- a/docs/audits/enterprise-readiness-audit.md
+++ b/docs/audits/enterprise-readiness-audit.md
@@ -16,7 +16,9 @@ The remaining risk is concentrated in release evidence and operational proof rat
 - DR restore must be rehearsed at least once and linked to release evidence;
 - release security scanner summaries, exception records, and named operator sign-off must be attached;
 - `RebuildJobListResponse` now exposes `total` and `has_more` truncation signals;
-- strict stale-owner restart composition is now covered by the integration suite, while production-scale validation remains future or optional unless a release explicitly requires it.
+- strict stale-owner restart composition is now covered by the integration suite;
+- the operational drill and scale-validation pack now defines the representative incident drills and bounded evidence capture model;
+- production-scale validation remains future or optional unless a release explicitly requires it.
 
 ## Post-Roadmap Reconciliation Status
 
@@ -30,7 +32,7 @@ Roadmap source-of-truth status is now aligned with `docs/release-evidence-pack.m
 | PR 4 — API Contract Cleanup | Satisfied | Core density, pagination, visualization, and rebuild job-list truncation seams are aligned. |
 | PR 5 — Recovery-Plane Completion | Satisfied - automated | RecoveryGate and reconciliation path are covered by targeted tests. |
 | PR 6 — Distributed Hosting Semantics Spec | Satisfied - documented | Current interpretation is consolidated in the canonical state-machine authority. |
-| PR 7 — Failure-Mode and Scale Validation | Partially satisfied | CI-bounded validation exists; strict stale-owner composition is covered by the integration suite, while production-scale validation remains optional/future unless release-scoped. |
+| PR 7 — Failure-Mode and Scale Validation | Partially satisfied | CI-bounded validation exists; strict stale-owner composition is covered by the integration suite, the operational drill pack is documented, and production-scale validation remains optional/future unless release-scoped. |
 | PR 8 — Security and Governance Hardening | Satisfied - manual evidence required | Repository controls exist; release requires scanner summaries, exception records, and approvals. |
 | PR 9 — Backup, Restore, and DR Runbook | Satisfied - manual evidence required | Strategy/runbook exist; restore rehearsal evidence is still required. |
 | PR C — Governance and State-Machine Hardening | Satisfied - documented | Canonical state-machine authority exists; governed behavior changes must keep it aligned. |
@@ -98,6 +100,7 @@ This repo already contains the right documents for a mature program:
 - observability master/spec docs;
 - persistence design docs;
 - release checklist and release evidence pack;
+- operational drill and scale-validation pack;
 - PR templates and scope guardrails;
 - operator authorization audit/quick reference;
 - canonical state-machine and operating authority.
@@ -153,7 +156,7 @@ The following should remain separately scoped:
 
 - strict stale-owner restart composition test;
 - production-scale graph/rebuild/persistence validation;
-- continuous operational drills for observability/runbook maturity;
+- operational drill execution and evidence capture for observability/runbook maturity;
 - multi-region or advanced hosting strategy.
 
 ## Remaining Gaps
@@ -168,7 +171,7 @@ The following should remain separately scoped:
 
 - strict stale-owner restart composition;
 - production-scale validation;
-- continuous operational drills.
+- operational drill execution and evidence capture.
 
 ### Strategic deferrals
 
@@ -188,6 +191,7 @@ The following should remain separately scoped:
 
 - `RebuildJobListResponse` exposes a truncation signal;
 - strict stale-owner restart composition is covered as one end-to-end scenario;
+- the operational drill pack is documented for incident-proof evidence capture;
 - production-scale evidence remains outside the bounded CI fixture set;
 - governance exists in docs, but release ownership must still be named per release.
 

--- a/docs/enterprise-readiness-index.md
+++ b/docs/enterprise-readiness-index.md
@@ -13,6 +13,7 @@
 | `docs/roadmap/enterprise-readiness-pr-board.md` | Operational PR board with status and exit criteria |
 | `docs/release-checklist.md` | Release gates and enterprise exit criteria |
 | `docs/release-evidence-pack.md` | Gate-by-gate release evidence matrix, targeted commands, manual artefacts, and blocker rules |
+| `docs/testing/operational-drill-and-scale-validation-pack.md` | Operational drill matrix and bounded scale-validation guidance for observability, SLO, dashboard, alert, and runbook proof |
 | `docs/governance/state-machine-and-operating-authority.md` | Current operational authority for rebuild/recovery state machines, invariants, ownership, and exception paths |
 | `docs/adr/0005-backup-restore-dr-strategy.md` | Backup, restore, DR strategy, data classification, RPO, and RTO |
 | `docs/runbooks/backup-restore-dr.md` | Operator procedures for backup verification, restore execution, and post-restore checks |
@@ -27,7 +28,8 @@ The remaining work is no longer primarily architectural. It is concentrated in l
 - DR restore rehearsal evidence against the documented backup/restore process;
 - release-commit security scanner review and named operator sign-off;
 - strict stale-owner restart composition testing;
-- production-scale validation and continuous operational drills.
+- the operational drill and scale-validation pack for observability and runbook proof;
+- production-scale validation that stays bounded outside normal CI.
 
 The DR documentation gap is closed at the strategy and runbook level through [ADR 0005](adr/0005-backup-restore-dr-strategy.md) and the [backup/restore/DR runbook](runbooks/backup-restore-dr.md). Final enterprise release readiness still requires operators to rehearse restore at least once and record the evidence in the release process.
 
@@ -40,7 +42,7 @@ Status legend follows the [Release Evidence Pack](release-evidence-pack.md): **S
 | Satisfied - automated | PR 1 durable graph persistence; PR 2 startup load/save integration; PR 4 core density, asset pagination, and frontend/backend contract seams; PR 5 RecoveryGate/reconciliation control-plane path; PR 7 CI-bounded failure-mode and representative-scale validation where covered |
 | Satisfied - documented | PR 6 distributed hosting semantics; PR C governance/state-machine authority; production architecture and deployment operating model |
 | Satisfied - manual evidence required | PR 3 hosted durable promotion proof for the target environment; PR 8 security scanner summary, exception review, and release sign-off; PR 9 restore rehearsal and post-restore smoke evidence |
-| Partially satisfied | Strict stale-owner restart composition is covered by integration tests; production-scale validation and continuous operational drills remain future operating-maturity work |
+| Partially satisfied | Strict stale-owner restart composition is covered by integration tests; the operational drill and scale-validation pack is documented; production-scale validation remains future operating-maturity work |
 | Blocked | No repository source-of-truth reconciliation blocker remains after this update. Enterprise release sign-off remains blocked until hosted promotion evidence, release-commit security scanner/exception review, named operator sign-off, and DR restore rehearsal evidence are attached or approved. |
 
 ## Recommended Reading Order
@@ -65,6 +67,7 @@ Repository tests and documentation may satisfy implementation evidence, but stag
 
 - [README.md](../README.md) — main repository entry point and production setup overview
 - [docs/release-evidence-pack.md](./release-evidence-pack.md) — auditable release evidence matrix
+- [docs/testing/operational-drill-and-scale-validation-pack.md](./testing/operational-drill-and-scale-validation-pack.md) — operator-facing drill matrix and bounded scale-validation guidance
 - [docs/governance/state-machine-and-operating-authority.md](./governance/state-machine-and-operating-authority.md) — current authority for rebuild/recovery/persistence state-machine governance
 - [docs/adr/0002-hosted-deployment-and-persistence.md](./adr/0002-hosted-deployment-and-persistence.md) — hosted persistence decision
 - [docs/adr/0005-backup-restore-dr-strategy.md](./adr/0005-backup-restore-dr-strategy.md) — backup, restore, and DR strategy

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -36,7 +36,7 @@ These are not stale roadmap items; they are bounded follow-up objectives.
 | `RebuildJobListResponse` truncation signal | Satisfied - automated | Response exposes `total` and `has_more`; tests cover default cap, explicit pagination, and status-filtered truncation semantics; no frontend consumer was found | Release evidence capture |
 | Strict stale-owner restart composition | Satisfied - automated | End-to-end restart pipeline proves stale-owner reset after lock expiry, restart load, and prevents stale owner mutation | Source-of-truth docs reconciliation |
 | Production-scale validation | Partially satisfied | Larger graph/load evidence is recorded outside normal CI or in a bounded scheduled workflow | Core release evidence PR |
-| Continuous operational drills | Partially satisfied | Operators exercise alert/runbook flows for graph load failure, lock loss, stale owner, degraded DB, and failed durable smoke | Initial staging proof |
+| Continuous operational drills | Satisfied - documented | The operational drill pack defines graph load failure, lock loss, stale owner, degraded DB, and failed durable smoke flows with evidence capture guidance | Initial staging proof |
 
 ## Board Notes
 
@@ -46,3 +46,4 @@ These are not stale roadmap items; they are bounded follow-up objectives.
 - PR 6 and PR C are no longer missing specifications; they are documented authorities that require review enforcement when governed behavior changes.
 - PR 8 and PR 9 are documentation/test/policy complete for their repository scope, but release sign-off still requires scanner/exception evidence and restore rehearsal evidence.
 - Production-scale validation should remain separately tracked so it does not blur release evidence capture with new runtime scope.
+- The operational drill pack is now the canonical documentation for representative incident drills; execution evidence remains a separate follow-up artifact.

--- a/docs/roadmap/enterprise-readiness-roadmap.md
+++ b/docs/roadmap/enterprise-readiness-roadmap.md
@@ -46,7 +46,7 @@ These items are valid but should not be bundled into the release-evidence reconc
 | `RebuildJobListResponse` truncation signal | Satisfied | Rebuild job-list responses expose `total` and `has_more`; tests cover default cap, explicit pagination, and status-filtered truncation semantics | None |
 | Strict stale-owner restart composition test | Satisfied - automated | The dedicated restart/recovery integration test now covers owner death, lock expiry, RecoveryGate reset, persisted restart load, and stale-owner fencing | Existing restart/recovery helpers, distributed lock test fixtures |
 | Production-scale validation | Partially satisfied | Representative CI fixtures exist, but production-scale rebuild, lock refresh, memory, and persistence-load evidence should run outside normal CI | Stable staging dataset, performance budget, observability dashboards |
-| Continuous operational drills | Partially satisfied | Alert/runbook maturity requires repeated incident drills, not only tests and documentation | Observability stack, runbooks, named operators |
+| Continuous operational drills | Satisfied - documented | The operational drill pack defines representative incident drills, metrics, dashboard panels, alert surfaces, and runbook responses | Observability stack, runbooks, named operators |
 | Multi-region / advanced hosting strategy | Partially satisfied | Too early until single-region durable staging/prod evidence and restore rehearsal are complete | Release evidence, DR evidence, cost and provider model |
 
 ## Key Dependencies
@@ -55,6 +55,7 @@ These items are valid but should not be bundled into the release-evidence reconc
 - The release evidence pack is now the controlling release-proof document for the nine gates.
 - Contract cleanup now includes `RebuildJobListResponse` truncation semantics through `total` and `has_more`.
 - Failure-mode validation should continue, but production-scale evidence should not block this docs-only reconciliation unless the release scope explicitly makes it mandatory.
+- The operational drill pack now documents the representative incident matrix; live drill execution remains an operational follow-up rather than a new CI surface.
 - Governance changes must keep `docs/governance/state-machine-and-operating-authority.md` aligned as the current authority.
 
 ## Risks
@@ -73,5 +74,5 @@ These items are valid but should not be bundled into the release-evidence reconc
 5. DR restore rehearsal and post-restore smoke evidence.
 6. Dedicated `RebuildJobListResponse` truncation signal PR completed.
 7. Strict stale-owner restart composition test completed.
-8. Production-scale validation and continuous operational drills.
+8. Production-scale validation and operational drill execution.
 9. Multi-region / advanced hosting strategy.

--- a/docs/testing/operational-drill-and-scale-validation-pack.md
+++ b/docs/testing/operational-drill-and-scale-validation-pack.md
@@ -44,7 +44,8 @@ The current drill set is chosen to exercise the control-plane boundaries already
 - Trigger: force graph persistence load failure in a safe non-production target.
 - Expected behavior: startup/readiness fails closed or reports a degraded state according to the startup contract.
 - Metrics to watch: `application_startup_failure_total`, `graph_rebuild_recovery_trigger_total`, and the
-  `graph_persistence_configured` / `persistence_loaded` / `startup_source` fields in `/api/health/detailed`.
+  `graph_persistence_configured` / `graph.persistence_loaded` / `graph.startup_source` fields in
+  `/api/health/detailed`.
 - Logs / events to watch: `graph_startup_source_detected` and `startup_reconciliation_failed`, plus the sanitized
   startup failure event emitted by the application lifecycle path.
 - Dashboard / alert focus: Application Lifecycle row, SLO Overview row, and any persistence-readiness alert surface.
@@ -95,8 +96,8 @@ The current drill set is chosen to exercise the control-plane boundaries already
 - Trigger: run hosted readiness with `--require-persistence` against a target without durable graph truth or with an
   intentionally invalid durable graph configuration.
 - Expected behavior: the smoke fails and cannot be used as promotion evidence.
-- Metrics to watch: `graph_persistence_configured`, `persistence_loaded`, `startup_source`, and the hosted readiness
-  command exit status.
+- Metrics to watch: `graph_persistence_configured`, `graph.persistence_loaded`, `graph.startup_source`, and the hosted
+  readiness command exit status.
 - Logs / events to watch: hosted readiness diagnostic output and the startup source evidence returned by the target.
 - Dashboard / alert focus: Promotion evidence workflow and any readiness gating dashboard that consumes the smoke.
 - Runbook response: remediate the graph persistence boundary before retrying promotion.

--- a/docs/testing/operational-drill-and-scale-validation-pack.md
+++ b/docs/testing/operational-drill-and-scale-validation-pack.md
@@ -1,0 +1,165 @@
+# Operational Drill and Scale-Validation Pack
+
+Status: Active
+Issue: #1317
+
+## Purpose
+
+This pack defines a bounded set of operational drills and representative-scale validation checks that prove the
+observability, SLOs, dashboards, alerts, and runbooks answer real incidents rather than existing only as static
+documentation.
+
+It is intentionally deterministic and CI-safe. It does not turn normal PR validation into a production-scale
+load-test harness.
+
+## Scope
+
+### In scope
+
+- 3--5 operational drills covering representative failure modes.
+- Trigger, expected runtime behavior, metrics, logs/events, dashboard/alert evidence, and runbook response for each drill.
+- Deterministic, fixed-size graph validation where it stays bounded and repeatable.
+- Evidence-capture guidance that operators can fill in after a manual drill.
+
+### Out of scope
+
+- New hosting architecture.
+- Normal CI production-scale load testing.
+- Release-candidate evidence capture.
+- DR restore rehearsal replacement.
+- Security scanner policy changes.
+
+## Drill Catalog
+
+The current drill set is chosen to exercise the control-plane boundaries already documented in the repository:
+
+1. Failed graph load drill.
+2. Lock loss drill.
+3. Stale owner drill.
+4. Degraded database drill.
+5. Failed durable smoke drill.
+
+### 1. Failed Graph Load Drill
+
+- Trigger: force graph persistence load failure in a safe non-production target.
+- Expected behavior: startup/readiness fails closed or reports a degraded state according to the startup contract.
+- Metrics to watch: `application_startup_failure_total`, `graph_rebuild_recovery_trigger_total`, and the
+  `graph_persistence_configured` / `persistence_loaded` / `startup_source` fields in `/api/health/detailed`.
+- Logs / events to watch: `graph_startup_source_detected` and `startup_reconciliation_failed`, plus the sanitized
+  startup failure event emitted by the application lifecycle path.
+- Dashboard / alert focus: Application Lifecycle row, SLO Overview row, and any persistence-readiness alert surface.
+- Runbook response: diagnose persistence configuration and follow the restore / recovery path before retrying
+  promotion.
+
+### 2. Lock Loss Drill
+
+- Trigger: simulate distributed lock loss during rebuild or make lock refresh fail.
+- Expected behavior: rebuild execution stops or fails safely; stale ownership cannot continue mutating state.
+- Metrics to watch: `rebuild_lock_refresh_total{status="failure"}`,
+  `rebuild_heartbeat_last_success_timestamp`, `graph_rebuild_recovery_trigger_total`,
+  `graph_rebuild_failure_total`, and `graph_rebuild_state_transition_total`.
+- Logs / events to watch: `graph_rebuild_recovery_trigger_total`-backed recovery events, `reconciliation_loop_blocked`
+  when the loop refuses execution, rebuild failure events, and blocked execution output from the recovery path.
+- Dashboard / alert focus: Rebuild Liveness & Heartbeat row, Rebuild Resilience & Recovery row, and the relevant
+  recovery alert panels.
+- Runbook response: confirm lock ownership, inspect the active writer, and stop any stale writer before retrying.
+
+### 3. Stale Owner Drill
+
+- Trigger: create a running rebuild job with an expired heartbeat and a stale active worker record.
+- Expected behavior: RecoveryGate blocks or resets according to the canonical authority rules; a fresh foreign owner
+  must not be reset.
+- Metrics to watch: `graph_rebuild_recovery_trigger_total`, `graph_rebuild_state_transition_total`,
+  `rebuild_lock_acquisition_total`, and `rebuild_heartbeat_last_success_timestamp`.
+- Logs / events to watch: recovery-gate decision logs, stale-owner detection events, and `reconciliation_loop_blocked`
+  output when a fresh foreign owner prevents mutation.
+- Dashboard / alert focus: Rebuild Resilience & Recovery row and the SLO Overview row.
+- Runbook response: verify ownership authority, then either allow the stale owner reset path or escalate to manual
+  investigation if the lock state is unsafe.
+
+### 4. Degraded Database Drill
+
+- Trigger: make the coordination, auth, or graph persistence database temporarily unavailable in a safe target.
+- Expected behavior: affected dependency reports degraded / unavailable without leaking secrets; unrelated boundaries
+  should remain correctly classified.
+- Metrics to watch: `application_startup_failure_total`, `rebuild_lock_refresh_total{status="failure"}`,
+  `graph_rebuild_failure_total`, and `reconciliation_duration_seconds`.
+- Logs / events to watch: sanitized database connection failures, degraded dependency events, and any recovery-gate
+  blocking event that results from the outage.
+- Dashboard / alert focus: Application Lifecycle row, Reconciliation Drift row, and the database-specific alert view.
+- Runbook response: diagnose the failing boundary, verify the affected database URL, and avoid treating a healthy
+  unrelated boundary as evidence of full system health.
+
+### 5. Failed Durable Smoke Drill
+
+- Trigger: run hosted readiness with `--require-persistence` against a target without durable graph truth or with an
+  intentionally invalid durable graph configuration.
+- Expected behavior: the smoke fails and cannot be used as promotion evidence.
+- Metrics to watch: `graph_persistence_configured`, `persistence_loaded`, `startup_source`, and the hosted readiness
+  command exit status.
+- Logs / events to watch: hosted readiness diagnostic output and the startup source evidence returned by the target.
+- Dashboard / alert focus: Promotion evidence workflow and any readiness gating dashboard that consumes the smoke.
+- Runbook response: remediate the graph persistence boundary before retrying promotion.
+
+## Evidence Matrix
+
+Record each drill with a compact evidence row. Use one row per drill execution.
+
+| Drill | Triggered in | Expected behavior | Metrics observed | Logs / events observed | Dashboard / alert observed | Runbook response verified | Result |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| Failed graph load |  |  |  |  |  |  | Not run |
+| Lock loss |  |  |  |  |  |  | Not run |
+| Stale owner |  |  |  |  |  |  | Not run |
+| Degraded DB |  |  |  |  |  |  | Not run |
+| Failed durable smoke |  |  |  |  |  |  | Not run |
+
+Allowed result values:
+
+- Passed
+- Failed
+- Blocked
+- Not run
+- Manual evidence required
+- Follow-up required
+
+## Scale-Validation Guidance
+
+Representative scale checks should stay deterministic, fixed-size, and broad enough to catch regressions without
+creating a production-scale harness in normal CI.
+
+Current bounded sizes already used by the repository:
+
+- small: 10 assets / 20 relationships
+- representative: 250 assets / 1,000 relationships
+- upper representative: 1,000 assets / 5,000 relationships
+
+Rules:
+
+- Keep the data deterministic.
+- Keep CI guardrails broad enough to avoid flake.
+- Treat timing numbers as regression baselines, not SLOs.
+- Keep true production-scale validation manual, scheduled, or nightly.
+- Record the environment, graph size, elapsed time, and whether the result is advisory or release-blocking.
+
+Current automated anchors:
+
+- `tests/integration/test_distributed_hosting_failure_modes.py`
+- `tests/integration/test_graph_persistence_scale_validation.py`
+- `docs/testing/failure-mode-and-scale-validation.md`
+
+## How To Use This Pack
+
+1. Choose one drill and run it only against a safe target.
+2. Capture the metrics, logs, dashboard evidence, and runbook response.
+3. Record the result in the evidence matrix.
+4. Keep any discovered observability or runbook gap as a separate follow-up item.
+
+## Related Documents
+
+- `docs/release-evidence-pack.md`
+- `docs/release-checklist.md`
+- `docs/enterprise-deployment-operating-model.md`
+- `docs/governance/state-machine-and-operating-authority.md`
+- `docs/runbooks/backup-restore-dr.md`
+- `docs/OBSERVABILITY_MASTER_SPEC.md`
+- `docs/testing/failure-mode-and-scale-validation.md`

--- a/docs/testing/operational-drill-and-scale-validation-pack.md
+++ b/docs/testing/operational-drill-and-scale-validation-pack.md
@@ -16,7 +16,7 @@ load-test harness.
 
 ### In scope
 
-- 3--5 operational drills covering representative failure modes.
+- 5 operational drills covering representative failure modes.
 - Trigger, expected runtime behavior, metrics, logs/events, dashboard/alert evidence, and runbook response for each drill.
 - Deterministic, fixed-size graph validation where it stays bounded and repeatable.
 - Evidence-capture guidance that operators can fill in after a manual drill.

--- a/docs/validation-gap-audit.md
+++ b/docs/validation-gap-audit.md
@@ -83,4 +83,5 @@ The strongest existing coverage is in auth audit logging, distributed lock handl
 This PR closes the highest-leverage validation gaps around graph density semantics, pagination values, rebuild job-list truncation,
 persistence field fidelity, clean restart-recovery composition, strict stale-owner restart composition, and frontend/backend
 serialization seams. The remaining open items are operational proof and maturity work rather than untested happy paths:
-attaching hosted restart/redeploy evidence and converting residual ad hoc frontend mocks to typed fixtures.
+attaching hosted restart/redeploy evidence, executing the operational drill pack, and converting residual ad hoc frontend
+mocks to typed fixtures.


### PR DESCRIPTION
## Primary Objective

Create an operational drill and scale-validation pack that proves observability, SLOs, dashboards, alerts, and runbooks answer real incidents.

## Description

Adds `docs/testing/operational-drill-and-scale-validation-pack.md` and updates the enterprise-readiness index, audit, roadmap, PR board, and validation-gap audit to reference the pack.

## In Scope

- Define five representative operational drills.
- Document expected metrics, logs/events, dashboard and alert surfaces, and runbook responses.
- Document deterministic bounded scale-validation guidance and the current test anchors.
- Reconcile readiness docs around operational drills and bounded production-scale validation.

## Out of Scope

- Runtime architecture changes.
- New load-test harnesses in normal CI.
- DR restore rehearsal replacement.
- Release-candidate evidence capture.

## Files Expected to Change

- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `docs/enterprise-readiness-index.md`
- `docs/audits/enterprise-readiness-audit.md`
- `docs/roadmap/enterprise-readiness-roadmap.md`
- `docs/roadmap/enterprise-readiness-pr-board.md`
- `docs/validation-gap-audit.md`

## Type of Change

- [ ] Architecture decision (ADR)
- [x] Documentation update
- [ ] Policy document addition/update
- [ ] Template modification
- [ ] Repository configuration

## Rationale

The repository already has bounded failure-mode and scale-validation tests. This PR turns the operational proof into a repeatable operator-facing pack instead of leaving the drill matrix implicit.

## Impact Assessment

### Positive Impacts

- Operators get a concrete drill/evidence template.
- Readiness docs point to one canonical drill pack.
- Scale validation stays bounded and deterministic.

### Potential Concerns

- The pack could be mistaken for completed live drill evidence.
- Production-scale validation remains outside normal CI.

### Mitigation Strategy

- The pack explicitly marks drill results as not run by default and keeps live execution evidence separate.
- The PR keeps production-scale validation bounded and non-blocking.

## Validation Commands

```bash
pre-commit run --files docs/testing/operational-drill-and-scale-validation-pack.md docs/enterprise-readiness-index.md docs/audits/enterprise-readiness-audit.md docs/roadmap/enterprise-readiness-roadmap.md docs/roadmap/enterprise-readiness-pr-board.md docs/validation-gap-audit.md
```

## Merge Criteria

- [ ] The drill pack documents 3-5 representative incident drills.
- [ ] The index, roadmap, and audit wording is consistent with the new pack.
- [ ] No runtime code changes are included.
- [ ] Changes stay within the observability / operational-proof scope.

## Related Documents

- `docs/release-evidence-pack.md`
- `docs/release-checklist.md`
- `docs/testing/failure-mode-and-scale-validation.md`
- `docs/OBSERVABILITY_MASTER_SPEC.md`
- `docs/governance/state-machine-and-operating-authority.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an operator-facing operational drill and scale-validation pack that defines five incident drills and bounded scale checks. Readiness docs now treat the pack as canonical, mark drills “Satisfied - documented,” and keep execution evidence and production-scale validation outside normal CI.

- **New Features**
  - Added `docs/testing/operational-drill-and-scale-validation-pack.md` with five drills (failed graph load, lock loss, stale owner, degraded DB, failed durable smoke), per-drill triggers/expected behavior/metrics (uses nested graph health fields like `graph.persistence_loaded` and `graph.startup_source`)/logs/dashboard+alert/runbook details, a compact evidence matrix, deterministic fixed sizes (10/20, 250/1k, 1k/5k), how-to steps, and links to current automated anchors.
  - Updated readiness docs (index, audit, roadmap, PR board, validation-gap audit) to link the pack, mark continuous operational drills as “Satisfied - documented,” and restate that drill execution evidence and production-scale validation remain separate from CI. Addresses Linear 1317 by making the drill matrix explicit and operator-facing.

<sup>Written for commit b8373fe68b9c192d9cd5c8436a8578cebe7a4550. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1318?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

