### PR TITLE
docs: add operational drill execution records register

### DIFF
--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -36,7 +36,7 @@ These are not stale roadmap items; they are bounded follow-up objectives.
 | `RebuildJobListResponse` truncation signal | Satisfied - automated | Response exposes `total` and `has_more`; tests cover default cap, explicit pagination, and status-filtered truncation semantics; no frontend consumer was found | Release evidence capture |
 | Strict stale-owner restart composition | Satisfied - automated | End-to-end restart pipeline proves stale-owner reset after lock expiry, restart load, and prevents stale owner mutation | Source-of-truth docs reconciliation |
 | Production-scale validation | Partially satisfied | Larger graph/load evidence is recorded outside normal CI or in a bounded scheduled workflow | Core release evidence PR |
-| Continuous operational drills | Satisfied - documented | The operational drill pack defines graph load failure, lock loss, stale owner, degraded DB, and failed durable smoke flows with evidence capture guidance | Initial staging proof |
+| Continuous operational drills | Satisfied - documented | The operational drill pack defines graph load failure, lock loss, stale owner, degraded DB, and failed durable smoke flows with evidence capture guidance; the execution-record register captures actual run artifacts | Initial staging proof |
 
 ## Board Notes
 
@@ -46,4 +46,4 @@ These are not stale roadmap items; they are bounded follow-up objectives.
 - PR 6 and PR C are no longer missing specifications; they are documented authorities that require review enforcement when governed behavior changes.
 - PR 8 and PR 9 are documentation/test/policy complete for their repository scope, but release sign-off still requires scanner/exception evidence and restore rehearsal evidence.
 - Production-scale validation should remain separately tracked so it does not blur release evidence capture with new runtime scope.
-- The operational drill pack is now the canonical documentation for representative incident drills; execution evidence remains a separate follow-up artifact.
+- The operational drill pack is now the canonical documentation for representative incident drills; the execution-record register is the separate follow-up artifact for actual run evidence.

--- a/docs/roadmap/enterprise-readiness-roadmap.md
+++ b/docs/roadmap/enterprise-readiness-roadmap.md
@@ -46,7 +46,7 @@ These items are valid but should not be bundled into the release-evidence reconc
 | `RebuildJobListResponse` truncation signal | Satisfied | Rebuild job-list responses expose `total` and `has_more`; tests cover default cap, explicit pagination, and status-filtered truncation semantics | None |
 | Strict stale-owner restart composition test | Satisfied - automated | The dedicated restart/recovery integration test now covers owner death, lock expiry, RecoveryGate reset, persisted restart load, and stale-owner fencing | Existing restart/recovery helpers, distributed lock test fixtures |
 | Production-scale validation | Partially satisfied | Representative CI fixtures exist, but production-scale rebuild, lock refresh, memory, and persistence-load evidence should run outside normal CI | Stable staging dataset, performance budget, observability dashboards |
-| Continuous operational drills | Satisfied - documented | The operational drill pack defines representative incident drills, metrics, dashboard panels, alert surfaces, and runbook responses | Observability stack, runbooks, named operators |
+| Continuous operational drills | Satisfied - documented | The operational drill pack defines representative incident drills, metrics, dashboard panels, alert surfaces, and runbook responses; the execution-record register captures actual run artifacts | Observability stack, runbooks, named operators |
 | Multi-region / advanced hosting strategy | Partially satisfied | Too early until single-region durable staging/prod evidence and restore rehearsal are complete | Release evidence, DR evidence, cost and provider model |
 
 ## Key Dependencies
@@ -55,7 +55,7 @@ These items are valid but should not be bundled into the release-evidence reconc
 - The release evidence pack is now the controlling release-proof document for the nine gates.
 - Contract cleanup now includes `RebuildJobListResponse` truncation semantics through `total` and `has_more`.
 - Failure-mode validation should continue, but production-scale evidence should not block this docs-only reconciliation unless the release scope explicitly makes it mandatory.
-- The operational drill pack now documents the representative incident matrix; live drill execution remains an operational follow-up rather than a new CI surface.
+- The operational drill pack now documents the representative incident matrix; the execution-record register captures live drill evidence as a separate follow-up artifact rather than a new CI surface.
 - Governance changes must keep `docs/governance/state-machine-and-operating-authority.md` aligned as the current authority.
 
 ## Risks

--- a/docs/testing/operational-drill-and-scale-validation-pack.md
+++ b/docs/testing/operational-drill-and-scale-validation-pack.md
@@ -147,6 +147,7 @@ Current automated anchors:
 - `tests/integration/test_distributed_hosting_failure_modes.py`
 - `tests/integration/test_graph_persistence_scale_validation.py`
 - `docs/testing/failure-mode-and-scale-validation.md`
+- `docs/testing/operational-drill-execution-records.md`
 
 ## How To Use This Pack
 
@@ -164,3 +165,4 @@ Current automated anchors:
 - `docs/runbooks/backup-restore-dr.md`
 - `docs/OBSERVABILITY_MASTER_SPEC.md`
 - `docs/testing/failure-mode-and-scale-validation.md`
+- `docs/testing/operational-drill-execution-records.md`

--- a/docs/testing/operational-drill-and-scale-validation-pack.md
+++ b/docs/testing/operational-drill-and-scale-validation-pack.md
@@ -147,7 +147,6 @@ Current automated anchors:
 - `tests/integration/test_distributed_hosting_failure_modes.py`
 - `tests/integration/test_graph_persistence_scale_validation.py`
 - `docs/testing/failure-mode-and-scale-validation.md`
-- `docs/testing/operational-drill-execution-records.md`
 
 ## How To Use This Pack
 

--- a/docs/testing/operational-drill-execution-records.md
+++ b/docs/testing/operational-drill-execution-records.md
@@ -63,8 +63,9 @@ Approver / reviewer:
 
 ## Execution Register
 
-Use one row per actual drill execution. If the drill has not been run yet, leave the row open and keep the parent
-issue open. This register tracks high-level execution links and results; for detailed metric and log observations during a run, refer to the Evidence Matrix in the [Operational Drill and Scale-Validation Pack](operational-drill-and-scale-validation-pack.md).
+Use one row per actual drill execution. If the drill has not been run yet, leave that row open until the corresponding
+per-run drill evidence issue exists. This register tracks high-level execution links and results; for detailed metric
+and log observations during a run, refer to the Evidence Matrix in the [Operational Drill and Scale-Validation Pack](operational-drill-and-scale-validation-pack.md).
 
 | Drill | Execution issue / evidence link | Environment | Commit SHA | Result | Notes | Follow-up issue |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/testing/operational-drill-execution-records.md
+++ b/docs/testing/operational-drill-execution-records.md
@@ -64,7 +64,7 @@ Approver / reviewer:
 ## Execution Register
 
 Use one row per actual drill execution. If the drill has not been run yet, leave the row open and keep the parent
-issue open.
+issue open. This register tracks high-level execution links and results; for detailed metric and log observations during a run, refer to the Evidence Matrix in the [Operational Drill and Scale-Validation Pack](operational-drill-and-scale-validation-pack.md).
 
 | Drill | Execution issue / evidence link | Environment | Commit SHA | Result | Notes | Follow-up issue |
 | --- | --- | --- | --- | --- | --- | --- |

--- a/docs/testing/operational-drill-execution-records.md
+++ b/docs/testing/operational-drill-execution-records.md
@@ -1,0 +1,99 @@
+# Operational Drill Execution Records
+
+Status: Active tracker
+Parent issue: #1328
+
+## Purpose
+
+This register is the repository-side index for actual operational drill execution records.
+
+Use it to point to the evidence issue or release-candidate evidence issue that captured a specific drill run, then
+summarize the attached evidence at a glance without duplicating the full artifact set.
+
+This document does not replace the operational drill pack, the evidence capture framework, or the dedicated issue
+templates. It links them together.
+
+## Scope
+
+In scope:
+
+- one record row per executed drill run;
+- canonical evidence object reference;
+- result classification;
+- follow-up issue links when the run exposes a defect or gap.
+
+Out of scope:
+
+- running the drills;
+- changing runtime behavior;
+- changing alert thresholds or dashboards;
+- duplicating the full drill artifact set inside this register.
+
+## Canonical Evidence Object
+
+Use the repository evidence grammar when attaching or summarizing a drill execution record.
+
+```text
+Evidence ID:
+Gate / drill:
+Claim being proven:
+Release candidate / commit SHA:
+Environment:
+Target URL or deployment label:
+Durability label:
+Database boundary labels:
+  Auth DB:
+  Coordination DB:
+  Asset Graph DB:
+Operator:
+Capture timestamp UTC:
+Command or observation source:
+Expected result:
+Actual result:
+Relevant fields observed:
+Metrics observed:
+Logs/events observed:
+Dashboard/alert observed:
+Runbook step verified:
+Result:
+Redaction performed:
+Follow-up issue(s):
+Approver / reviewer:
+```
+
+## Execution Register
+
+Use one row per actual drill execution. If the drill has not been run yet, leave the row open and keep the parent
+issue open.
+
+| Drill | Execution issue / evidence link | Environment | Commit SHA | Result | Notes | Follow-up issue |
+| --- | --- | --- | --- | --- | --- | --- |
+| Failed graph load |  |  |  | Not run |  |  |
+| Lock loss |  |  |  | Not run |  |  |
+| Stale owner |  |  |  | Not run |  |  |
+| Degraded DB |  |  |  | Not run |  |  |
+| Failed durable smoke |  |  |  | Not run |  |  |
+
+Allowed result values:
+
+- Passed
+- Failed
+- Blocked
+- Not run
+- Manual evidence required
+- Follow-up required
+
+## Recording Rules
+
+- Open one dedicated operational drill evidence issue per drill run by default.
+- Link the drill evidence issue here once the record is complete.
+- Update the release-candidate evidence issue only when the drill is directly release-scoped or release-blocking.
+- Create a focused follow-up issue for any missing metric, ambiguous dashboard, flaky drill, or unsafe runtime behavior.
+
+## Related Documents
+
+- [Operational Drill and Scale-Validation Pack](operational-drill-and-scale-validation-pack.md)
+- [Operational Evidence Capture Framework](../operations/operational-evidence-capture-framework.md)
+- [Operational Drill Evidence Issue Template](../../.github/ISSUE_TEMPLATE/operational_drill_evidence.md)
+- [Release Candidate Evidence Template](../../.github/ISSUE_TEMPLATE/release_candidate_evidence.md)
+- [Release Evidence Pack](../release-evidence-pack.md)


### PR DESCRIPTION
## Primary Objective

Add a repository-side execution-record register for operational drill runs so actual drill evidence can be linked, summarized, and reviewed in one canonical place.

## Description

This PR adds `docs/testing/operational-drill-execution-records.md` and wires it into the operational drill pack and roadmap notes. The new register is the place to point actual drill evidence issues or release-candidate evidence issues once a drill has been run. It uses the same canonical evidence object as the operational evidence capture framework and keeps the drill pack as the source of drill intent.

This PR does not claim that the drills were executed here. It creates the tracking surface for drill evidence and keeps the repository docs aligned with the issue-template workflow introduced in PR #1321.

Closes #1328.

## In Scope

- Add a drill execution-record register doc.
- Cross-link the register from the operational drill pack.
- Clarify the roadmap wording so the register is the follow-up artifact for actual run evidence.
- Preserve the separation between drill intent, drill execution records, and release-candidate evidence.

## Out of Scope

- No runtime code changes.
- No dashboard, alert, or metric changes.
- No hosted readiness logic changes.
- No new issue templates.
- No drill execution claims that are not backed by actual evidence.
- No release-gate semantic changes.

## Files Expected to Change

- `docs/testing/operational-drill-execution-records.md`
- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `docs/roadmap/enterprise-readiness-roadmap.md`
- `docs/roadmap/enterprise-readiness-pr-board.md`

## Type of Change

- [x] Documentation update
- [ ] Architecture decision (ADR)
- [ ] Policy document addition/update
- [ ] Template modification
- [ ] Repository configuration

## Rationale

The repository already has the drill pack, the evidence capture framework, and dedicated drill evidence issue templates. What was still missing was a canonical repository-side register for actual drill execution records so operators and reviewers have one place to link the evidence issues and summarize the run without duplicating the full artifact set.

## Impact Assessment

### Positive Impacts

- Gives the repo a single index for actual drill execution records.
- Makes drill evidence easier to discover from the operational drill pack.
- Keeps the evidence workflow consistent with the canonical evidence grammar.

### Potential Concerns

- The register could be mistaken for proof that the drills were executed.
- The new doc adds another pointer in the operational documentation chain.

### Mitigation Strategy

The register explicitly states that it is a tracker and that the issue remains open until actual drill evidence is attached. The PR body and file content avoid claiming execution that did not happen.

## Validation Commands

```bash
pre-commit run --files \
  docs/testing/operational-drill-execution-records.md \
  docs/testing/operational-drill-and-scale-validation-pack.md \
  docs/roadmap/enterprise-readiness-roadmap.md \
  docs/roadmap/enterprise-readiness-pr-board.md
```

## Merge Criteria

- [x] The register exists and uses the canonical evidence object.
- [x] The drill pack links to the register.
- [x] Roadmap wording reflects the register as the actual-run evidence artifact.
- [x] The PR does not claim drill execution that was not performed.

## Related Documents

- `#1328`
- `docs/testing/operational-drill-and-scale-validation-pack.md`
- `docs/testing/operational-drill-execution-records.md`
- `docs/operations/operational-evidence-capture-framework.md`
- `.github/ISSUE_TEMPLATE/operational_drill_evidence.md`
- `docs/release-evidence-pack.md`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a repository-side register for operational drill execution records so real drill evidence links live in one place. Implements #1328 and clarifies how to record per-run evidence and follow-ups.

- **New Features**
  - Added `docs/testing/operational-drill-execution-records.md` with the canonical evidence object, a one-row-per-run register, allowed result values, and clear recording rules (link per-run evidence issues, when to update release-candidate evidence, and how to file follow-ups).
  - Linked the register from `docs/testing/operational-drill-and-scale-validation-pack.md`; roadmap and PR board now state the register captures actual run artifacts as the follow-up surface.
  - Preserves separation between drill intent (pack), execution records (register), and release-candidate evidence; no runtime or CI changes.

<sup>Written for commit a92ba40c82d7f33cb3fb9124659cd8086b3f57a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

