### PR TITLE
fix: clarify hosted readiness json evidence

### DIFF
--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -38,7 +38,7 @@ FORBIDDEN_DETAILED_TOP_LEVEL_FIELDS = {
     "traceback",
 }
 
-SAFE_OBSERVED_FIELD_PATHS = ("status", "graph_persistence_configured")
+SAFE_OBSERVED_FIELDS = ("status", "graph_persistence_configured")
 
 
 class _NoRedirectHandler(HTTPRedirectHandler):
@@ -298,7 +298,7 @@ def _collect_observed_fields(payload: dict[str, Any]) -> dict[str, Any]:
     """Return safely observed readiness fields for JSON evidence output."""
     observed_fields: dict[str, Any] = {}
 
-    for field_name in SAFE_OBSERVED_FIELD_PATHS:
+    for field_name in SAFE_OBSERVED_FIELDS:
         if field_name in payload:
             observed_fields[field_name] = payload[field_name]
 

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -701,7 +701,9 @@ def test_main_json_outputs_machine_readable_success(capsys: pytest.CaptureFixtur
     assert "example.com" not in captured.out
 
 
-def test_main_json_uses_default_redacted_base_url_label(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
+def test_main_json_uses_default_redacted_base_url_label(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
     """JSON mode should default to a redacted base URL label when none is provided."""
     script = _load_script()
 

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -701,6 +701,35 @@ def test_main_json_outputs_machine_readable_success(capsys: pytest.CaptureFixtur
     assert "example.com" not in captured.out
 
 
+def test_main_json_uses_default_redacted_base_url_label(capsys: pytest.CaptureFixture[str]) -> None:
+    """JSON mode should default to a redacted base URL label when none is provided."""
+    script = _load_script()
+
+    def fake_get_json(url: str, timeout: float) -> tuple[int, dict[str, Any]]:
+        """Return fake JSON payloads for both smoke-check endpoints."""
+        if url.endswith("/api/health"):
+            return 200, {"status": "healthy", "graph_initialized": True}
+        if url.endswith("/api/health/detailed"):
+            return 200, _healthy_detailed_payload_with_persistence()
+        raise AssertionError(f"unexpected URL: {url}")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(script, "_get_json", fake_get_json)
+    try:
+        exit_code = script.main(["https://example.com", "--json"])
+    finally:
+        monkeypatch.undo()
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+
+    assert exit_code == script.SUCCESS
+    assert captured.err == ""
+    assert data["status"] == "passed"
+    assert data["base_url_label"] == "redacted"
+    assert "example.com" not in captured.out
+
+
 def test_main_json_outputs_machine_readable_failure(capsys: pytest.CaptureFixture[str]) -> None:
     """JSON mode should emit valid bounded failure output with observed fields."""
     script = _load_script()

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -701,7 +701,7 @@ def test_main_json_outputs_machine_readable_success(capsys: pytest.CaptureFixtur
     assert "example.com" not in captured.out
 
 
-def test_main_json_uses_default_redacted_base_url_label(capsys: pytest.CaptureFixture[str]) -> None:
+def test_main_json_uses_default_redacted_base_url_label(capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
     """JSON mode should default to a redacted base URL label when none is provided."""
     script = _load_script()
 
@@ -713,12 +713,8 @@ def test_main_json_uses_default_redacted_base_url_label(capsys: pytest.CaptureFi
             return 200, _healthy_detailed_payload_with_persistence()
         raise AssertionError(f"unexpected URL: {url}")
 
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(script, "_get_json", fake_get_json)
-    try:
-        exit_code = script.main(["https://example.com", "--json"])
-    finally:
-        monkeypatch.undo()
+    exit_code = script.main(["https://example.com", "--json"])
 
     captured = capsys.readouterr()
     data = json.loads(captured.out)


### PR DESCRIPTION
## Validator / workflow follow-up summary

This PR resolves the two review comments that were left unresolved when PR #1326 was merged:
- rename the observed-field constant for clarity;
- add a regression test for the default redacted JSON label path.

## Policy being followed

- [x] This PR does not introduce a new dependency policy.
- [x] This PR updates tests/workflows/docs to match an existing documented policy.
- [x] If runtime dependency semantics changed, that decision was made in a separate PR.

Reference policy or prior PR:

- PR #1326
- `docs/release-evidence-pack.md`
- `docs/operations/operational-evidence-capture-framework.md`

## Scope

This PR changes:

- renames `SAFE_OBSERVED_FIELD_PATHS` to `SAFE_OBSERVED_FIELDS` for clarity;
- adds a unit test proving JSON mode defaults to the redacted base URL label when `--base-url-label` is omitted.

This PR does **not** change:

- JSON output shape;
- text-mode smoke-check behavior;
- exit codes;
- hosted readiness validation semantics;
- any runtime API, workflow, or deployment behavior.

## Touched files

- tests: `tests/unit/test_check_hosted_readiness.py`
- workflows: none
- docs: `scripts/check_hosted_readiness.py`

## Why this is separate

PR #1326 had already been merged when these comments were surfaced, so this follow-up keeps the fix narrowly scoped and avoids reopening the merged branch history.

## Validation run locally

```bash
pre-commit run --files scripts/check_hosted_readiness.py tests/unit/test_check_hosted_readiness.py
pytest tests/unit/test_check_hosted_readiness.py -q
```

## Guardrail checklist

- [x] This PR follows an existing documented model instead of redefining it.
- [x] I did not alter dependency files unless that was strictly required and explicitly explained.
- [x] I kept the scope to validator/workflow/doc alignment only.
- [x] The PR description does not overstate what has been fixed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies hosted readiness JSON evidence by renaming `SAFE_OBSERVED_FIELD_PATHS` to `SAFE_OBSERVED_FIELDS` and adds a regression test confirming JSON mode defaults to the redacted `base_url_label` when `--base-url-label` is omitted and does not leak the base URL. No runtime behavior, JSON output shape, or exit codes changed; includes minor formatting cleanups only.

<sup>Written for commit 0116a50d6077b6b06b7aa75fb9dfed81d5542229. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1327?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

