### PR TITLE
fix(compound): handle SchemaError in standing_brief CLI

### DIFF
--- a/scripts/compound/standing_brief.py
+++ b/scripts/compound/standing_brief.py
@@ -12,7 +12,14 @@ _SCRIPTS_ROOT = Path(__file__).resolve().parent.parent
 if str(_SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_ROOT))
 
-from compound.schema import BRIEFS_DIR, DOMAINS, LEDGER_PATH, assert_writable  # noqa: E402
+from compound.schema import (  # noqa: E402
+    BRIEFS_DIR,
+    DOMAINS,
+    LEDGER_PATH,
+    PathPolicyError,
+    SchemaError,
+    assert_writable,
+)
 from compound.synthesize import _latest_by_primary_ref, load_ledger  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -71,7 +78,7 @@ def main(argv: list[str] | None = None) -> int:
         path = write_standing_brief(args.repo_root, as_of=args.as_of)
         print(f"wrote: {path.relative_to(args.repo_root).as_posix()}")
         return 0
-    except (OSError, PermissionError, ValueError) as exc:
+    except (SchemaError, PathPolicyError, OSError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/scripts/compound/standing_brief.py
+++ b/scripts/compound/standing_brief.py
@@ -78,7 +78,7 @@ def main(argv: list[str] | None = None) -> int:
         path = write_standing_brief(args.repo_root, as_of=args.as_of)
         print(f"wrote: {path.relative_to(args.repo_root).as_posix()}")
         return 0
-    except (SchemaError, PathPolicyError, OSError) as exc:
+    except (SchemaError, PathPolicyError, OSError, ValueError) as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
 

--- a/tests/unit/test_compound_standing_brief.py
+++ b/tests/unit/test_compound_standing_brief.py
@@ -63,15 +63,15 @@ class TestStandingBrief:
         assert "[landed]" in text
         assert "architecture" in text
 
-    def test_main_prints_error_on_schema_error(
+    def test_main_prints_error_on_path_policy_error(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """CLI maps SchemaError to a clean error: diagnostic."""
-
-        def _raise_schema_error(*_args, **_kwargs):
-            raise SchemaError("malformed ledger line")
-
-        monkeypatch.setattr("compound.standing_brief.write_standing_brief", _raise_schema_error)
+        """CLI maps PathPolicyError to a clean error: diagnostic."""
+    
+        def _raise_path_policy_error(*_args, **_kwargs):
+            raise PathPolicyError("policy violation")
+    
+        monkeypatch.setattr("compound.standing_brief.write_standing_brief", _raise_path_policy_error)
         assert main(["--repo-root", str(tmp_path)]) == 1
         captured = capsys.readouterr()
-        assert captured.err.startswith("error: malformed ledger line")
+        assert captured.err.startswith("error: policy violation")

--- a/tests/unit/test_compound_standing_brief.py
+++ b/tests/unit/test_compound_standing_brief.py
@@ -67,10 +67,10 @@ class TestStandingBrief:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """CLI maps PathPolicyError to a clean error: diagnostic."""
-    
+
         def _raise_path_policy_error(*_args, **_kwargs):
             raise PathPolicyError("policy violation")
-    
+
         monkeypatch.setattr("compound.standing_brief.write_standing_brief", _raise_path_policy_error)
         assert main(["--repo-root", str(tmp_path)]) == 1
         captured = capsys.readouterr()

--- a/tests/unit/test_compound_standing_brief.py
+++ b/tests/unit/test_compound_standing_brief.py
@@ -13,8 +13,8 @@ SCRIPTS_ROOT = REPO_ROOT / "scripts"
 if str(SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_ROOT))
 
-from compound.schema import observation_from_mapping  # noqa: E402
-from compound.standing_brief import render_standing_brief, write_standing_brief  # noqa: E402
+from compound.schema import SchemaError, observation_from_mapping  # noqa: E402
+from compound.standing_brief import main, render_standing_brief, write_standing_brief  # noqa: E402
 
 
 @pytest.mark.unit
@@ -62,3 +62,16 @@ class TestStandingBrief:
         text = render_standing_brief([obs], as_of="2026-07-09")
         assert "[landed]" in text
         assert "architecture" in text
+
+    def test_main_prints_error_on_schema_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """CLI maps SchemaError to a clean error: diagnostic."""
+
+        def _raise_schema_error(*_args, **_kwargs):
+            raise SchemaError("malformed ledger line")
+
+        monkeypatch.setattr("compound.standing_brief.write_standing_brief", _raise_schema_error)
+        assert main(["--repo-root", str(tmp_path)]) == 1
+        captured = capsys.readouterr()
+        assert captured.err.startswith("error: malformed ledger line")

--- a/tests/unit/test_compound_standing_brief.py
+++ b/tests/unit/test_compound_standing_brief.py
@@ -75,3 +75,16 @@ class TestStandingBrief:
         assert main(["--repo-root", str(tmp_path)]) == 1
         captured = capsys.readouterr()
         assert captured.err.startswith("error: policy violation")
+
+    def test_main_prints_error_on_schema_error(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """CLI maps SchemaError to a clean error: diagnostic."""
+
+        def _raise_schema_error(*_args, **_kwargs):
+            raise SchemaError("schema violation")
+
+        monkeypatch.setattr("compound.standing_brief.write_standing_brief", _raise_schema_error)
+        assert main(["--repo-root", str(tmp_path)]) == 1
+        captured = capsys.readouterr()
+        assert captured.err.startswith("error: schema violation")

--- a/tests/unit/test_compound_standing_brief.py
+++ b/tests/unit/test_compound_standing_brief.py
@@ -13,7 +13,7 @@ SCRIPTS_ROOT = REPO_ROOT / "scripts"
 if str(SCRIPTS_ROOT) not in sys.path:
     sys.path.insert(0, str(SCRIPTS_ROOT))
 
-from compound.schema import SchemaError, observation_from_mapping  # noqa: E402
+from compound.schema import PathPolicyError, SchemaError, observation_from_mapping  # noqa: E402
 from compound.standing_brief import main, render_standing_brief, write_standing_brief  # noqa: E402
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective
Address review feedback: ensure `standing_brief` CLI maps ledger `SchemaError` (and path-policy failures) to a clean `error: ...` diagnostic instead of an unhandled traceback.

## In Scope
- Catch `SchemaError` and `PathPolicyError` explicitly in `main()` (aligned with `synthesize` / `bootstrap`)
- Unit test covering the `error:` stderr format on `SchemaError`

## Out of Scope
- Changing `load_ledger` skip-vs-raise semantics for malformed lines
- Broader compound CLI refactors

## Files Expected to Change
- `scripts/compound/standing_brief.py`
- `tests/unit/test_compound_standing_brief.py`

## Validation Commands
```bash
pytest tests/unit/test_compound_standing_brief.py -v
pre-commit run --files scripts/compound/standing_brief.py tests/unit/test_compound_standing_brief.py
```

## Merge Criteria
- Tests pass
- CLI exits non-zero with `error: ...` on `SchemaError` / `PathPolicyError` / `OSError`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-670c9b68-e757-44c7-9528-1135422fd154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-670c9b68-e757-44c7-9528-1135422fd154"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the `standing_brief` CLI print a clean "error: ..." to stderr and exit 1 on ledger schema or path-policy failures, matching `synthesize` and `bootstrap`.

- **Bug Fixes**
  - Catch `SchemaError` and `PathPolicyError` in `main()` and map them to "error: ..." with exit code 1 (also handles `OSError`/`ValueError`).
  - Add CLI tests for both errors via `main()` to assert exit code 1 and stderr format.

<sup>Written for commit e575933e09f4629c9e3f7a4cea3cf81d5871c6d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the `standing_brief` CLI handle ledger and path-policy failures cleanly.

- Adds explicit `SchemaError` and `PathPolicyError` imports in `standing_brief`.
- Returns `error: ...` and exit code 1 for those CLI failures.
- Adds unit tests for the new CLI error output.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/compound/standing_brief.py | Adds explicit exception imports and includes them in the CLI error handler. |
| tests/unit/test_compound_standing_brief.py | Imports the needed exceptions and adds tests for clean CLI error output. |

<sub>Reviews (5): Last reviewed commit: ["Potential fix for pull request finding"](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/e575933e09f4629c9e3f7a4cea3cf81d5871c6d0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43478558)</sub>

<!-- /greptile_comment -->