### PR TITLE
docs: post-#1520 GitHub Environment readiness for H-P0-04

### DIFF
--- a/.github/ISSUE_TEMPLATE/database_authorization_closure.md
+++ b/.github/ISSUE_TEMPLATE/database_authorization_closure.md
@@ -21,11 +21,18 @@ assignees: ""
 - [Public redacted pass template](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/evidence-records/templates/db-authz-public-redacted-pass.md)
 - [Restricted worksheet template](https://github.com/DashFin-FarDb/financial-asset-relationship-db/blob/main/docs/evidence-records/templates/db-authz-restricted-closure.md)
 
+## GitHub Environment readiness
+
+- [ ] `staging` Environment exists (for `staging-promotion`)
+- [ ] `staging-manual-gate` Environment exists (tagged dispatches)
+- [ ] `release-evidence` Environment exists (for `release-evidence-verify`)
+- [ ] `production` / `production-manual-gate` Environments exist when closing production
+
 ## Environment secret readiness (presence only)
 
-- [ ] `ASSET_GRAPH_DATABASE_URL` present on the GitHub Environment
-- [ ] `DATABASE_URL` or `POSTGRES_URL` present
-- [ ] `COORDINATION_DATABASE_URL` present
+- [ ] `ASSET_GRAPH_DATABASE_URL` present on every Environment the selected workflow can enter
+- [ ] `DATABASE_URL` or `POSTGRES_URL` present on those Environments
+- [ ] `COORDINATION_DATABASE_URL` present on those Environments
 - [ ] Empty `FARDB_UNTRUSTED_DATABASE_ROLES` left unset (or intentional custom value retained in restricted record)
 - [ ] If any boundary uses the global/default inventory: Environment **secret** `FARDB_EXPOSED_DATABASE_SCHEMAS` set to the full inventoried list (include `public` when exposed; or confirmed `public`-only). Skip when every boundary uses an override
 - [ ] Per-boundary overrides set where needed (`FARDB_EXPOSED_DATABASE_SCHEMAS_DATABASE` / `_ASSET_GRAPH` / `_COORDINATION` / `_POSTGRES`)

--- a/.github/ISSUE_TEMPLATE/database_authorization_closure.md
+++ b/.github/ISSUE_TEMPLATE/database_authorization_closure.md
@@ -24,7 +24,8 @@ assignees: ""
 ## GitHub Environment readiness
 
 - [ ] `staging` Environment exists (for `staging-promotion`)
-- [ ] `staging-manual-gate` Environment exists (tagged dispatches)
+- [ ] `staging-manual-gate` Environment exists (for `staging-promotion` /
+      `release-evidence-verify` when tags include `[manual-stop]` or `[star]`)
 - [ ] `release-evidence` Environment exists (for `release-evidence-verify`)
 - [ ] `production` / `production-manual-gate` Environments exist when closing production
 

--- a/docs/runbooks/database-authorization-closure.md
+++ b/docs/runbooks/database-authorization-closure.md
@@ -19,6 +19,19 @@ evidence publicly.
 | Restricted / public worksheets            | Yes (templates under `docs/evidence-records/templates/`) | Complete them for the target env             |
 | Live inventory, roles, policies, advisers | No (must stay restricted)                                | Capture and remediate off-repo               |
 
+## Prerequisites (GitHub Environments)
+
+Workflows bind to named Environments. Create these under repository **Settings → Environments** before attaching
+secrets (GitHub may auto-create an Environment on first dispatch, but secrets are not present until configured):
+
+| Workflow                      | Default Environment | Manual-gate Environment (tags `[manual-stop]` / `[star]`) |
+| ----------------------------- | ------------------- | --------------------------------------------------------- |
+| `staging-promotion.yml`       | `staging`           | `staging-manual-gate`                                     |
+| `release-evidence-verify.yml` | `release-evidence`  | `staging-manual-gate`                                     |
+| `production-promotion.yml`    | `production`        | `production-manual-gate`                                  |
+
+Confirm each Environment the selected workflow can enter exists before treating secret readiness as complete.
+
 ## Prerequisites (GitHub Environment secrets)
 
 Promotion and Assert-path authz steps fail closed unless **all** required boundaries are present:

--- a/docs/staging-deployment-operating-baseline.md
+++ b/docs/staging-deployment-operating-baseline.md
@@ -112,8 +112,9 @@ differ by database URL—or every non-`public` inventory is per-URL—set the fi
 (`FARDB_EXPOSED_DATABASE_SCHEMAS_DATABASE`, `FARDB_EXPOSED_DATABASE_SCHEMAS_ASSET_GRAPH`,
 `FARDB_EXPOSED_DATABASE_SCHEMAS_COORDINATION`, `FARDB_EXPOSED_DATABASE_SCHEMAS_POSTGRES`); each replaces the
 global/default for its URL. The global secret is not required when every boundary uses an override. Unset defaults to
-`public` only. Configure these secrets on every Environment the selected workflow can enter (including
-`*-manual-gate`). Operator procedure:
+`public` only. First confirm the named GitHub Environments exist (`staging`, `staging-manual-gate`,
+`release-evidence`, and production twins as applicable), then configure these secrets on every Environment the
+selected workflow can enter (including `*-manual-gate`). Operator procedure:
 [Database authorization closure runbook](runbooks/database-authorization-closure.md).
 
 Record only variable presence, provider labels, project labels, redacted URLs, and reviewer sign-off.

--- a/docs/strategy/fardb-project-continuity.md
+++ b/docs/strategy/fardb-project-continuity.md
@@ -77,15 +77,17 @@ Primary authorities:
   recovery, and restore regression proof; provider advisers; credential review; operator approval; Environment secrets
   for staging/production promotion paths.
 - **Evidence and provenance:** ADR 0007 is accepted and the bounded checker was merged through PR #1482. Fail-closed
-  Assert-path wiring landed through PR #1506. The operator closure setup path (runbook, worksheets, issue template)
-  lands through PR #1520. The ADR explicitly says that it does not mutate the live database or close the gate without
-  target-environment evidence.
-- **Next action and completion test:** Open a `[DB AUTHZ]` closure issue from the template, complete the restricted
-  worksheet offline, configure GitHub Environment secrets, execute ADR 0007's remediation sequence against staging,
-  dispatch staging-promotion (or release-evidence with `hardening_tier=P0`), and attach a redacted
+  Assert-path wiring landed through PR #1506. The operator closure setup path (runbook, worksheets, issue template,
+  per-boundary schema secrets) landed through PR #1520 (`e121b54d` on `main`). The ADR explicitly says that it does
+  not mutate the live database or close the gate without target-environment evidence.
+- **Next action and completion test:** Confirm required GitHub Environments exist (`staging`, `staging-manual-gate`,
+  `release-evidence`, and for production paths `production` / `production-manual-gate`). Open a `[DB AUTHZ]` closure
+  issue from the template, complete the restricted worksheet offline, configure Environment **secrets** on every
+  Environment the selected workflow can enter, execute ADR 0007's remediation sequence against staging, dispatch
+  staging-promotion (or release-evidence with `hardening_tier=P0`), and attach a redacted
   `db_authz: PASS|<opaque-workflow-run-or-artifact-id>` showing every exit criterion is satisfied or a named,
-  time-bounded exception is approved.
-- **Last updated:** 2026-07-22
+  time-bounded exception is approved. Do not mark H-P0-04 Satisfied until that marker is attached.
+- **Last updated:** 2026-07-23
 
 ### FPC-2026-07-21-02 — Prove release repeatability for the exact artefact
 
@@ -386,8 +388,9 @@ Primary authorities:
 ### Next highest-value action
 
 Close **FPC-2026-07-21-01** using the
-[closure runbook](../runbooks/database-authorization-closure.md); see that entry’s **Next action and completion
-test**. Repository Assert-path fail-closed wiring does not substitute for a live redacted
+[closure runbook](../runbooks/database-authorization-closure.md) (operator setup landed in PR #1520); see that
+entry’s **Next action and completion test**. First confirm GitHub Environments exist, then attach secrets and
+remediate. Repository Assert-path fail-closed wiring does not substitute for a live redacted
 `db_authz: PASS|<opaque-ref>`.
 
 ### Completion test

--- a/tests/integration/test_adr0007_closure_setup.py
+++ b/tests/integration/test_adr0007_closure_setup.py
@@ -27,6 +27,9 @@ def test_adr0007_closure_runbook_exists() -> None:
     assert "FARDB_EXPOSED_DATABASE_SCHEMAS" in text
     assert "FARDB_EXPOSED_DATABASE_SCHEMAS_ASSET_GRAPH" in text
     assert "environment **secrets**" in text.lower() or "environment secrets" in text.lower()
+    assert "staging-manual-gate" in text
+    assert "release-evidence" in text
+    assert "Settings → Environments" in text or "settings → environments" in text.lower()
     assert "full" in text.lower() and "inventoried" in text.lower()
     assert "hardening_tier=P0" in text
     assert "repository root" in text.lower()
@@ -66,6 +69,8 @@ def test_adr0007_issue_template_exists() -> None:
     assert "staging-promotion" in text
     assert "production-promotion" in text
     assert "release-evidence-verify" in text
+    assert "`staging` Environment exists" in text
+    assert "`release-evidence` Environment exists" in text
 
 
 def test_env_example_documents_untrusted_roles() -> None:

--- a/tests/integration/test_adr0007_closure_setup.py
+++ b/tests/integration/test_adr0007_closure_setup.py
@@ -70,6 +70,7 @@ def test_adr0007_issue_template_exists() -> None:
     assert "production-promotion" in text
     assert "release-evidence-verify" in text
     assert "`staging` Environment exists" in text
+    assert "`staging-manual-gate` Environment exists" in text
     assert "`release-evidence` Environment exists" in text
 
 


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective
Unblock the next operator step after PR #1520 by making GitHub Environment **existence** an explicit H-P0-04 prerequisite and recording that the ADR 0007 operator setup path has landed on `main`.

## In Scope
- Continuity FPC-2026-07-21-01 provenance: PR #1520 landed (`e121b54d`); next action starts with Environment existence
- Runbook table of workflow → Environment names (`staging`, `staging-manual-gate`, `release-evidence`, production twins)
- Issue template checkboxes for Environment existence before secret readiness
- Staging baseline pointer; contract test coverage

## Out of Scope
- Creating GitHub Environments or attaching live secrets (requires human org access)
- Live DB remediation / marking H-P0-04 Satisfied
- Workflow dispatch against staging

## Why this matters
Repo Environments currently include `production` but do **not** list `staging`, `staging-manual-gate`, or `release-evidence`. Without those Environments, operators cannot attach the required DB authz secrets for the wired workflows.

## Validation
```bash
pytest tests/integration/test_adr0007_closure_setup.py -q
npx prettier@3.3.3 --check docs/runbooks/database-authorization-closure.md
```

## Merge Criteria
- Docs/tests only; does not claim H-P0-04 Satisfied
- Contract tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make GitHub Environment existence a hard prerequisite for H‑P0‑04 database authorization closure and note ADR 0007 operator setup from PR #1520 is on `main`. Updated the runbook with a workflow→Environment table, added Environment readiness checklists to the issue template, clarified staging baseline/strategy docs, and expanded integration tests to enforce the guidance, now including `staging-manual-gate`.

- **Bug Fixes**
  - Added a missing contract test that asserts the `staging-manual-gate` Environment checkbox in the closure issue template, keeping coverage consistent with the runbook and workflow bindings.

<sup>Written for commit 7d7241943f744500bf0442ab5ac3d3f181ca4b1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1523?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Document GitHub Environment prerequisites for the H-P0-04 closure flow**

### What Changed
- The runbook now says the required GitHub Environments must already exist before secrets are added, and it lists the workflow-to-Environment mapping for staging, release evidence, and production.
- The closure issue template now adds a separate checklist for Environment readiness and makes secret checks apply to every Environment a workflow can use.
- The strategy and baseline docs now point operators to confirm Environment existence first, then attach secrets and continue the remediation path.
- Integration tests now verify the docs mention the new Environment readiness steps and names.

### Impact
`✅ Fewer closure setup misses`
`✅ Clearer GitHub Environment setup`
`✅ Safer secret preparation for staging and release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This docs-and-tests PR makes GitHub Environment **existence** an explicit prerequisite for the H-P0-04 database authorization closure path, recording that the ADR 0007 operator setup from PR #1520 has landed on `main` and unblocking the next operator step.

- Adds a "GitHub Environment readiness" checklist section to the issue template, and a workflow-to-Environment mapping table to the runbook, so operators know which Environments (`staging`, `staging-manual-gate`, `release-evidence`, and production twins) must be created before secrets can be attached.
- Updates the staging baseline and continuity strategy docs to place Environment existence ahead of secret configuration in the operator sequence, and extends the contract test suite with assertions that verify each new doc section and checkbox is present.

<h3>Confidence Score: 5/5</h3>

Docs-and-tests only change; no executable code is modified and the contract tests are well-aligned with the new documentation content.

Every changed file is either a Markdown document or a Python contract test. The new test assertions accurately match the strings added to the docs, and the docs themselves consistently order Environment creation before secret configuration across all three authority documents.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/ISSUE_TEMPLATE/database_authorization_closure.md | Adds a "GitHub Environment readiness" section with four ordered checkboxes before the existing secret-readiness checklist; updates secret items to reference "every Environment the selected workflow can enter" |
| docs/runbooks/database-authorization-closure.md | Inserts a new "Prerequisites (GitHub Environments)" section with a workflow-to-Environment mapping table and a note that auto-created Environments will not have secrets pre-configured |
| docs/staging-deployment-operating-baseline.md | Prepends a "first confirm the named GitHub Environments exist" sentence before the secret-configuration instruction to align operator ordering with the runbook |
| docs/strategy/fardb-project-continuity.md | Records PR #1520 provenance (commit e121b54d), updates "Next action" to start with Environment existence confirmation, adds explicit "Do not mark H-P0-04 Satisfied" guard, and refreshes last-updated date |
| tests/integration/test_adr0007_closure_setup.py | Extends two contract test functions with assertions for the new runbook Environment table strings and the three new issue-template Environment existence checkboxes |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Open [DB AUTHZ] closure issue\nfrom template"] --> B{GitHub Environments\nexist?}
    B -->|No| C["Create under Settings → Environments:\n• staging\n• staging-manual-gate\n• release-evidence\n• production / production-manual-gate"]
    C --> D
    B -->|Yes| D["Configure secrets on every\nEnvironment the workflow can enter\n(ASSET_GRAPH_DATABASE_URL,\nDATABASE_URL, COORDINATION_DATABASE_URL,\nFARDB_EXPOSED_DATABASE_SCHEMAS…)"]
    D --> E["Complete restricted worksheet\noffline"]
    E --> F["Execute ADR 0007 remediation\nsequence against staging"]
    F --> G{Dispatch workflow}
    G -->|staging path| H["staging-promotion.yml\n→ staging / staging-manual-gate"]
    G -->|release path| I["release-evidence-verify.yml\nhardening_tier=P0\n→ release-evidence / staging-manual-gate"]
    G -->|production path| J["production-promotion.yml\n→ production / production-manual-gate"]
    H & I & J --> K{"db-authz-output.json\nstatus = passed?"}
    K -->|No| L["Remediate and retry"]
    L --> F
    K -->|Yes| M["Attach redacted marker:\ndb_authz: PASS|opaque-ref"]
    M --> N["Mark H-P0-04 Satisfied"]
```

<sub>Reviews (2): Last reviewed commit: ["fix: cover staging-manual-gate in ADR 00..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/7d7241943f744500bf0442ab5ac3d3f181ca4b1b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46557833)</sub>

<!-- /greptile_comment -->