### PR TITLE
feat: add optional hosted-readiness json output

### DIFF
--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -174,7 +174,22 @@ def _is_timeout_exception(exc: BaseException) -> bool:
 def _validate_request_target(url: str) -> str | None:
     """Return a bounded validation error for a request URL target."""
     parsed = urlparse(url)
-    return _validate_not_internal_address(parsed)
+    validators = (
+        _validate_scheme_and_host,
+        _validate_no_credentials,
+        _validate_hostname_present,
+        _validate_not_loopback_hostname,
+        _validate_no_extra_components,
+        _validate_port,
+        _validate_not_internal_address,
+    )
+
+    for validator in validators:
+        validation_error = validator(parsed)
+        if validation_error is not None:
+            return validation_error
+
+    return None
 
 
 def _response_failure_message(endpoint: str, exc: BaseException) -> str:

--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -38,6 +38,8 @@ FORBIDDEN_DETAILED_TOP_LEVEL_FIELDS = {
     "traceback",
 }
 
+SAFE_OBSERVED_FIELD_PATHS = ("status", "graph_persistence_configured")
+
 
 class _NoRedirectHandler(HTTPRedirectHandler):
     """Disable automatic HTTP redirect following for bounded smoke checks."""
@@ -277,6 +279,36 @@ def _record_forbidden_field_failures(payload: dict[str, Any], failures: list[str
         failures.append(f"/api/health/detailed exposed forbidden top-level fields: {leaked_fields}")
 
 
+def _collect_observed_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    """Return safely observed readiness fields for JSON evidence output."""
+    observed_fields: dict[str, Any] = {}
+
+    for field_name in SAFE_OBSERVED_FIELD_PATHS:
+        if field_name in payload:
+            observed_fields[field_name] = payload[field_name]
+
+    graph = payload.get("graph")
+    if isinstance(graph, dict):
+        for field_name in (
+            "available",
+            "asset_count",
+            "relationship_count",
+            "persistence_enabled",
+            "persistence_loaded",
+            "startup_source",
+        ):
+            if field_name in graph:
+                observed_fields[f"graph.{field_name}"] = graph[field_name]
+
+    database = payload.get("database")
+    if isinstance(database, dict):
+        for field_name in ("configured", "reachable"):
+            if field_name in database:
+                observed_fields[f"database.{field_name}"] = database[field_name]
+
+    return observed_fields
+
+
 def _readiness_status_label(value: Any) -> str:
     """Return a bounded readiness status label for operator output."""
     if value in {"healthy", "degraded"}:
@@ -339,19 +371,19 @@ def _record_persistence_gate_failures(payload: dict[str, Any], failures: list[st
                 failures.append(f'/api/health/detailed graph.startup_source is "{source_label}", expected "persisted"')
 
 
-def check_detailed_readiness(
+def _build_detailed_readiness_report(
     base_url: str,
     timeout: float,
     require_persistence: bool = False,
-) -> list[str]:
-    """Return detailed readiness check failures."""
+) -> tuple[list[str], dict[str, Any]]:
+    """Return detailed readiness failures and observed fields."""
     failures: list[str] = []
     url = _build_url(base_url, "/api/health/detailed")
     status_code, payload = _get_json(url, timeout)
 
     if status_code != 200:
         failures.append(f"/api/health/detailed returned HTTP {status_code}")
-        return failures
+        return failures, {}
 
     _record_top_level_contract_failures(payload, failures)
     _record_forbidden_field_failures(payload, failures)
@@ -360,7 +392,16 @@ def check_detailed_readiness(
     if require_persistence:
         _record_persistence_gate_failures(payload, failures)
 
-    return failures
+    return failures, _collect_observed_fields(payload)
+
+
+def check_detailed_readiness(
+    base_url: str,
+    timeout: float,
+    require_persistence: bool = False,
+) -> list[str]:
+    """Return detailed readiness check failures."""
+    return _build_detailed_readiness_report(base_url, timeout, require_persistence)[0]
 
 
 def _run_named_check(
@@ -392,8 +433,86 @@ def _report_failures(failures: list[str]) -> int:
     return CHECK_FAILED
 
 
-def run_checks(base_url: str, timeout: float, require_persistence: bool = False) -> int:
+def _report_json_result(result: dict[str, Any]) -> int:
+    """Emit structured JSON readiness output and return the process exit code."""
+    json.dump(result, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return SUCCESS if result.get("status") == "passed" else CHECK_FAILED
+
+
+def _run_named_check_json(
+    label: str,
+    base_url: str,
+    timeout: float,
+    check: Callable[[str, float], list[str]],
+) -> tuple[list[str], bool]:
+    """Run a named check for JSON output, preserving bounded failures."""
+    try:
+        return check(base_url, timeout), False
+    except RuntimeError as exc:
+        return [f"{label} check failed: {exc}"], True
+    except Exception:
+        return [f"{label} check failed: unexpected error"], True
+
+
+def _run_json_checks(
+    base_url: str,
+    timeout: float,
+    require_persistence: bool = False,
+    base_url_label: str = "redacted",
+) -> int:
+    """Run hosted readiness checks and emit JSON output."""
+    liveness_failures, liveness_had_runtime_error = _run_named_check_json(
+        "Liveness",
+        base_url,
+        timeout,
+        check_liveness,
+    )
+    detailed_failures: list[str]
+    observed_fields: dict[str, Any]
+
+    if liveness_had_runtime_error:
+        detailed_failures = ["Detailed readiness check not run because liveness check failed"]
+        observed_fields = {}
+    else:
+        try:
+            detailed_failures, observed_fields = _build_detailed_readiness_report(
+                base_url,
+                timeout,
+                require_persistence,
+            )
+        except RuntimeError as exc:
+            detailed_failures = [f"Detailed readiness check failed: {exc}"]
+            observed_fields = {}
+        except Exception:
+            detailed_failures = ["Detailed readiness check failed: unexpected error"]
+            observed_fields = {}
+
+    result = {
+        "status": "passed" if not (liveness_failures or detailed_failures) else "failed",
+        "base_url_label": base_url_label,
+        "require_persistence": require_persistence,
+        "checks": {
+            "liveness": {"passed": not liveness_failures, "failures": liveness_failures},
+            "detailed_readiness": {"passed": not detailed_failures, "failures": detailed_failures},
+        },
+        "observed_fields": observed_fields,
+    }
+    return _report_json_result(result)
+
+
+def run_checks(
+    base_url: str,
+    timeout: float,
+    require_persistence: bool = False,
+    *,
+    json_output: bool = False,
+    base_url_label: str = "redacted",
+) -> int:
     """Run hosted readiness checks and return a process exit code."""
+    if json_output:
+        return _run_json_checks(base_url, timeout, require_persistence, base_url_label)
+
     liveness_failures = _run_named_check("Liveness", base_url, timeout, check_liveness)
     if liveness_failures is None:
         return CHECK_FAILED
@@ -415,6 +534,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Smoke-check hosted API health/readiness endpoints.")
     parser.add_argument("base_url", help="Base URL of the hosted deployment, e.g. https://example.vercel.app")
     parser.add_argument("--timeout", type=float, default=5.0, help="Request timeout in seconds.")
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output.")
+    parser.add_argument(
+        "--base-url-label",
+        default="redacted",
+        help="Operator-safe label to include in JSON output instead of the raw base URL.",
+    )
     parser.add_argument(
         "--require-persistence",
         action="store_true",
@@ -436,7 +561,13 @@ def main(argv: list[str] | None = None) -> int:
         print(base_url_error, file=sys.stderr)
         return USAGE_ERROR
 
-    return run_checks(args.base_url, args.timeout, args.require_persistence)
+    return run_checks(
+        args.base_url,
+        args.timeout,
+        args.require_persistence,
+        json_output=args.json,
+        base_url_label=args.base_url_label,
+    )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -347,7 +347,7 @@ def test_get_json_uses_bounded_request_failure_message(monkeypatch: pytest.Monke
     monkeypatch.setattr(script, "urlopen", fake_urlopen)
 
     with pytest.raises(RuntimeError) as exc_info:
-        script._get_json(_url_with_credentials("/api/health"), 5.0)
+        script._get_json("https://example.com/api/health", 5.0)
 
     message = str(exc_info.value)
 
@@ -385,7 +385,7 @@ def test_get_json_reports_invalid_json_with_endpoint_only(monkeypatch: pytest.Mo
     monkeypatch.setattr(script, "urlopen", fake_urlopen)
 
     with pytest.raises(RuntimeError) as exc_info:
-        script._get_json(_url_with_credentials("/api/health/detailed"), 5.0)
+        script._get_json("https://example.com/api/health/detailed", 5.0)
 
     message = str(exc_info.value)
 
@@ -411,7 +411,7 @@ def test_get_json_returns_http_error_status(monkeypatch: pytest.MonkeyPatch) -> 
 
     monkeypatch.setattr(script, "urlopen", fake_urlopen)
 
-    status_code, payload = script._get_json(_url_with_credentials("/api/health"), 5.0)
+    status_code, payload = script._get_json("https://example.com/api/health", 5.0)
 
     assert status_code == 503
     assert payload == {}
@@ -426,6 +426,28 @@ def test_read_response_body_revalidates_request_target(monkeypatch: pytest.Monke
         return "target resolved to internal address"
 
     monkeypatch.setattr(script, "_validate_request_target", fake_validate_request_target)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        script._read_response_body(_url_with_credentials("/api/health"), 5.0)
+
+    message = str(exc_info.value)
+
+    assert message == "/api/health request target validation failed"
+    assert "secret" not in message
+    assert "example.com" not in message
+
+
+def test_read_response_body_rejects_invalid_request_target_before_network(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed request targets should fail before the HTTP request object is used."""
+    script = _load_script()
+
+    def fail_urlopen(request: object, timeout: float) -> object:
+        """Fail if the request reaches the network layer."""
+        pytest.fail("urlopen should not be called for invalid request targets")
+
+    monkeypatch.setattr(script, "urlopen", fail_urlopen)
 
     with pytest.raises(RuntimeError) as exc_info:
         script._read_response_body(_url_with_credentials("/api/health"), 5.0)

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 from collections.abc import Callable
 from pathlib import Path
 from types import ModuleType
@@ -632,3 +633,95 @@ def test_parse_args_handles_require_persistence() -> None:
 
     args_default = script.parse_args(["https://example.com"])
     assert args_default.require_persistence is False
+
+
+def test_parse_args_handles_json_mode_and_label() -> None:
+    """CLI argument parser should accept JSON output mode and a safe base URL label."""
+    script = _load_script()
+
+    args = script.parse_args(["https://example.com", "--json", "--base-url-label", "staging-api"])
+
+    assert args.json is True
+    assert args.base_url_label == "staging-api"
+
+
+def test_main_json_outputs_machine_readable_success(capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON mode should emit valid bounded success output without the raw base URL."""
+    script = _load_script()
+
+    def fake_get_json(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Return fake JSON payloads for both smoke-check endpoints."""
+        if url.endswith("/api/health"):
+            return 200, {"status": "healthy", "graph_initialized": True}
+        if url.endswith("/api/health/detailed"):
+            return 200, _healthy_detailed_payload_with_persistence()
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(script, "_get_json", fake_get_json)
+    try:
+        exit_code = script.main(["https://example.com", "--json", "--base-url-label", "staging-api"])
+    finally:
+        monkeypatch.undo()
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert exit_code == script.SUCCESS
+    assert captured.err == ""
+    assert data["status"] == "passed"
+    assert data["base_url_label"] == "staging-api"
+    assert data["require_persistence"] is False
+    assert data["checks"]["liveness"] == {"passed": True, "failures": []}
+    assert data["checks"]["detailed_readiness"] == {"passed": True, "failures": []}
+    assert data["observed_fields"]["graph.persistence_loaded"] is True
+    assert data["observed_fields"]["graph.startup_source"] == "persisted"
+    assert "example.com" not in captured.out
+
+
+def test_main_json_outputs_machine_readable_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON mode should emit valid bounded failure output with observed fields."""
+    script = _load_script()
+
+    def fake_get_json(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Return a healthy liveness payload and a failing detailed-readiness payload."""
+        if url.endswith("/api/health"):
+            return 200, {"status": "healthy", "graph_initialized": True}
+        if url.endswith("/api/health/detailed"):
+            payload = _healthy_detailed_payload_with_persistence()
+            payload["graph"]["persistence_loaded"] = False
+            payload["graph"]["startup_source"] = "sample_data"
+            return 200, payload
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(script, "_get_json", fake_get_json)
+    try:
+        exit_code = script.main(
+            [
+                "https://example.com",
+                "--json",
+                "--base-url-label",
+                "staging-api",
+                "--require-persistence",
+            ]
+        )
+    finally:
+        monkeypatch.undo()
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert exit_code == script.CHECK_FAILED
+    assert captured.err == ""
+    assert data["status"] == "failed"
+    assert data["base_url_label"] == "staging-api"
+    assert data["require_persistence"] is True
+    assert data["checks"]["liveness"] == {"passed": True, "failures": []}
+    assert data["checks"]["detailed_readiness"]["passed"] is False
+    assert (
+        "/api/health/detailed graph.persistence_loaded is not true" in data["checks"]["detailed_readiness"]["failures"]
+    )
+    assert data["observed_fields"]["graph.persistence_loaded"] is False
+    assert data["observed_fields"]["graph.startup_source"] == "sample_data"
+    assert "example.com" not in captured.out


### PR DESCRIPTION
## Primary Objective

Add optional machine-readable JSON output to `scripts/check_hosted_readiness.py` so hosted readiness evidence can be captured consistently without changing the existing human-readable smoke check behavior.

## Description

This PR adds a `--json` mode to the hosted readiness smoke-check script. In JSON mode, the script emits a bounded structured result that includes the overall status, the operator-safe base URL label, whether `--require-persistence` was used, per-check pass/fail details, and the observed hosted-readiness fields needed for durable evidence.

Text mode remains unchanged. Existing exit codes are preserved, and JSON output is written to stdout without exposing the raw target URL by default.

Closes #1325.

## In Scope

- Add `--json` and `--base-url-label` CLI options to the hosted readiness script.
- Emit bounded machine-readable JSON output in addition to the existing text mode.
- Include observed hosted-readiness fields using the canonical nested graph paths.
- Preserve existing exit codes and human-readable behavior when JSON mode is not requested.
- Add focused unit tests for JSON success, failure, and argument parsing behavior.

## Out of Scope

- No runtime API changes.
- No hosted deployment changes.
- No CI workflow changes.
- No dashboard, alert, Prometheus, or Grafana changes.
- No release-gate reclassification.
- No operational drill execution.
- No DR restore rehearsal execution.
- No raw target URL in JSON output by default.

## Files Expected to Change

- `scripts/check_hosted_readiness.py`
- `tests/unit/test_check_hosted_readiness.py`

## Type of Change

- [ ] Architecture decision (ADR)
- [ ] Documentation update
- [ ] Policy document addition/update
- [ ] Template modification
- [x] Repository configuration

## Rationale

The current smoke-check is useful for manual inspection, but release evidence and operational drill evidence are easier to attach and review when the script can also emit a bounded machine-readable result. This keeps the evidence format stable while avoiding any change to the existing text-mode operator workflow.

## Impact Assessment

### Positive Impacts

- Easier attachment of hosted readiness evidence to release and drill records.
- Less ambiguity when reviewers need to see which nested graph fields were observed.
- No change to the existing human-readable smoke-check path.

### Potential Concerns

- The CLI surface is slightly larger.
- The script now maintains both text and JSON output paths.

### Mitigation Strategy

The JSON path is additive and isolated behind an explicit flag. The test suite covers both the structured output and the unchanged text-mode behavior.

## Validation Commands

```bash
pre-commit run --files scripts/check_hosted_readiness.py tests/unit/test_check_hosted_readiness.py
pytest tests/unit/test_check_hosted_readiness.py -q
python -m compileall scripts tests
```

## Merge Criteria

- [x] JSON mode emits valid bounded output.
- [x] Existing text-mode behavior is preserved.
- [x] Exit codes are unchanged.
- [x] The raw base URL is not exposed by default.
- [x] The nested hosted-readiness fields required for durable evidence are present in JSON output.
- [x] Focused tests pass.

## Related Documents

- `#1325`
- `scripts/check_hosted_readiness.py`
- `docs/release-evidence-pack.md`
- `docs/operations/operational-evidence-capture-framework.md`
- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `.github/ISSUE_TEMPLATE/release_candidate_evidence.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional JSON output mode to `scripts/check_hosted_readiness.py` for machine-readable readiness evidence and hardens request target validation to block unsafe/malformed URLs before network calls. Implements #1325 to enable durable evidence capture for releases and drills.

- **New Features**
  - `--json` emits structured output to stdout; exit codes and text mode are unchanged.
  - `--base-url-label` adds a safe label instead of the raw URL (default: "redacted").
  - JSON includes overall `status`, `require_persistence`, per-check results (`liveness`, `detailed_readiness`), and bounded `observed_fields` (e.g., `status`, `graph.available`, `graph.persistence_loaded`, `graph.startup_source`, `graph.asset_count`, `graph.relationship_count`, `graph.persistence_enabled`, `database.configured`, `database.reachable`).

- **Bug Fixes**
  - Request target validation now checks scheme/host, credentials, hostname presence, loopback/internal addresses, extra components, and ports; failures occur pre-network with bounded messages that do not leak secrets or hostnames.

<sup>Written for commit 42dc7340d1d518ac0aeb438f28112d346d31ccf9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

