### PR TITLE
docs: add operational evidence issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
+++ b/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
@@ -72,6 +72,7 @@ Approver / reviewer:
 ### Failed graph load
 
 - [ ] `graph_persistence_configured` observed.
+- [ ] `graph.persistence_enabled` observed.
 - [ ] `graph.persistence_loaded` observed.
 - [ ] `graph.startup_source` observed.
 - [ ] No false persisted-graph claim was emitted.
@@ -110,6 +111,7 @@ Approver / reviewer:
 
 - [ ] Hosted readiness command exit status was recorded.
 - [ ] `graph_persistence_configured` was observed.
+- [ ] `graph.persistence_enabled` was observed.
 - [ ] `graph.persistence_loaded` was observed.
 - [ ] `graph.startup_source` was observed.
 - [ ] Assets smoke result was recorded.

--- a/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
+++ b/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
@@ -110,6 +110,7 @@ Approver / reviewer:
 ### Failed durable smoke
 
 - [ ] Hosted readiness command exit status was recorded.
+- [ ] Hosted readiness was run with `--require-persistence`.
 - [ ] `graph_persistence_configured` was observed.
 - [ ] `graph.persistence_enabled` was observed.
 - [ ] `graph.persistence_loaded` was observed.

--- a/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
+++ b/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
@@ -1,0 +1,150 @@
+---
+name: Operational drill evidence
+about: Capture evidence from one operational drill execution
+title: "[DRILL EVIDENCE] "
+labels: ["operations", "evidence", "observability", "verification"]
+assignees: ""
+---
+
+## Metadata
+
+**Drill name:**
+**Related issue or PR:**
+**Claim being proven:**
+**Execution date/time UTC:**
+**Operator:**
+**Reviewer / approver:**
+**Environment:** <!-- local / preview / staging / production / scratch -->
+**Target URL or deployment label:**
+**Release candidate link, if directly release-scoped:**
+**Release commit SHA, if directly release-scoped:**
+
+## Drill Classification
+
+- [ ] Failed graph load
+- [ ] Lock loss
+- [ ] Stale owner
+- [ ] Degraded DB
+- [ ] Failed durable smoke
+
+**Result classification:** <!-- Passed / Failed / Blocked / Not run / Manual evidence required / Follow-up required -->
+
+## Expected and Actual Behavior
+
+**Expected behavior:**
+**Actual behavior:**
+**Did the actual behavior match the expected behavior?**
+
+## Canonical Evidence Object
+
+Capture the artifact using the common evidence grammar from the operational evidence capture framework.
+
+```text
+Evidence ID:
+Gate / drill:
+Claim being proven:
+Release candidate / commit SHA:
+Environment:
+Target URL or deployment label:
+Durability label:
+Database boundary labels:
+  Auth DB:
+  Coordination DB:
+  Asset Graph DB:
+Operator:
+Capture timestamp UTC:
+Command or observation source:
+Expected result:
+Actual result:
+Relevant fields observed:
+Metrics observed:
+Logs/events observed:
+Dashboard/alert observed:
+Runbook step verified:
+Result:
+Redaction performed:
+Follow-up issue(s):
+Approver / reviewer:
+```
+
+## Drill-Specific Evidence
+
+### Failed graph load
+
+- [ ] `graph_persistence_configured` observed.
+- [ ] `graph.persistence_loaded` observed.
+- [ ] `graph.startup_source` observed.
+- [ ] No false persisted-graph claim was emitted.
+- [ ] The expected startup failure or degraded signal was observed.
+- [ ] The runbook response was recorded.
+
+### Lock loss
+
+- [ ] Lock holder before the drill was recorded.
+- [ ] Lock holder after the drill was recorded.
+- [ ] Lock refresh metric or event was observed.
+- [ ] Rebuild job status before and after was recorded.
+- [ ] The stale-owner mutation result was recorded.
+- [ ] The failure or recovery category was recorded.
+
+### Stale owner
+
+- [ ] Owner ID was recorded.
+- [ ] Heartbeat timestamp was recorded.
+- [ ] Lock expiry timestamp was recorded.
+- [ ] Current UTC was recorded.
+- [ ] RecoveryGate decision was recorded.
+- [ ] New-owner mutation result was recorded.
+- [ ] Stale-owner mutation result was recorded.
+
+### Degraded DB
+
+- [ ] The affected boundary was named explicitly.
+- [ ] The unaffected boundaries were named explicitly.
+- [ ] Health status was recorded.
+- [ ] `database.reachable` was recorded where relevant.
+- [ ] The relevant log or event was attached.
+- [ ] The runbook step followed was recorded.
+
+### Failed durable smoke
+
+- [ ] Hosted readiness command exit status was recorded.
+- [ ] `graph_persistence_configured` was observed.
+- [ ] `graph.persistence_loaded` was observed.
+- [ ] `graph.startup_source` was observed.
+- [ ] Assets smoke result was recorded.
+- [ ] Promotion decision impact was recorded.
+
+## Observability Evidence
+
+**Metric or query evidence:**
+**Log or event evidence:**
+**Dashboard evidence:**
+**Alert state:** <!-- inactive / pending / firing / silenced / not configured / not applicable -->
+**Dashboard time range and timezone:**
+**Scrape or observation window:**
+
+## Runbook Verification
+
+**Runbook or doc consulted:**
+**Runbook step followed:**
+**Ambiguity found, if any:**
+**Follow-up issue, if needed:**
+
+## Redaction Confirmation
+
+- [ ] No secrets, raw database URLs, bearer tokens, private keys, provider account identifiers, full graph dumps, or raw exception traces are included.
+- [ ] Redaction preserved field names, booleans, counts, status labels, timestamps needed for ordering, environment labels, and boundary labels.
+
+## Closure
+
+**Decision:** <!-- Passed / Failed / Blocked / Follow-up required -->
+**Decision owner:**
+**Decision date:**
+**Notes:**
+
+## Related Documents
+
+- [Operational Evidence Capture Framework](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/operations/operational-evidence-capture-framework.md)
+- [Operational Drill and Scale-Validation Pack](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/testing/operational-drill-and-scale-validation-pack.md)
+- [Release Evidence Pack](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-evidence-pack.md)

--- a/.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
+++ b/.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
@@ -1,0 +1,109 @@
+---
+name: Restore rehearsal evidence
+about: Capture evidence from one backup/restore or DR rehearsal
+title: "[RESTORE EVIDENCE] "
+labels: ["disaster-recovery", "evidence", "operations", "verification"]
+assignees: ""
+---
+
+## Metadata
+
+**Restore rehearsal date/time UTC:**
+**Restore operator:**
+**Reviewer / approver:**
+**Source environment:**
+**Scratch or non-production restore target:**
+**Release candidate link, if directly release-scoped:**
+**Release commit SHA, if directly release-scoped:**
+
+## Restore Point
+
+**Restore point timestamp or backup identifier:**
+**Backup / restore mechanism:** <!-- PITR / snapshot / logical dump / provider export / other -->
+**Provider:**
+**Restore type:** <!-- new target / in-place -->
+**Restore point inside expected retention / RPO window?**
+
+## Boundary Results
+
+### Auth/application DB boundary result
+
+**Source label:**
+**Restored target label:**
+**Result:**
+**Notes:**
+
+### Coordination DB boundary result
+
+**Source label:**
+**Restored target label:**
+**Result:**
+**Notes:**
+
+### Asset Graph DB boundary result
+
+**Source label:**
+**Restored target label:**
+**Result:**
+**Notes:**
+
+**Does coordination share the app/auth boundary?**
+**If yes, what shared-boundary fallback was confirmed?**
+
+## Verification Evidence
+
+**Restore cleanup / restart precheck:**
+**Restored distributed lock inspection result:**
+**Restored in-flight rebuild job inspection result:**
+**Cleanup action taken, if any:**
+**Confirmation that `running_rebuild_jobs_count == 0` before restart, or documented exception:**
+
+**Table presence result:**
+**Assets count:**
+**Relationships count:**
+**Regulatory events count:**
+**Running rebuild jobs count:**
+**Orphan relationship count:**
+**Regulatory event orphan counts:**
+**Baseline or sentinel comparison result:**
+
+## Persisted Graph Evidence
+
+**Hosted readiness command used:**
+
+```bash
+python scripts/check_hosted_readiness.py <base_url> --require-persistence
+```
+
+**Post-restore readiness result (`--require-persistence`):**
+**Redacted `/api/health/detailed` evidence:**
+**Redacted `/api/assets?per_page=1` or approved sentinel evidence:**
+**`graph_persistence_configured`:**
+**`graph.persistence_enabled`:**
+**`graph.persistence_loaded`:**
+**`graph.startup_source`:**
+**Persisted graph counts or approved sentinel baseline:**
+
+## RPO / RTO Metrics
+
+**RPO target:**
+**Observed RPO:**
+**RTO target:**
+**Observed RTO:**
+**Target miss classification:** <!-- Blocking / Non-blocking / Not applicable -->
+**Follow-up issue for misses or ambiguity:**
+
+## Closure
+
+**Restore rehearsal decision:** <!-- Passed / Failed / Blocked -->
+**Decision owner:**
+**Decision date:**
+**Notes:**
+**Redaction performed:**
+**Approver / reviewer:**
+
+## Related Documents
+
+- [Operational Evidence Capture Framework](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/operations/operational-evidence-capture-framework.md)
+- [Release Evidence Pack](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-evidence-pack.md)
+- [Backup, Restore, and DR Runbook](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/runbooks/backup-restore-dr.md)


### PR DESCRIPTION
## Primary Objective

Add dedicated operational drill and restore rehearsal issue templates so operational evidence is captured separately from release-candidate evidence and follows the canonical evidence grammar.

## Description

This PR adds two new issue templates under `.github/ISSUE_TEMPLATE/`:

- `operational_drill_evidence.md`
- `restore_rehearsal_evidence.md`

Both templates reference the operational evidence capture framework, the operational drill and scale-validation pack, the release evidence pack, and the DR runbook. The restore rehearsal template uses the repo’s canonical boundary wording, requires `--require-persistence` for post-restore readiness evidence, and adds a `Target miss classification` field separate from the final decision.

Closes #1321.

## In Scope

- Add a dedicated operational drill evidence issue template.
- Add a dedicated restore rehearsal evidence issue template.
- Align both templates with the canonical evidence grammar and redaction expectations.
- Keep release-candidate evidence separate from drill and restore evidence.

## Out of Scope

- No runtime code changes.
- No tests or CI workflow changes.
- No release-gate semantic changes.
- No hosted readiness logic changes.
- No deployment or staging configuration changes.

## Files Expected to Change

- `.github/ISSUE_TEMPLATE/operational_drill_evidence.md`
- `.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md`

## Type of Change

- [x] Documentation update
- [x] Template modification
- [ ] Architecture decision (ADR)
- [ ] Policy document addition/update
- [ ] Repository configuration

## Rationale

Operators need dedicated issue templates for operational drills and restore rehearsals so evidence is captured with the right level of detail without overloading the release-candidate evidence issue. This keeps release evidence focused while preserving the canonical structure required for review and redaction.

## Impact Assessment

### Positive Impacts

- Operational evidence is easier to capture consistently.
- Release-candidate evidence stays focused on release-blocking proof.
- Reviewers get the expected fields for boundary labels, redaction, and follow-up linkage.

### Potential Concerns

- Users may choose the wrong template for a given evidence artifact.
- The additional templates add another decision point when filing operational evidence.

### Mitigation Strategy

The new templates link back to the canonical evidence framework, the drill pack, the release evidence pack, and the DR runbook so operators can choose the right artifact path quickly.

## Validation Commands

```bash
pre-commit run --files \
  .github/ISSUE_TEMPLATE/operational_drill_evidence.md \
  .github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
```

## Merge Criteria

- [x] Both templates exist and validate cleanly.
- [x] No runtime code changes are included.
- [x] Cross-references point to the canonical evidence and DR documents.
- [x] Release-candidate evidence remains separate from drill and restore evidence.
- [x] The PR stays template/docs-only.

## Related Documents

- `#1321`
- `docs/operations/operational-evidence-capture-framework.md`
- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `docs/release-evidence-pack.md`
- `docs/runbooks/backup-restore-dr.md`
- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two GitHub issue templates for operational drills and DR restore rehearsals using the canonical evidence grammar. Keeps operational/DR evidence separate from release-candidate evidence and requires `--require-persistence` for durable smoke and post-restore readiness.

- **New Features**
  - Added `.github/ISSUE_TEMPLATE/operational_drill_evidence.md` with drill metadata, classification checklists (failed graph load, lock loss, stale owner, degraded DB, failed durable smoke), observability, runbook verification, and redaction. Durable smoke checks require hosted readiness with `--require-persistence`.
  - Added `.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md` with boundary results, RPO/RTO fields, post-restore persisted-graph readiness via `--require-persistence`, and lock/rebuild cleanup checks.
  - Linked to the operational evidence framework, drill/scale pack, release evidence pack, and DR runbook. Docs-only; no runtime or CI impact. Closes #1321.

<sup>Written for commit 12dcb4ed52f83a434ddc64a3b2ae9a3317ed90f8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1322?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

