### PR TITLE
fix(compound): harden architecture-compound workflow commit/push path

### DIFF
--- a/.github/workflows/architecture-compound.yml
+++ b/.github/workflows/architecture-compound.yml
@@ -40,6 +40,8 @@ jobs:
       contents: write
       pull-requests: read
     steps:
+      # Initial checkout uses the event SHA for history; compound scripts are always
+      # overlaid from a trusted TRIGGER_SHA (main / PR base / origin/main for dispatch).
       - name: Checkout triggering ref
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -62,11 +64,17 @@ jobs:
           FORCE_INPUT: ${{ github.event.inputs.force_synthesize || 'false' }}
         shell: bash
         run: |
-          # Use trusted scripts from the PR base (main) on pull_request events.
-          # Keep compound scripts from the triggering commit; switch docs/ledger to knowledge tip.
+          set -euo pipefail
+          # Trusted scripts only (contents: write must not run unreviewed compound code):
+          # - pull_request: PR base SHA (main)
+          # - push: the pushed main SHA
+          # - workflow_dispatch: origin/main tip (never the selected non-main ref)
           TRIGGER_SHA="${GITHUB_SHA}"
           if [ "$EVENT_NAME" = "pull_request" ] && [ -n "${PR_BASE_SHA:-}" ] && git cat-file -e "${PR_BASE_SHA}:scripts/compound/schema.py" 2>/dev/null; then
             TRIGGER_SHA="$PR_BASE_SHA"
+          elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            git fetch --no-tags --depth=1 origin main
+            TRIGGER_SHA="$(git rev-parse origin/main)"
           fi
           if git ls-remote --exit-code --heads origin knowledge/architecture-expert >/dev/null 2>&1; then
             git fetch origin knowledge/architecture-expert
@@ -150,39 +158,62 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          # Ensure overlayed scripts/compound from the triggering SHA are not committed to the knowledge branch.
-          git restore --staged -- scripts/compound || true
+          KNOWLEDGE_BRANCH="knowledge/architecture-expert"
 
-          # Stage generated knowledge outputs.
-          git add docs/compound .cursor/rules .openhands/microagents/architecture_expert.md
+          # Fully restore scripts/compound (index + worktree) so overlay never ships
+          # and cannot interfere with rebase/push-retry against the remote branch.
+          git restore --source=HEAD --staged --worktree -- scripts/compound || true
+
+          # Stage only allowlisted generated outputs (never the whole .cursor/rules tree).
+          git add docs/compound \
+            .cursor/rules/architecture-expert.mdc \
+            .cursor/rules/architecture-expert-query.mdc \
+            .openhands/microagents/architecture_expert.md
 
           if git diff --cached --quiet; then
             echo "No knowledge changes to commit"
             exit 0
           fi
           git commit -m "chore(compound): synthesize architecture memory"
+
+          # Push with one rebase retry; record conflict only after both attempts fail.
           push_knowledge() {
-            git push origin HEAD:knowledge/architecture-expert
+            if git push origin "HEAD:refs/heads/${KNOWLEDGE_BRANCH}"; then
+              return 0
+            fi
+            echo "::warning::Push to ${KNOWLEDGE_BRANCH} rejected"
+            return 1
           }
+
           if push_knowledge; then
+            echo "Pushed knowledge updates to ${KNOWLEDGE_BRANCH}"
             exit 0
           fi
-          echo "Push failed; fetch/rebase once then retry"
-          # Clear dirty TRIGGER_SHA script overlay so rebase is not blocked by local edits.
-          git restore --source=HEAD --worktree --staged -- scripts/compound || true
-          git fetch origin knowledge/architecture-expert || true
-          git rebase origin/knowledge/architecture-expert || git rebase --abort || true
-          if push_knowledge; then
+
+          echo "::warning::Initial push failed; attempting rebase retry"
+          git restore --source=HEAD --staged --worktree -- scripts/compound || true
+          git fetch origin "${KNOWLEDGE_BRANCH}" || true
+          if ! git rebase "origin/${KNOWLEDGE_BRANCH}"; then
+            git rebase --abort || true
+            echo "::error::Rebase onto origin/${KNOWLEDGE_BRANCH} failed"
+          elif push_knowledge; then
+            echo "Pushed knowledge updates after rebase retry"
             exit 0
           fi
-          # Re-apply triggering scripts for conflict recording, then unstage again.
+
+          # Actual push failure path: briefly overlay reviewed scripts to record conflict,
+          # then fully restore before staging runtime.yml.
+          echo "::error::Push still rejected after rebase retry"
           if [ -n "${TRIGGER_SHA:-}" ]; then
             git checkout "${TRIGGER_SHA}" -- scripts/compound
             git restore --staged scripts/compound
           fi
           python scripts/compound/append_observation.py --record-push-conflict || true
+          git restore --source=HEAD --staged --worktree -- scripts/compound || true
           git add docs/compound/runtime.yml
-          git commit -m "chore(compound): record knowledge-branch push conflict"
-          git fetch origin knowledge/architecture-expert
-          git merge --no-edit origin/knowledge/architecture-expert
-          git push origin HEAD:knowledge/architecture-expert
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(compound): record knowledge-branch push conflict" || true
+            push_knowledge || true
+          fi
+          exit 1
+          # Intentionally never merges into main (human promotion only).

--- a/tests/integration/test_architecture_compound_workflow.py
+++ b/tests/integration/test_architecture_compound_workflow.py
@@ -73,7 +73,7 @@ class TestArchitectureCompoundWorkflow:
         assert "docs/compound/runtime.yml" in text
         assert "record knowledge-branch push conflict" in text
         assert "push_knowledge()" in text
-        assert 'exit 0' in text
+        assert "exit 0" in text
         assert "Push still rejected after rebase retry" in text
 
     def test_workflow_dispatch_pins_scripts_to_origin_main(self) -> None:

--- a/tests/integration/test_architecture_compound_workflow.py
+++ b/tests/integration/test_architecture_compound_workflow.py
@@ -72,6 +72,28 @@ class TestArchitectureCompoundWorkflow:
         assert "--record-push-conflict" in text
         assert "docs/compound/runtime.yml" in text
         assert "record knowledge-branch push conflict" in text
+        assert "push_knowledge()" in text
+        assert 'exit 0' in text
+        assert "Push still rejected after rebase retry" in text
+
+    def test_workflow_dispatch_pins_scripts_to_origin_main(self) -> None:
+        """Manual dispatch must run reviewed scripts from origin/main, not selected ref."""
+        text = WORKFLOW.read_text(encoding="utf-8")
+        assert 'elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then' in text
+        assert "git fetch --no-tags --depth=1 origin main" in text
+        assert 'TRIGGER_SHA="$(git rev-parse origin/main)"' in text
+        assert "never the selected non-main ref" in text
+
+    def test_commit_stages_allowlisted_sidecars_only(self) -> None:
+        """Commit step stages allowlisted outputs and fully restores scripts/compound."""
+        text = WORKFLOW.read_text(encoding="utf-8")
+        assert "git add .cursor/rules" not in text
+        assert ".cursor/rules/architecture-expert.mdc" in text
+        assert ".cursor/rules/architecture-expert-query.mdc" in text
+        assert ".openhands/microagents/architecture_expert.md" in text
+        assert "git add docs/compound" in text
+        assert "git restore --source=HEAD --staged --worktree -- scripts/compound" in text
+        assert "git push origin" in text
 
     def test_actions_pinned_and_scripts_overlay(self) -> None:
         """Checkout/setup-python are SHA-pinned; scripts overlay from triggering SHA."""
@@ -80,7 +102,7 @@ class TestArchitectureCompoundWorkflow:
         assert "actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065" in text
         assert 'git checkout "${TRIGGER_SHA}" -- scripts/compound' in text
         assert "git restore --staged scripts/compound" in text
-        assert "git restore --source=HEAD --worktree --staged -- scripts/compound" in text
+        assert "git restore --source=HEAD --staged --worktree -- scripts/compound" in text
         assert 'echo "TRIGGER_SHA=${TRIGGER_SHA}" >> "$GITHUB_ENV"' in text
         assert "continue-on-error:" not in text
         assert "cancel-in-progress: false" in text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective

Address review findings on `.github/workflows/architecture-compound.yml` so the compound workflow always runs reviewed scripts, commits allowlisted knowledge outputs successfully, and only records push conflicts after a real push failure.

## In Scope

- Pin `TRIGGER_SHA` to `origin/main` for `workflow_dispatch` (never the selected non-main ref when `contents: write` is available).
- Real staging/commit/push success path with one rebase retry via `push_knowledge`.
- Stage only allowlisted sidecars (`docs/compound`, architecture-expert rule/query packs, OpenHands microagent).
- Fully restore `scripts/compound` (index + worktree) before commit and before push-retry/rebase.
- Record `--record-push-conflict` only after both push attempts fail; `exit 1` only on that failure path.
- Integration test coverage for the above guardrails.

## Out of Scope

- Changes to compound Python synthesizers beyond what the workflow invokes.
- Merging into `main` or altering knowledge-branch promotion policy.

## Validation

```bash
.venv/bin/python -m pytest tests/integration/test_architecture_compound_workflow.py -v
```

(9 passed)

## Merge Criteria

- Workflow no longer stages `.cursor/rules` wholesale.
- Manual dispatch cannot execute unreviewed `scripts/compound` from a non-main ref.
- Successful push exits 0; conflict recording runs only after push failure.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b51f76bc-2add-4af5-b495-a8ba1ad62693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b51f76bc-2add-4af5-b495-a8ba1ad62693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the architecture-compound workflow to always run reviewed `scripts/compound`, stage only allowlisted outputs, and record push conflicts only after a real push failure. Adds integration tests for these guardrails.

- **Bug Fixes**
  - Pin `TRIGGER_SHA`: PR base for pull_request, pushed main SHA for push, and fetched `origin/main` for `workflow_dispatch` so `contents: write` never runs unreviewed scripts.
  - Fully restore `scripts/compound` (index and worktree) before commit, before rebase retry, and after conflict recording.
  - Stage only allowlisted outputs: `docs/compound`, `.cursor/rules/architecture-expert.mdc`, `.cursor/rules/architecture-expert-query.mdc`, `.openhands/microagents/architecture_expert.md`.
  - Push with one rebase retry via `push_knowledge`; on success exit 0. After two failures, overlay reviewed scripts to run `append_observation.py --record-push-conflict`, stage `docs/compound/runtime.yml`, and exit 1.

- **Tests**
  - Added tests for dispatch pinning to `origin/main`, allowlisted staging and full restore, rebase-retry paths and messages, and conflict recording including `runtime.yml`.

<sup>Written for commit 3b7fbe89df0f847fa5c66ad726db941d9b1fdf91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1446?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the architecture-compound workflow's commit/push path: `workflow_dispatch` now always fetches `origin/main` to pin `TRIGGER_SHA` (preventing unreviewed code from running), staging is restricted to an explicit allowlist of four knowledge-output files instead of the entire `.cursor/rules` tree, and the push retry is rebuilt around a single rebase with a properly structured `push_knowledge` helper.

- **TRIGGER_SHA hardening**: `workflow_dispatch` now runs `git fetch --no-tags --depth=1 origin main && git rev-parse origin/main`, ensuring `contents: write` never executes scripts from a non-main ref.
- **Allowlisted staging**: `git add .cursor/rules` (directory) is replaced with explicit paths (`architecture-expert.mdc`, `architecture-expert-query.mdc`, `architecture_expert.md`), preventing accidental inclusion of unrelated cursor rules.
- **Rebase-retry commit path**: first push attempt → rebase on failure → second push attempt; conflict recording with `exit 1` only after both pushes are rejected. The old `fetch + merge + push` block in the conflict-recording section was removed, which means when the rebase itself fails the conflict-record commit will not reach the remote (see inline comment).

<h3>Confidence Score: 3/5</h3>

The TRIGGER_SHA pinning and allowlist staging changes are solid improvements, but the rewrite of the conflict-recording push path introduces a regression: conflict records are silently dropped whenever the rebase attempt fails.

The dispatch-pinning and allowlist-only staging changes are correct and well-tested. The rebase-retry structure for the happy path is clean. The problem is in the conflict-recording section: removing the old fetch+merge+push block and replacing it with push_knowledge or true means that after a rebase failure HEAD is still behind the remote tip, the push is rejected silently, and the conflict-record commit never reaches knowledge/architecture-expert. This is a behavioral regression on the failure path that the existing test suite does not catch.

.github/workflows/architecture-compound.yml lines 196-218 (conflict-recording push section after rebase failure)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/architecture-compound.yml | Hardens TRIGGER_SHA pinning for workflow_dispatch (fetches origin/main), replaces wholesale .cursor/rules staging with allowlisted files, and rewrites commit/push logic with a rebase retry. However, the removal of the pre-push fetch+merge in the conflict-recording path means the conflict-record commit will silently fail to reach the remote whenever the rebase path was taken (HEAD remains behind the remote tip). |
| tests/integration/test_architecture_compound_workflow.py | Adds three new string-matching guardrail tests (dispatch pinning, allowlisted-only staging, push-conflict path) and fixes an argument-order assertion. All tests pass against the new YAML, but one assertion checks for comment prose rather than executable logic, making it unnecessarily fragile. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant WF as Workflow (shell)
    participant KB as knowledge/architecture-expert (remote)

    GH->>WF: Trigger (PR / push / workflow_dispatch)
    WF->>WF: Determine TRIGGER_SHA
    WF->>WF: Checkout knowledge branch
    WF->>WF: Overlay scripts/compound from TRIGGER_SHA
    WF->>WF: Run observation + synthesis Python scripts
    WF->>WF: restore --staged scripts/compound
    Note over WF: Commit & Push step
    WF->>WF: restore scripts/compound to HEAD
    WF->>WF: git add allowlisted outputs
    WF->>WF: git commit synthesize
    WF->>KB: push_knowledge attempt 1
    alt push succeeds
        KB-->>WF: accepted exit 0
    else push rejected
        WF->>WF: restore scripts/compound
        WF->>KB: git fetch knowledge branch
        WF->>WF: git rebase origin/knowledge-branch
        alt rebase succeeds
            WF->>KB: push_knowledge attempt 2
            alt push succeeds
                KB-->>WF: accepted exit 0
            else push rejected again
                WF->>WF: conflict recording section
            end
        else rebase fails
            WF->>WF: git rebase --abort
            WF->>WF: conflict recording section
        end
        Note over WF: HEAD not rebased in rebase-fail path
        WF->>WF: overlay scripts run append_observation
        WF->>WF: restore scripts git add runtime.yml commit
        WF->>KB: push_knowledge or true - likely fails
        WF->>WF: exit 1
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant GH as GitHub Actions
    participant WF as Workflow (shell)
    participant KB as knowledge/architecture-expert (remote)

    GH->>WF: Trigger (PR / push / workflow_dispatch)
    WF->>WF: Determine TRIGGER_SHA
    WF->>WF: Checkout knowledge branch
    WF->>WF: Overlay scripts/compound from TRIGGER_SHA
    WF->>WF: Run observation + synthesis Python scripts
    WF->>WF: restore --staged scripts/compound
    Note over WF: Commit & Push step
    WF->>WF: restore scripts/compound to HEAD
    WF->>WF: git add allowlisted outputs
    WF->>WF: git commit synthesize
    WF->>KB: push_knowledge attempt 1
    alt push succeeds
        KB-->>WF: accepted exit 0
    else push rejected
        WF->>WF: restore scripts/compound
        WF->>KB: git fetch knowledge branch
        WF->>WF: git rebase origin/knowledge-branch
        alt rebase succeeds
            WF->>KB: push_knowledge attempt 2
            alt push succeeds
                KB-->>WF: accepted exit 0
            else push rejected again
                WF->>WF: conflict recording section
            end
        else rebase fails
            WF->>WF: git rebase --abort
            WF->>WF: conflict recording section
        end
        Note over WF: HEAD not rebased in rebase-fail path
        WF->>WF: overlay scripts run append_observation
        WF->>WF: restore scripts git add runtime.yml commit
        WF->>KB: push_knowledge or true - likely fails
        WF->>WF: exit 1
    end
```

</a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22cursor%2Farchitecture-compound-workflow-harden-2693%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Farchitecture-compound-workflow-harden-2693%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0A.github%2Fworkflows%2Farchitecture-compound.yml%3A196-218%0A**Conflict-recording%20push%20is%20a%20guaranteed%20no-op%20after%20rebase%20failure**%0A%0AWhen%20%60git%20rebase%60%20fails%20and%20is%20aborted%20%28line%20197%29%2C%20HEAD%20returns%20to%20the%20unrebase%20synthesis%20commit%20%E2%80%94%20still%20behind%20%60origin%2F%24%7BKNOWLEDGE_BRANCH%7D%60.%20The%20conflict-recording%20section%20then%20commits%20on%20top%20of%20that%20unrebase%20HEAD%20and%20calls%20%60push_knowledge%20%7C%7C%20true%60.%20Because%20HEAD%20is%20not%20up-to-date%20with%20the%20remote%20%28the%20exact%20reason%20rebase%20was%20needed%29%2C%20the%20push%20is%20rejected%2C%20and%20%60%7C%7C%20true%60%20silently%20swallows%20the%20failure.%20The%20conflict%20record%20never%20reaches%20the%20remote%20branch.%0A%0AThe%20previous%20code%20handled%20this%20by%20running%20%60git%20fetch%20origin%20knowledge%2Farchitecture-expert%20%26%26%20git%20merge%20--no-edit%20origin%2Fknowledge%2Farchitecture-expert%60%20before%20the%20final%20push%2C%20which%20brought%20HEAD%20current%20and%20made%20delivery%20reliable.%20That%20fetch-and-merge%20was%20removed%20in%20this%20PR%2C%20so%20the%20conflict-recording%20commit%20is%20now%20only%20local%20whenever%20the%20rebase%20path%20was%20taken.%0A%0A%23%23%23%20Issue%202%20of%202%0Atests%2Fintegration%2Ftest_architecture_compound_workflow.py%3A82-85%0A**Test%20asserts%20on%20comment%20prose%2C%20not%20functional%20logic**%0A%0A%60assert%20%22never%20the%20selected%20non-main%20ref%22%20in%20text%60%20matches%20a%20YAML%20comment%2C%20not%20an%20executable%20statement.%20Any%20reformatting%20or%20rewording%20of%20that%20comment%20%28e.g.%2C%20during%20a%20spell-check%20or%20copy-edit%20pass%29%20will%20break%20the%20test%20without%20changing%20behavior.%20The%20meaningful%20invariant%20to%20assert%20is%20the%20fetch%20%2B%20rev-parse%20sequence%20itself%2C%20both%20of%20which%20are%20already%20covered%20by%20the%20adjacent%20two%20assertions%20on%20the%20same%20lines.%0A%0A&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1446&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
.github/workflows/architecture-compound.yml:196-218
**Conflict-recording push is a guaranteed no-op after rebase failure**

When `git rebase` fails and is aborted (line 197), HEAD returns to the unrebase synthesis commit — still behind `origin/${KNOWLEDGE_BRANCH}`. The conflict-recording section then commits on top of that unrebase HEAD and calls `push_knowledge || true`. Because HEAD is not up-to-date with the remote (the exact reason rebase was needed), the push is rejected, and `|| true` silently swallows the failure. The conflict record never reaches the remote branch.

The previous code handled this by running `git fetch origin knowledge/architecture-expert && git merge --no-edit origin/knowledge/architecture-expert` before the final push, which brought HEAD current and made delivery reliable. That fetch-and-merge was removed in this PR, so the conflict-recording commit is now only local whenever the rebase path was taken.

### Issue 2 of 2
tests/integration/test_architecture_compound_workflow.py:82-85
**Test asserts on comment prose, not functional logic**

`assert "never the selected non-main ref" in text` matches a YAML comment, not an executable statement. Any reformatting or rewording of that comment (e.g., during a spell-check or copy-edit pass) will break the test without changing behavior. The meaningful invariant to assert is the fetch + rev-parse sequence itself, both of which are already covered by the adjacent two assertions on the same lines.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[autofix.ci\] apply automated fixes"](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/3b7fbe89df0f847fa5c66ad726db941d9b1fdf91) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43291668)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->