### PR TITLE
fix(frontend): align react-plotly.js v4 with shipped types

### DIFF
--- a/frontend/__tests__/config/package-validation.test.ts
+++ b/frontend/__tests__/config/package-validation.test.ts
@@ -297,13 +297,8 @@ describe("Package.json Validation", () => {
 
   describe("TypeScript Configuration Consistency", () => {
     it("should have TypeScript type definitions for dependencies that need them", () => {
-      const depsNeedingTypes = [
-        "react",
-        "react-dom",
-        "node",
-        "plotly.js",
-        "react-plotly.js",
-      ];
+      // react-plotly.js >=4 ships its own declarations; omit @types/react-plotly.js.
+      const depsNeedingTypes = ["react", "react-dom", "node", "plotly.js"];
 
       depsNeedingTypes.forEach((dep) => {
         const typesDep = `@types/${dep}`;
@@ -518,10 +513,12 @@ describe("Package.json Validation", () => {
     });
 
     it("should have type definitions for plotly", () => {
+      // react-plotly.js >=4 ships its own TypeScript declarations; do not
+      // also require @types/react-plotly.js (DefinitelyTyped) or types diverge.
       expect(packageJson.devDependencies["@types/plotly.js"]).toBeDefined();
       expect(
         packageJson.devDependencies["@types/react-plotly.js"],
-      ).toBeDefined();
+      ).toBeUndefined();
     });
   });
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,7 +31,6 @@
         "@types/plotly.js": "^3.0.10",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@types/react-plotly.js": "^2.6.4",
         "@typescript-eslint/eslint-plugin": "^8.63.0",
         "@typescript-eslint/parser": "^8.63.0",
         "autoprefixer": "^10.5.2",
@@ -3797,17 +3796,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
-    },
-    "node_modules/@types/react-plotly.js": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/@types/react-plotly.js/-/react-plotly.js-2.6.4.tgz",
-      "integrity": "sha512-AU6w1u3qEGM0NmBA69PaOgNc0KPFA/+qkH6Uu9EBTJ45/WYOUoXi9AF5O15PRM2klpHSiHAAs4WnlI+OZAFmUA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/plotly.js": "*",
-        "@types/react": "*"
       }
     },
     "node_modules/@types/stack-utils": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,7 +40,6 @@
     "@types/plotly.js": "^3.0.10",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@types/react-plotly.js": "^2.6.4",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.63.0",
     "autoprefixer": "^10.5.2",


### PR DESCRIPTION
## **User description**
## Summary
- Remove stale `@types/react-plotly.js` (DefinitelyTyped 2.x) now that `react-plotly.js` is on v4 and ships its own declarations
- Update package-validation tests so they no longer require the DT package (and assert it is absent)

## Test plan
- [x] `npx jest package-validation.test.ts` — 84 passed
- [ ] `cd frontend && npm run build` (optional smoke for typecheck)

EOF

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only dependency and test expectation changes; no application runtime or auth/data paths touched.
> 
> **Overview**
> Removes **`@types/react-plotly.js`** from frontend devDependencies and the lockfile so TypeScript uses the declarations bundled with **`react-plotly.js` v4** instead of stale DefinitelyTyped 2.x types that can conflict.
> 
> **`package-validation.test.ts`** is updated to stop requiring `@types/react-plotly.js` in the “deps needing types” list and to **assert it is absent**, while still requiring **`@types/plotly.js`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a96e0ad97e8e92cf625bf6e34baeb72536fe07c. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed stale `@types/react-plotly.js` now that `react-plotly.js` v4 ships its own TypeScript declarations, and updated package-validation tests to reflect this. This aligns type checks with the runtime and avoids mismatches from the old DefinitelyTyped v2 types.

<sup>Written for commit 9a96e0ad97e8e92cf625bf6e34baeb72536fe07c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Remove stale React Plotly type package**

### What Changed
- Removed the old `@types/react-plotly.js` package from the frontend so TypeScript uses the types bundled with `react-plotly.js` v4
- Updated package checks to stop expecting that extra type package and to confirm it is no longer installed
- Kept the Plotly type package that is still needed for chart types

### Impact
`✅ Fewer type mismatches in Plotly charts`
`✅ Cleaner frontend dependency setup`
`✅ Reduced risk of broken builds from outdated chart types`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the frontend Plotly type packages with the installed React Plotly package.

- Removes the stale `@types/react-plotly.js` dev dependency.
- Removes the matching lockfile package entry.
- Updates package validation tests to expect the shipped `react-plotly.js` types.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/package.json | Removes `@types/react-plotly.js` from frontend dev dependencies. |
| frontend/package-lock.json | Removes the lockfile entries for `@types/react-plotly.js`. |
| frontend/__tests__/config/package-validation.test.ts | Updates dependency validation to omit `@types/react-plotly.js` and assert it is absent. |

<sub>Reviews (1): Last reviewed commit: ["fix(frontend): drop stale @types/react-p..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/9a96e0ad97e8e92cf625bf6e34baeb72536fe07c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43616653)</sub>

<!-- /greptile_comment -->