### PR TITLE
feat: foundation gates for hardening backlog P0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,16 +3,16 @@ FRONTEND_PORT=3000
 NEXT_PUBLIC_API_URL=http://localhost:8000
 
 # Backend
-BACKEND_PORT=8000
-GRADIO_SERVER_PORT=7860
-ENV=development
 ALLOWED_ORIGINS=http://localhost:3000
+BACKEND_PORT=8000
+ENV=development
+GRADIO_SERVER_PORT=7860
 
 # Auth/application DB (local). Prefer sqlite:dev.db — avoid sqlite:///./… under this repo's resolver.
+ADMIN_PASSWORD=replace-with-a-strong-password
+ADMIN_USERNAME=admin
 DATABASE_URL=sqlite:dev.db
 SECRET_KEY=replace-with-a-long-random-secret-at-least-32-chars
-ADMIN_USERNAME=admin
-ADMIN_PASSWORD=replace-with-a-strong-password
 
 # Hosted / durable boundaries (staging & production). Leave unset for local SQLite-only demos.
 # ASSET_GRAPH_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/graph

--- a/.env.example
+++ b/.env.example
@@ -5,8 +5,16 @@ NEXT_PUBLIC_API_URL=http://localhost:8000
 # Backend
 BACKEND_PORT=8000
 GRADIO_SERVER_PORT=7860
+ENV=development
 ALLOWED_ORIGINS=http://localhost:3000
-DATABASE_URL=sqlite:///./asset_graph.db
-SECRET_KEY=replace-with-a-long-random-secret
+
+# Auth/application DB (local). Prefer sqlite:dev.db — avoid sqlite:///./… under this repo's resolver.
+DATABASE_URL=sqlite:dev.db
+SECRET_KEY=replace-with-a-long-random-secret-at-least-32-chars
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=replace-with-a-strong-password
+
+# Hosted / durable boundaries (staging & production). Leave unset for local SQLite-only demos.
+# ASSET_GRAPH_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/graph
+# COORDINATION_DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/coordination
+# POSTGRES_URL=postgresql://USER:PASSWORD@HOST:5432/app

--- a/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
+++ b/.github/ISSUE_TEMPLATE/operational_drill_evidence.md
@@ -27,6 +27,7 @@ assignees: ""
 - [ ] Degraded DB
 - [ ] Failed durable smoke
 
+**Mapped hardening ID(s), if any:** <!-- e.g. H-P1-03, H-P2-05 -->
 **Result classification:** <!-- Passed / Failed / Blocked / Not run / Manual evidence required / Follow-up required -->
 
 ## Expected and Actual Behavior

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -128,6 +128,24 @@ Record named owners for this release candidate:
 - [ ] Restore rehearsal decision recorded: Passed / Failed / Blocked.
 - [ ] Follow-up issues are linked for unresolved ambiguity or failed steps.
 
+## Hardening backlog (machine-checkable markers)
+
+Copy these markers into the committed evidence file used by `staging-promotion.yml`.
+Reference: [Hardening evidence markers](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/release-evidence-pack.md#hardening-evidence-markers).
+
+```text
+hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06
+topology: jobs=asset_graph; locks=coordination
+db_authz: PASS
+```
+
+- [ ] H-P0-01 topology marker present (`jobs=asset_graph; locks=coordination`)
+- [ ] H-P0-02 table-scoped restore cleanup confirmed on job + lock boundaries
+- [ ] H-P0-03 `release-evidence-verify` run with `hardening_tier=P0` (strict; hosted must PASS)
+- [ ] H-P0-04 `db_authz: PASS` (or `PASS|<opaque-ref>`) attached; no topology/secrets leaked
+- [ ] H-P0-06 this packet is SHA-bound to the release commit above (RC1 not reused as CURRENT)
+- [ ] Release-evidence / staging-promotion workflow run URL attached:
+
 ## Gate Status Summary
 
 Use the status values from the release evidence pack.

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -142,7 +142,7 @@ db_authz: PASS|<replace-with-workflow-run-id>
 Replace the `db_authz` placeholder with a real opaque ref from a workflow that ran
 `scripts/check_database_authorization.py` (for example `db_authz: PASS|1506-run-123456` or
 `db_authz: PASS|run-1234567890`). Allowed shapes: `run-<digits>`, `artifact-<digits>`,
-`<prefix>-run-<digits>`, or a numeric workflow run id (>=6 digits). Bare `PASS` and placeholders
+`<prefix>-run-<digits>`, or a numeric workflow run ID (>=6 digits). Bare `PASS` and placeholders
 such as `TBD` / angle-bracket templates are rejected.
 
 - [ ] H-P0-01 topology marker present (`jobs=asset_graph; locks=coordination`)

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -89,13 +89,13 @@ Use this only when a drill is directly release-blocking or explicitly included i
 
 Record named owners for this release candidate:
 
-| Role | Named owner | Sign-off status | Notes |
-| --- | --- | --- | --- |
-| Deploy operator |  | Pending |  |
-| Promotion approver |  | Pending |  |
-| Rollback owner |  | Pending |  |
-| Restore operator |  | Pending |  |
-| Persistence verification owner |  | Pending |  |
+| Role                           | Named owner | Sign-off status | Notes |
+| ------------------------------ | ----------- | --------------- | ----- |
+| Deploy operator                |             | Pending         |       |
+| Promotion approver             |             | Pending         |       |
+| Rollback owner                 |             | Pending         |       |
+| Restore operator               |             | Pending         |       |
+| Persistence verification owner |             | Pending         |       |
 
 ## Disaster Recovery Rehearsal Evidence
 
@@ -156,17 +156,17 @@ such as `TBD` / angle-bracket templates are rejected.
 
 Use the status values from the release evidence pack.
 
-| Gate | Status | Evidence link or note | Release blocker? |
-| --- | --- | --- | --- |
-| Architecture |  |  |  |
-| Durable Persistence |  |  |  |
-| Restart / Reload |  |  |  |
-| Promotion |  |  |  |
-| API Contract |  |  |  |
-| Recovery / Rebuild |  |  |  |
-| Security |  |  |  |
-| Governance |  |  |  |
-| Disaster Recovery |  |  |  |
+| Gate                | Status | Evidence link or note | Release blocker? |
+| ------------------- | ------ | --------------------- | ---------------- |
+| Architecture        |        |                       |                  |
+| Durable Persistence |        |                       |                  |
+| Restart / Reload    |        |                       |                  |
+| Promotion           |        |                       |                  |
+| API Contract        |        |                       |                  |
+| Recovery / Rebuild  |        |                       |                  |
+| Security            |        |                       |                  |
+| Governance          |        |                       |                  |
+| Disaster Recovery   |        |                       |                  |
 
 ## Final Decision
 

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -136,13 +136,17 @@ Reference: [Hardening evidence markers](https://github.com/DashFin-FarDb/financi
 ```text
 hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06
 topology: jobs=asset_graph; locks=coordination
-db_authz: PASS
+db_authz: PASS|<replace-with-workflow-run-id>
 ```
+
+Replace the `db_authz` placeholder with a real opaque ref from a workflow that ran
+`scripts/check_database_authorization.py` (for example `db_authz: PASS|1506-run-123456`).
+Bare `db_authz: PASS` is rejected by `verify_staging_promotion.py`. Do not leave the template placeholder.
 
 - [ ] H-P0-01 topology marker present (`jobs=asset_graph; locks=coordination`)
 - [ ] H-P0-02 table-scoped restore cleanup confirmed on job + lock boundaries
 - [ ] H-P0-03 `release-evidence-verify` run with `hardening_tier=P0` (strict; hosted must PASS)
-- [ ] H-P0-04 `db_authz: PASS` (or `PASS|<opaque-ref>`) attached; no topology/secrets leaked
+- [ ] H-P0-04 live DB authorization passed in staging-promotion (secrets required); evidence has `db_authz: PASS|<opaque-ref>`
 - [ ] H-P0-06 this packet is SHA-bound to the release commit above (RC1 not reused as CURRENT)
 - [ ] Release-evidence / staging-promotion workflow run URL attached:
 

--- a/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
+++ b/.github/ISSUE_TEMPLATE/release_candidate_evidence.md
@@ -140,8 +140,10 @@ db_authz: PASS|<replace-with-workflow-run-id>
 ```
 
 Replace the `db_authz` placeholder with a real opaque ref from a workflow that ran
-`scripts/check_database_authorization.py` (for example `db_authz: PASS|1506-run-123456`).
-Bare `db_authz: PASS` is rejected by `verify_staging_promotion.py`. Do not leave the template placeholder.
+`scripts/check_database_authorization.py` (for example `db_authz: PASS|1506-run-123456` or
+`db_authz: PASS|run-1234567890`). Allowed shapes: `run-<digits>`, `artifact-<digits>`,
+`<prefix>-run-<digits>`, or a numeric workflow run id (>=6 digits). Bare `PASS` and placeholders
+such as `TBD` / angle-bracket templates are rejected.
 
 - [ ] H-P0-01 topology marker present (`jobs=asset_graph; locks=coordination`)
 - [ ] H-P0-02 table-scoped restore cleanup confirmed on job + lock boundaries

--- a/.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
+++ b/.github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
@@ -50,11 +50,22 @@ assignees: ""
 **Does coordination share the app/auth boundary?**
 **If yes, what shared-boundary fallback was confirmed?**
 
+## Hardening / topology (H-P0-01, H-P0-02)
+
+```text
+topology: jobs=asset_graph; locks=coordination
+```
+
+- [ ] Locks inspected/cleared on the **coordination** boundary
+- [ ] In-flight jobs failed/cleaned on the **Asset Graph (job)** boundary
+- [ ] `running_rebuild_jobs_count == 0` confirmed on the **job** boundary before restart
+- [ ] Hardening ID H-P0-02 recorded as closed for this rehearsal (or follow-up linked)
+
 ## Verification Evidence
 
 **Restore cleanup / restart precheck:**
-**Restored distributed lock inspection result:**
-**Restored in-flight rebuild job inspection result:**
+**Restored distributed lock inspection result (coordination boundary):**
+**Restored in-flight rebuild job inspection result (Asset Graph boundary):**
 **Cleanup action taken, if any:**
 **Confirmation that `running_rebuild_jobs_count == 0` before restart, or documented exception:**
 

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -21,14 +21,11 @@ on:
         type: boolean
         default: false
       hardening_tier:
-        description: "Hardening backlog tier to enforce (P0 default for RC; none = soft rehearsal)"
+        description: "Hardening backlog tier to enforce. Only none and P0 are implemented; P0 (default) forces strict hosted readiness. none = soft rehearsal."
         type: choice
         options:
           - none
           - P0
-          - P1
-          - P2
-          - P3
         default: P0
       tags:
         description: "Manual sign-off tags (e.g., [manual-stop] or [star])"

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -221,7 +221,8 @@ jobs:
             exit 0
           fi
           set +e
-          python scripts/check_database_authorization.py > db-authz-log.txt 2>&1
+          # Bounded stdout/stderr only (control ids/messages). Do not upload raw logs as artifacts.
+          python scripts/check_database_authorization.py
           code=$?
           if [ "$code" -eq 0 ]; then
             echo '{"status":"passed"}' > db-authz-output.json
@@ -243,7 +244,6 @@ jobs:
           if [ ! -f db-authz-output.json ]; then
             echo '{"status":"skipped","reason":"db_authz_not_run"}' > db-authz-output.json
           fi
-          touch db-authz-log.txt
 
       - name: Upload Artifacts
         if: always()
@@ -255,7 +255,6 @@ jobs:
             release-source/readiness-output.json
             release-source/docs-readiness.json
             release-source/db-authz-output.json
-            release-source/db-authz-log.txt
 
       - name: Assert All Gates Passed
         if: always()

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -233,6 +233,21 @@ jobs:
           echo "{\"status\":\"failed\",\"exit_code\":$code}" > db-authz-output.json
           exit 1
 
+      - name: Prepare Artifact Placeholders
+        if: always()
+        working-directory: release-source
+        run: |
+          if [ ! -f readiness-output.json ]; then
+            echo '{"status":"skipped","reason":"hosted_readiness_not_run"}' > readiness-output.json
+          fi
+          if [ ! -f docs-readiness.json ]; then
+            echo '{"status":"skipped","reason":"docs_gate_not_run"}' > docs-readiness.json
+          fi
+          if [ ! -f db-authz-output.json ]; then
+            echo '{"status":"skipped","reason":"db_authz_not_run"}' > db-authz-output.json
+          fi
+          touch db-authz-log.txt
+
       - name: Upload Artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -243,6 +258,7 @@ jobs:
             release-source/readiness-output.json
             release-source/docs-readiness.json
             release-source/db-authz-output.json
+            release-source/db-authz-log.txt
 
       - name: Assert All Gates Passed
         if: always()

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -17,9 +17,19 @@ on:
         type: boolean
         default: true
       strict_rc_gate:
-        description: "Strict RC promotion gate (fails if hosted readiness is skipped)"
+        description: "Strict RC promotion gate (fails if hosted readiness is skipped). Forced true when hardening_tier != none."
         type: boolean
         default: false
+      hardening_tier:
+        description: "Hardening backlog tier to enforce (P0 default for RC; none = soft rehearsal)"
+        type: choice
+        options:
+          - none
+          - P0
+          - P1
+          - P2
+          - P3
+        default: P0
       tags:
         description: "Manual sign-off tags (e.g., [manual-stop] or [star])"
         required: false
@@ -198,6 +208,31 @@ jobs:
             echo "{}" > readiness-output.json
           fi
 
+      - name: Check Database Authorization
+        id: gate_db_authz
+        continue-on-error: true
+        working-directory: release-source
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          ASSET_GRAPH_DATABASE_URL: ${{ secrets.ASSET_GRAPH_DATABASE_URL }}
+          COORDINATION_DATABASE_URL: ${{ secrets.COORDINATION_DATABASE_URL }}
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+          FARDB_UNTRUSTED_DATABASE_ROLES: ${{ secrets.FARDB_UNTRUSTED_DATABASE_ROLES }}
+        run: |
+          if [ -z "${DATABASE_URL}${ASSET_GRAPH_DATABASE_URL}${COORDINATION_DATABASE_URL}${POSTGRES_URL}" ]; then
+            echo '{"status":"skipped","reason":"no_database_url_configured"}' > db-authz-output.json
+            exit 0
+          fi
+          set +e
+          python scripts/check_database_authorization.py > db-authz-log.txt 2>&1
+          code=$?
+          if [ "$code" -eq 0 ]; then
+            echo '{"status":"passed"}' > db-authz-output.json
+            exit 0
+          fi
+          echo "{\"status\":\"failed\",\"exit_code\":$code}" > db-authz-output.json
+          exit 1
+
       - name: Upload Artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -207,15 +242,24 @@ jobs:
             release-source/results-*.xml
             release-source/readiness-output.json
             release-source/docs-readiness.json
+            release-source/db-authz-output.json
 
       - name: Assert All Gates Passed
         if: always()
         working-directory: release-source
         env:
           STRICT_RC_GATE: ${{ inputs.strict_rc_gate }}
+          HARDENING_TIER: ${{ inputs.hardening_tier }}
         run: |
           docs_status=$(jq -r '.status // "skipped"' docs-readiness.json 2>/dev/null || echo "skipped")
           readiness_status=$(jq -r '.status // "skipped"' readiness-output.json 2>/dev/null || echo "skipped")
+          db_authz_status=$(jq -r '.status // "skipped"' db-authz-output.json 2>/dev/null || echo "skipped")
+
+          EFFECTIVE_STRICT="$STRICT_RC_GATE"
+          if [ "$HARDENING_TIER" != "none" ]; then
+            EFFECTIVE_STRICT="true"
+            echo "hardening_tier=$HARDENING_TIER forces strict RC gate."
+          fi
 
           if [ "${{ steps.gate_persistence.outcome }}" != "success" ] || \
           [ "${{ steps.gate_restart.outcome }}" != "success" ] || \
@@ -228,9 +272,14 @@ jobs:
             exit 1
           fi
 
-          if [ "$STRICT_RC_GATE" == "true" ]; then
+          if [ "$db_authz_status" == "failed" ] || [ "${{ steps.gate_db_authz.outcome }}" == "failure" ]; then
+            echo "Database authorization gate failed (H-P0-04)."
+            exit 1
+          fi
+
+          if [ "$EFFECTIVE_STRICT" == "true" ]; then
             if [ "$readiness_status" != "passed" ] || [ "$docs_status" != "passed" ]; then
-              echo "Strict RC promotion requires hosted readiness and docs checks to pass."
+              echo "Strict RC promotion requires hosted readiness and docs checks to pass (hardening_tier=$HARDENING_TIER)."
               exit 1
             fi
           else
@@ -247,6 +296,8 @@ jobs:
       - name: Emit Gate Summary
         if: always()
         working-directory: release-source
+        env:
+          HARDENING_TIER: ${{ inputs.hardening_tier }}
         run: |
           python - <<'PY'
           import glob
@@ -300,6 +351,7 @@ jobs:
               ("Disaster Recovery", "MANUAL EVIDENCE REQUIRED", "docs/runbooks/backup-restore-dr.md; docs/adr/0005-backup-restore-dr-strategy.md"),
           ]
 
+          hardening_tier = os.environ.get("HARDENING_TIER", "P0")
           summary_path = os.environ["GITHUB_STEP_SUMMARY"]
           with open(summary_path, "a", encoding="utf-8") as out:
               out.write("## Release Evidence Gate Summary\n")
@@ -311,6 +363,17 @@ jobs:
               out.write("Supplementary checks (not part of the nine canonical gates):\n")
               out.write(
                   f"- AI System Documentation (Article 13/14): {json_status('docs-readiness.json')} (`docs-readiness.json`)\n"
+              )
+              out.write(
+                  f"- Database authorization (H-P0-04): {json_status('db-authz-output.json')} (`db-authz-output.json`)\n"
+              )
+              out.write("\n")
+              out.write("## Hardening backlog\n")
+              out.write(f"- hardening_tier input: `{hardening_tier}`\n")
+              out.write(
+                  "- Canon: `docs/release-evidence-pack.md#hardening-backlog-p0p3` "
+                  "(H-P0-01 … H-P3-05). Skipped DB authz still requires staging evidence "
+                  "`db_authz: PASS` before promotion.\n"
               )
 
           sys.exit(0)

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -52,12 +52,14 @@ jobs:
           FARDB_UNTRUSTED_DATABASE_ROLES: ${{ secrets.FARDB_UNTRUSTED_DATABASE_ROLES }}
         run: |
           if [ -z "${DATABASE_URL}${ASSET_GRAPH_DATABASE_URL}${COORDINATION_DATABASE_URL}${POSTGRES_URL}" ]; then
-            echo "No database URL secrets configured; relying on evidence-file db_authz marker (H-P0-04)."
-            echo '{"status":"skipped","reason":"no_database_url_configured"}' > db-authz-output.json
-            exit 0
+            echo '{"status":"failed","reason":"no_database_url_configured"}' > db-authz-output.json
+            echo "H-P0-04 requires live database authorization secrets on the staging Environment."
+            echo "Configure DATABASE_URL and/or ASSET_GRAPH_DATABASE_URL (and optional COORDINATION/POSTGRES) secrets."
+            exit 1
           fi
           set +e
-          python scripts/check_database_authorization.py > db-authz-log.txt 2>&1
+          # Bounded stdout/stderr only (control ids/messages). Do not upload raw logs as artifacts.
+          python scripts/check_database_authorization.py
           code=$?
           if [ "$code" -eq 0 ]; then
             echo '{"status":"passed"}' > db-authz-output.json
@@ -110,6 +112,7 @@ jobs:
 
       - name: Prepare Artifact Placeholders
         if: always()
+        working-directory: ${{ github.workspace }}
         run: |
           if [ ! -f readiness-output.json ]; then
             echo '{"status":"skipped","reason":"hosted_readiness_not_run"}' > readiness-output.json
@@ -117,7 +120,6 @@ jobs:
           if [ ! -f db-authz-output.json ]; then
             echo '{"status":"skipped","reason":"db_authz_not_run"}' > db-authz-output.json
           fi
-          touch db-authz-log.txt
 
       - name: Upload Artifacts
         if: always()
@@ -127,5 +129,4 @@ jobs:
           path: |
             readiness-output.json
             db-authz-output.json
-            db-authz-log.txt
             promotion_audit.log

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -108,6 +108,17 @@ jobs:
           echo "Logging promotion decision for AI system transparency (Article 13)..."
           echo "Promotion run at $(date -u) — result: ${{ job.status }}" >> promotion_audit.log
 
+      - name: Prepare Artifact Placeholders
+        if: always()
+        run: |
+          if [ ! -f readiness-output.json ]; then
+            echo '{"status":"skipped","reason":"hosted_readiness_not_run"}' > readiness-output.json
+          fi
+          if [ ! -f db-authz-output.json ]; then
+            echo '{"status":"skipped","reason":"db_authz_not_run"}' > db-authz-output.json
+          fi
+          touch db-authz-log.txt
+
       - name: Upload Artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -116,4 +127,5 @@ jobs:
           path: |
             readiness-output.json
             db-authz-output.json
+            db-authz-log.txt
             promotion_audit.log

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -42,6 +42,31 @@ jobs:
           EVIDENCE_FILE: ${{ github.event.inputs.evidence_file }}
         run: python scripts/verify_staging_promotion.py "$EVIDENCE_FILE"
 
+      - name: Check Database Authorization
+        id: db_authz
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          ASSET_GRAPH_DATABASE_URL: ${{ secrets.ASSET_GRAPH_DATABASE_URL }}
+          COORDINATION_DATABASE_URL: ${{ secrets.COORDINATION_DATABASE_URL }}
+          POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+          FARDB_UNTRUSTED_DATABASE_ROLES: ${{ secrets.FARDB_UNTRUSTED_DATABASE_ROLES }}
+        run: |
+          if [ -z "${DATABASE_URL}${ASSET_GRAPH_DATABASE_URL}${COORDINATION_DATABASE_URL}${POSTGRES_URL}" ]; then
+            echo "No database URL secrets configured; relying on evidence-file db_authz marker (H-P0-04)."
+            echo '{"status":"skipped","reason":"no_database_url_configured"}' > db-authz-output.json
+            exit 0
+          fi
+          set +e
+          python scripts/check_database_authorization.py > db-authz-log.txt 2>&1
+          code=$?
+          if [ "$code" -eq 0 ]; then
+            echo '{"status":"passed"}' > db-authz-output.json
+            exit 0
+          fi
+          echo "{\"status\":\"failed\",\"exit_code\":$code}" > db-authz-output.json
+          echo "Database authorization gate failed (H-P0-04)."
+          exit 1
+
       - name: Check Hosted Readiness
         id: readiness
         env:
@@ -90,4 +115,5 @@ jobs:
           name: staging-readiness
           path: |
             readiness-output.json
+            db-authz-output.json
             promotion_audit.log

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -37,24 +37,21 @@ jobs:
       - name: Install Dependencies
         run: pip install -r requirements.txt
 
-      - name: Verify Staging Baseline Checklist
-        env:
-          EVIDENCE_FILE: ${{ github.event.inputs.evidence_file }}
-        run: python scripts/verify_staging_promotion.py "$EVIDENCE_FILE"
-
-      - name: Check Database Authorization
+      - name: Verify Staging Baseline and Database Authorization
         id: db_authz
         env:
+          EVIDENCE_FILE: ${{ github.event.inputs.evidence_file }}
           DATABASE_URL: ${{ secrets.DATABASE_URL }}
           ASSET_GRAPH_DATABASE_URL: ${{ secrets.ASSET_GRAPH_DATABASE_URL }}
           COORDINATION_DATABASE_URL: ${{ secrets.COORDINATION_DATABASE_URL }}
           POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
           FARDB_UNTRUSTED_DATABASE_ROLES: ${{ secrets.FARDB_UNTRUSTED_DATABASE_ROLES }}
         run: |
+          python scripts/verify_staging_promotion.py "$EVIDENCE_FILE"
           if [ -z "${DATABASE_URL}${ASSET_GRAPH_DATABASE_URL}${COORDINATION_DATABASE_URL}${POSTGRES_URL}" ]; then
             echo '{"status":"failed","reason":"no_database_url_configured"}' > db-authz-output.json
             echo "H-P0-04 requires live database authorization secrets on the staging Environment."
-            echo "Configure DATABASE_URL and/or ASSET_GRAPH_DATABASE_URL (and optional COORDINATION/POSTGRES) secrets."
+            echo "Configure the auth/app, asset-graph, and optional coordination/postgres URL secrets."
             exit 1
           fi
           set +e

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,6 +66,8 @@ jobs:
           VALIDATE_PYTHON_ISORT: false
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
-          # Pyink is still enabled by default in super-linter v7 (removed in v8).
-          # There is no PYTHON_PYINK_LINE_LENGTH setting; use pyproject.toml instead.
-          PYTHON_PYINK_CONFIG_FILE: pyproject.toml
+          # Keep Python formatting out of super-linter; black/ruff/pre-commit own it.
+          # Pyink defaults on in v7 and was removed in v8; do not point
+          # PYTHON_PYINK_CONFIG_FILE at repo-root pyproject.toml (resolved under
+          # LINTER_RULES_PATH and fatals when missing).
+          VALIDATE_PYTHON_PYINK: false

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,5 +66,6 @@ jobs:
           VALIDATE_PYTHON_ISORT: false
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
-          # Align pyink with repository black/ruff line length (pyproject.toml).
-          PYTHON_PYINK_LINE_LENGTH: 120
+          # Pyink is still enabled by default in super-linter v7 (removed in v8).
+          # There is no PYTHON_PYINK_LINE_LENGTH setting; use pyproject.toml instead.
+          PYTHON_PYINK_CONFIG_FILE: pyproject.toml

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -66,3 +66,5 @@ jobs:
           VALIDATE_PYTHON_ISORT: false
           VALIDATE_PYTHON_MYPY: false
           VALIDATE_PYTHON_PYLINT: false
+          # Align pyink with repository black/ruff line length (pyproject.toml).
+          PYTHON_PYINK_LINE_LENGTH: 120

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,6 +4,8 @@
     "siblings_only": false
   },
   "MD013": {
-    "line_length": 120
+    "line_length": 400,
+    "code_blocks": false,
+    "tables": false
   }
 }

--- a/docs/adr/0002-hosted-deployment-and-persistence.md
+++ b/docs/adr/0002-hosted-deployment-and-persistence.md
@@ -31,6 +31,7 @@ The initial hosted deployment target is the existing Vercel monorepo path for bo
 ### Option 1: Vercel monorepo + PostgreSQL (Chosen)
 
 **Pros:**
+
 - Vercel already configured (`vercel.json` present)
 - Single project for frontend + backend
 - Automatic preview deployments
@@ -39,16 +40,19 @@ The initial hosted deployment target is the existing Vercel monorepo path for bo
 - Good Python/FastAPI ecosystem support for PostgreSQL
 
 **Cons:**
+
 - Requires database migration implementation
 - Serverless cold starts (acceptable for initial use)
 
 ### Option 2: Vercel frontend + separate backend service + PostgreSQL
 
 **Pros:**
+
 - Dedicated backend resources
 - More control over backend scaling
 
 **Cons:**
+
 - More complex deployment
 - Separate service management
 - Higher operational overhead
@@ -56,9 +60,11 @@ The initial hosted deployment target is the existing Vercel monorepo path for bo
 ### Option 3: Managed SQLite-compatible storage
 
 **Pros:**
+
 - Minimal code changes
 
 **Cons:**
+
 - Limited serverless-compatible options
 - Turso/libSQL requires dependency changes
 - Less mature ecosystem
@@ -66,9 +72,11 @@ The initial hosted deployment target is the existing Vercel monorepo path for bo
 ### Option 4: Hosted file-backed SQLite with persistent volume
 
 **Pros:**
+
 - Existing SQLite code works
 
 **Cons:**
+
 - Not compatible with Vercel serverless
 - Requires VM or container hosting
 - Connection pooling challenges
@@ -76,9 +84,11 @@ The initial hosted deployment target is the existing Vercel monorepo path for bo
 ### Option 5: Local-first only (defer hosted deployment)
 
 **Pros:**
+
 - No immediate work
 
 **Cons:**
+
 - Blocks hosted use cases
 - Delays production feedback
 
@@ -114,6 +124,7 @@ Current database tests exercise SQLite URIs only. Phase 1 must add PostgreSQL-sp
 Add PostgreSQL support for the API auth/user database while preserving SQLite local dev compatibility.
 
 **Scope:**
+
 - Add PostgreSQL adapter to `api/database.py` ✅
 - Add psycopg2-binary driver to `requirements.txt` ✅
 - PostgreSQL-compatible DDL for `user_credentials` table ✅
@@ -124,6 +135,7 @@ Add PostgreSQL support for the API auth/user database while preserving SQLite lo
 - Comprehensive test coverage (unit + opt-in integration) ✅
 
 **Explicitly Deferred to Phase 4:**
+
 - Production-grade connection pooling for serverless
 - Database migration tooling (Alembic)
 
@@ -152,23 +164,27 @@ Connection pooling tuning, caching strategy, and monitoring remain future produc
 ## Required Hosted Environment Variables
 
 **Backend (Required):**
+
 - `DATABASE_URL` — Auth/application database. Local/dev: recommended `sqlite:dev.db` or `sqlite:///:memory:` (avoid `sqlite:///./…` under this repo’s custom resolver in `api/database.py`). Hosted staging/production: PostgreSQL URL (**landed** in `api/database.py`; Phase 1 complete).
 - `SECRET_KEY` — JWT signing key (≥32 characters outside development/test)
 - `ADMIN_USERNAME` — Bootstrap admin username
 - `ADMIN_PASSWORD` — Bootstrap admin password
 
 **Backend (Hosted durable graph — required for staging/production promotion):**
+
 - `ASSET_GRAPH_DATABASE_URL` — Durable graph-truth boundary (PostgreSQL in hosted environments)
 - `COORDINATION_DATABASE_URL` — Optional; rebuild lock boundary. When unset, settings fall back to `DATABASE_URL` then `POSTGRES_URL`.
 - `POSTGRES_URL` — Provider fallback when `DATABASE_URL` is unset (for example Vercel Postgres)
 
 **Backend (Optional):**
+
 - `ENV` — Environment mode (production/staging/development)
 - `ALLOWED_ORIGINS` — CORS allowlist (comma-separated)
 - `GRAPH_CACHE_PATH` — Graph cache path (ephemeral on serverless)
 - `USE_REAL_DATA_FETCHER` — Enable real data fetcher
 
 **Frontend (Required):**
+
 - `NEXT_PUBLIC_API_URL` — API endpoint URL
 
 ## Deferred Items

--- a/docs/adr/0002-hosted-deployment-and-persistence.md
+++ b/docs/adr/0002-hosted-deployment-and-persistence.md
@@ -24,7 +24,7 @@ The current database layer (`api/database.py`) only supports SQLite connections.
 
 The initial hosted deployment target is the existing Vercel monorepo path for both the Next.js frontend and FastAPI backend.
 
-**PostgreSQL support is not yet implemented in the current database layer.** Until PostgreSQL support lands, hosted deployments using SQLite are demo/preview only and must not be treated as durable production persistence.
+**PostgreSQL support is landed** in `api/database.py` and the graph persistence layer (Phases 1–3 complete). Hosted staging/production must use PostgreSQL durable boundaries; SQLite remains local/dev (and non-durable demo/preview) only.
 
 ## Options Considered
 
@@ -152,10 +152,15 @@ Connection pooling tuning, caching strategy, and monitoring remain future produc
 ## Required Hosted Environment Variables
 
 **Backend (Required):**
-- `DATABASE_URL` — current implementation requires a SQLite URI. For hosted preview/demo before Phase 1, use ephemeral SQLite only, such as `sqlite:///:memory:` or an explicit `/tmp` SQLite path. PostgreSQL connection strings are the Phase 1+ production target and are not supported by `api/database.py` yet.
-- `SECRET_KEY` — JWT signing key
+- `DATABASE_URL` — Auth/application database. Local/dev: recommended `sqlite:dev.db` or `sqlite:///:memory:` (avoid `sqlite:///./…` under this repo’s custom resolver in `api/database.py`). Hosted staging/production: PostgreSQL URL (**landed** in `api/database.py`; Phase 1 complete).
+- `SECRET_KEY` — JWT signing key (≥32 characters outside development/test)
 - `ADMIN_USERNAME` — Bootstrap admin username
 - `ADMIN_PASSWORD` — Bootstrap admin password
+
+**Backend (Hosted durable graph — required for staging/production promotion):**
+- `ASSET_GRAPH_DATABASE_URL` — Durable graph-truth boundary (PostgreSQL in hosted environments)
+- `COORDINATION_DATABASE_URL` — Optional; rebuild lock boundary. When unset, settings fall back to `DATABASE_URL` then `POSTGRES_URL`.
+- `POSTGRES_URL` — Provider fallback when `DATABASE_URL` is unset (for example Vercel Postgres)
 
 **Backend (Optional):**
 - `ENV` — Environment mode (production/staging/development)

--- a/docs/adr/0005-backup-restore-dr-strategy.md
+++ b/docs/adr/0005-backup-restore-dr-strategy.md
@@ -23,9 +23,18 @@ FarDb uses a dual-database architecture:
 
 The two database boundaries may point to the same physical PostgreSQL instance or to separate logical databases. Operators must treat them as separate recovery concerns unless the deployment explicitly documents a shared database boundary.
 
-The rebuild coordination plane may also be isolated through `COORDINATION_DATABASE_URL`. **Landed runtime placement** (`api/routers/graph_admin.py`): `distributed_locks` use the coordination session (`COORDINATION_DATABASE_URL`, falling back through `DATABASE_URL` then `POSTGRES_URL` in settings), while `rebuild_jobs` (heartbeats/checkpoints) use the domain / Asset Graph session (`ASSET_GRAPH_DATABASE_URL`). DR procedures must resolve the actual deployed connection-string topology and clean up **table-scoped** (locks vs jobs) before restart.
+The rebuild coordination plane may also be isolated through `COORDINATION_DATABASE_URL`.
+**Landed runtime placement** (`api/routers/graph_admin.py`): `distributed_locks` use the
+coordination session (`COORDINATION_DATABASE_URL`, falling back through `DATABASE_URL` then
+`POSTGRES_URL` in settings), while `rebuild_jobs` (heartbeats/checkpoints) use the domain /
+Asset Graph session (`ASSET_GRAPH_DATABASE_URL`). DR procedures must resolve the actual
+deployed connection-string topology and clean up **table-scoped** (locks vs jobs) before restart.
 
-Graph data and coordination/auth data have different recovery properties. Graph data can be rebuilt from source data through `RebuildExecutor` when source data remains available and fresh enough for the target environment. Coordination/auth data is less replaceable: user credentials, rebuild job history, lock state, and checkpoint metadata cannot be fully reconstructed from the graph source feed alone.
+Graph data and coordination/auth data have different recovery properties. Graph data can be
+rebuilt from source data through `RebuildExecutor` when source data remains available and fresh
+enough for the target environment. Coordination/auth data is less replaceable: user credentials,
+rebuild job history, lock state, and checkpoint metadata cannot be fully reconstructed from the
+graph source feed alone.
 
 The distributed rebuild control plane also introduces timing constraints. `distributed_locks` rows expire through TTL semantics, with the current default maximum operational assumption of 300 seconds. A restored lock row with a future `expires_at` can temporarily block new rebuild lock acquisition until it expires or is cleared by an operator.
 
@@ -35,10 +44,10 @@ FarDb adopts a documented disaster recovery strategy for staging and production 
 
 ### Recovery objectives
 
-| Data class | RPO target | RTO target | Notes |
-| --- | --- | --- | --- |
-| Graph data | Tied to approved source-data freshness | 2 hours for full service restoration, including verification | Graph truth is important but rebuildable through `RebuildExecutor` if source data remains available. |
-| Coordination/auth data | 1 hour | 2 hours for full service restoration, including verification | Includes auth/application state and rebuild coordination state that cannot be completely inferred from graph source data. |
+| Data class             | RPO target                             | RTO target                                                   | Notes                                                                                                                     |
+| ---------------------- | -------------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Graph data             | Tied to approved source-data freshness | 2 hours for full service restoration, including verification | Graph truth is important but rebuildable through `RebuildExecutor` if source data remains available.                      |
+| Coordination/auth data | 1 hour                                 | 2 hours for full service restoration, including verification | Includes auth/application state and rebuild coordination state that cannot be completely inferred from graph source data. |
 
 The 2-hour RTO includes restore execution, schema verification, application restart/redeployment, health verification, lifecycle verification, and functional smoke testing.
 
@@ -52,19 +61,19 @@ Provider-managed point-in-time recovery (PITR) is the primary backup and restore
 
 Hosted staging and production should maintain:
 
-| Backup type | Retention |
-| --- | --- |
-| Daily backups | 7-day rolling retention |
-| Weekly snapshots | 30-day retention |
+| Backup type      | Retention               |
+| ---------------- | ----------------------- |
+| Daily backups    | 7-day rolling retention |
+| Weekly snapshots | 30-day retention        |
 
 Provider-managed PITR retention must meet or exceed the intended recovery window. If a provider tier cannot satisfy the retention policy, operators must supplement it with scheduled `pg_dump` snapshots retained outside the primary database service.
 
 ### Data classification
 
-| Classification | Tables / state | Recovery priority | Rationale |
-| --- | --- | --- | --- |
-| **Critical / Non-rebuildable** | `distributed_locks`, `rebuild_jobs` coordination state, user credentials if stored | Highest | These records control operator access, rebuild coordination, checkpoints, and lock ownership. They cannot be regenerated from graph source data alone. |
-| **Important / Rebuildable** | `assets`, `asset_relationships`, `regulatory_events`, `regulatory_event_assets` | High | These records represent graph truth. They should be restored when possible but can be rebuilt from source through `RebuildExecutor` if backup data is unavailable or stale. |
+| Classification                 | Tables / state                                                                     | Recovery priority | Rationale                                                                                                                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Critical / Non-rebuildable** | `distributed_locks`, `rebuild_jobs` coordination state, user credentials if stored | Highest           | These records control operator access, rebuild coordination, checkpoints, and lock ownership. They cannot be regenerated from graph source data alone.                      |
+| **Important / Rebuildable**    | `assets`, `asset_relationships`, `regulatory_events`, `regulatory_event_assets`    | High              | These records represent graph truth. They should be restored when possible but can be rebuilt from source through `RebuildExecutor` if backup data is unavailable or stale. |
 
 Graph data backup loss is recoverable when source data is available and an approved rebuild can be run. In that case, the graph RPO is bounded by source data freshness and rebuild acceptance criteria rather than by database backup age alone.
 

--- a/docs/adr/0005-backup-restore-dr-strategy.md
+++ b/docs/adr/0005-backup-restore-dr-strategy.md
@@ -23,7 +23,7 @@ FarDb uses a dual-database architecture:
 
 The two database boundaries may point to the same physical PostgreSQL instance or to separate logical databases. Operators must treat them as separate recovery concerns unless the deployment explicitly documents a shared database boundary.
 
-The rebuild coordination plane may also be isolated through `COORDINATION_DATABASE_URL`. When present, that URL is the authoritative location for coordination tables such as `rebuild_jobs` and `distributed_locks`; when absent, it falls back to `DATABASE_URL` and then provider fallback configuration. DR procedures must therefore resolve the actual deployed connection-string topology before backup or restore.
+The rebuild coordination plane may also be isolated through `COORDINATION_DATABASE_URL`. **Landed runtime placement** (`api/routers/graph_admin.py`): `distributed_locks` use the coordination session (`COORDINATION_DATABASE_URL`, falling back through `DATABASE_URL` then `POSTGRES_URL` in settings), while `rebuild_jobs` (heartbeats/checkpoints) use the domain / Asset Graph session (`ASSET_GRAPH_DATABASE_URL`). DR procedures must resolve the actual deployed connection-string topology and clean up **table-scoped** (locks vs jobs) before restart.
 
 Graph data and coordination/auth data have different recovery properties. Graph data can be rebuilt from source data through `RebuildExecutor` when source data remains available and fresh enough for the target environment. Coordination/auth data is less replaceable: user credentials, rebuild job history, lock state, and checkpoint metadata cannot be fully reconstructed from the graph source feed alone.
 

--- a/docs/ci-required-checks-policy.md
+++ b/docs/ci-required-checks-policy.md
@@ -38,7 +38,7 @@ branch-protection checks for ordinary PR merge. RC cuts must run them explicitly
 
 | Workflow | Purpose | Hardening notes |
 | --- | --- | --- |
-| `release-evidence-verify.yml` | Pytest gate bundles + hosted readiness + gate summary | Default `hardening_tier=P0` forces strict hosted readiness (fail on SKIPPED). Use `hardening_tier=none` only for soft rehearsal. |
+| `release-evidence-verify.yml` | Pytest gate bundles + hosted readiness + gate summary | Input allows only `none` / `P0`. Default `P0` forces strict hosted readiness (fail on SKIPPED). Use `none` only for soft rehearsal. P1–P3 are backlog IDs until tier-specific checks exist. |
 | `staging-promotion.yml` | Evidence-file checklist + live `--require-persistence` | Verifier requires P0 hardening markers (`hardening_ids`, topology, `db_authz`). Optional live DB authorization check when secrets exist. |
 | `hosted-readiness.yml` | Thin hosted smoke | Does not replace release-evidence or staging-promotion. |
 

--- a/docs/ci-required-checks-policy.md
+++ b/docs/ci-required-checks-policy.md
@@ -31,6 +31,19 @@ These are heavyweight or scanner jobs that run on a daily/weekly schedule or dur
 - Scheduled + push-to-main: Trivy (`trivy.yml`), Bandit (`bandit.yml`), CodeQL (`codeql.yml`), Dependency Check (`dependency-check.yml`)
 - Scheduled + PR/push: Semgrep (`semgrep.yml`)
 
+### 4. Release-only / dispatch (not PR merge gates)
+
+These workflows prove hosted durability, staging promotion, and hardening backlog items. They are **not** required
+branch-protection checks for ordinary PR merge. RC cuts must run them explicitly.
+
+| Workflow | Purpose | Hardening notes |
+| --- | --- | --- |
+| `release-evidence-verify.yml` | Pytest gate bundles + hosted readiness + gate summary | Default `hardening_tier=P0` forces strict hosted readiness (fail on SKIPPED). Use `hardening_tier=none` only for soft rehearsal. |
+| `staging-promotion.yml` | Evidence-file checklist + live `--require-persistence` | Verifier requires P0 hardening markers (`hardening_ids`, topology, `db_authz`). Optional live DB authorization check when secrets exist. |
+| `hosted-readiness.yml` | Thin hosted smoke | Does not replace release-evidence or staging-promotion. |
+
+Hardening backlog IDs: [Release Evidence Pack](release-evidence-pack.md#hardening-backlog-p0p3).
+
 ## Platform Deduplication
 
 - We use GitHub Actions as the primary CI.

--- a/docs/ci-required-checks-policy.md
+++ b/docs/ci-required-checks-policy.md
@@ -36,11 +36,11 @@ These are heavyweight or scanner jobs that run on a daily/weekly schedule or dur
 These workflows prove hosted durability, staging promotion, and hardening backlog items. They are **not** required
 branch-protection checks for ordinary PR merge. RC cuts must run them explicitly.
 
-| Workflow | Purpose | Hardening notes |
-| --- | --- | --- |
-| `release-evidence-verify.yml` | Pytest gate bundles + hosted readiness + gate summary | Input allows only `none` / `P0`. Default `P0` forces strict hosted readiness (fail on SKIPPED). Use `none` only for soft rehearsal. P1–P3 are backlog IDs until tier-specific checks exist. |
-| `staging-promotion.yml` | Evidence-file checklist + live `--require-persistence` | Verifier requires P0 hardening markers (`hardening_ids`, topology, `db_authz`). Optional live DB authorization check when secrets exist. |
-| `hosted-readiness.yml` | Thin hosted smoke | Does not replace release-evidence or staging-promotion. |
+| Workflow                      | Purpose                                                | Hardening notes                                                                                                                                                                             |
+| ----------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `release-evidence-verify.yml` | Pytest gate bundles + hosted readiness + gate summary  | Input allows only `none` / `P0`. Default `P0` forces strict hosted readiness (fail on SKIPPED). Use `none` only for soft rehearsal. P1–P3 are backlog IDs until tier-specific checks exist. |
+| `staging-promotion.yml`       | Evidence-file checklist + live `--require-persistence` | Verifier requires P0 hardening markers (`hardening_ids`, topology, `db_authz`). Optional live DB authorization check when secrets exist.                                                    |
+| `hosted-readiness.yml`        | Thin hosted smoke                                      | Does not replace release-evidence or staging-promotion.                                                                                                                                     |
 
 Hardening backlog IDs: [Release Evidence Pack](release-evidence-pack.md#hardening-backlog-p0p3).
 

--- a/docs/compound/watched-series.yml
+++ b/docs/compound/watched-series.yml
@@ -1,4 +1,20 @@
 version: 1
 prs: []
-labels: []
-path_globs: []
+labels:
+  - hardening
+  - release-evidence
+  - disaster-recovery
+  - enterprise-readiness
+path_globs:
+  - docs/release-evidence-pack.md
+  - docs/roadmap/enterprise-readiness-pr-board.md
+  - docs/runbooks/backup-restore-dr.md
+  - docs/ci-required-checks-policy.md
+  - .github/workflows/release-evidence-verify.yml
+  - .github/workflows/staging-promotion.yml
+  - .github/workflows/hosted-readiness.yml
+  - .github/ISSUE_TEMPLATE/release_candidate_evidence.md
+  - .github/ISSUE_TEMPLATE/restore_rehearsal_evidence.md
+  - scripts/check_hosted_readiness.py
+  - scripts/check_database_authorization.py
+  - scripts/verify_staging_promotion.py

--- a/docs/enterprise-readiness-index.md
+++ b/docs/enterprise-readiness-index.md
@@ -30,6 +30,11 @@ durable promotion checker, API contract cleanup, recovery/governance hardening, 
 validation, security/governance documentation, DR documentation, and release evidence pack are now
 part of the repository baseline.
 
+Boundary hardening follow-ups are tracked as stable IDs **H-P0-*** … **H-P3-*** in
+[Release Evidence Pack — Hardening backlog](release-evidence-pack.md#hardening-backlog-p0p3)
+and mirrored on the [enterprise-readiness PR board](roadmap/enterprise-readiness-pr-board.md#hardening-backlog-p0p3).
+RC dispatch defaults to `hardening_tier=P0` (strict hosted readiness). Soft rehearsal uses `hardening_tier=none`.
+
 The remaining work is no longer primarily architectural. It is concentrated in live release evidence and bounded follow-up hardening:
 
 - release-blocking database authorization closure with restricted live evidence and public redacted proof;

--- a/docs/enterprise-readiness-index.md
+++ b/docs/enterprise-readiness-index.md
@@ -17,10 +17,10 @@
 | `docs/testing/operational-drill-and-scale-validation-pack.md` | Operational drill matrix and bounded scale-validation guidance for observability, SLO, dashboard, alert, and runbook proof |
 | `docs/governance/state-machine-and-operating-authority.md`    | Current operational authority for rebuild/recovery state machines, invariants, ownership, and exception paths              |
 | `docs/adr/0007-database-authorization-boundary.md`            | Accepted hosted database authorization boundary and bounded verification contract                                          |
-| `docs/adr/0006-release-and-deployment-automation.md`          | Release and Deployment automation strategy, GitHub actions constraints                                                     |
+| `docs/adr/0006-release-and-deployment-automation.md`          | Release and Deployment automation strategy, GitHub Actions constraints                                                     |
 | `docs/adr/0005-backup-restore-dr-strategy.md`                 | Backup, restore, DR strategy, data classification, RPO, and RTO                                                            |
 | `docs/runbooks/backup-restore-dr.md`                          | Operator procedures for backup verification, restore execution, and post-restore checks                                    |
-| `docs/compound/INDEX.md`                                      | Additive architecture-expert compounded memory index (provisional vs landed)                                              |
+| `docs/compound/INDEX.md`                                      | Additive architecture-expert compounded memory index (provisional vs landed)                                               |
 
 ## Executive Summary
 
@@ -30,7 +30,7 @@ durable promotion checker, API contract cleanup, recovery/governance hardening, 
 validation, security/governance documentation, DR documentation, and release evidence pack are now
 part of the repository baseline.
 
-Boundary hardening follow-ups are tracked as stable IDs **H-P0-*** … **H-P3-*** in
+Boundary hardening follow-ups are tracked as stable IDs **H-P0-\*** … **H-P3-\*** in
 [Release Evidence Pack — Hardening backlog](release-evidence-pack.md#hardening-backlog-p0p3)
 and mirrored on the [enterprise-readiness PR board](roadmap/enterprise-readiness-pr-board.md#hardening-backlog-p0p3).
 RC dispatch defaults to `hardening_tier=P0` (strict hosted readiness). Soft rehearsal uses `hardening_tier=none`.
@@ -55,12 +55,12 @@ The DR documentation gap is closed at the strategy and runbook level through [AD
 
 Status legend follows the [Release Evidence Pack](release-evidence-pack.md): **Satisfied - automated**, **Satisfied - documented**, **Satisfied - manual evidence required**, **Partially satisfied**, and **Blocked**.
 
-| Status                               | Current items                                                                                                                                                                                                                                                                                       |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Satisfied - automated                | PR 1 durable graph persistence; PR 2 startup load/save integration; PR 4 core density, asset pagination, and frontend/backend contract seams; PR 5 RecoveryGate/reconciliation control-plane path; PR 7 CI-bounded failure-mode and representative-scale validation where covered                   |
-| Satisfied - documented               | PR 6 distributed hosting semantics; PR C governance/state-machine authority; production architecture and deployment operating model                                                                                                                                                                 |
-| Satisfied - manual evidence required | PR 3 hosted durable promotion proof for the target environment; PR 8 security scanner summary, exception review, and release sign-off; PR 9 restore rehearsal and post-restore smoke evidence                                                                                                       |
-| Partially satisfied                  | Strict stale-owner restart composition is covered by integration tests; the operational evidence-capture framework and drill pack are documented; production-scale validation remains future operating-maturity work                                                                                |
+| Status                               | Current items                                                                                                                                                                                                                                                                                                            |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Satisfied - automated                | PR 1 durable graph persistence; PR 2 startup load/save integration; PR 4 core density, asset pagination, and frontend/backend contract seams; PR 5 RecoveryGate/reconciliation control-plane path; PR 7 CI-bounded failure-mode and representative-scale validation where covered                                        |
+| Satisfied - documented               | PR 6 distributed hosting semantics; PR C governance/state-machine authority; production architecture and deployment operating model                                                                                                                                                                                      |
+| Satisfied - manual evidence required | PR 3 hosted durable promotion proof for the target environment; PR 8 security scanner summary, exception review, and release sign-off; PR 9 restore rehearsal and post-restore smoke evidence                                                                                                                            |
+| Partially satisfied                  | Strict stale-owner restart composition is covered by integration tests; the operational evidence-capture framework and drill pack are documented; production-scale validation remains future operating-maturity work                                                                                                     |
 | Blocked                              | Database authorization closure remains release-blocking. Enterprise release sign-off also requires hosted promotion evidence, release-commit security scanner/exception review (via `.github/workflows/release-evidence-verify.yml` plus source workflows), and named operator sign-off + DR restore rehearsal evidence. |
 
 ## Recommended Reading Order

--- a/docs/enterprise-readiness-index.md
+++ b/docs/enterprise-readiness-index.md
@@ -34,6 +34,7 @@ Boundary hardening follow-ups are tracked as stable IDs **H-P0-*** … **H-P3-**
 [Release Evidence Pack — Hardening backlog](release-evidence-pack.md#hardening-backlog-p0p3)
 and mirrored on the [enterprise-readiness PR board](roadmap/enterprise-readiness-pr-board.md#hardening-backlog-p0p3).
 RC dispatch defaults to `hardening_tier=P0` (strict hosted readiness). Soft rehearsal uses `hardening_tier=none`.
+Workflow input currently implements only those two values; P1–P3 remain backlog IDs until tier-specific checks land.
 
 The remaining work is no longer primarily architectural. It is concentrated in live release evidence and bounded follow-up hardening:
 

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -368,6 +368,8 @@ connection strings, role inventories, or topology details from the authorization
 
 Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.
 Use `hardening_tier=none` only for soft rehearsal runs that must not be treated as RC proof.
+Higher tiers (P1–P3) remain backlog IDs in this pack; they are not selectable in
+`release-evidence-verify.yml` until tier-specific checks are wired.
 
 ## Release Evidence Attachment Checklist
 

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -328,30 +328,30 @@ machine-checkable evidence markers listed under [Hardening evidence markers](#ha
 
 Board mirror: [Enterprise Readiness PR Board — Hardening backlog](roadmap/enterprise-readiness-pr-board.md#hardening-backlog-p0p3).
 
-| ID | Priority | Work | Mapped gate | Automation | Status |
-| --- | --- | --- | --- | --- | --- |
-| H-P0-01 | P0 | Align DR docs with code table placement: `rebuild_jobs` on Asset Graph (domain); `distributed_locks` on coordination | Disaster Recovery / Governance | Docs + staging verifier topology marker | Satisfied - documented |
-| H-P0-02 | P0 | Table-scoped post-restore cleanup (locks where locks live; jobs where jobs live) + `running=0` on job boundary | Disaster Recovery | Docs + restore template + verifier markers | Satisfied - documented |
-| H-P0-03 | P0 | RC path forces strict hosted readiness (`hardening_tier=P0` → fail on SKIPPED) | Promotion | `release-evidence-verify.yml` | Satisfied - automated |
-| H-P0-04 | P0 | Wire `scripts/check_database_authorization.py` into release-evidence + staging-promotion (redacted pass/fail) | Security (ADR 0007) | Dispatch workflows + verifier `db_authz:` marker | Partially satisfied |
-| H-P0-05 | P0 | Refresh ADR 0002 / `.env.example` to runtime truth (Postgres supported; recommended SQLite URL forms) | Architecture / Durable Persistence | Docs | Satisfied - documented |
-| H-P0-06 | P0 | Fresh RC companion record for current `main` SHA (do not reuse RC1 as CURRENT) | All manual gates | Issue template + evidence-records | Satisfied - manual evidence required |
-| H-P1-01 | P1 | `--assets-smoke` on hosted readiness when persistence required | Promotion | Script + workflows | Partially satisfied |
-| H-P1-02 | P1 | Production promotion twin of `staging-promotion.yml` | Promotion | New workflow | Partially satisfied |
-| H-P1-03 | P1 | Post-rollback / post-restore mandatory re-smoke artifact | DR / Promotion | Dispatch recipe + artifact | Partially satisfied |
-| H-P1-04 | P1 | Reconcile required check names (policy ↔ Mergify ↔ branch protection) | Governance / CI | Docs + Mergify | Partially satisfied |
-| H-P1-05 | P1 | Docker/Compose: Gradio non-prod in CI; production images smoke with persistence | Architecture | CI + compose | Partially satisfied |
-| H-P1-06 | P1 | RC / restore / drill templates require hardening ID checkboxes | All manual | Templates + verifier | Satisfied - automated |
-| H-P2-01 | P2 | Active executor from heartbeat+lock (stop always-false local bool) | Recovery | Code + ci-gate-spec / pytest | Partially satisfied |
-| H-P2-02 | P2 | Fencing token checked on graph/job writes | Recovery | Code + tests | Partially satisfied |
-| H-P2-03 | P2 | Partial unique index: ≤1 `RUNNING` rebuild job (Postgres) | Durable Persistence | Migration + integration test | Partially satisfied |
-| H-P2-04 | P2 | Unify startup vs periodic auto-recovery for stale-only orphans under lock | Recovery / Restart | Code + restart tests | Partially satisfied |
-| H-P2-05 | P2 | Cross-boundary restore skew check (Graph vs Coordination) | Disaster Recovery | Script / readiness extension | Partially satisfied |
-| H-P3-01 | P3 | Lock down or ACL metrics/SLO/OpenAPI in production | Security | Settings + tests | Partially satisfied |
-| H-P3-02 | P3 | Global rate limits + proxy-aware IP + shared store | Security | Code + tests | Partially satisfied |
-| H-P3-03 | P3 | Rebuild RBAC; stop silent admin upsert every boot | Security / Governance | Auth + audit tests | Partially satisfied |
-| H-P3-04 | P3 | Slim Vercel API deps; connection pooling | Durable Persistence | Deploy config + ADR Phase 4 | Partially satisfied |
-| H-P3-05 | P3 | SoD + evidence expiry enforcement on RC packets | Governance | Template + verifier | Partially satisfied |
+| ID      | Priority | Work                                                                                                                 | Mapped gate                        | Automation                                       | Status                               |
+| ------- | -------- | -------------------------------------------------------------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------ | ------------------------------------ |
+| H-P0-01 | P0       | Align DR docs with code table placement: `rebuild_jobs` on Asset Graph (domain); `distributed_locks` on coordination | Disaster Recovery / Governance     | Docs + staging verifier topology marker          | Satisfied - documented               |
+| H-P0-02 | P0       | Table-scoped post-restore cleanup (locks where locks live; jobs where jobs live) + `running=0` on job boundary       | Disaster Recovery                  | Docs + restore template + verifier markers       | Satisfied - documented               |
+| H-P0-03 | P0       | RC path forces strict hosted readiness (`hardening_tier=P0` → fail on SKIPPED)                                       | Promotion                          | `release-evidence-verify.yml`                    | Satisfied - automated                |
+| H-P0-04 | P0       | Wire `scripts/check_database_authorization.py` into release-evidence + staging-promotion (redacted pass/fail)        | Security (ADR 0007)                | Dispatch workflows + verifier `db_authz:` marker | Partially satisfied                  |
+| H-P0-05 | P0       | Refresh ADR 0002 / `.env.example` to runtime truth (Postgres supported; recommended SQLite URL forms)                | Architecture / Durable Persistence | Docs                                             | Satisfied - documented               |
+| H-P0-06 | P0       | Fresh RC companion record for current `main` SHA (do not reuse RC1 as CURRENT)                                       | All manual gates                   | Issue template + evidence-records                | Satisfied - manual evidence required |
+| H-P1-01 | P1       | `--assets-smoke` on hosted readiness when persistence required                                                       | Promotion                          | Script + workflows                               | Partially satisfied                  |
+| H-P1-02 | P1       | Production promotion twin of `staging-promotion.yml`                                                                 | Promotion                          | New workflow                                     | Partially satisfied                  |
+| H-P1-03 | P1       | Post-rollback / post-restore mandatory re-smoke artifact                                                             | DR / Promotion                     | Dispatch recipe + artifact                       | Partially satisfied                  |
+| H-P1-04 | P1       | Reconcile required check names (policy ↔ Mergify ↔ branch protection)                                              | Governance / CI                    | Docs + Mergify                                   | Partially satisfied                  |
+| H-P1-05 | P1       | Docker/Compose: Gradio non-prod in CI; production images smoke with persistence                                      | Architecture                       | CI + compose                                     | Partially satisfied                  |
+| H-P1-06 | P1       | RC / restore / drill templates require hardening ID checkboxes                                                       | All manual                         | Templates + verifier                             | Satisfied - automated                |
+| H-P2-01 | P2       | Active executor from heartbeat+lock (stop always-false local bool)                                                   | Recovery                           | Code + ci-gate-spec / pytest                     | Partially satisfied                  |
+| H-P2-02 | P2       | Fencing token checked on graph/job writes                                                                            | Recovery                           | Code + tests                                     | Partially satisfied                  |
+| H-P2-03 | P2       | Partial unique index: ≤1 `RUNNING` rebuild job (Postgres)                                                            | Durable Persistence                | Migration + integration test                     | Partially satisfied                  |
+| H-P2-04 | P2       | Unify startup vs periodic auto-recovery for stale-only orphans under lock                                            | Recovery / Restart                 | Code + restart tests                             | Partially satisfied                  |
+| H-P2-05 | P2       | Cross-boundary restore skew check (Graph vs Coordination)                                                            | Disaster Recovery                  | Script / readiness extension                     | Partially satisfied                  |
+| H-P3-01 | P3       | Lock down or ACL metrics/SLO/OpenAPI in production                                                                   | Security                           | Settings + tests                                 | Partially satisfied                  |
+| H-P3-02 | P3       | Global rate limits + proxy-aware IP + shared store                                                                   | Security                           | Code + tests                                     | Partially satisfied                  |
+| H-P3-03 | P3       | Rebuild RBAC; stop silent admin upsert every boot                                                                    | Security / Governance              | Auth + audit tests                               | Partially satisfied                  |
+| H-P3-04 | P3       | Slim Vercel API deps; connection pooling                                                                             | Durable Persistence                | Deploy config + ADR Phase 4                      | Partially satisfied                  |
+| H-P3-05 | P3       | SoD + evidence expiry enforcement on RC packets                                                                      | Governance                         | Template + verifier                              | Partially satisfied                  |
 
 ### Hardening evidence markers
 
@@ -363,12 +363,12 @@ topology: jobs=asset_graph; locks=coordination
 db_authz: PASS|<opaque-workflow-run-or-artifact-id>
 ```
 
-`db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must match an allowed
-run/artifact shape: `run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or a numeric workflow run id
-(at least 6 digits). Placeholders such as `TBD`, `TODO`, or angle-bracket templates are rejected. Staging
-promotion fails closed when database URL secrets are missing so H-P0-04 cannot be satisfied by a copied
-template alone. Do not embed connection strings, role inventories, or topology details from the authorization
-checker.
+`db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must match an
+allowed run/artifact shape: `run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or a numeric
+workflow run ID (at least 6 digits). Placeholders such as `TBD`, `TODO`, or angle-bracket templates are
+rejected. Staging promotion fails closed when database URL secrets are missing so H-P0-04 cannot be
+satisfied by a copied template alone. Do not embed connection strings, role inventories, or topology
+details from the authorization checker.
 
 Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.
 Use `hardening_tier=none` only for soft rehearsal runs that must not be treated as RC proof.

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -360,10 +360,12 @@ Staging promotion evidence files must include these markers (case-insensitive) f
 ```text
 hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06
 topology: jobs=asset_graph; locks=coordination
-db_authz: PASS
+db_authz: PASS|<opaque-workflow-run-or-artifact-id>
 ```
 
-`db_authz: PASS` may be followed by an opaque reference (for example `db_authz: PASS|run-123`). Do not embed
+`db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must identify a real
+authorization check run (for example a staging-promotion workflow run id). Staging promotion fails closed when
+database URL secrets are missing so H-P0-04 cannot be satisfied by a copied template alone. Do not embed
 connection strings, role inventories, or topology details from the authorization checker.
 
 Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -363,10 +363,12 @@ topology: jobs=asset_graph; locks=coordination
 db_authz: PASS|<opaque-workflow-run-or-artifact-id>
 ```
 
-`db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must identify a real
-authorization check run (for example a staging-promotion workflow run id). Staging promotion fails closed when
-database URL secrets are missing so H-P0-04 cannot be satisfied by a copied template alone. Do not embed
-connection strings, role inventories, or topology details from the authorization checker.
+`db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must match an allowed
+run/artifact shape: `run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or a numeric workflow run id
+(at least 6 digits). Placeholders such as `TBD`, `TODO`, or angle-bracket templates are rejected. Staging
+promotion fails closed when database URL secrets are missing so H-P0-04 cannot be satisfied by a copied
+template alone. Do not embed connection strings, role inventories, or topology details from the authorization
+checker.
 
 Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.
 Use `hardening_tier=none` only for soft rehearsal runs that must not be treated as RC proof.

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -319,6 +319,56 @@ Blocking rule:
 - DR restore rehearsal remains manual evidence. Do not mark this gate complete until an actual rehearsal artefact is
   attached.
 
+## Hardening backlog (P0–P3)
+
+Stable IDs for boundary hardening follow-ups. Status legend matches this pack. An item may move to
+`Satisfied - automated` only when it is enforced in `release-evidence-verify.yml` (Assert path),
+`staging-promotion.yml`, merge-required CI, or `ci-gate-spec.yaml`. Manual items require the
+machine-checkable evidence markers listed under [Hardening evidence markers](#hardening-evidence-markers).
+
+Board mirror: [Enterprise Readiness PR Board — Hardening backlog](roadmap/enterprise-readiness-pr-board.md#hardening-backlog-p0p3).
+
+| ID | Priority | Work | Mapped gate | Automation | Status |
+| --- | --- | --- | --- | --- | --- |
+| H-P0-01 | P0 | Align DR docs with code table placement: `rebuild_jobs` on Asset Graph (domain); `distributed_locks` on coordination | Disaster Recovery / Governance | Docs + staging verifier topology marker | Satisfied - documented |
+| H-P0-02 | P0 | Table-scoped post-restore cleanup (locks where locks live; jobs where jobs live) + `running=0` on job boundary | Disaster Recovery | Docs + restore template + verifier markers | Satisfied - documented |
+| H-P0-03 | P0 | RC path forces strict hosted readiness (`hardening_tier=P0` → fail on SKIPPED) | Promotion | `release-evidence-verify.yml` | Satisfied - automated |
+| H-P0-04 | P0 | Wire `scripts/check_database_authorization.py` into release-evidence + staging-promotion (redacted pass/fail) | Security (ADR 0007) | Dispatch workflows + verifier `db_authz:` marker | Partially satisfied |
+| H-P0-05 | P0 | Refresh ADR 0002 / `.env.example` to runtime truth (Postgres supported; recommended SQLite URL forms) | Architecture / Durable Persistence | Docs | Satisfied - documented |
+| H-P0-06 | P0 | Fresh RC companion record for current `main` SHA (do not reuse RC1 as CURRENT) | All manual gates | Issue template + evidence-records | Satisfied - manual evidence required |
+| H-P1-01 | P1 | `--assets-smoke` on hosted readiness when persistence required | Promotion | Script + workflows | Partially satisfied |
+| H-P1-02 | P1 | Production promotion twin of `staging-promotion.yml` | Promotion | New workflow | Partially satisfied |
+| H-P1-03 | P1 | Post-rollback / post-restore mandatory re-smoke artifact | DR / Promotion | Dispatch recipe + artifact | Partially satisfied |
+| H-P1-04 | P1 | Reconcile required check names (policy ↔ Mergify ↔ branch protection) | Governance / CI | Docs + Mergify | Partially satisfied |
+| H-P1-05 | P1 | Docker/Compose: Gradio non-prod in CI; production images smoke with persistence | Architecture | CI + compose | Partially satisfied |
+| H-P1-06 | P1 | RC / restore / drill templates require hardening ID checkboxes | All manual | Templates + verifier | Satisfied - automated |
+| H-P2-01 | P2 | Active executor from heartbeat+lock (stop always-false local bool) | Recovery | Code + ci-gate-spec / pytest | Partially satisfied |
+| H-P2-02 | P2 | Fencing token checked on graph/job writes | Recovery | Code + tests | Partially satisfied |
+| H-P2-03 | P2 | Partial unique index: ≤1 `RUNNING` rebuild job (Postgres) | Durable Persistence | Migration + integration test | Partially satisfied |
+| H-P2-04 | P2 | Unify startup vs periodic auto-recovery for stale-only orphans under lock | Recovery / Restart | Code + restart tests | Partially satisfied |
+| H-P2-05 | P2 | Cross-boundary restore skew check (Graph vs Coordination) | Disaster Recovery | Script / readiness extension | Partially satisfied |
+| H-P3-01 | P3 | Lock down or ACL metrics/SLO/OpenAPI in production | Security | Settings + tests | Partially satisfied |
+| H-P3-02 | P3 | Global rate limits + proxy-aware IP + shared store | Security | Code + tests | Partially satisfied |
+| H-P3-03 | P3 | Rebuild RBAC; stop silent admin upsert every boot | Security / Governance | Auth + audit tests | Partially satisfied |
+| H-P3-04 | P3 | Slim Vercel API deps; connection pooling | Durable Persistence | Deploy config + ADR Phase 4 | Partially satisfied |
+| H-P3-05 | P3 | SoD + evidence expiry enforcement on RC packets | Governance | Template + verifier | Partially satisfied |
+
+### Hardening evidence markers
+
+Staging promotion evidence files must include these markers (case-insensitive) for the P0 foundation:
+
+```text
+hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06
+topology: jobs=asset_graph; locks=coordination
+db_authz: PASS
+```
+
+`db_authz: PASS` may be followed by an opaque reference (for example `db_authz: PASS|run-123`). Do not embed
+connection strings, role inventories, or topology details from the authorization checker.
+
+Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.
+Use `hardening_tier=none` only for soft rehearsal runs that must not be treated as RC proof.
+
 ## Release Evidence Attachment Checklist
 
 Open one release-candidate evidence issue per release candidate using the

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -45,17 +45,17 @@ Canon IDs and automation mapping live in
 [Release Evidence Pack — Hardening backlog](../release-evidence-pack.md#hardening-backlog-p0p3).
 Do not reopen closed PR1–9 rows; track hardening here and in the evidence pack only.
 
-| ID | Status | Exit criteria (short) | Do not bundle with |
-| --- | --- | --- | --- |
-| H-P0-01 | Satisfied - documented | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination) | Runtime rebuild changes |
-| H-P0-02 | Satisfied - documented | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart | Schema migrations |
-| H-P0-03 | Satisfied - automated | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness | Soft rehearsal (`hardening_tier=none`) |
-| H-P0-04 | Partially satisfied | DB authorization checker wired; redacted PASS attached for target env | Publishing live role/topology details |
-| H-P0-05 | Satisfied - documented | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms | Hosted infra changes |
-| H-P0-06 | Satisfied - manual evidence required | Fresh SHA-bound RC companion (RC1 not reused as CURRENT) | Bundling unrelated product work |
-| H-P1-01 … H-P1-06 | Partially satisfied / Satisfied - automated | See evidence pack | Mixing P1 Docker work with P0 docs |
-| H-P2-01 … H-P2-05 | Partially satisfied | See evidence pack | P0 gate wiring |
-| H-P3-01 … H-P3-05 | Partially satisfied | See evidence pack | P0/P1 release gates |
+| ID                | Status                                      | Exit criteria (short)                                                                           | Do not bundle with                     |
+| ----------------- | ------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------------------------------- |
+| H-P0-01           | Satisfied - documented                      | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination) | Runtime rebuild changes                |
+| H-P0-02           | Satisfied - documented                      | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart                   | Schema migrations                      |
+| H-P0-03           | Satisfied - automated                       | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness            | Soft rehearsal (`hardening_tier=none`) |
+| H-P0-04           | Partially satisfied                         | DB authorization checker wired; redacted PASS attached for target env                           | Publishing live role/topology details  |
+| H-P0-05           | Satisfied - documented                      | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms                 | Hosted infra changes                   |
+| H-P0-06           | Satisfied - manual evidence required        | Fresh SHA-bound RC companion (RC1 not reused as CURRENT)                                        | Bundling unrelated product work        |
+| H-P1-01 … H-P1-06 | Partially satisfied / Satisfied - automated | See evidence pack                                                                               | Mixing P1 Docker work with P0 docs     |
+| H-P2-01 … H-P2-05 | Partially satisfied                         | See evidence pack                                                                               | P0 gate wiring                         |
+| H-P3-01 … H-P3-05 | Partially satisfied                         | See evidence pack                                                                               | P0/P1 release gates                    |
 
 ## Board Notes
 

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -39,6 +39,24 @@ These are not stale roadmap items; they are bounded follow-up objectives.
 | Continuous operational drills              | Satisfied - documented               | The operational drill pack defines graph load failure, lock loss, stale owner, degraded DB, and failed durable smoke flows with evidence capture guidance; the execution-record register captures actual run artifacts | Initial staging proof               |
 | Objective 8                                | Partially satisfied                  | Release and Deployment Automation Layer: GitHub Actions is the canonical PR gate; heavyweight jobs shifted; production containers split; staging verification automated                                                | Stable CI platform, Docker          |
 
+## Hardening backlog (P0–P3)
+
+Canon IDs and automation mapping live in
+[Release Evidence Pack — Hardening backlog](../release-evidence-pack.md#hardening-backlog-p0p3).
+Do not reopen closed PR1–9 rows; track hardening here and in the evidence pack only.
+
+| ID | Status | Exit criteria (short) | Do not bundle with |
+| --- | --- | --- | --- |
+| H-P0-01 | Satisfied - documented | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination) | Runtime rebuild changes |
+| H-P0-02 | Satisfied - documented | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart | Schema migrations |
+| H-P0-03 | Satisfied - automated | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness | Soft rehearsal (`hardening_tier=none`) |
+| H-P0-04 | Partially satisfied | DB authorization checker wired; redacted PASS attached for target env | Publishing live role/topology details |
+| H-P0-05 | Satisfied - documented | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms | Hosted infra changes |
+| H-P0-06 | Satisfied - manual evidence required | Fresh SHA-bound RC companion (RC1 not reused as CURRENT) | Bundling unrelated product work |
+| H-P1-01 … H-P1-06 | Partially satisfied / Satisfied - automated | See evidence pack | Mixing P1 Docker work with P0 docs |
+| H-P2-01 … H-P2-05 | Partially satisfied | See evidence pack | P0 gate wiring |
+| H-P3-01 … H-P3-05 | Partially satisfied | See evidence pack | P0/P1 release gates |
+
 ## Board Notes
 
 - PR 1 and PR 2 remain the foundation for promotion, failure-mode, and DR evidence.

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -14,7 +14,7 @@ Use this runbook when:
 - recovering from data loss, accidental destructive writes, failed migrations, or database-provider incidents;
 - proving that restore procedures remain executable for enterprise release readiness.
 
-The intended audience is operators with database, hosting, and deployment authority. It is not an end-user support document.
+The intended audience is operators with database, hosting, and deployment authority. It is not an end user support document.
 
 This runbook distinguishes application rollback from data restore. Vercel rollback/promotion restores application code and configuration only; it does not restore database state.
 

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -177,7 +177,7 @@ For hosted deployments, this is usually performed by stopping traffic, disabling
 
 ### 2. Verify no active rebuild is in progress
 
-Use `/api/health/detailed` if the application is still reachable and safe to query. If the application is offline, query the effective Coordination DB directly:
+Use `/api/health/detailed` if the application is still reachable and safe to query. If the application is offline, query **`rebuild_jobs` on the Asset Graph (domain) boundary** (`ASSET_GRAPH_DATABASE_URL`), not the Coordination DB:
 
 ```sql
 SELECT job_id, status, active_worker_id, last_heartbeat_at, updated_at
@@ -190,7 +190,7 @@ If any active rebuild exists, prefer to wait for it to complete or fail before r
 
 ### 3. Handle live distributed locks before restore
 
-Inspect the rebuild lock in the effective Coordination DB:
+Inspect the rebuild lock on the **coordination** boundary (`COORDINATION_DATABASE_URL`, else `DATABASE_URL` / `POSTGRES_URL` fallback):
 
 ```sql
 SELECT lock_name, holder_id, expires_at, updated_at

--- a/docs/runbooks/backup-restore-dr.md
+++ b/docs/runbooks/backup-restore-dr.md
@@ -41,7 +41,13 @@ FarDb can use up to three logical PostgreSQL database boundaries, although a dep
 - Coordination DB: `COORDINATION_DATABASE_URL`, falling back to `DATABASE_URL` and then `POSTGRES_URL` when unset.
 - Asset Graph DB: `ASSET_GRAPH_DATABASE_URL`.
 
-The Coordination DB is the authoritative location for rebuild coordination state when `COORDINATION_DATABASE_URL` is set separately. This includes `rebuild_jobs` and `distributed_locks`; omitting this boundary from backup or restore can lose checkpoint state or resurrect stale lock/job state after a DR event.
+**Landed table placement (verify against `api/routers/graph_admin.py` before restore):**
+
+- `rebuild_jobs` (including heartbeats/checkpoints) are written on the **domain / Asset Graph** session (`ASSET_GRAPH_DATABASE_URL`).
+- `distributed_locks` are written on the **coordination** session (`COORDINATION_DATABASE_URL`, falling back through `DATABASE_URL` then `POSTGRES_URL` in `src/config/settings.py`).
+- Evidence marker for staging packets: `topology: jobs=asset_graph; locks=coordination`.
+
+Omitting either physical boundary from backup or restore can lose checkpoint state or resurrect stale lock/job state after a DR event. Do not assume jobs live on the Coordination DB merely because that URL is set.
 
 For each environment, resolve and record the effective connection strings before backup:
 
@@ -148,7 +154,7 @@ SELECT COUNT(*) AS distributed_locks_count FROM distributed_locks;
 
 For the Auth DB, run equivalent checks for application/auth tables present in that boundary. If user credentials are stored, verify the credentials table exists and has expected row counts without exposing hashes or secrets.
 
-For a separate Coordination DB, verify `rebuild_jobs` and `distributed_locks` from the coordination scratch restore, not from the graph scratch restore.
+Verify `distributed_locks` on the restored coordination boundary and `rebuild_jobs` on the restored Asset Graph (domain) boundary. When both URLs resolve to one physical database, one restore covers both tables — still record that shared-boundary topology in the evidence.
 
 ### 5. Backup schedule recommendation
 
@@ -204,13 +210,13 @@ DELETE FROM distributed_locks
 WHERE lock_name = 'graph_rebuild';
 ```
 
-This live-database quiescence step does not clean the restored database. PITR or `pg_restore` can reintroduce historical `distributed_locks` and `rebuild_jobs` rows, so the post-restore, pre-restart cleanup step below must still be executed on the restored Coordination DB.
+This live-database quiescence step does not clean the restored database. PITR or `pg_restore` can reintroduce historical `distributed_locks` and `rebuild_jobs` rows, so the post-restore, pre-restart cleanup step below must still be executed **table-scoped** (locks on the coordination boundary; jobs on the Asset Graph boundary).
 
 ### 4. Record in-flight rebuild state for incident evidence
 
 Before restoring, record any in-flight `rebuild_jobs` rows and the selected restore timestamp in the incident or rehearsal evidence. Do not rely on pre-restore updates to `rebuild_jobs` for cleanup: the restore operation overwrites the current database state with the selected historical state.
 
-RecoveryGate false-orphan prevention must be performed after restore and before application restart, against the restored Coordination DB.
+RecoveryGate false-orphan prevention must be performed after restore and before application restart, against the restored boundaries that actually hold locks and jobs (see table placement above).
 
 ## Restore Execution Procedure
 
@@ -263,11 +269,15 @@ pg_restore \
 
 If Auth DB, Coordination DB, and Asset Graph DB are separate, restore each dump to its corresponding target database. Do not restore the graph dump over the auth or coordination database, or the auth/coordination dump over the graph database.
 
-### 3. Post-restore, pre-restart coordination cleanup
+### 3. Post-restore, pre-restart table-scoped cleanup
 
-Run this step after PITR/`pg_restore` has completed and before any application process is allowed to start against the restored database. Execute it against the restored Coordination DB. If `COORDINATION_DATABASE_URL` is unset, this means the restored database reached through the settings fallback order.
+Run this step after PITR/`pg_restore` has completed and before any application process is allowed to start against the restored database. Cleanup is **table-scoped**, not URL-label-scoped:
 
-Inspect restored locks:
+1. Clear or expire `distributed_locks` on the **coordination** boundary (`COORDINATION_DATABASE_URL`, else `DATABASE_URL` / `POSTGRES_URL` fallback).
+2. Fail in-flight `rebuild_jobs` on the **Asset Graph / domain** boundary (`ASSET_GRAPH_DATABASE_URL`).
+3. Confirm `running_rebuild_jobs_count = 0` on the **job** boundary before restart.
+
+Inspect restored locks (coordination boundary):
 
 ```sql
 SELECT lock_name, holder_id, expires_at, updated_at
@@ -284,7 +294,7 @@ WHERE lock_name = 'graph_rebuild';
 
 A restored lock row with a mismatched `holder_id` can block new lock acquisition until it expires or is cleared.
 
-Clean up restored in-flight rebuild jobs so RecoveryGate does not classify historical state as a live orphaned rebuild. For schemas using the current `sanitized_failure_category` and `sanitized_failure_message` columns:
+Clean up restored in-flight rebuild jobs on the **Asset Graph** boundary so RecoveryGate does not classify historical state as a live orphaned rebuild. For schemas using the current `sanitized_failure_category` and `sanitized_failure_message` columns:
 
 ```sql
 UPDATE rebuild_jobs
@@ -495,7 +505,7 @@ Private personal contact details, phone numbers, and provider account identifier
 A restore incident or rehearsal is complete only when:
 
 1. the selected database restore point is documented;
-2. stale lock and in-flight rebuild job state have been resolved on the restored Coordination DB;
+2. stale lock state has been resolved on the coordination boundary and in-flight rebuild jobs have been cleaned on the Asset Graph (job) boundary;
 3. schema verification passes;
 4. graph integrity checks pass;
 5. the application has restarted successfully;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,11 @@ extend-exclude = '''
 )/
 '''
 
+# Used by super-linter v7 PYTHON_PYINK (pyink --config pyproject.toml).
+[tool.pyink]
+line-length = 120
+target-version = ["py312"]
+
 [tool.isort]
 profile = "black"
 line_length = 120

--- a/scripts/verify_staging_promotion.py
+++ b/scripts/verify_staging_promotion.py
@@ -281,8 +281,9 @@ TOPOLOGY_MARKER_PATTERN = re.compile(
     re.IGNORECASE,
 )
 # Bare PASS is rejected; require an opaque run/artifact reference after '|'.
+# Capture a single non-space token (no reluctant quantifier / backtracking).
 DB_AUTHZ_PASS_PATTERN = re.compile(
-    r"^\s*db_authz\s*:\s*PASS\s*\|\s*(\S[^\n]*?)\s*$",
+    r"^\s*db_authz\s*:\s*PASS\s*\|\s*(\S+)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 # Allowlist: run/artifact-shaped refs with a numeric id (>=3 digits). Rejects
@@ -316,27 +317,40 @@ def _hardening_id_tokens(ids_blob: str) -> set[str]:
     return tokens
 
 
-def _check_hardening_foundation(content: str, missing: List[str]) -> None:
-    """Check P0 hardening backlog markers required for staging promotion."""
+def _check_hardening_ids(content: str, missing: List[str]) -> None:
+    """Require the P0 hardening_ids marker with exact foundation IDs."""
     ids_match = HARDENING_IDS_LINE_PATTERN.search(content)
     if ids_match is None:
         missing.append("hardening_ids marker with P0 foundation IDs")
-    else:
-        ids_tokens = _hardening_id_tokens(ids_match.group(1))
-        missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_tokens]
-        if missing_ids:
-            missing.append("hardening_ids missing required IDs: " + ", ".join(missing_ids))
+        return
+    ids_tokens = _hardening_id_tokens(ids_match.group(1))
+    missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_tokens]
+    if missing_ids:
+        missing.append("hardening_ids missing required IDs: " + ", ".join(missing_ids))
 
+
+def _check_hardening_topology(content: str, missing: List[str]) -> None:
+    """Require the jobs/locks topology marker."""
     if TOPOLOGY_MARKER_PATTERN.search(content) is None:
         missing.append("topology: jobs=asset_graph; locks=coordination")
 
+
+def _check_hardening_db_authz(content: str, missing: List[str]) -> None:
+    """Require db_authz PASS with an allowlisted opaque run/artifact ref."""
     authz_match = DB_AUTHZ_PASS_PATTERN.search(content)
     if authz_match is None:
         missing.append("db_authz: PASS|<opaque-ref> (bare PASS is not accepted)")
-    else:
-        opaque_ref = authz_match.group(1).strip()
-        if DB_AUTHZ_OPAQUE_REF_PATTERN.fullmatch(opaque_ref) is None:
-            missing.append(DB_AUTHZ_OPAQUE_REF_ERROR)
+        return
+    opaque_ref = authz_match.group(1).strip()
+    if DB_AUTHZ_OPAQUE_REF_PATTERN.fullmatch(opaque_ref) is None:
+        missing.append(DB_AUTHZ_OPAQUE_REF_ERROR)
+
+
+def _check_hardening_foundation(content: str, missing: List[str]) -> None:
+    """Check P0 hardening backlog markers required for staging promotion."""
+    _check_hardening_ids(content, missing)
+    _check_hardening_topology(content, missing)
+    _check_hardening_db_authz(content, missing)
 
 
 def verify_staging_promotion(evidence_file: str) -> None:

--- a/scripts/verify_staging_promotion.py
+++ b/scripts/verify_staging_promotion.py
@@ -280,12 +280,33 @@ TOPOLOGY_MARKER_PATTERN = re.compile(
     r"topology\s*:\s*jobs\s*=\s*asset_graph\s*;\s*locks\s*=\s*coordination",
     re.IGNORECASE,
 )
+# Bare PASS is rejected; require an opaque run/artifact reference after '|'.
 DB_AUTHZ_PASS_PATTERN = re.compile(
-    r"^\s*db_authz\s*:\s*PASS(?:\s*\|\s*\S[^\n]*)?\s*$",
+    r"^\s*db_authz\s*:\s*PASS\s*\|\s*(\S[^\n]*?)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
 HARDENING_IDS_LINE_PATTERN = re.compile(r"hardening_ids\s*:\s*([^\n]+)", re.IGNORECASE)
-HARDENING_ID_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9-])H-P0-\d{2}(?![A-Z0-9-])")
+HARDENING_ID_TOKEN_PATTERN = re.compile(r"^H-P0-\d{2}$")
+PLACEHOLDER_OPAQUE_REFS = frozenset(
+    {
+        "REPLACE-WITH-WORKFLOW-RUN-ID",
+        "REPLACE_WITH_WORKFLOW_RUN_ID",
+        "<WORKFLOW-RUN-OR-OPAQUE-REF>",
+        "<REPLACE-WITH-WORKFLOW-RUN-ID>",
+    }
+)
+
+
+def _hardening_id_tokens(ids_blob: str) -> set[str]:
+    """Split a hardening_ids value on commas and keep exact H-P0-NN tokens."""
+    tokens: set[str] = set()
+    for raw_token in ids_blob.split(","):
+        # Drop trailing `# ...` comments on a comma segment before matching.
+        without_comment = raw_token.split("#", 1)[0]
+        token = without_comment.strip().upper()
+        if HARDENING_ID_TOKEN_PATTERN.fullmatch(token):
+            tokens.add(token)
+    return tokens
 
 
 def _check_hardening_foundation(content: str, missing: List[str]) -> None:
@@ -294,7 +315,7 @@ def _check_hardening_foundation(content: str, missing: List[str]) -> None:
     if ids_match is None:
         missing.append("hardening_ids marker with P0 foundation IDs")
     else:
-        ids_tokens = set(HARDENING_ID_TOKEN_PATTERN.findall(ids_match.group(1).upper()))
+        ids_tokens = _hardening_id_tokens(ids_match.group(1))
         missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_tokens]
         if missing_ids:
             missing.append("hardening_ids missing required IDs: " + ", ".join(missing_ids))
@@ -302,8 +323,13 @@ def _check_hardening_foundation(content: str, missing: List[str]) -> None:
     if TOPOLOGY_MARKER_PATTERN.search(content) is None:
         missing.append("topology: jobs=asset_graph; locks=coordination")
 
-    if DB_AUTHZ_PASS_PATTERN.search(content) is None:
-        missing.append("db_authz: PASS (optional opaque ref allowed)")
+    authz_match = DB_AUTHZ_PASS_PATTERN.search(content)
+    if authz_match is None:
+        missing.append("db_authz: PASS|<opaque-ref> (bare PASS is not accepted)")
+    else:
+        opaque_ref = authz_match.group(1).strip()
+        if opaque_ref.upper() in PLACEHOLDER_OPAQUE_REFS or opaque_ref.startswith("<"):
+            missing.append("db_authz opaque ref must be a real workflow run/artifact id, not a template placeholder")
 
 
 def verify_staging_promotion(evidence_file: str) -> None:

--- a/scripts/verify_staging_promotion.py
+++ b/scripts/verify_staging_promotion.py
@@ -269,6 +269,39 @@ def _check_operational_evidence(content: str, missing: List[str]) -> None:
         missing.append("Non-redacted evidence found (secrets/tokens must be redacted)")
 
 
+REQUIRED_HARDENING_IDS = (
+    "H-P0-01",
+    "H-P0-02",
+    "H-P0-03",
+    "H-P0-04",
+    "H-P0-06",
+)
+TOPOLOGY_MARKER_PATTERN = re.compile(
+    r"topology\s*:\s*jobs\s*=\s*asset_graph\s*;\s*locks\s*=\s*coordination",
+    re.IGNORECASE,
+)
+DB_AUTHZ_PASS_PATTERN = re.compile(r"\bdb_authz\s*:\s*PASS(?:\s*\|[^\n]*)?", re.IGNORECASE)
+HARDENING_IDS_LINE_PATTERN = re.compile(r"hardening_ids\s*:\s*([^\n]+)", re.IGNORECASE)
+
+
+def _check_hardening_foundation(content: str, missing: List[str]) -> None:
+    """Check P0 hardening backlog markers required for staging promotion."""
+    ids_match = HARDENING_IDS_LINE_PATTERN.search(content)
+    if ids_match is None:
+        missing.append("hardening_ids marker with P0 foundation IDs")
+    else:
+        ids_blob = ids_match.group(1).upper()
+        missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_blob]
+        if missing_ids:
+            missing.append("hardening_ids missing required IDs: " + ", ".join(missing_ids))
+
+    if TOPOLOGY_MARKER_PATTERN.search(content) is None:
+        missing.append("topology: jobs=asset_graph; locks=coordination")
+
+    if DB_AUTHZ_PASS_PATTERN.search(content) is None:
+        missing.append("db_authz: PASS (optional opaque ref allowed)")
+
+
 def verify_staging_promotion(evidence_file: str) -> None:
     """Verify baseline items in a staging promotion evidence file."""
     evidence_path_obj = REPO_ROOT / _repo_relative_evidence_path(evidence_file)
@@ -293,6 +326,7 @@ def verify_staging_promotion(evidence_file: str) -> None:
     _check_persistence_proof(content_raw, missing)
     _check_urls(content_lower, missing)
     _check_operational_evidence(content_lower, missing)
+    _check_hardening_foundation(content_raw, missing)
 
     if missing:
         print(

--- a/scripts/verify_staging_promotion.py
+++ b/scripts/verify_staging_promotion.py
@@ -285,16 +285,23 @@ DB_AUTHZ_PASS_PATTERN = re.compile(
     r"^\s*db_authz\s*:\s*PASS\s*\|\s*(\S[^\n]*?)\s*$",
     re.IGNORECASE | re.MULTILINE,
 )
+# Allowlist: run/artifact-shaped refs with a numeric id (>=3 digits). Rejects
+# denylist-evading placeholders such as TBD/TODO/N/A and angle-bracket templates.
+DB_AUTHZ_OPAQUE_REF_PATTERN = re.compile(
+    r"^(?:"
+    r"\d{6,}"  # bare GitHub Actions run id
+    r"|run-\d{3,}"  # run-123
+    r"|artifact-\d{3,}"  # artifact-456
+    r"|[A-Za-z0-9][A-Za-z0-9._-]{0,64}-run-\d{3,}"  # 1506-run-123456
+    r")$",
+    re.IGNORECASE,
+)
+DB_AUTHZ_OPAQUE_REF_ERROR = (
+    "db_authz opaque ref must match run-<digits>, artifact-<digits>, "
+    "<prefix>-run-<digits>, or a numeric workflow run id (>=6 digits)"
+)
 HARDENING_IDS_LINE_PATTERN = re.compile(r"hardening_ids\s*:\s*([^\n]+)", re.IGNORECASE)
 HARDENING_ID_TOKEN_PATTERN = re.compile(r"^H-P0-\d{2}$")
-PLACEHOLDER_OPAQUE_REFS = frozenset(
-    {
-        "REPLACE-WITH-WORKFLOW-RUN-ID",
-        "REPLACE_WITH_WORKFLOW_RUN_ID",
-        "<WORKFLOW-RUN-OR-OPAQUE-REF>",
-        "<REPLACE-WITH-WORKFLOW-RUN-ID>",
-    }
-)
 
 
 def _hardening_id_tokens(ids_blob: str) -> set[str]:
@@ -328,8 +335,8 @@ def _check_hardening_foundation(content: str, missing: List[str]) -> None:
         missing.append("db_authz: PASS|<opaque-ref> (bare PASS is not accepted)")
     else:
         opaque_ref = authz_match.group(1).strip()
-        if opaque_ref.upper() in PLACEHOLDER_OPAQUE_REFS or opaque_ref.startswith("<"):
-            missing.append("db_authz opaque ref must be a real workflow run/artifact id, not a template placeholder")
+        if DB_AUTHZ_OPAQUE_REF_PATTERN.fullmatch(opaque_ref) is None:
+            missing.append(DB_AUTHZ_OPAQUE_REF_ERROR)
 
 
 def verify_staging_promotion(evidence_file: str) -> None:

--- a/scripts/verify_staging_promotion.py
+++ b/scripts/verify_staging_promotion.py
@@ -280,8 +280,12 @@ TOPOLOGY_MARKER_PATTERN = re.compile(
     r"topology\s*:\s*jobs\s*=\s*asset_graph\s*;\s*locks\s*=\s*coordination",
     re.IGNORECASE,
 )
-DB_AUTHZ_PASS_PATTERN = re.compile(r"\bdb_authz\s*:\s*PASS(?:\s*\|[^\n]*)?", re.IGNORECASE)
+DB_AUTHZ_PASS_PATTERN = re.compile(
+    r"^\s*db_authz\s*:\s*PASS(?:\s*\|\s*\S[^\n]*)?\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
 HARDENING_IDS_LINE_PATTERN = re.compile(r"hardening_ids\s*:\s*([^\n]+)", re.IGNORECASE)
+HARDENING_ID_TOKEN_PATTERN = re.compile(r"(?<![A-Z0-9-])H-P0-\d{2}(?![A-Z0-9-])")
 
 
 def _check_hardening_foundation(content: str, missing: List[str]) -> None:
@@ -290,8 +294,8 @@ def _check_hardening_foundation(content: str, missing: List[str]) -> None:
     if ids_match is None:
         missing.append("hardening_ids marker with P0 foundation IDs")
     else:
-        ids_blob = ids_match.group(1).upper()
-        missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_blob]
+        ids_tokens = set(HARDENING_ID_TOKEN_PATTERN.findall(ids_match.group(1).upper()))
+        missing_ids = [item_id for item_id in REQUIRED_HARDENING_IDS if item_id not in ids_tokens]
         if missing_ids:
             missing.append("hardening_ids missing required IDs: " + ", ".join(missing_ids))
 

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -231,6 +231,35 @@ def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
 
 
 @pytest.mark.unit
+@pytest.mark.parametrize("db_authz_line", ["db_authz: PASSED\n", "db_authz: PASSWORD\n", "db_authz: PASSAGE\n"])
+def test_check_hardening_foundation_rejects_non_exact_db_authz_pass(db_authz_line):
+    """Test that db_authz only accepts exact PASS markers."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        f"{db_authz_line}",
+        missing,
+    )
+    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize("invalid_id", ["H-P0-06-deferred", "H-P0-060"])
+def test_check_hardening_foundation_requires_exact_hardening_ids(invalid_id):
+    """Test that hardening IDs are validated as discrete identifiers."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, "
+        f"{invalid_id}\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        "db_authz: PASS\n",
+        missing,
+    )
+    assert "hardening_ids missing required IDs: H-P0-06" in missing
+
+
+@pytest.mark.unit
 def test_check_operational_evidence():
     """Test that operational evidence like smoke tests are correctly checked."""
     missing = []

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -22,6 +22,10 @@ HARDENING_MARKERS = (
     "db_authz: PASS|run-123\n"
 )
 DB_AUTHZ_REQUIRED_MSG = "db_authz: PASS|<opaque-ref> (bare PASS is not accepted)"
+DB_AUTHZ_OPAQUE_REF_ERROR = (
+    "db_authz opaque ref must match run-<digits>, artifact-<digits>, "
+    "<prefix>-run-<digits>, or a numeric workflow run id (>=6 digits)"
+)
 
 
 @pytest.mark.unit
@@ -230,13 +234,18 @@ def test_check_hardening_foundation_rejects_bare_db_authz_pass():
 @pytest.mark.parametrize(
     "db_authz_line",
     [
+        "db_authz: PASS|TBD\n",
+        "db_authz: PASS|TODO\n",
+        "db_authz: PASS|N/A\n",
+        "db_authz: PASS|pending\n",
         "db_authz: PASS|<replace-with-workflow-run-id>\n",
-        "db_authz: PASS|<workflow-run-or-opaque-ref>\n",
         "db_authz: PASS|REPLACE-WITH-WORKFLOW-RUN-ID\n",
+        "db_authz: PASS|run-12\n",  # too few digits
+        "db_authz: PASS|12345\n",  # bare numeric id too short
     ],
 )
-def test_check_hardening_foundation_rejects_placeholder_opaque_ref(db_authz_line):
-    """Test that template placeholder opaque refs are rejected."""
+def test_check_hardening_foundation_rejects_invalid_opaque_ref(db_authz_line):
+    """Test that placeholder and non-shaped opaque refs are rejected by allowlist."""
     missing = []
     _check_hardening_foundation(
         "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
@@ -244,7 +253,24 @@ def test_check_hardening_foundation_rejects_placeholder_opaque_ref(db_authz_line
         f"{db_authz_line}",
         missing,
     )
-    assert "db_authz opaque ref must be a real workflow run/artifact id, not a template placeholder" in missing
+    assert DB_AUTHZ_OPAQUE_REF_ERROR in missing
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "opaque_ref",
+    ["run-123", "artifact-456", "1506-run-123456", "1234567890"],
+)
+def test_check_hardening_foundation_accepts_shaped_opaque_refs(opaque_ref):
+    """Test that allowlisted run/artifact opaque refs are accepted."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        f"db_authz: PASS|{opaque_ref}\n",
+        missing,
+    )
+    assert not missing
 
 
 @pytest.mark.unit

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -7,12 +7,19 @@ import pytest
 
 from scripts.verify_staging_promotion import (
     _check_database_boundaries,
+    _check_hardening_foundation,
     _check_operational_evidence,
     _check_persistence_proof,
     _check_provider_labels,
     _check_urls,
     _read_evidence_file,
     verify_staging_promotion,
+)
+
+HARDENING_MARKERS = (
+    "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
+    "topology: jobs=asset_graph; locks=coordination\n"
+    "db_authz: PASS\n"
 )
 
 
@@ -198,6 +205,32 @@ def test_check_urls():
 
 
 @pytest.mark.unit
+def test_check_hardening_foundation_accepts_required_markers():
+    """Test that P0 hardening markers satisfy the foundation check."""
+    missing = []
+    _check_hardening_foundation(HARDENING_MARKERS + "db_authz: PASS|run-123\n", missing)
+    assert not missing
+
+
+@pytest.mark.unit
+def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
+    """Test that missing hardening markers are reported distinctly."""
+    missing = []
+    _check_hardening_foundation("no hardening markers here", missing)
+    assert "hardening_ids marker with P0 foundation IDs" in missing
+    assert "topology: jobs=asset_graph; locks=coordination" in missing
+    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02\ntopology: jobs=asset_graph; locks=coordination\ndb_authz: FAIL\n",
+        missing,
+    )
+    assert any("hardening_ids missing required IDs" in item for item in missing)
+    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+
+
+@pytest.mark.unit
 def test_check_operational_evidence():
     """Test that operational evidence like smoke tests are correctly checked."""
     missing = []
@@ -241,7 +274,8 @@ def test_verify_staging_promotion_success(tmp_path):
     """Test successful staging promotion verification."""
     evidence_path = tmp_path / "evidence.md"
     evidence_path.write_text(
-        "supabase vercel mapping database_url asset_graph_database_url distinct asset_graph_database_url shared-boundary statement "
+        HARDENING_MARKERS
+        + "supabase vercel mapping database_url asset_graph_database_url distinct asset_graph_database_url shared-boundary statement "
         "durable preview "
         "https://github.com/org/repo/actions/runs/123 asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary "
         "```json\n"

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -208,7 +208,20 @@ def test_check_urls():
 def test_check_hardening_foundation_accepts_required_markers():
     """Test that P0 hardening markers satisfy the foundation check."""
     missing = []
-    _check_hardening_foundation(HARDENING_MARKERS + "db_authz: PASS|run-123\n", missing)
+    _check_hardening_foundation(HARDENING_MARKERS, missing)
+    assert not missing
+
+
+@pytest.mark.unit
+def test_check_hardening_foundation_accepts_db_authz_opaque_ref():
+    """Test that db_authz PASS|<ref> is accepted without a plain PASS line."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        "db_authz: PASS|run-123\n",
+        missing,
+    )
     assert not missing
 
 

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -16,16 +16,22 @@ from scripts.verify_staging_promotion import (
     verify_staging_promotion,
 )
 
-HARDENING_MARKERS = (
-    "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
-    "topology: jobs=asset_graph; locks=coordination\n"
-    "db_authz: PASS|run-123\n"
-)
+HARDENING_IDS = "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06"
+TOPOLOGY_MARKER = "topology: jobs=asset_graph; locks=coordination"
+HARDENING_MARKERS = f"{HARDENING_IDS}\n{TOPOLOGY_MARKER}\ndb_authz: PASS|run-123\n"
 DB_AUTHZ_REQUIRED_MSG = "db_authz: PASS|<opaque-ref> (bare PASS is not accepted)"
 DB_AUTHZ_OPAQUE_REF_ERROR = (
     "db_authz opaque ref must match run-<digits>, artifact-<digits>, "
     "<prefix>-run-<digits>, or a numeric workflow run id (>=6 digits)"
 )
+OPERATIONAL_EVIDENCE = (
+    "asset smoke evidence hosted readiness --require-persistence " "health json named owners scanner summary"
+)
+
+
+def _hardening_content(db_authz_line: str, hardening_ids: str = HARDENING_IDS) -> str:
+    """Build a minimal hardening marker block for foundation checks."""
+    return f"{hardening_ids}\n{TOPOLOGY_MARKER}\n{db_authz_line}"
 
 
 @pytest.mark.unit
@@ -88,12 +94,12 @@ def test_check_database_boundaries_accepts_nearby_distinct_boundary():
         """
         ```json
         {
-          "graph_persistence_configured": true,
-          "graph": {
-            "persistence_enabled": true,
-            "persistence_loaded": true,
-            "startup_source": "persisted"
-          }
+            "graph_persistence_configured": true,
+            "graph": {
+                "persistence_enabled": true,
+                "persistence_loaded": true,
+                "startup_source": "persisted"
+            }
         }
         ```
         durable preview
@@ -101,12 +107,12 @@ def test_check_database_boundaries_accepts_nearby_distinct_boundary():
         """
         ```json
         {
-          "observed_fields": {
-            "graph_persistence_configured": true,
-            "graph.persistence_enabled": true,
-            "graph.persistence_loaded": true,
-            "graph.startup_source": "persisted"
-          }
+            "observed_fields": {
+                "graph_persistence_configured": true,
+                "graph.persistence_enabled": true,
+                "graph.persistence_loaded": true,
+                "graph.startup_source": "persisted"
+            }
         }
         ```
         durable preview
@@ -136,12 +142,12 @@ def test_persistence_proof_invalid_data():
     missing = []
     false_json = """
     {
-      "graph_persistence_configured": false,
-      "graph": {
-        "persistence_enabled": false,
-        "persistence_loaded": false,
-        "startup_source": "sample"
-      }
+        "graph_persistence_configured": false,
+        "graph": {
+            "persistence_enabled": false,
+            "persistence_loaded": false,
+            "startup_source": "sample"
+        }
     }
     durable preview
     """
@@ -151,11 +157,11 @@ def test_persistence_proof_invalid_data():
     missing = []
     bare_json = """
     {
-      "graph_persistence_configured": true,
-      "persistence_enabled": true,
-      "persistence_loaded": true,
-      "startup_source": "persisted",
-      "graph": {}
+        "graph_persistence_configured": true,
+        "persistence_enabled": true,
+        "persistence_loaded": true,
+        "startup_source": "persisted",
+        "graph": {}
     }
     durable preview
     """
@@ -177,17 +183,17 @@ def test_persistence_proof_invalid_data():
     Here is the first block:
     ```json
     {
-      "graph_persistence_configured": true
+        "graph_persistence_configured": true
     }
     ```
     And the second block:
     ```json
     {
-      "graph": {
-        "persistence_enabled": true,
-        "persistence_loaded": true,
-        "startup_source": "persisted"
-      }
+        "graph": {
+            "persistence_enabled": true,
+            "persistence_loaded": true,
+            "startup_source": "persisted"
+        }
     }
     ```
     durable preview
@@ -221,12 +227,7 @@ def test_check_hardening_foundation_accepts_required_markers():
 def test_check_hardening_foundation_rejects_bare_db_authz_pass():
     """Test that bare db_authz: PASS is rejected without an opaque ref."""
     missing = []
-    _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        "db_authz: PASS\n",
-        missing,
-    )
+    _check_hardening_foundation(_hardening_content("db_authz: PASS\n"), missing)
     assert DB_AUTHZ_REQUIRED_MSG in missing
 
 
@@ -247,12 +248,7 @@ def test_check_hardening_foundation_rejects_bare_db_authz_pass():
 def test_check_hardening_foundation_rejects_invalid_opaque_ref(db_authz_line):
     """Test that placeholder and non-shaped opaque refs are rejected by allowlist."""
     missing = []
-    _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        f"{db_authz_line}",
-        missing,
-    )
+    _check_hardening_foundation(_hardening_content(db_authz_line), missing)
     assert DB_AUTHZ_OPAQUE_REF_ERROR in missing
 
 
@@ -265,9 +261,7 @@ def test_check_hardening_foundation_accepts_shaped_opaque_refs(opaque_ref):
     """Test that allowlisted run/artifact opaque refs are accepted."""
     missing = []
     _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        f"db_authz: PASS|{opaque_ref}\n",
+        _hardening_content(f"db_authz: PASS|{opaque_ref}\n"),
         missing,
     )
     assert not missing
@@ -284,7 +278,10 @@ def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
 
     missing = []
     _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02\ntopology: jobs=asset_graph; locks=coordination\ndb_authz: FAIL\n",
+        _hardening_content(
+            "db_authz: FAIL\n",
+            hardening_ids="hardening_ids: H-P0-01, H-P0-02",
+        ),
         missing,
     )
     assert any("hardening_ids missing required IDs" in item for item in missing)
@@ -294,17 +291,17 @@ def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
 @pytest.mark.unit
 @pytest.mark.parametrize(
     "db_authz_line",
-    ["db_authz: PASSED\n", "db_authz: PASSWORD\n", "db_authz: PASSAGE\n", "db_authz: PASS\n"],
+    [
+        "db_authz: PASSED\n",
+        "db_authz: PASSWORD\n",
+        "db_authz: PASSAGE\n",
+        "db_authz: PASS\n",
+    ],
 )
 def test_check_hardening_foundation_rejects_non_exact_db_authz_pass(db_authz_line):
     """Test that db_authz only accepts PASS|<opaque-ref> markers."""
     missing = []
-    _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        f"{db_authz_line}",
-        missing,
-    )
+    _check_hardening_foundation(_hardening_content(db_authz_line), missing)
     assert DB_AUTHZ_REQUIRED_MSG in missing
 
 
@@ -314,10 +311,10 @@ def test_check_hardening_foundation_requires_exact_hardening_ids(invalid_id):
     """Test that hardening IDs are validated as discrete identifiers."""
     missing = []
     _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, "
-        f"{invalid_id}\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        "db_authz: PASS|run-123\n",
+        _hardening_content(
+            "db_authz: PASS|run-123\n",
+            hardening_ids=("hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, " + invalid_id),
+        ),
         missing,
     )
     assert "hardening_ids missing required IDs: H-P0-06" in missing
@@ -328,9 +325,10 @@ def test_check_hardening_foundation_ignores_comment_text_after_comma_tokens():
     """Test that comma tokenization keeps only exact ID tokens."""
     missing = []
     _check_hardening_foundation(
-        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06 # H-P0-99 elsewhere\n"
-        "topology: jobs=asset_graph; locks=coordination\n"
-        "db_authz: PASS|run-123\n",
+        _hardening_content(
+            "db_authz: PASS|run-123\n",
+            hardening_ids=f"{HARDENING_IDS} # H-P0-99 elsewhere",
+        ),
         missing,
     )
     assert not missing
@@ -340,9 +338,7 @@ def test_check_hardening_foundation_ignores_comment_text_after_comma_tokens():
 def test_check_operational_evidence():
     """Test that operational evidence like smoke tests are correctly checked."""
     missing = []
-    _check_operational_evidence(
-        "asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary", missing
-    )
+    _check_operational_evidence(OPERATIONAL_EVIDENCE, missing)
     assert not missing
 
     missing = []
@@ -353,23 +349,21 @@ def test_check_operational_evidence():
 
     missing = []
     _check_operational_evidence(
-        "asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary secret: supersecretvalue",
+        f"{OPERATIONAL_EVIDENCE} secret: supersecretvalue",
         missing,
     )
     assert "Non-redacted evidence found (secrets/tokens must be redacted)" in missing
 
     missing = []
     _check_operational_evidence(
-        "asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary "
-        "secret: benign-narrative-string",
+        f"{OPERATIONAL_EVIDENCE} secret: benign-narrative-string",
         missing,
     )
     assert "Non-redacted evidence found (secrets/tokens must be redacted)" in missing
 
     missing = []
     _check_operational_evidence(
-        "asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary "
-        f"secret: {'a' * 10000}",
+        f"{OPERATIONAL_EVIDENCE} secret: {'a' * 10000}",
         missing,
     )
     assert "Non-redacted evidence found (secrets/tokens must be redacted)" in missing
@@ -380,18 +374,19 @@ def test_verify_staging_promotion_success(tmp_path):
     """Test successful staging promotion verification."""
     evidence_path = tmp_path / "evidence.md"
     evidence_path.write_text(
-        HARDENING_MARKERS
-        + "supabase vercel mapping database_url asset_graph_database_url distinct asset_graph_database_url shared-boundary statement "
+        HARDENING_MARKERS + "supabase vercel mapping database_url asset_graph_database_url "
+        "distinct asset_graph_database_url shared-boundary statement "
         "durable preview "
-        "https://github.com/org/repo/actions/runs/123 asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary "
+        "https://github.com/org/repo/actions/runs/123 "
+        f"{OPERATIONAL_EVIDENCE} "
         "```json\n"
         "{\n"
-        '  "graph_persistence_configured": true,\n'
-        '  "graph": {\n'
-        '    "persistence_enabled": true,\n'
-        '    "persistence_loaded": true,\n'
-        '    "startup_source": "persisted"\n'
-        "  }\n"
+        '    "graph_persistence_configured": true,\n'
+        '    "graph": {\n'
+        '        "persistence_enabled": true,\n'
+        '        "persistence_loaded": true,\n'
+        '        "startup_source": "persisted"\n'
+        "    }\n"
         "}\n"
         "```",
         encoding="utf-8",

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -19,8 +19,9 @@ from scripts.verify_staging_promotion import (
 HARDENING_MARKERS = (
     "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
     "topology: jobs=asset_graph; locks=coordination\n"
-    "db_authz: PASS\n"
+    "db_authz: PASS|run-123\n"
 )
+DB_AUTHZ_REQUIRED_MSG = "db_authz: PASS|<opaque-ref> (bare PASS is not accepted)"
 
 
 @pytest.mark.unit
@@ -213,16 +214,37 @@ def test_check_hardening_foundation_accepts_required_markers():
 
 
 @pytest.mark.unit
-def test_check_hardening_foundation_accepts_db_authz_opaque_ref():
-    """Test that db_authz PASS|<ref> is accepted without a plain PASS line."""
+def test_check_hardening_foundation_rejects_bare_db_authz_pass():
+    """Test that bare db_authz: PASS is rejected without an opaque ref."""
     missing = []
     _check_hardening_foundation(
         "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
         "topology: jobs=asset_graph; locks=coordination\n"
-        "db_authz: PASS|run-123\n",
+        "db_authz: PASS\n",
         missing,
     )
-    assert not missing
+    assert DB_AUTHZ_REQUIRED_MSG in missing
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "db_authz_line",
+    [
+        "db_authz: PASS|<replace-with-workflow-run-id>\n",
+        "db_authz: PASS|<workflow-run-or-opaque-ref>\n",
+        "db_authz: PASS|REPLACE-WITH-WORKFLOW-RUN-ID\n",
+    ],
+)
+def test_check_hardening_foundation_rejects_placeholder_opaque_ref(db_authz_line):
+    """Test that template placeholder opaque refs are rejected."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        f"{db_authz_line}",
+        missing,
+    )
+    assert "db_authz opaque ref must be a real workflow run/artifact id, not a template placeholder" in missing
 
 
 @pytest.mark.unit
@@ -232,7 +254,7 @@ def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
     _check_hardening_foundation("no hardening markers here", missing)
     assert "hardening_ids marker with P0 foundation IDs" in missing
     assert "topology: jobs=asset_graph; locks=coordination" in missing
-    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+    assert DB_AUTHZ_REQUIRED_MSG in missing
 
     missing = []
     _check_hardening_foundation(
@@ -240,13 +262,16 @@ def test_check_hardening_foundation_requires_ids_topology_and_db_authz():
         missing,
     )
     assert any("hardening_ids missing required IDs" in item for item in missing)
-    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+    assert DB_AUTHZ_REQUIRED_MSG in missing
 
 
 @pytest.mark.unit
-@pytest.mark.parametrize("db_authz_line", ["db_authz: PASSED\n", "db_authz: PASSWORD\n", "db_authz: PASSAGE\n"])
+@pytest.mark.parametrize(
+    "db_authz_line",
+    ["db_authz: PASSED\n", "db_authz: PASSWORD\n", "db_authz: PASSAGE\n", "db_authz: PASS\n"],
+)
 def test_check_hardening_foundation_rejects_non_exact_db_authz_pass(db_authz_line):
-    """Test that db_authz only accepts exact PASS markers."""
+    """Test that db_authz only accepts PASS|<opaque-ref> markers."""
     missing = []
     _check_hardening_foundation(
         "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06\n"
@@ -254,7 +279,7 @@ def test_check_hardening_foundation_rejects_non_exact_db_authz_pass(db_authz_lin
         f"{db_authz_line}",
         missing,
     )
-    assert "db_authz: PASS (optional opaque ref allowed)" in missing
+    assert DB_AUTHZ_REQUIRED_MSG in missing
 
 
 @pytest.mark.unit
@@ -266,10 +291,23 @@ def test_check_hardening_foundation_requires_exact_hardening_ids(invalid_id):
         "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, "
         f"{invalid_id}\n"
         "topology: jobs=asset_graph; locks=coordination\n"
-        "db_authz: PASS\n",
+        "db_authz: PASS|run-123\n",
         missing,
     )
     assert "hardening_ids missing required IDs: H-P0-06" in missing
+
+
+@pytest.mark.unit
+def test_check_hardening_foundation_ignores_comment_text_after_comma_tokens():
+    """Test that comma tokenization keeps only exact ID tokens."""
+    missing = []
+    _check_hardening_foundation(
+        "hardening_ids: H-P0-01, H-P0-02, H-P0-03, H-P0-04, H-P0-06 # H-P0-99 elsewhere\n"
+        "topology: jobs=asset_graph; locks=coordination\n"
+        "db_authz: PASS|run-123\n",
+        missing,
+    )
+    assert not missing
 
 
 @pytest.mark.unit

--- a/tests/unit/test_verify_staging_promotion.py
+++ b/tests/unit/test_verify_staging_promotion.py
@@ -25,7 +25,7 @@ DB_AUTHZ_OPAQUE_REF_ERROR = (
     "<prefix>-run-<digits>, or a numeric workflow run id (>=6 digits)"
 )
 OPERATIONAL_EVIDENCE = (
-    "asset smoke evidence hosted readiness --require-persistence " "health json named owners scanner summary"
+    "asset smoke evidence hosted readiness --require-persistence health json named owners scanner summary"
 )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI (production path)
- Frontend: Next.js (production path)
- Gradio: non-production (demo/testing only)

No production runtime behavior change beyond release/staging gate enforcement and documentation truth alignment.

## Primary Objective

Establish an automatable hardening spine: stable backlog IDs, machine-checkable evidence markers, strict RC defaults, and wired DB authorization checking — so boundary hardening cannot silently skip.

## Scope

### In Scope

- Hardening backlog table (H-P0 … H-P3) in `docs/release-evidence-pack.md` + board mirror
- DR topology truth: `rebuild_jobs` on Asset Graph; `distributed_locks` on coordination
- ADR 0002 / ADR 0005 / `.env.example` runtime-truth updates
- RC / restore / drill issue template hardening checkboxes
- `verify_staging_promotion.py` requires P0 markers (`hardening_ids`, topology, `db_authz`)
- `release-evidence-verify.yml`: `hardening_tier` (default P0) forces strict hosted readiness; DB authz step + summary
- `staging-promotion.yml`: live DB authz when secrets present; artifact upload
- CI required-checks policy: release-only / dispatch section
- Compound `watched-series.yml` labels/globs for hardening paths

### Out of Scope

- P1 assets-smoke script flag, production-promotion workflow twin
- P2 multi-worker fencing / unique RUNNING index code
- P3 RBAC / rate-limit / OpenAPI lockdown
- Clearing ADR 0007 Blocked without attached live redacted proof (wiring only)

### Files Expected to Change

- Evidence pack, board, index, runbook, ADRs, templates, workflows, verifier script + tests, `.env.example`, watched-series, CI policy

## Validation Commands

```bash
pytest tests/unit/test_verify_staging_promotion.py -q
pre-commit run --files scripts/verify_staging_promotion.py tests/unit/test_verify_staging_promotion.py .github/workflows/release-evidence-verify.yml .github/workflows/staging-promotion.yml
rg -n "hardening_tier|H-P0-01|jobs=asset_graph" docs/release-evidence-pack.md .github/workflows/release-evidence-verify.yml scripts/verify_staging_promotion.py
```

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Validation commands pass locally
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] Docs/policy/architecture changes are not mixed with unrelated product runtime work
- [x] No runtime rebuild/recovery semantics changed (docs align to existing code placement)
- [x] Branch/ref verified against `main`
- [x] Checked against production architecture and `.github/AUTOMATION_SCOPE_POLICY.md`
- [x] Governed restore topology documentation updated to match landed session factories

### Testing Best Practices

- [x] Verifier tests cover observable marker acceptance/rejection
- [x] No coupling to exact log strings beyond required evidence markers

---

**Related Documentation**:

- [Release Evidence Pack — Hardening backlog](docs/release-evidence-pack.md#hardening-backlog-p0p3)
- [Automation Scope Policy](.github/AUTOMATION_SCOPE_POLICY.md)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets up the P0 hardening foundation with machine-checkable markers and strict RC defaults, and wires DB authorization gates into release and staging. Updates ADRs, evidence/templates, and CI to match runtime truth and enforce the gate path.

- **New Features**
  - Requires P0 markers in staging evidence: `hardening_ids` (H-P0-01/02/03/04/06), `topology: jobs=asset_graph; locks=coordination`, and `db_authz: PASS|<opaque-ref>` (allowlisted shapes); adds focused unit tests.
  - `release-evidence-verify.yml` adds `hardening_tier` (`P0` default; `none` for soft rehearsal), forces strict hosted readiness when not `none`, adds a DB authz gate with fail-on-authz-failure, emits a hardening summary, and writes placeholders for skipped steps.
  - `staging-promotion.yml` verifies evidence, hard-fails when DB URL secrets are missing, runs live DB authz when secrets exist, uploads readiness/authz artifacts, and writes placeholders on short-circuits; DR/docs/templates align to runtime truth (jobs on Asset Graph; locks on coordination; PostgreSQL support landed + recommended SQLite forms).

- **Bug Fixes**
  - Limits `hardening_tier` input to `none` and `P0` only.
  - Requires real `db_authz` refs with an allowlist (`run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or bare numeric run id ≥6); rejects placeholders and bare `PASS`.
  - Stops uploading raw DB authz logs; artifacts use bounded `db-authz-output.json` only; merges staging verify/authz into one step and removes secret-name echoes.
  - Disables super-linter Pyink in `super-linter.yml` to avoid config-path fatals; relaxes `.markdownlint.json` line-length and excludes code blocks/tables; fixes a Sonar warning by merging `OPERATIONAL_EVIDENCE` into one literal.

<sup>Written for commit 646761c3d5978c73b1b3168d739e26db95f4739e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1506?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR establishes a machine-checkable P0 hardening spine: stable backlog IDs (H-P0-01 through H-P0-06), three new evidence markers (`hardening_ids`, `topology`, `db_authz: PASS|<opaque-ref>`), and wired DB authorization gates in both the release-evidence and staging-promotion workflows. It also aligns DR runbook/ADR topology prose with the landed runtime placement of `rebuild_jobs` (Asset Graph) and `distributed_locks` (coordination).

- **`verify_staging_promotion.py`** gains `_check_hardening_foundation` — three sub-checks with well-anchored case-insensitive patterns; the `db_authz` check rejects bare `PASS` and validates the opaque ref against an explicit allowlist.
- **`staging-promotion.yml`** merges evidence verification and live DB authz into one step that hard-fails when database URL secrets are absent; `Prepare Artifact Placeholders` (`if: always()`) ensures artifacts are always present for upload.
- **`release-evidence-verify.yml`** adds `hardening_tier` input (default `P0`, forces strict hosted readiness gate) and a DB authz step with `continue-on-error: true` whose outcome is re-checked in `Assert All Gates Passed`.

<h3>Confidence Score: 4/5</h3>

Safe to merge for docs/workflow/test changes; the gate wiring in both dispatch workflows is logically sound, but the step summary in release-evidence-verify.yml still instructs operators to add bare db_authz: PASS which the verifier explicitly rejects, leaving a confusing failure path for the first operator who follows it.

The hardening verifier logic and test coverage are solid. The staging-promotion.yml combined step is correctly ordered and the placeholder mechanism ensures artifacts are always uploaded. The one outstanding issue is the Emit Gate Summary step, which writes db_authz: PASS before promotion into the GitHub step summary; an operator who copies that verbatim will be blocked by the verifier with a cryptic bare PASS is not accepted error.

release-evidence-verify.yml — the Emit Gate Summary Python block at lines 386-388 needs the guidance string updated from bare db_authz: PASS to db_authz: PASS|<opaque-ref>.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/verify_staging_promotion.py | Adds _check_hardening_foundation with three sub-checks (IDs, topology marker, db_authz opaque-ref allowlist); patterns are well-anchored with IGNORECASE and proper MULTILINE flags. |
| tests/unit/test_verify_staging_promotion.py | New hardening foundation tests cover accept, reject-bare-pass, reject-invalid-opaque-ref, boundary digits, and comment-stripping cases; HARDENING_MARKERS constant carries a complete valid set including a properly-shaped opaque ref. |
| .github/workflows/staging-promotion.yml | Merges evidence verifier + live DB authz into one step (hard-fail when secrets absent); adds Prepare Artifact Placeholders (if: always()) so readiness and authz JSON files always exist for upload. |
| .github/workflows/release-evidence-verify.yml | Adds hardening_tier input (P0 default forces strict gate), DB authz step with continue-on-error, placeholder preparation, and hardening summary; contains a known inconsistency in the summary text (bare db_authz: PASS guidance vs verifier requirement for opaque-ref). |
| docs/release-evidence-pack.md | Adds the H-P0-P3 hardening backlog table and machine-checkable evidence-marker spec; opaque-ref format guidance is accurate and consistent with the verifier allowlist. |
| docs/runbooks/backup-restore-dr.md | Aligns table-placement prose (rebuild_jobs to Asset Graph; distributed_locks to coordination) and table-scoped cleanup instructions with runtime code topology. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Op as Operator
    participant SP as staging-promotion.yml
    participant VSP as verify_staging_promotion.py
    participant DBA as check_database_authorization.py
    participant REV as release-evidence-verify.yml
    participant AG as Assert All Gates Passed

    Op->>SP: dispatch evidence_file and secrets
    SP->>VSP: verify evidence file
    VSP-->>SP: check hardening_ids
    VSP-->>SP: check topology marker
    VSP-->>SP: check db_authz PASS with opaque-ref
    SP->>SP: check DB URL secrets present
    alt secrets absent
        SP-->>Op: FAIL H-P0-04 requires live secrets
    else secrets present
        SP->>DBA: run live authz check
        DBA-->>SP: exit code
        alt authz fails
            SP-->>Op: FAIL db-authz-output status failed
        else authz passes
            SP->>SP: Check Hosted Readiness
            SP-->>Op: PASS artifact uploaded
        end
    end

    Op->>REV: dispatch release_sha hardening_tier P0
    REV->>REV: run pytest gates
    REV->>DBA: run authz check continue-on-error
    DBA-->>REV: db-authz-output.json
    REV->>AG: assert all gates
    AG->>AG: if db_authz_status failed then exit 1
    AG->>AG: if EFFECTIVE_STRICT and readiness not passed then exit 1
    AG-->>Op: gate summary emitted
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Op as Operator
    participant SP as staging-promotion.yml
    participant VSP as verify_staging_promotion.py
    participant DBA as check_database_authorization.py
    participant REV as release-evidence-verify.yml
    participant AG as Assert All Gates Passed

    Op->>SP: dispatch evidence_file and secrets
    SP->>VSP: verify evidence file
    VSP-->>SP: check hardening_ids
    VSP-->>SP: check topology marker
    VSP-->>SP: check db_authz PASS with opaque-ref
    SP->>SP: check DB URL secrets present
    alt secrets absent
        SP-->>Op: FAIL H-P0-04 requires live secrets
    else secrets present
        SP->>DBA: run live authz check
        DBA-->>SP: exit code
        alt authz fails
            SP-->>Op: FAIL db-authz-output status failed
        else authz passes
            SP->>SP: Check Hosted Readiness
            SP-->>Op: PASS artifact uploaded
        end
    end

    Op->>REV: dispatch release_sha hardening_tier P0
    REV->>REV: run pytest gates
    REV->>DBA: run authz check continue-on-error
    DBA-->>REV: db-authz-output.json
    REV->>AG: assert all gates
    AG->>AG: if db_authz_status failed then exit 1
    AG->>AG: if EFFECTIVE_STRICT and readiness not passed then exit 1
    AG-->>Op: gate summary emitted
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `.github/workflows/staging-promotion.yml`, line 111-119 ([link](https://github.com/dashfin-fardb/financial-asset-relationship-db/blob/b1a40d2e4dcb8927358b9d44b35b3b2e6c670d0b/.github/workflows/staging-promotion.yml#L111-L119)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`db-authz-log.txt` excluded from artifact upload**

   When the "Check Database Authorization" step fails (`exit 1`), `db-authz-log.txt` captures the detailed output of `check_database_authorization.py` but is not included in the `staging-readiness` artifact. Once the workflow run expires, there is no way to examine why the live authorization check failed. Consider uploading the log file alongside `db-authz-output.json`, noting that the script already redacts sensitive topology details by design.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: .github/workflows/staging-promotion.yml
   Line: 111-119

   Comment:
   **`db-authz-log.txt` excluded from artifact upload**

   When the "Check Database Authorization" step fails (`exit 1`), `db-authz-log.txt` captures the detailed output of `check_database_authorization.py` but is not included in the `staging-readiness` artifact. Once the workflow run expires, there is no way to examine why the live authorization check failed. Consider uploading the log file alongside `db-authz-output.json`, noting that the script already redacts sensitive topology details by design.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22cursor%2Fhardening-foundation-gates-27d1%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fhardening-foundation-gates-27d1%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20.github%2Fworkflows%2Fstaging-promotion.yml%0ALine%3A%20111-119%0A%0AComment%3A%0A**%60db-authz-log.txt%60%20excluded%20from%20artifact%20upload**%0A%0AWhen%20the%20%22Check%20Database%20Authorization%22%20step%20fails%20%28%60exit%201%60%29%2C%20%60db-authz-log.txt%60%20captures%20the%20detailed%20output%20of%20%60check_database_authorization.py%60%20but%20is%20not%20included%20in%20the%20%60staging-readiness%60%20artifact.%20Once%20the%20workflow%20run%20expires%2C%20there%20is%20no%20way%20to%20examine%20why%20the%20live%20authorization%20check%20failed.%20Consider%20uploading%20the%20log%20file%20alongside%20%60db-authz-output.json%60%2C%20noting%20that%20the%20script%20already%20redacts%20sensitive%20topology%20details%20by%20design.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1506&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["fix: disable super-linter pyink and pret..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/646761c3d5978c73b1b3168d739e26db95f4739e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45739498)</sub>

<!-- /greptile_comment -->