### PR TITLE
fix(frontend): restore libc filters with postcss 8.5.20 bump

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -42,7 +42,7 @@
         "jest": "^30.4.2",
         "jest-environment-jsdom": "^30.4.0",
         "jest-junit": "^17.0.0",
-        "postcss": "^8.5.19",
+        "postcss": "^8.5.20",
         "tailwindcss": "^4.3.2",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.62.1"
@@ -2891,10 +2891,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.3.3",
@@ -2911,10 +2908,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.3.3",
@@ -2931,10 +2925,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.3.3",
@@ -2951,10 +2942,7 @@
       ],
       "engines": {
         "node": ">= 20"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.3.3",
@@ -10328,10 +10316,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
@@ -10352,10 +10337,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
@@ -10376,10 +10358,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "glibc"
-      ]
+      }
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
@@ -10400,10 +10379,7 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      },
-      "libc": [
-        "musl"
-      ]
+      }
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",
@@ -10874,16 +10850,15 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -11703,9 +11678,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -11721,9 +11696,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2891,7 +2891,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
       "version": "4.3.3",
@@ -2908,7 +2911,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
       "version": "4.3.3",
@@ -2925,7 +2931,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
       "version": "4.3.3",
@@ -2942,7 +2951,10 @@
       ],
       "engines": {
         "node": ">= 20"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
       "version": "4.3.3",
@@ -10316,7 +10328,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/lightningcss-linux-arm64-musl": {
       "version": "1.32.0",
@@ -10337,7 +10352,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/lightningcss-linux-x64-gnu": {
       "version": "1.32.0",
@@ -10358,7 +10376,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "glibc"
+      ]
     },
     "node_modules/lightningcss-linux-x64-musl": {
       "version": "1.32.0",
@@ -10379,7 +10400,10 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "libc": [
+        "musl"
+      ]
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
       "version": "1.32.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,7 +52,7 @@
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.0",
     "jest-junit": "^17.0.0",
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "tailwindcss": "^4.3.2",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.62.1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI (production path) — unchanged
- Frontend: Next.js (production path) — lockfile optional-native metadata only
- Gradio: non-production — unchanged

## Primary Objective

Ship the Depfu `postcss` 8.5.20 bump **without** dropping `libc` discriminators from Linux optional native packages in `frontend/package-lock.json`.

## Scope

### In Scope

- Keep `postcss` `8.5.19 → 8.5.20` and indirect `nanoid` `3.3.15 → 3.3.16` from #1498
- Restore `"libc": ["glibc"]` / `"libc": ["musl"]` on the eight `@tailwindcss/oxide-linux-*` and `lightningcss-linux-*` optional packages so npm can select the correct native binary on musl (Alpine) hosts

### Out of Scope

- Broader frontend dependency upgrades
- Changing Tailwind/Lightning CSS versions
- Docker/CI image base changes

### Files Expected to Change

- `frontend/package.json` — postcss pin (from Depfu)
- `frontend/package-lock.json` — postcss/nanoid bump + restored `libc` fields

## Validation Commands

```bash
# Confirm all eight libc discriminators are present
rg -n '"libc"' frontend/package-lock.json

# Confirm postcss bump landed
node -p "require('./frontend/package-lock.json').packages['node_modules/postcss'].version"
```

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] `libc` selectors match `main` for the eight native optional packages
- [x] Changes align with production architecture (FastAPI + Next.js)

## Notes

Addresses Greptile review feedback on #1498 (unexpected `libc` removal during lockfile regeneration). Prefer this PR over #1498; Depfu’s branch can be closed once this merges.

Same restore pattern as #1493 / `036e776e`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3352903c-c9d7-4bcb-8ac3-3c19f9a8e17c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3352903c-c9d7-4bcb-8ac3-3c19f9a8e17c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores `libc` filters dropped by the `postcss` 8.5.20 lockfile regen so npm picks the right Linux native binaries (incl. Alpine/musl). Also bumps `postcss` to 8.5.20.

- Bug Fixes
  - Re-added `"libc"` discriminators for `@tailwindcss/oxide-linux-*` and `lightningcss-linux-*` optional packages in `frontend/package-lock.json` to ensure correct native binary on musl hosts.

- Dependencies
  - Update `postcss` 8.5.19 → 8.5.20 in `frontend/package.json` and lockfile.
  - Indirect bump `nanoid` to `3.3.16` via `postcss`.

<sup>Written for commit 04e546431437c35022aa42141b5b1b3c8e0b1f24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bumps `postcss` from 8.5.19 to 8.5.20 (and its transitive dependency `nanoid` from 3.3.15 to 3.3.16) while explicitly preserving the `"libc"` discriminators in `frontend/package-lock.json` that a prior Depfu automation PR (#1498) had accidentally dropped.

- **`frontend/package.json`**: devDependency pin updated `postcss ^8.5.19 → ^8.5.20`.
- **`frontend/package-lock.json`**: Resolved versions bumped for `postcss` and `nanoid`; `postcss`'s internal `nanoid` range tightened to `^3.3.16`; cosmetic `\"license\"` field removed from both entries by npm's lockfile generator; all 8 `libc` discriminators (`glibc`/`musl` on the four `@tailwindcss/oxide-linux-*` and four `lightningcss-linux-*` optional packages) remain intact, ensuring correct native binary selection on musl (Alpine) hosts.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only postcss/nanoid version strings and lockfile metadata change; no application logic is touched.

The diff is entirely confined to two lockfile entries (postcss and nanoid) with verified integrity hashes, a matching package.json pin update, and no modifications to any source files. All eight libc discriminators are confirmed present in both the base and the head, so the native binary selection for Alpine/musl hosts is unaffected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| frontend/package.json | Single-line devDependency bump: postcss ^8.5.19 → ^8.5.20; no other changes. |
| frontend/package-lock.json | Bumps postcss 8.5.19→8.5.20 and its transitive dep nanoid 3.3.15→3.3.16; tightens postcss's nanoid range constraint from ^3.3.12 to ^3.3.16; removes cosmetic license field from both entries; all 8 libc discriminators (glibc/musl for @tailwindcss/oxide-linux-{arm64,x64} and lightningcss-linux-{arm64,x64}) are preserved unchanged. |

<sub>Reviews (1): Last reviewed commit: ["fix(frontend): restore libc filters afte..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/04e546431437c35022aa42141b5b1b3c8e0b1f24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45689311)</sub>

<!-- /greptile_comment -->