### PR TITLE
docs: tighten release-candidate evidence template

### DIFF
--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -60,14 +60,14 @@ Reference:
 - [ ] Hosted readiness output attached with secrets redacted.
 - [ ] Redacted `/api/health/detailed` output attached.
 - [ ] Redacted `/api/assets?per_page=1` output attached.
-- [ ] `/api/health/detailed.graph_persistence_configured == true` is confirmed.
-- [ ] `/api/health/detailed.graph.persistence_enabled == true` is confirmed.
-- [ ] `/api/health/detailed.graph.persistence_loaded == true` is confirmed.
-- [ ] `/api/health/detailed.graph.startup_source == "persisted"` is confirmed.
+- [ ] /api/health/detailed response graph_persistence_configured == true is confirmed.
+- [ ] /api/health/detailed response graph.persistence_enabled == true is confirmed.
+- [ ] /api/health/detailed response graph.persistence_loaded == true is confirmed.
+- [ ] /api/health/detailed response graph.startup_source == "persisted" is confirmed.
 - [ ] Hosted durable persistence evidence object or supporting evidence issue link is recorded.
 - [ ] Persisted graph counts or approved sentinel baseline are confirmed.
 
-False-positive guardrail: CI success, documentation existence, passing repository tests, or `/api/health/detailed.status == "healthy"` alone does not prove hosted durable graph truth. Durable promotion evidence requires target-environment hosted readiness with `--require-persistence` and nested graph fields showing persisted graph load.
+False-positive guardrail: CI success, documentation existence, passing repository tests, or /api/health/detailed response status == "healthy" alone does not prove hosted durable graph truth. Durable promotion evidence requires target-environment hosted readiness with --require-persistence and nested graph fields showing persisted graph load.
 
 ## Operational Drill Evidence, if release-scoped
 

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -13,6 +13,10 @@ assignees: ""
 **Target environment:** <!-- staging / production -->
 **Evidence owner:**
 **Evidence capture date:**
+**Canonical evidence framework/version:**
+**Linked operational evidence issue(s):**
+**Linked restore rehearsal evidence issue:**
+**Linked operational drill evidence issue(s), if release-scoped:**
 
 ## Scope
 
@@ -24,6 +28,7 @@ Reference:
 - [Release Evidence Pack](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-evidence-pack.md)
 - [Enterprise Release Checklist](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-checklist.md)
 - [Enterprise Deployment Operating Model](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/enterprise-deployment-operating-model.md)
+- [Operational Evidence Capture Framework](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/operations/operational-evidence-capture-framework.md)
 
 ## Automated Release Commit Evidence
 
@@ -41,7 +46,8 @@ Reference:
 - [ ] Staging asset graph database boundary label is recorded.
 - [ ] Staging coordination database boundary label or shared-boundary fallback is recorded.
 - [ ] `COORDINATION_DATABASE_URL` is configured when coordination is separated, or shared-boundary fallback is documented.
-- [ ] Preview evidence is labelled `durable` or `non-durable`, if preview evidence is attached.
+- [ ] Preview evidence is labelled `durable`, `non-durable`, or `not used`, if preview evidence is attached.
+- [ ] Non-durable preview evidence is not used as staging or production durable graph proof.
 - [ ] `DATABASE_URL` is configured for the target durable app/auth database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is configured for the target durable graph database.
 - [ ] `ASSET_GRAPH_DATABASE_URL` is distinct from `DATABASE_URL`, or an approved exception is attached.
@@ -54,8 +60,22 @@ Reference:
 - [ ] Hosted readiness output attached with secrets redacted.
 - [ ] Redacted `/api/health/detailed` output attached.
 - [ ] Redacted `/api/assets?per_page=1` output attached.
-- [ ] Persisted startup source is confirmed.
+- [ ] `/api/health/detailed.graph_persistence_configured == true` is confirmed.
+- [ ] `/api/health/detailed.graph.persistence_enabled == true` is confirmed.
+- [ ] `/api/health/detailed.graph.persistence_loaded == true` is confirmed.
+- [ ] `/api/health/detailed.graph.startup_source == "persisted"` is confirmed.
+- [ ] Hosted durable persistence evidence object or supporting evidence issue link is recorded.
 - [ ] Persisted graph counts or approved sentinel baseline are confirmed.
+
+False-positive guardrail: CI success, documentation existence, passing repository tests, or `/api/health/detailed.status == "healthy"` alone does not prove hosted durable graph truth. Durable promotion evidence requires target-environment hosted readiness with `--require-persistence` and nested graph fields showing persisted graph load.
+
+## Operational Drill Evidence, if release-scoped
+
+Use this only when a drill is directly release-blocking or explicitly included in the release scope.
+
+- [ ] Operational drill evidence issue linked, if applicable.
+- [ ] Drill result summarized: Passed / Failed / Blocked / Follow-up required / Not applicable.
+- [ ] Release impact summarized.
 
 ## Security Scanner and Exception Evidence
 
@@ -81,6 +101,7 @@ Record named owners for this release candidate:
 - [ ] Restore rehearsal date recorded.
 - [ ] Restore operator recorded.
 - [ ] Source environment recorded.
+- [ ] Restore rehearsal evidence issue linked.
 - [ ] Restore point timestamp or backup identifier recorded.
 - [ ] Scratch/non-production restore target recorded.
 - [ ] Backup/restore mechanism recorded: PITR / snapshot / logical dump / provider export / other.


### PR DESCRIPTION
## Primary Objective

Tighten the release-candidate evidence template so hosted durable graph proof cannot be confused with CI success, documentation presence, or unlabeled preview output.

## Description

This PR updates `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` to make release evidence capture more explicit and harder to misclassify. The template now records the canonical evidence framework, links to supporting evidence issues, distinguishes durable versus non-durable preview evidence, names the canonical nested graph field paths, and adds a false-positive guardrail that CI/docs/healthy responses alone do not prove durable hosted truth.

It also adds a short optional section for release-scoped operational drill evidence and a restore rehearsal link field so reviewers can tie the release decision back to the underlying evidence objects without duplicating the full artifacts inline.

Closes #1323.

## In Scope

- Tighten `.github/ISSUE_TEMPLATE/release_candidate_evidence.md` only.
- Add evidence reference fields at the top of the template.
- Add explicit nested graph field path checks for durable hosted proof.
- Add preview durability labeling and a non-durable preview guardrail.
- Add a short release-scoped operational drill evidence reference section.
- Add a restore rehearsal evidence issue link field.
- Add a false-positive warning explaining what does not count as durable hosted proof.

## Out of Scope

- No runtime code changes.
- No tests or CI workflow changes.
- No hosted readiness script changes.
- No new issue templates.
- No release gate reclassification.
- No staging, deployment, or provider configuration changes.
- No changes to the release evidence pack beyond this template tightening.

## Files Expected to Change

- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`

## Type of Change

- [x] Documentation update
- [x] Template modification
- [ ] Architecture decision (ADR)
- [ ] Policy document addition/update
- [ ] Repository configuration

## Rationale

The existing template already collected the broad release evidence categories, but it did not force reviewers to distinguish durable hosted proof from weaker proxies such as CI success, documentation existence, or generic healthy responses. This change closes that gap while preserving the separation between release-candidate evidence and the underlying drill or restore artifacts.

## Impact Assessment

### Positive Impacts

- Release reviewers get clearer proof requirements for durable hosted evidence.
- Preview evidence is explicitly labeled and cannot be mistaken for durable proof.
- Operational drill and restore evidence can be referenced without duplicating full artifacts.

### Potential Concerns

- The template becomes slightly longer and more prescriptive.
- Operators must link supporting evidence more explicitly than before.

### Mitigation Strategy

The added fields are confined to the existing release-candidate template and reuse the canonical evidence language already defined in the repository, so the extra structure should reduce ambiguity rather than create new process overhead.

## Validation Commands

```bash
pre-commit run --files .github/ISSUE_TEMPLATE/release_candidate_evidence.md
```

## Merge Criteria

- [x] The release-candidate template includes explicit nested graph field paths.
- [x] Preview evidence must be labeled durable, non-durable, or not used.
- [x] Supporting evidence links are captured without duplicating full artifacts.
- [x] The template warns against false-positive durable-proof claims.
- [x] No runtime or workflow behavior changes are introduced.

## Related Documents

- `#1323`
- `docs/release-evidence-pack.md`
- `docs/operations/operational-evidence-capture-framework.md`
- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `docs/runbooks/backup-restore-dr.md`
- `.github/ISSUE_TEMPLATE/operational_drill_evidence.md`
- `.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens the release-candidate evidence template to require explicit proof of durable hosted graph load and direct links to supporting evidence. Clarifies that CI/docs/tests/healthy status alone are not durable proof and that preview evidence must be clearly labeled.

- **New Features**
  - Adds top-level fields for canonical evidence framework/version, linked operational evidence issue(s), restore rehearsal evidence issue, and optional release-scoped drill issue(s).
  - Requires preview evidence to be labeled as durable, non-durable, or not used; bars non-durable previews from serving as durable proof.
  - Introduces explicit readiness checks for nested graph fields (persistence configured/enabled/loaded, startup_source == "persisted") and requires recording a hosted durable persistence evidence object or link.
  - Adds an optional release-scoped operational drill section to link the drill and briefly summarize result and release impact.

<sup>Written for commit ed6ceb4b75d566d1a52482aeafc8874aa6eef090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1324?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

