### PR TITLE
fix: fail-closed H-P0-04 db authz on P0 release-evidence path

### DIFF
--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -221,6 +221,30 @@ jobs:
             echo '{"status":"skipped","reason":"no_database_url_configured"}' > db-authz-output.json
             exit 0
           fi
+          # Fail closed on missing required boundaries before authz runs.
+          # The checker only validates URLs that are present, so a partial
+          # secret set must not pass H-P0-04 (parity with production-promotion).
+          if [ -z "$ASSET_GRAPH_DATABASE_URL" ]; then
+            reason='missing_asset_graph_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the asset-graph DB secret for authorization."
+            exit 1
+          fi
+          if [ -z "${DATABASE_URL}${POSTGRES_URL}" ]; then
+            reason='missing_auth_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the auth/app DB secret for authorization."
+            exit 1
+          fi
+          if [ -z "$COORDINATION_DATABASE_URL" ]; then
+            reason='missing_coordination_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the coordination DB secret for authorization."
+            exit 1
+          fi
           # GitHub injects unset secrets as empty strings. An empty value makes
           # the checker reject config instead of applying default roles, so
           # drop it before invocation.
@@ -297,15 +321,21 @@ jobs:
           fi
 
           if [ "$EFFECTIVE_STRICT" == "true" ]; then
-            if [ "$readiness_status" != "passed" ] || [ "$docs_status" != "passed" ]; then
-              echo "Strict RC promotion requires hosted readiness and docs checks to pass (hardening_tier=$HARDENING_TIER)."
-              exit 1
+            # Collect all strict-gate failures so operators see every blocker
+            # (readiness, docs, and H-P0-04) in one diagnostic exit.
+            FAILURES=""
+            if [ "$readiness_status" != "passed" ]; then
+              FAILURES="${FAILURES}hosted readiness, "
             fi
-            # H-P0-04: P0 Assert path fails closed when DB authz secrets are missing
-            # (same posture as staging-promotion). Soft rehearsal uses hardening_tier=none.
+            if [ "$docs_status" != "passed" ]; then
+              FAILURES="${FAILURES}docs readiness, "
+            fi
             if [ "$db_authz_status" != "passed" ]; then
-              echo "Strict RC promotion requires database authorization to pass (H-P0-04; hardening_tier=$HARDENING_TIER)."
-              echo "Configure the required database URL Environment secrets, or use hardening_tier=none for soft rehearsal."
+              FAILURES="${FAILURES}database authorization (H-P0-04), "
+            fi
+            if [ -n "$FAILURES" ]; then
+              echo "Strict RC promotion requires the following to pass: ${FAILURES%, } (hardening_tier=$HARDENING_TIER)."
+              echo "Configure the required Environment secrets (auth/app, asset-graph, and coordination DB URLs), or use hardening_tier=none for soft rehearsal."
               exit 1
             fi
           else

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -305,7 +305,7 @@ jobs:
             # (same posture as staging-promotion). Soft rehearsal uses hardening_tier=none.
             if [ "$db_authz_status" != "passed" ]; then
               echo "Strict RC promotion requires database authorization to pass (H-P0-04; hardening_tier=$HARDENING_TIER)."
-              echo "Configure DATABASE_URL / ASSET_GRAPH_DATABASE_URL (and related) secrets, or use hardening_tier=none for soft rehearsal."
+              echo "Configure the required database URL Environment secrets, or use hardening_tier=none for soft rehearsal."
               exit 1
             fi
           else

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -221,6 +221,12 @@ jobs:
             echo '{"status":"skipped","reason":"no_database_url_configured"}' > db-authz-output.json
             exit 0
           fi
+          # GitHub injects unset secrets as empty strings. An empty value makes
+          # the checker reject config instead of applying default roles, so
+          # drop it before invocation.
+          if [ -z "$FARDB_UNTRUSTED_DATABASE_ROLES" ]; then
+            unset FARDB_UNTRUSTED_DATABASE_ROLES
+          fi
           set +e
           # Bounded stdout/stderr only (control ids/messages). Do not upload raw logs as artifacts.
           python scripts/check_database_authorization.py
@@ -295,6 +301,13 @@ jobs:
               echo "Strict RC promotion requires hosted readiness and docs checks to pass (hardening_tier=$HARDENING_TIER)."
               exit 1
             fi
+            # H-P0-04: P0 Assert path fails closed when DB authz secrets are missing
+            # (same posture as staging-promotion). Soft rehearsal uses hardening_tier=none.
+            if [ "$db_authz_status" != "passed" ]; then
+              echo "Strict RC promotion requires database authorization to pass (H-P0-04; hardening_tier=$HARDENING_TIER)."
+              echo "Configure DATABASE_URL / ASSET_GRAPH_DATABASE_URL (and related) secrets, or use hardening_tier=none for soft rehearsal."
+              exit 1
+            fi
           else
             if [ "$readiness_status" != "passed" ] && [ "$readiness_status" != "skipped" ]; then
               echo "Hosted readiness must pass or be intentionally skipped."
@@ -302,6 +315,10 @@ jobs:
             fi
             if [ "$docs_status" != "passed" ] && [ "$docs_status" != "skipped" ]; then
               echo "Docs readiness must pass or be intentionally skipped."
+              exit 1
+            fi
+            if [ "$db_authz_status" != "passed" ] && [ "$db_authz_status" != "skipped" ]; then
+              echo "Database authorization must pass or be intentionally skipped (H-P0-04)."
               exit 1
             fi
           fi
@@ -385,8 +402,9 @@ jobs:
               out.write(f"- hardening_tier input: `{hardening_tier}`\n")
               out.write(
                   "- Canon: `docs/release-evidence-pack.md#hardening-backlog-p0p3` "
-                  "(H-P0-01 … H-P3-05). Skipped DB authz still requires staging evidence "
-                  "`db_authz: PASS` before promotion.\n"
+                  "(H-P0-01 … H-P3-05). With `hardening_tier=P0`, skipped DB authz "
+                  "fails the Assert path; staging/production promotion still require "
+                  "`db_authz: PASS|<opaque-ref>` in evidence before promotion.\n"
               )
 
           sys.exit(0)

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -48,12 +48,32 @@ jobs:
           FARDB_UNTRUSTED_DATABASE_ROLES: ${{ secrets.FARDB_UNTRUSTED_DATABASE_ROLES }}
         run: |
           python scripts/verify_staging_promotion.py "$EVIDENCE_FILE"
-          if [ -z "${DATABASE_URL}${ASSET_GRAPH_DATABASE_URL}${COORDINATION_DATABASE_URL}${POSTGRES_URL}" ]; then
-            echo '{"status":"failed","reason":"no_database_url_configured"}' > db-authz-output.json
-            echo "H-P0-04 requires live database authorization secrets on the staging Environment."
-            echo "Configure the auth/app, asset-graph, and optional coordination/postgres URL secrets."
+
+          # Fail closed on missing required boundaries before authz runs.
+          # The checker only validates URLs that are present, so a partial
+          # secret set must not pass H-P0-04 (parity with production-promotion).
+          if [ -z "$ASSET_GRAPH_DATABASE_URL" ]; then
+            reason='missing_asset_graph_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the asset-graph DB secret on staging."
             exit 1
           fi
+          if [ -z "${DATABASE_URL}${POSTGRES_URL}" ]; then
+            reason='missing_auth_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the auth/app DB secret on staging."
+            exit 1
+          fi
+          if [ -z "$COORDINATION_DATABASE_URL" ]; then
+            reason='missing_coordination_database_url'
+            echo "{\"status\":\"failed\",\"reason\":\"$reason\"}" \
+              > db-authz-output.json
+            echo "H-P0-04 requires the coordination DB secret on staging."
+            exit 1
+          fi
+
           # GitHub injects unset secrets as empty strings. An empty value makes
           # the checker reject config instead of applying default roles, so
           # drop it before invocation.

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -54,6 +54,12 @@ jobs:
             echo "Configure the auth/app, asset-graph, and optional coordination/postgres URL secrets."
             exit 1
           fi
+          # GitHub injects unset secrets as empty strings. An empty value makes
+          # the checker reject config instead of applying default roles, so
+          # drop it before invocation.
+          if [ -z "$FARDB_UNTRUSTED_DATABASE_ROLES" ]; then
+            unset FARDB_UNTRUSTED_DATABASE_ROLES
+          fi
           set +e
           # Bounded stdout/stderr only (control ids/messages). Do not upload raw logs as artifacts.
           python scripts/check_database_authorization.py

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -367,9 +367,16 @@ db_authz: PASS|<opaque-workflow-run-or-artifact-id>
 `db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must match an
 allowed run/artifact shape: `run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or a numeric
 workflow run ID (at least 6 digits). Placeholders such as `TBD`, `TODO`, or angle-bracket templates are
-rejected. Staging promotion fails closed when database URL secrets are missing so H-P0-04 cannot be
-satisfied by a copied template alone. Do not embed connection strings, role inventories, or topology
-details from the authorization checker.
+rejected. Staging and production promotion fail closed when required database URL secrets are missing so
+H-P0-04 cannot be satisfied by a copied template alone. On the release-evidence Assert path,
+`hardening_tier=P0` (default) also fails closed when database authorization is skipped or failed; use
+`hardening_tier=none` only for soft rehearsal. Do not embed connection strings, role inventories, or
+topology details from the authorization checker.
+
+**H-P0-04 remaining for Satisfied:** attach a target-environment redacted `db_authz: PASS|<opaque-ref>`
+from a staging (or production) promotion / release-evidence run that executed
+`scripts/check_database_authorization.py` successfully. Repository wiring alone does not close the live
+authorization gate (ADR 0007 / FPC-2026-07-21-01).
 
 Release-evidence dispatch: set `hardening_tier=P0` (default) so hosted readiness cannot SKIP under the Assert path.
 Use `hardening_tier=none` only for soft rehearsal runs that must not be treated as RC proof.

--- a/docs/release-evidence-pack.md
+++ b/docs/release-evidence-pack.md
@@ -367,11 +367,13 @@ db_authz: PASS|<opaque-workflow-run-or-artifact-id>
 `db_authz` **requires** `PASS|<opaque-ref>` (bare `PASS` is rejected). The opaque ref must match an
 allowed run/artifact shape: `run-<digits>`, `artifact-<digits>`, `<prefix>-run-<digits>`, or a numeric
 workflow run ID (at least 6 digits). Placeholders such as `TBD`, `TODO`, or angle-bracket templates are
-rejected. Staging and production promotion fail closed when required database URL secrets are missing so
-H-P0-04 cannot be satisfied by a copied template alone. On the release-evidence Assert path,
-`hardening_tier=P0` (default) also fails closed when database authorization is skipped or failed; use
-`hardening_tier=none` only for soft rehearsal. Do not embed connection strings, role inventories, or
-topology details from the authorization checker.
+rejected. Staging and production promotion fail closed when any required boundary secret is missing
+(asset-graph, auth/app or postgres fallback, and coordination) so H-P0-04 cannot pass on a partial
+URL set or a copied template alone. On the release-evidence Assert path, `hardening_tier=P0`
+(default) also fails closed when database authorization is skipped or failed, and the authz step
+applies the same per-boundary prechecks before the checker runs; use `hardening_tier=none` only for
+soft rehearsal. Do not embed connection strings, role inventories, or topology details from the
+authorization checker.
 
 **H-P0-04 remaining for Satisfied:** attach a target-environment redacted `db_authz: PASS|<opaque-ref>`
 from a staging (or production) promotion / release-evidence run that executed

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -50,7 +50,7 @@ Do not reopen closed PR1–9 rows; track hardening here and in the evidence pack
 | H-P0-01           | Satisfied - documented               | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination)  | Runtime rebuild changes                  |
 | H-P0-02           | Satisfied - documented               | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart                    | Schema migrations                        |
 | H-P0-03           | Satisfied - automated                | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness             | Soft rehearsal (`hardening_tier=none`)   |
-| H-P0-04           | Partially satisfied                  | DB authorization checker wired; redacted PASS attached for target env                            | Publishing live role/topology details    |
+| H-P0-04           | Partially satisfied                  | Fail-closed wiring in release-evidence (P0) + staging/production; live redacted PASS still required | Publishing live role/topology details    |
 | H-P0-05           | Satisfied - documented               | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms                  | Hosted infra changes                     |
 | H-P0-06           | Satisfied - manual evidence required | Fresh SHA-bound RC companion (RC1 not reused as CURRENT)                                         | Bundling unrelated product work          |
 | H-P1-01           | Satisfied - automated                | `--require-persistence` auto-enables `--assets-smoke` in hosted readiness                        | Empty persisted graphs fail promotion    |

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -56,7 +56,7 @@ Do not reopen closed PR1–9 rows; track hardening here and in the evidence pack
 | H-P1-01           | Satisfied - automated                | `--require-persistence` auto-enables `--assets-smoke` in hosted readiness                           | Empty persisted graphs fail promotion    |
 | H-P1-02           | Satisfied - automated                | `production-promotion.yml` twin of staging (prod Environment + persistence/assets smoke)            | Mixing with Docker/compose P1 work       |
 | H-P1-03           | Satisfied - automated                | `post-recovery-readiness.yml` mandatory re-smoke + context-named artifacts                          | Reusing promotion artifact names         |
-| H-P1-04           | Satisfied - documented               | Policy ↔ Mergify ↔ workflow job names reconciled; maintainer must apply BP names in GitHub UI       | Hard-requiring path-filtered frontend-ci |
+| H-P1-04           | Satisfied - documented               | Policy ↔ Mergify ↔ workflow job names reconciled; maintainer must apply BP names in GitHub UI     | Hard-requiring path-filtered frontend-ci |
 | H-P1-05           | Satisfied - automated                | Gradio Docker CI labeled non-prod; production-container rebuild→restart persistence+assets smoke    | Mixing with hosted promotion evidence    |
 | H-P1-06           | Satisfied - automated                | See evidence pack                                                                                   | Mixing P1 Docker work with P0 docs       |
 | H-P2-01 … H-P2-05 | Partially satisfied                  | See evidence pack                                                                                   | P0 gate wiring                           |

--- a/docs/roadmap/enterprise-readiness-pr-board.md
+++ b/docs/roadmap/enterprise-readiness-pr-board.md
@@ -45,22 +45,22 @@ Canon IDs and automation mapping live in
 [Release Evidence Pack — Hardening backlog](../release-evidence-pack.md#hardening-backlog-p0p3).
 Do not reopen closed PR1–9 rows; track hardening here and in the evidence pack only.
 
-| ID                | Status                               | Exit criteria (short)                                                                            | Do not bundle with                       |
-| ----------------- | ------------------------------------ | ------------------------------------------------------------------------------------------------ | ---------------------------------------- |
-| H-P0-01           | Satisfied - documented               | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination)  | Runtime rebuild changes                  |
-| H-P0-02           | Satisfied - documented               | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart                    | Schema migrations                        |
-| H-P0-03           | Satisfied - automated                | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness             | Soft rehearsal (`hardening_tier=none`)   |
+| ID                | Status                               | Exit criteria (short)                                                                               | Do not bundle with                       |
+| ----------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| H-P0-01           | Satisfied - documented               | Runbook/ADR table placement matches code (`rebuild_jobs` on Asset Graph; locks on coordination)     | Runtime rebuild changes                  |
+| H-P0-02           | Satisfied - documented               | Post-restore cleanup is table-scoped; job-boundary `running=0` before restart                       | Schema migrations                        |
+| H-P0-03           | Satisfied - automated                | `release-evidence-verify` with `hardening_tier=P0` fails on SKIPPED hosted readiness                | Soft rehearsal (`hardening_tier=none`)   |
 | H-P0-04           | Partially satisfied                  | Fail-closed wiring in release-evidence (P0) + staging/production; live redacted PASS still required | Publishing live role/topology details    |
-| H-P0-05           | Satisfied - documented               | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms                  | Hosted infra changes                     |
-| H-P0-06           | Satisfied - manual evidence required | Fresh SHA-bound RC companion (RC1 not reused as CURRENT)                                         | Bundling unrelated product work          |
-| H-P1-01           | Satisfied - automated                | `--require-persistence` auto-enables `--assets-smoke` in hosted readiness                        | Empty persisted graphs fail promotion    |
-| H-P1-02           | Satisfied - automated                | `production-promotion.yml` twin of staging (prod Environment + persistence/assets smoke)         | Mixing with Docker/compose P1 work       |
-| H-P1-03           | Satisfied - automated                | `post-recovery-readiness.yml` mandatory re-smoke + context-named artifacts                       | Reusing promotion artifact names         |
-| H-P1-04           | Satisfied - documented               | Policy ↔ Mergify ↔ workflow job names reconciled; maintainer must apply BP names in GitHub UI  | Hard-requiring path-filtered frontend-ci |
-| H-P1-05           | Satisfied - automated                | Gradio Docker CI labeled non-prod; production-container rebuild→restart persistence+assets smoke | Mixing with hosted promotion evidence    |
-| H-P1-06           | Satisfied - automated                | See evidence pack                                                                                | Mixing P1 Docker work with P0 docs       |
-| H-P2-01 … H-P2-05 | Partially satisfied                  | See evidence pack                                                                                | P0 gate wiring                           |
-| H-P3-01 … H-P3-05 | Partially satisfied                  | See evidence pack                                                                                | P0/P1 release gates                      |
+| H-P0-05           | Satisfied - documented               | ADR 0002 / `.env.example` match runtime Postgres + recommended SQLite URL forms                     | Hosted infra changes                     |
+| H-P0-06           | Satisfied - manual evidence required | Fresh SHA-bound RC companion (RC1 not reused as CURRENT)                                            | Bundling unrelated product work          |
+| H-P1-01           | Satisfied - automated                | `--require-persistence` auto-enables `--assets-smoke` in hosted readiness                           | Empty persisted graphs fail promotion    |
+| H-P1-02           | Satisfied - automated                | `production-promotion.yml` twin of staging (prod Environment + persistence/assets smoke)            | Mixing with Docker/compose P1 work       |
+| H-P1-03           | Satisfied - automated                | `post-recovery-readiness.yml` mandatory re-smoke + context-named artifacts                          | Reusing promotion artifact names         |
+| H-P1-04           | Satisfied - documented               | Policy ↔ Mergify ↔ workflow job names reconciled; maintainer must apply BP names in GitHub UI       | Hard-requiring path-filtered frontend-ci |
+| H-P1-05           | Satisfied - automated                | Gradio Docker CI labeled non-prod; production-container rebuild→restart persistence+assets smoke    | Mixing with hosted promotion evidence    |
+| H-P1-06           | Satisfied - automated                | See evidence pack                                                                                   | Mixing P1 Docker work with P0 docs       |
+| H-P2-01 … H-P2-05 | Partially satisfied                  | See evidence pack                                                                                   | P0 gate wiring                           |
+| H-P3-01 … H-P3-05 | Partially satisfied                  | See evidence pack                                                                                   | P0/P1 release gates                      |
 
 ## Board Notes
 

--- a/docs/strategy/fardb-project-continuity.md
+++ b/docs/strategy/fardb-project-continuity.md
@@ -67,7 +67,8 @@ Primary authorities:
 - **Repository scope:** `docs/adr/0007-database-authorization-boundary.md`,
   `scripts/check_database_authorization.py`, provider configuration, restricted closure evidence, release record.
   Workflow wiring exists in `release-evidence-verify.yml`, `staging-promotion.yml`, and `production-promotion.yml`
-  (H-P0-04 Partially satisfied).
+  (H-P0-04 Partially satisfied). Assert-path `hardening_tier=P0` fails closed when DB authz is skipped; staging and
+  production promotion fail closed when required DB URL secrets are missing.
 - **Dependencies or blockers:** Live inventory; least-privilege role and policy design; negative tests; application,
   recovery, and restore regression proof; provider advisers; credential review; operator approval; Environment secrets
   for staging/production promotion paths.
@@ -75,8 +76,9 @@ Primary authorities:
   explicitly says that it does not mutate the live database or close the gate without target-environment evidence.
 - **Next action and completion test:** Execute ADR 0007's remediation sequence against staging, preserve sensitive
   findings in a restricted record, and attach a redacted pass result showing every exit criterion is satisfied or a
-  named, time-bounded exception is approved.
-- **Last updated:** 2026-07-21
+  named, time-bounded exception is approved. Public evidence marker form:
+  `db_authz: PASS|<opaque-workflow-run-or-artifact-id>`.
+- **Last updated:** 2026-07-22
 
 ### FPC-2026-07-21-02 — Prove release repeatability for the exact artefact
 
@@ -377,10 +379,9 @@ Primary authorities:
 ### Next highest-value action
 
 Close FPC-2026-07-21-01: execute and evidence the ADR 0007 hosted database authorization contract in staging. This is
-the nearest release blocker and a prerequisite for credible sensitive-domain or enterprise positioning.
-
-Repository automation follow-through (merge #1510 / H-P1-03, then H-P1-04/H-P1-05 as scoped) supports
-FPC-2026-07-21-02 but does not substitute for live authorization closure.
+the nearest release blocker and a prerequisite for credible sensitive-domain or enterprise positioning. Repository
+Assert-path fail-closed wiring for skipped DB authz does not substitute for a live redacted
+`db_authz: PASS|<opaque-ref>`.
 
 ### Completion test
 

--- a/docs/strategy/fardb-project-continuity.md
+++ b/docs/strategy/fardb-project-continuity.md
@@ -67,8 +67,9 @@ Primary authorities:
 - **Repository scope:** `docs/adr/0007-database-authorization-boundary.md`,
   `scripts/check_database_authorization.py`, provider configuration, restricted closure evidence, release record.
   Workflow wiring exists in `release-evidence-verify.yml`, `staging-promotion.yml`, and `production-promotion.yml`
-  (H-P0-04 Partially satisfied). Assert-path `hardening_tier=P0` fails closed when DB authz is skipped; staging and
-  production promotion fail closed when required DB URL secrets are missing.
+  (H-P0-04 Partially satisfied). Assert-path `hardening_tier=P0` fails closed when DB authz is skipped; staging,
+  production, and release-evidence authz steps fail closed when any required boundary secret is missing
+  (asset-graph, auth/app or postgres fallback, and coordination).
 - **Dependencies or blockers:** Live inventory; least-privilege role and policy design; negative tests; application,
   recovery, and restore regression proof; provider advisers; credential review; operator approval; Environment secrets
   for staging/production promotion paths.
@@ -398,7 +399,7 @@ time-bounded exception.
 - Repository agent instructions and production-architecture declaration.
 - Enterprise-readiness index, audit, roadmap, PR board, validation-gap audit, release checklist, release evidence pack,
   hosted staging baseline, operational evidence framework, drill and scale-validation documents, and risk register.
-- ADRs and governance authorities referenced by those indexes, including ADRs 0001, 0002, 0005, 0006, and 0007.
+- ADRs and governance authorities referenced by those indices, including ADRs 0001, 0002, 0005, 0006, and 0007.
 - RC1 committed evidence record and its repository companion issue record.
 - Current-state strategy, claims taxonomy, and Big Read chronology.
 - Merged hardening PRs #1506, #1508, #1509 and open PR #1510.

--- a/tests/integration/test_hp004_db_authz_workflows.py
+++ b/tests/integration/test_hp004_db_authz_workflows.py
@@ -1,0 +1,82 @@
+"""Contract tests for H-P0-04 database authorization gate wiring."""
+
+from pathlib import Path
+
+import pytest
+import yaml  # type: ignore[import-untyped]
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RELEASE_EVIDENCE_PATH = REPO_ROOT / ".github" / "workflows" / "release-evidence-verify.yml"
+STAGING_PROMOTION_PATH = REPO_ROOT / ".github" / "workflows" / "staging-promotion.yml"
+PRODUCTION_PROMOTION_PATH = REPO_ROOT / ".github" / "workflows" / "production-promotion.yml"
+
+
+@pytest.fixture(name="release_evidence_raw")
+def release_evidence_raw_fixture() -> str:
+    """Return raw release-evidence-verify.yml text."""
+    return RELEASE_EVIDENCE_PATH.read_text(encoding="utf-8")
+
+
+@pytest.fixture(name="staging_promotion_raw")
+def staging_promotion_raw_fixture() -> str:
+    """Return raw staging-promotion.yml text."""
+    return STAGING_PROMOTION_PATH.read_text(encoding="utf-8")
+
+
+def test_release_evidence_workflow_exists() -> None:
+    """H-P0-04 requires the release-evidence Assert path workflow."""
+    assert RELEASE_EVIDENCE_PATH.is_file()
+
+
+def test_release_evidence_invokes_database_authorization_checker(release_evidence_raw: str) -> None:
+    """Release-evidence must run the ADR 0007 bounded checker."""
+    assert "check_database_authorization.py" in release_evidence_raw
+    assert "gate_db_authz" in release_evidence_raw
+    assert "db-authz-output.json" in release_evidence_raw
+
+
+def test_release_evidence_p0_fails_closed_on_skipped_db_authz(release_evidence_raw: str) -> None:
+    """hardening_tier=P0 must require db_authz status=passed (H-P0-04)."""
+    assert 'db_authz_status" != "passed"' in release_evidence_raw or (
+        '[ "$db_authz_status" != "passed" ]' in release_evidence_raw
+    )
+    assert "Strict RC promotion requires database authorization to pass" in release_evidence_raw
+    assert "hardening_tier=none" in release_evidence_raw
+
+
+def test_release_evidence_unsets_empty_untrusted_roles(release_evidence_raw: str) -> None:
+    """Empty FARDB_UNTRUSTED_DATABASE_ROLES must not block default roles."""
+    assert "unset FARDB_UNTRUSTED_DATABASE_ROLES" in release_evidence_raw
+    assert 'if [ -z "$FARDB_UNTRUSTED_DATABASE_ROLES" ]' in release_evidence_raw
+
+
+def test_staging_promotion_fails_closed_without_db_secrets(staging_promotion_raw: str) -> None:
+    """Staging promotion must not soft-skip H-P0-04 when secrets are missing."""
+    assert "no_database_url_configured" in staging_promotion_raw
+    assert '"status":"failed","reason":"no_database_url_configured"' in staging_promotion_raw
+    assert "H-P0-04 requires live database authorization secrets" in staging_promotion_raw
+    assert "check_database_authorization.py" in staging_promotion_raw
+
+
+def test_staging_promotion_unsets_empty_untrusted_roles(staging_promotion_raw: str) -> None:
+    """Staging must match production unset behavior for empty untrusted-roles secret."""
+    assert "unset FARDB_UNTRUSTED_DATABASE_ROLES" in staging_promotion_raw
+    assert 'if [ -z "$FARDB_UNTRUSTED_DATABASE_ROLES" ]' in staging_promotion_raw
+
+
+def test_production_promotion_still_enforces_db_authz() -> None:
+    """Production twin must keep H-P0-04 fail-closed wiring."""
+    text = PRODUCTION_PROMOTION_PATH.read_text(encoding="utf-8")
+    assert "check_database_authorization.py" in text
+    assert "unset FARDB_UNTRUSTED_DATABASE_ROLES" in text
+    assert "Database authorization gate failed (H-P0-04)" in text
+
+
+def test_release_evidence_parses_as_workflow() -> None:
+    """release-evidence-verify.yml must remain valid YAML for Actions."""
+    with open(RELEASE_EVIDENCE_PATH, encoding="utf-8") as handle:
+        data = yaml.safe_load(handle)
+    assert isinstance(data, dict)
+    if True in data and "on" not in data:
+        data["on"] = data.pop(True)
+    assert "jobs" in data

--- a/tests/integration/test_hp004_db_authz_workflows.py
+++ b/tests/integration/test_hp004_db_authz_workflows.py
@@ -37,9 +37,7 @@ def test_release_evidence_invokes_database_authorization_checker(release_evidenc
 
 def test_release_evidence_p0_fails_closed_on_skipped_db_authz(release_evidence_raw: str) -> None:
     """hardening_tier=P0 must require db_authz status=passed (H-P0-04)."""
-    assert 'db_authz_status" != "passed"' in release_evidence_raw or (
-        '[ "$db_authz_status" != "passed" ]' in release_evidence_raw
-    )
+    assert '[ "$db_authz_status" != "passed" ]' in release_evidence_raw
     assert "Strict RC promotion requires database authorization to pass" in release_evidence_raw
     assert "hardening_tier=none" in release_evidence_raw
 
@@ -72,11 +70,8 @@ def test_production_promotion_still_enforces_db_authz() -> None:
     assert "Database authorization gate failed (H-P0-04)" in text
 
 
-def test_release_evidence_parses_as_workflow() -> None:
+def test_release_evidence_parses_as_workflow(release_evidence_raw: str) -> None:
     """release-evidence-verify.yml must remain valid YAML for Actions."""
-    with open(RELEASE_EVIDENCE_PATH, encoding="utf-8") as handle:
-        data = yaml.safe_load(handle)
+    data = yaml.safe_load(release_evidence_raw)
     assert isinstance(data, dict)
-    if True in data and "on" not in data:
-        data["on"] = data.pop(True)
     assert "jobs" in data

--- a/tests/integration/test_hp004_db_authz_workflows.py
+++ b/tests/integration/test_hp004_db_authz_workflows.py
@@ -38,8 +38,26 @@ def test_release_evidence_invokes_database_authorization_checker(release_evidenc
 def test_release_evidence_p0_fails_closed_on_skipped_db_authz(release_evidence_raw: str) -> None:
     """hardening_tier=P0 must require db_authz status=passed (H-P0-04)."""
     assert '[ "$db_authz_status" != "passed" ]' in release_evidence_raw
-    assert "Strict RC promotion requires database authorization to pass" in release_evidence_raw
+    assert "database authorization (H-P0-04)" in release_evidence_raw
     assert "hardening_tier=none" in release_evidence_raw
+
+
+def test_release_evidence_aggregates_strict_gate_failures(release_evidence_raw: str) -> None:
+    """Strict Assert path must report readiness, docs, and db_authz failures together."""
+    assert 'FAILURES=""' in release_evidence_raw
+    assert "hosted readiness" in release_evidence_raw
+    assert "docs readiness" in release_evidence_raw
+    assert "Strict RC promotion requires the following to pass:" in release_evidence_raw
+
+
+def test_release_evidence_requires_all_db_boundaries(release_evidence_raw: str) -> None:
+    """Partial URL secret sets must not produce db_authz passed (production parity)."""
+    assert "missing_asset_graph_database_url" in release_evidence_raw
+    assert "missing_auth_database_url" in release_evidence_raw
+    assert "missing_coordination_database_url" in release_evidence_raw
+    assert 'if [ -z "$ASSET_GRAPH_DATABASE_URL" ]' in release_evidence_raw
+    assert 'if [ -z "$COORDINATION_DATABASE_URL" ]' in release_evidence_raw
+    assert 'if [ -z "${DATABASE_URL}${POSTGRES_URL}" ]' in release_evidence_raw
 
 
 def test_release_evidence_unsets_empty_untrusted_roles(release_evidence_raw: str) -> None:
@@ -49,10 +67,11 @@ def test_release_evidence_unsets_empty_untrusted_roles(release_evidence_raw: str
 
 
 def test_staging_promotion_fails_closed_without_db_secrets(staging_promotion_raw: str) -> None:
-    """Staging promotion must not soft-skip H-P0-04 when secrets are missing."""
-    assert "no_database_url_configured" in staging_promotion_raw
-    assert '"status":"failed","reason":"no_database_url_configured"' in staging_promotion_raw
-    assert "H-P0-04 requires live database authorization secrets" in staging_promotion_raw
+    """Staging promotion must fail closed on missing required H-P0-04 boundaries."""
+    assert "missing_asset_graph_database_url" in staging_promotion_raw
+    assert "missing_auth_database_url" in staging_promotion_raw
+    assert "missing_coordination_database_url" in staging_promotion_raw
+    assert "no_database_url_configured" not in staging_promotion_raw
     assert "check_database_authorization.py" in staging_promotion_raw
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective
Advance **H-P0-04** by closing the remaining repository automation gap: the release-evidence Assert path (`hardening_tier=P0`) must fail closed when database authorization is skipped, matching staging/production promotion posture.

## In Scope
- `release-evidence-verify.yml`: P0/strict requires `db_authz` status=`passed` (skipped is no longer allowed)
- Unset empty `FARDB_UNTRUSTED_DATABASE_ROLES` on staging + release-evidence (parity with production)
- Contract tests in `tests/integration/test_hp004_db_authz_workflows.py`
- Evidence pack / PR board / continuity ledger notes clarifying live redacted PASS is still required
- CI/review follow-ups: no secret-name `echo`s; tighter contract assertions

## Out of Scope
- Live staging/production authorization remediation or attaching a real `db_authz: PASS|<opaque-ref>`
- Publishing role inventories, topology, or provider adviser details
- Marking H-P0-04 Satisfied (remains **Partially satisfied** until target-env redacted PASS)

## Validation
```bash
pytest tests/integration/test_hp004_db_authz_workflows.py \
  tests/integration/test_workflow_security_advanced.py::TestWorkflowSecretHandling::test_secrets_not_echoed_in_logs -q
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail-close H-P0-04 database authorization on the P0 release-evidence Assert path and align staging with production by requiring all DB boundary secrets and aggregating strict gate failures into one message. A live redacted `db_authz: PASS|<opaque-ref>` is still required for full closure.

- New Features
  - `release-evidence-verify.yml`: P0 requires `db_authz` status=passed; fail closed if any of asset-graph, auth/app (or postgres), or coordination DB secrets are missing; unset empty `FARDB_UNTRUSTED_DATABASE_ROLES`; aggregate strict failures (readiness, docs, db authz) into one message; soft (`hardening_tier=none`) still allows passed or skipped.
  - `staging-promotion.yml`: same boundary prechecks; unset empty `FARDB_UNTRUSTED_DATABASE_ROLES` (production parity).
  - Contract tests `tests/integration/test_hp004_db_authz_workflows.py` cover strict fail-closed, boundary prechecks, unset guard, staging/production enforcement, YAML validity; docs updated to reflect Assert-path and promotion posture.

- Bug Fixes
  - Sanitized echo guidance to avoid secret identifiers; tightened contract assertions.
  - Formatted `docs/roadmap/enterprise-readiness-pr-board.md` with Prettier 3.3.3 so Super-linter `MARKDOWN_PRETTIER` passes.

<sup>Written for commit 7985109a9a5e403a4ff9e01555c53f1484da0905. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR closes the H-P0-04 fail-closed gap on the release-evidence Assert path by requiring `db_authz: passed` (not just non-failed) when `hardening_tier=P0`, and hardens both the release-evidence and staging promotion workflows with per-boundary DB secret prechecks before the authorization checker runs. A live redacted `db_authz: PASS|<opaque-ref>` from a target-environment run is still required before H-P0-04 can be marked Satisfied.

- **`release-evidence-verify.yml`**: Adds individual prechecks for `ASSET_GRAPH_DATABASE_URL`, `DATABASE_URL`/`POSTGRES_URL`, and `COORDINATION_DATABASE_URL` (failing with a specific reason JSON if any is absent), adds `unset FARDB_UNTRUSTED_DATABASE_ROLES` when the secret is empty, and replaces the single readiness+docs early-exit with a `FAILURES` accumulation that reports all strict-gate blockers (readiness, docs, db_authz) in one diagnostic message.
- **`staging-promotion.yml`**: Replaces the old combined all-URL-missing check with the same per-boundary prechecks and `unset FARDB_UNTRUSTED_DATABASE_ROLES` guard, removing the `no_database_url_configured` skip path that staging should never have allowed.
- **`tests/integration/test_hp004_db_authz_workflows.py`**: New contract tests validate the fail-closed wiring, per-boundary precheck strings, unset-roles guard, and YAML validity across release-evidence, staging, and production workflows.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the gate changes are well-structured and fail closed in all target scenarios.

The workflow logic correctly enforces per-boundary prechecks before the authz checker runs, the FAILURES aggregation works as intended for the skipped-vs-passed distinction, and staging/production parity is achieved. The one finding is a test docstring that promises three-way coverage but only asserts two of the three FAILURES entries — a gap in contract coverage, not in the production gate itself.

tests/integration/test_hp004_db_authz_workflows.py — the aggregation test could add one assertion to fully match its docstring.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-evidence-verify.yml | Adds per-boundary DB secret prechecks before the authz checker runs and replaces the single readiness+docs early-exit with a FAILURES aggregation that surfaces all strict-gate blockers (readiness, docs, db_authz) in one message; soft-rehearsal path correctly allows skipped, strict P0 path fails closed on skipped. |
| .github/workflows/staging-promotion.yml | Replaces single all-empty DB URL check with per-boundary prechecks (matching release-evidence) and adds `unset FARDB_UNTRUSTED_DATABASE_ROLES` guard for production parity; old `no_database_url_configured` path removed as expected. |
| tests/integration/test_hp004_db_authz_workflows.py | New contract test file covering strict fail-closed, per-boundary prechecks, untrusted-roles unset, staging/production enforcement, and YAML validity; `test_release_evidence_aggregates_strict_gate_failures` docstring promises three-way coverage but assertions only verify two of the three FAILURES entries. |
| docs/release-evidence-pack.md | Documentation accurately reflects the new per-boundary precheck requirement, clarifies hardening_tier=P0 fail-closed posture on the Assert path, and adds the H-P0-04 remaining-for-Satisfied note. |
| docs/roadmap/enterprise-readiness-pr-board.md | H-P0-04 row updated to reflect the new fail-closed wiring across release-evidence, staging, and production; status correctly remains Partially satisfied. |
| docs/strategy/fardb-project-continuity.md | FPC-2026-07-21-01 updated to document Assert-path fail-closed behavior and per-boundary precheck scope; last-updated date bumped; minor fix from indexes to indices. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Check Database Authorization step
continue-on-error: true] --> B{All 4 DB URLs
empty?}
    B -- Yes --> C[Write status:skipped
no_database_url_configured
exit 0]
    B -- No --> D{ASSET_GRAPH_DATABASE_URL
present?}
    D -- No --> E[Write status:failed
missing_asset_graph...
exit 1]
    D -- Yes --> F{DATABASE_URL or
POSTGRES_URL present?}
    F -- No --> G[Write status:failed
missing_auth...
exit 1]
    F -- Yes --> H{COORDINATION_DATABASE_URL
present?}
    H -- No --> I[Write status:failed
missing_coordination...
exit 1]
    H -- Yes --> J[Unset empty FARDB_UNTRUSTED_DATABASE_ROLES
Run checker script]
    J --> K{Checker exit code 0?}
    K -- Yes --> L[Write status:passed]
    K -- No --> M[Write status:failed
exit 1]
    C & L & M & E & G & I --> N[Assert All Gates Passed step]
    N --> O{db_authz_status==failed OR
gate_db_authz.outcome==failure?}
    O -- Yes --> P[Exit 1: Database authorization gate failed]
    O -- No --> Q{EFFECTIVE_STRICT == true?}
    Q -- Yes --> R[Collect FAILURES:
readiness + docs + db_authz
if any != passed]
    R --> S{FAILURES non-empty?}
    S -- Yes --> T[Exit 1: Strict RC promotion requires all listed to pass]
    S -- No --> U[Gate passes]
    Q -- No --> V{Each of readiness/docs/authz
== passed or skipped?}
    V -- No --> W[Exit 1]
    V -- Yes --> U
```

<sub>Reviews (4): Last reviewed commit: ["fix: format PR board with Super-linter P..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/7985109a9a5e403a4ff9e01555c53f1484da0905) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46339857)</sub>

<!-- /greptile_comment -->