### PR TITLE
Fix ci-common install/build/test script wrapper

### DIFF
--- a/.github/actions/ci-common/action.yml
+++ b/.github/actions/ci-common/action.yml
@@ -55,22 +55,15 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        SCRIPT_CONTENT: ${{ toJSON(inputs.install) }}
+        SCRIPT_CONTENT: ${{ inputs.install }}
       run: |
         set -euo pipefail
-        # Write commands to a temporary script file to prevent injection
         SCRIPT_FILE="$(mktemp)"
         trap 'rm -f "$SCRIPT_FILE"' EXIT
-        # Decode JSON-encoded content using jq (always available on GitHub-hosted runners)
-        printf '%s' "$SCRIPT_CONTENT" | jq -r '.' > "$SCRIPT_FILE" || {
-          echo "Error: Failed to decode script content" >&2
-          exit 1
-        }
-        # Trim whitespace and exit early if the script body is effectively empty
+        printf '%s\n' "$SCRIPT_CONTENT" > "$SCRIPT_FILE"
         if ! grep -q '[^[:space:]]' "$SCRIPT_FILE"; then
           exit 0
         fi
-        # Execute the script file with proper error handling
         bash -euo pipefail "$SCRIPT_FILE"
 
     - name: Build
@@ -78,22 +71,15 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        SCRIPT_CONTENT: ${{ toJSON(inputs.build) }}
+        SCRIPT_CONTENT: ${{ inputs.build }}
       run: |
         set -euo pipefail
-        # Write commands to a temporary script file to prevent injection
         SCRIPT_FILE="$(mktemp)"
         trap 'rm -f "$SCRIPT_FILE"' EXIT
-        # Decode JSON-encoded content using jq (always available on GitHub-hosted runners)
-        printf '%s' "$SCRIPT_CONTENT" | jq -r '.' > "$SCRIPT_FILE" || {
-          echo "Error: Failed to decode script content" >&2
-          exit 1
-        }
-        # Trim whitespace and exit early if the script body is effectively empty
+        printf '%s\n' "$SCRIPT_CONTENT" > "$SCRIPT_FILE"
         if ! grep -q '[^[:space:]]' "$SCRIPT_FILE"; then
           exit 0
         fi
-        # Execute the script file with proper error handling
         bash -euo pipefail "$SCRIPT_FILE"
 
     - name: Test
@@ -101,20 +87,13 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       env:
-        SCRIPT_CONTENT: ${{ toJSON(inputs.test) }}
+        SCRIPT_CONTENT: ${{ inputs.test }}
       run: |
         set -euo pipefail
-        # Write commands to a temporary script file to prevent injection
         SCRIPT_FILE="$(mktemp)"
         trap 'rm -f "$SCRIPT_FILE"' EXIT
-        # Decode JSON-encoded content using jq (always available on GitHub-hosted runners)
-        printf '%s' "$SCRIPT_CONTENT" | jq -r '.' > "$SCRIPT_FILE" || {
-          echo "Error: Failed to decode script content" >&2
-          exit 1
-        }
-        # Trim whitespace and exit early if the script body is effectively empty
+        printf '%s\n' "$SCRIPT_CONTENT" > "$SCRIPT_FILE"
         if ! grep -q '[^[:space:]]' "$SCRIPT_FILE"; then
           exit 0
         fi
-        # Execute the script file with proper error handling
         bash -euo pipefail "$SCRIPT_FILE"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective
Fix CI failures where the `ci-common` composite action exits before running install/build/test commands.

## In Scope
- Replace the `toJSON` + `jq` temp-script decode path in `.github/actions/ci-common/action.yml`
- Use `env` + `printf` so multiline command inputs are written and executed without expression injection into `run:`

## Out of Scope
- Codacy project token / non-UTF-8 file issues (separate from this wrapper failure)
- Changing caller workflows or rewriting free-form install/test inputs into allowlisted selectors

## Files Expected to Change
- `.github/actions/ci-common/action.yml`

## Validation Commands
- Local smoke of the env + printf wrapper with a multiline script
- Rely on CI workflows that invoke `ci-common` (e.g. `.github/workflows/ci.yml`)

## Merge Criteria
- Install/Build/Test steps in jobs using `ci-common` run the intended commands (ruff/pytest/npm/etc. appear in logs)
- No regression to setup-python / setup-node steps

## Why
The previous wrapper decoded `${{ toJSON(inputs.*) }}` with `jq -r '.'` into a temp file, then ran it. That layer failed (exit 64) before Python/Node CI commands executed. Direct `run: ${{ inputs.* }}` is unsafe (expression injection). Mapping the input through `env` and writing it with `printf` keeps multiline scripts working while avoiding splicing untrusted expressions into the shell script text.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ec241a1-6d49-4171-9cc9-c9e3710fbd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ec241a1-6d49-4171-9cc9-c9e3710fbd45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `ci-common` composite action so install/build/test commands run reliably in CI. Replaces the fragile `toJSON` + `jq` decode with an env + `printf` temp-script flow to preserve multiline inputs and avoid expression injection.

- **Bug Fixes**
  - Write `${{ inputs.install/build/test }}` to a temp script via env + `printf`, and exit early if empty.
  - Remove `toJSON`/`jq` decoding that caused premature exits before commands ran.
  - No changes required in caller workflows; language setup steps remain unchanged.

<sup>Written for commit 5a2c8997086e0a1acee222e6493314f588df9e6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the shared CI action wrapper for install, build, and test commands.

- Replaces JSON decoding through `jq` with direct environment-variable input passing.
- Writes each command input to a temporary script with `printf`.
- Keeps the empty-script guard and `bash -euo pipefail` execution path.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/ci-common/action.yml | Updates the mirrored install, build, and test wrapper steps to write action inputs directly to temporary scripts before execution. |

<sub>Reviews (1): Last reviewed commit: ["Fix ci-common script wrapper without jq/..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/5a2c8997086e0a1acee222e6493314f588df9e6d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43502879)</sub>

<!-- /greptile_comment -->