### PR TITLE
fix: raise hosted readiness timeout for Vercel cold starts

### DIFF
--- a/.github/workflows/hosted-readiness.yml
+++ b/.github/workflows/hosted-readiness.yml
@@ -10,7 +10,7 @@ name: Hosted readiness smoke check
       timeout:
         description: "Request timeout in seconds."
         required: false
-        default: "10"
+        default: "30"
         type: string
       require_persistence:
         description: "Prove persisted graph load rather than fallback generation."

--- a/.github/workflows/post-recovery-readiness.yml
+++ b/.github/workflows/post-recovery-readiness.yml
@@ -32,7 +32,7 @@ on:
       timeout:
         description: Request timeout in seconds
         required: false
-        default: "10"
+        default: "30"
         type: string
       base_url_label:
         description: Operator-safe label for JSON evidence

--- a/.github/workflows/production-promotion.yml
+++ b/.github/workflows/production-promotion.yml
@@ -169,9 +169,10 @@ jobs:
           echo "::add-mask::$URL"
 
           # --require-persistence also enables --assets-smoke.
+          # 30s covers Vercel Python cold starts; script default (5s) is too tight.
           # Temp file avoids empty artifacts on failed runs.
           if ! python scripts/check_hosted_readiness.py \
-            "$URL" --json --require-persistence \
+            "$URL" --json --timeout 30 --require-persistence \
             > readiness-output.tmp; then
             if [ -s readiness-output.tmp ]; then
               mv readiness-output.tmp readiness-output.json

--- a/.github/workflows/release-evidence-verify.yml
+++ b/.github/workflows/release-evidence-verify.yml
@@ -201,7 +201,10 @@ jobs:
           fi
 
           if [ -n "$URL" ]; then
-            python scripts/check_hosted_readiness.py "$URL" --json "${LABEL_ARGS[@]}" $PERSISTENCE_FLAG > readiness-output.json
+            # 30s covers Vercel Python cold starts; script default (5s) is too tight.
+            python scripts/check_hosted_readiness.py \
+              "$URL" --json --timeout 30 "${LABEL_ARGS[@]}" $PERSISTENCE_FLAG \
+              > readiness-output.json
           else
             echo "{}" > readiness-output.json
           fi

--- a/.github/workflows/staging-promotion.yml
+++ b/.github/workflows/staging-promotion.yml
@@ -122,7 +122,10 @@ jobs:
           echo "::add-mask::$URL"
 
           # --require-persistence also enables --assets-smoke (H-P1-01).
-          python scripts/check_hosted_readiness.py "$URL" --json --require-persistence > readiness-output.json
+          # 30s covers Vercel Python cold starts; script default (5s) is too tight.
+          python scripts/check_hosted_readiness.py \
+            "$URL" --json --timeout 30 --require-persistence \
+            > readiness-output.json
 
       - name: Assert Persistence Loaded
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ If branch/ref identity is unclear, stop and verify before proceeding.
 
 ## Quick orientation
 
-This repo contains a Python "asset relationship graph" core, exposed via two UIs:
+This repository contains a Python "asset relationship graph" core, exposed via two UIs:
 
 - **FastAPI + Next.js (PRODUCTION)**: FastAPI backend in `api/` (default `http://localhost:8000`) with Next.js frontend in `frontend/` (default `http://localhost:3000`).
 - **Gradio UI (NON-PRODUCTION)**: `app.py` (default `http://localhost:7860`) calls the graph/visualization code directly. For demos and testing only.
@@ -322,7 +322,10 @@ Configuration + persistence:
 - **Enterprise Readiness:** The system is transitioning to an enterprise-grade posture. Refer to `docs/enterprise-readiness-index.md` for the audit, roadmap, and PR plan. Ensure work aligns with these plans, particularly the rule that **durable persistence is the gating dependency** for restart, promotion, and DR. SQLite compatibility must be preserved.
 - **PR scope guardrails:** All PRs must include Primary Objective, In Scope, Out of Scope, Files Expected to Change, Validation Commands, and Merge Criteria.
 - **High-risk work:** Database, auth, deployment, CI, security scanner config, and persistence changes require low-autonomy contracts. See "High-risk change control" in `.github/AI_AGENT_GUARDRAILS.md`.
-- **Runtime configuration:** use `src/config/settings.py` and `load_settings()` or `get_settings()` for centralized settings. Auth settings (`SECRET_KEY`, `ADMIN_*`), CORS settings, and database URL resolution are centralized through the settings layer. Some legacy/runtime seams may still use direct `os.getenv()` access where migration has been intentionally deferred; do not assume full migration away from environment reads.
+- **Runtime configuration:** use `src/config/settings.py` and `load_settings()` or `get_settings()` for
+  centralized settings. Auth settings (`SECRET_KEY`, `ADMIN_*`), CORS settings, and database URL resolution are
+  centralized through the settings layer. Some legacy/runtime seams may still use direct `os.getenv()` access where
+  migration has been intentionally deferred; do not assume full migration away from environment reads.
 - **Pre-commit hooks:** Run `pre-commit run --files <files>` before committing. Key checks: black (120 char lines), flake8-docstrings (D101/D102/D103), ruff, mypy.
 - **Plotting/visualization:** Standardized on **Plotly** (see `AI_RULES.md`).
 - When changing relationship semantics or graph-derived metrics, expect to update:
@@ -346,13 +349,16 @@ GitHub Actions (`.github/workflows/`) include, among others:
 
 ## Cursor Cloud specific instructions
 
-Environment is Linux with Python 3.12 and Node 22 (Cursor Cloud images may update over time). In Cursor Cloud, dependencies (Python `.venv` + `frontend/node_modules`) are refreshed automatically by the platform-managed startup/update process, so you normally only need to start services and run checks. Standard commands live in the "Common commands" section above and in `run-dev.sh`; the notes below only cover non-obvious cloud gotchas.
+Environment is Linux with Python 3.12 and Node 22 (Cursor Cloud images may update over time). In Cursor Cloud,
+dependencies (Python `.venv` + `frontend/node_modules`) are refreshed automatically by the platform-managed
+startup/update process, so you normally only need to start services and run checks. Standard commands live in the
+"Common commands" section above and in `run-dev.sh`; the notes below only cover non-obvious cloud gotchas.
 
 - **`python` is not on PATH — only `python3`.** In Cursor Cloud, `run-dev.sh` and some docs invoke bare `python`, which fails unless your venv is activated (`source .venv/bin/activate` provides `python`). If `.venv` does not exist yet, create it first with `python3 -m venv .venv`; otherwise activate the venv or substitute `python3`.
-- **SQLite `DATABASE_URL` gotcha (backend won't start otherwise):** this repo uses a **custom URL-to-path resolver** in `api/database.py` (`_resolve_file_path`), _not_ SQLAlchemy URL handling.
+- **SQLite `DATABASE_URL` gotcha (backend won't start otherwise):** this repository uses a **custom URL-to-path resolver** in `api/database.py` (`_resolve_file_path`), _not_ SQLAlchemy URL handling.
   - **Problem:** SQLAlchemy-style `sqlite:///./dev.db` resolves to `/dev.db` under this resolver and is usually unwritable (`sqlite3.OperationalError: unable to open database file`).
   - **Known-bad examples:** `sqlite:///./dev.db`, `sqlite:///./asset_graph.db`.
-  - **Recommended values:** `sqlite:dev.db` (repo-relative), `sqlite:///:memory:`, or an explicit writable absolute path such as `sqlite:////absolute/path/dev.db`.
+  - **Recommended values:** `sqlite:dev.db` (repository-relative), `sqlite:///:memory:`, or an explicit writable absolute path such as `sqlite:////absolute/path/dev.db`.
 - **Backend startup env vars:** importing `api.main` needs `DATABASE_URL` and `SECRET_KEY`; if the auth DB is empty (typical for new SQLite files), also set `ADMIN_USERNAME` + `ADMIN_PASSWORD` to seed the first user (otherwise pre-populate the DB). Example working start:
   ```bash
   DATABASE_URL=sqlite:dev.db \
@@ -371,7 +377,13 @@ Environment is Linux with Python 3.12 and Node 22 (Cursor Cloud images may updat
   ```
   Avoid pasting generated secrets into shared logs/history; prefer a local uncommitted `.env`.
 - **Frontend → backend wiring:** start the frontend with `NEXT_PUBLIC_API_URL=http://localhost:8000` (defaults to that anyway). Public dashboard routes (visualization/metrics/assets) need no login; JWT is only needed for `/api/users/me` and rebuild-admin endpoints (use `/token` to obtain a JWT).
-- **Backend serves sample data by default**; no external DB or `USE_REAL_DATA_FETCHER` needed for local E2E.
+- **Backend serves sample data by default**; no external DB or `USE_REAL_DATA_FETCHER` needed for local end-to-end.
 - **Venv package note:** this image uses Python 3.12 and normally has venv support preinstalled. If that changes or setup is skipped, install the versioned package (`python3.12-venv`) manually (for example: `sudo apt-get install python3.12-venv`).
-- **Known pre-existing test failure (not an environment issue):** `tests/unit/test_workflow_yaml_files.py` fails on `codeql.yml` (via `pytest.fail`) because `.github/workflows/codeql.yml` does not exist in the repo.
-- **Frontend dependency baseline (do not bump past these majors without updating peers):** the frontend must stay on **TypeScript 5.9.x** and **ESLint 9.x**. `@typescript-eslint/*` / `typescript-eslint@8.x` (pulled in transitively by `eslint-config-next@16.x`) pin `typescript` to `>=4.8.4 <6.1.0`, so bumping `typescript` to 7.x (or `eslint`/`@eslint/js` to 10.x ahead of the ecosystem) breaks `npm ci`/`npm install` with an `ERESOLVE` peer-dependency conflict. If you regenerate `frontend/package-lock.json` via `npm install`, run `npm install` a second time before relying on `npm ci` — the first pass can leave the lockfile out of sync with the `overrides` block (`npm ci` then errors with `Missing: glob@... from lock file`).
+- **Known pre-existing test failure (not an environment issue):** `tests/unit/test_workflow_yaml_files.py` fails on `codeql.yml` (via `pytest.fail`) because `.github/workflows/codeql.yml` does not exist in the repository.
+- **Frontend dependency baseline (do not bump past these majors without updating peers):** the frontend must stay on
+  **TypeScript 5.9.x** and **ESLint 9.x**. `@typescript-eslint/*` / `typescript-eslint@8.x` (pulled in transitively by
+  `eslint-config-next@16.x`) pin `typescript` to `>=4.8.4 <6.1.0`, so bumping `typescript` to 7.x (or `eslint` /
+  `@eslint/js` to 10.x ahead of the ecosystem) breaks `npm ci`/`npm install` with an `ERESOLVE` peer-dependency
+  conflict. If you regenerate `frontend/package-lock.json` via `npm install`, run `npm install` a second time before
+  relying on `npm ci` — the first pass can leave the lockfile out of sync with the `overrides` block (`npm ci` then
+  errors with `Missing: glob@... from lock file`).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,12 +218,12 @@ Note: Docker configuration currently references Gradio. Aligning deployment arti
 Inputs/env:
 
 - `base_url` workflow input or `HOSTED_READINESS_BASE_URL` repository secret (the workflow skips when neither is set)
-- `timeout` workflow input (seconds; defaults to `10`)
+- `timeout` workflow input (seconds; defaults to `30`)
 
 Run locally:
 
 ```pwsh
-python scripts/check_hosted_readiness.py <base_url> --timeout 10
+python scripts/check_hosted_readiness.py <base_url> --timeout 30
 ```
 
 ## High-level architecture
@@ -349,7 +349,7 @@ GitHub Actions (`.github/workflows/`) include, among others:
 Environment is Linux with Python 3.12 and Node 22 (Cursor Cloud images may update over time). In Cursor Cloud, dependencies (Python `.venv` + `frontend/node_modules`) are refreshed automatically by the platform-managed startup/update process, so you normally only need to start services and run checks. Standard commands live in the "Common commands" section above and in `run-dev.sh`; the notes below only cover non-obvious cloud gotchas.
 
 - **`python` is not on PATH — only `python3`.** In Cursor Cloud, `run-dev.sh` and some docs invoke bare `python`, which fails unless your venv is activated (`source .venv/bin/activate` provides `python`). If `.venv` does not exist yet, create it first with `python3 -m venv .venv`; otherwise activate the venv or substitute `python3`.
-- **SQLite `DATABASE_URL` gotcha (backend won't start otherwise):** this repo uses a **custom URL-to-path resolver** in `api/database.py` (`_resolve_file_path`), *not* SQLAlchemy URL handling.
+- **SQLite `DATABASE_URL` gotcha (backend won't start otherwise):** this repo uses a **custom URL-to-path resolver** in `api/database.py` (`_resolve_file_path`), _not_ SQLAlchemy URL handling.
   - **Problem:** SQLAlchemy-style `sqlite:///./dev.db` resolves to `/dev.db` under this resolver and is usually unwritable (`sqlite3.OperationalError: unable to open database file`).
   - **Known-bad examples:** `sqlite:///./dev.db`, `sqlite:///./asset_graph.db`.
   - **Recommended values:** `sqlite:dev.db` (repo-relative), `sqlite:///:memory:`, or an explicit writable absolute path such as `sqlite:////absolute/path/dev.db`.

--- a/docs/operations/hosted-readiness-evidence-guide.md
+++ b/docs/operations/hosted-readiness-evidence-guide.md
@@ -51,6 +51,9 @@ curl -fsS "<base_url>/api/health/detailed"
 curl -fsS "<base_url>/api/assets?per_page=1"
 ```
 
+Use `--timeout 30` (or higher) when the target is a Vercel Python deployment that may cold-start.
+The script default is 30 seconds; promotion workflows also pass `--timeout 30` explicitly.
+
 If JSON output is available and preferred for release evidence capture, use:
 
 ```bash

--- a/scripts/check_hosted_readiness.py
+++ b/scripts/check_hosted_readiness.py
@@ -746,7 +746,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description="Smoke-check hosted API health/readiness endpoints.")
     parser.add_argument("base_url", help="Base URL of the hosted deployment, e.g. https://example.vercel.app")
-    parser.add_argument("--timeout", type=float, default=5.0, help="Request timeout in seconds.")
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=30.0,
+        help="Request timeout in seconds (default: 30; covers hosted cold starts).",
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON output.")
     parser.add_argument(
         "--base-url-label",

--- a/tests/integration/test_hosted_readiness_workflow.py
+++ b/tests/integration/test_hosted_readiness_workflow.py
@@ -206,6 +206,7 @@ class TestHostedReadinessWorkflowInputs:
         timeout_input = inputs["timeout"]
         assert "default" in timeout_input, "timeout input must have a 'default' value"
         assert isinstance(timeout_input["default"], str), "timeout input default must be a string"
+        assert timeout_input["default"] == "30", "timeout default must cover Vercel Python cold starts"
 
     def test_require_persistence_input_configuration(self, hosted_readiness_workflow):
         """require_persistence input must exist and be a boolean default false."""

--- a/tests/integration/test_hp004_db_authz_workflows.py
+++ b/tests/integration/test_hp004_db_authz_workflows.py
@@ -76,6 +76,12 @@ def test_release_evidence_wires_exposed_schemas_env(release_evidence_raw: str) -
     assert 'unset "$schema_secret"' in release_evidence_raw
 
 
+def test_release_evidence_uses_hosted_readiness_cold_start_timeout(release_evidence_raw: str) -> None:
+    """Release-evidence readiness must pin --timeout 30 for Vercel Python cold starts."""
+    assert "check_hosted_readiness.py" in release_evidence_raw
+    assert "--timeout 30" in release_evidence_raw
+
+
 def test_staging_promotion_fails_closed_without_db_secrets(staging_promotion_raw: str) -> None:
     """Staging promotion must fail closed on missing required H-P0-04 boundaries."""
     assert "missing_asset_graph_database_url" in staging_promotion_raw
@@ -83,6 +89,13 @@ def test_staging_promotion_fails_closed_without_db_secrets(staging_promotion_raw
     assert "missing_coordination_database_url" in staging_promotion_raw
     assert "no_database_url_configured" not in staging_promotion_raw
     assert "check_database_authorization.py" in staging_promotion_raw
+
+
+def test_staging_promotion_uses_hosted_readiness_cold_start_timeout(staging_promotion_raw: str) -> None:
+    """Staging promotion readiness must pin --timeout 30 for Vercel Python cold starts."""
+    assert "check_hosted_readiness.py" in staging_promotion_raw
+    assert "--timeout 30" in staging_promotion_raw
+    assert "--require-persistence" in staging_promotion_raw
 
 
 def test_staging_promotion_unsets_empty_untrusted_roles(staging_promotion_raw: str) -> None:

--- a/tests/integration/test_post_recovery_readiness_workflow.py
+++ b/tests/integration/test_post_recovery_readiness_workflow.py
@@ -43,6 +43,7 @@ def test_post_recovery_is_manual_dispatch_only(post_recovery_workflow: dict) -> 
     assert "target_environment" in inputs
     assert "base_url" in inputs
     assert "timeout" in inputs
+    assert inputs["timeout"]["default"] == "30"
     assert "base_url_label" in inputs
 
 
@@ -94,6 +95,7 @@ def test_post_recovery_enforces_persistence_and_assets_smoke(post_recovery_raw: 
     assert "check_hosted_readiness.py" in post_recovery_raw
     assert "--json" in post_recovery_raw
     assert "--require-persistence" in post_recovery_raw
+    assert '--timeout "$TIMEOUT"' in post_recovery_raw
     assert "checks.assets_smoke.passed" in post_recovery_raw
     assert "assets.total" in post_recovery_raw
     assert '[ "$total" -gt 0 ]' in post_recovery_raw or '"$total" -gt 0' in post_recovery_raw

--- a/tests/integration/test_production_promotion_workflow.py
+++ b/tests/integration/test_production_promotion_workflow.py
@@ -102,6 +102,7 @@ def test_production_promotion_enforces_persistence_and_assets_smoke(
     """Live readiness must use --require-persistence (assets-smoke auto-enabled)."""
     assert "check_hosted_readiness.py" in production_promotion_raw
     assert "--require-persistence" in production_promotion_raw
+    assert "--timeout 30" in production_promotion_raw
     assert "checks.assets_smoke.passed" in production_promotion_raw
     assert "assets.total" in production_promotion_raw
     assert '[ "$total" -gt 0 ]' in production_promotion_raw or '"$total" -gt 0' in production_promotion_raw

--- a/tests/unit/test_check_hosted_readiness.py
+++ b/tests/unit/test_check_hosted_readiness.py
@@ -624,6 +624,7 @@ def test_parse_args_handles_require_persistence() -> None:
 
     args_default = script.parse_args(["https://example.com"])
     assert args_default.require_persistence is False
+    assert args_default.timeout == 30.0
 
 
 def test_parse_args_handles_assets_smoke() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective

Stop flaky `Liveness check failed: /api/health request timed out` failures against the Vercel Python deployment during cold starts.

## In Scope

- Raise `scripts/check_hosted_readiness.py` default `--timeout` from 5s to 30s
- Pass `--timeout 30` in staging/production promotion and release-evidence workflows
- Align `hosted-readiness.yml` and `post-recovery-readiness.yml` workflow_dispatch defaults to 30s
- Document the cold-start guidance and lock the defaults in tests

## Out of Scope

- Changing health endpoint behavior or Vercel routing
- Marking H-P0-04 Satisfied (still needs live `db_authz: PASS|<opaque-ref>`)
- GitHub Environment secret provisioning

## Files Expected to Change

- `scripts/check_hosted_readiness.py`
- `.github/workflows/{staging-promotion,production-promotion,release-evidence-verify,hosted-readiness,post-recovery-readiness}.yml`
- `docs/operations/hosted-readiness-evidence-guide.md`, `AGENTS.md`
- Related unit/integration tests

## Validation Commands

```bash
pytest tests/unit/test_check_hosted_readiness.py \
  tests/integration/test_hosted_readiness_workflow.py \
  tests/integration/test_production_promotion_workflow.py \
  tests/integration/test_post_recovery_readiness_workflow.py -q

python scripts/check_hosted_readiness.py \
  https://financial-asset-relationship-db-nine.vercel.app \
  --timeout 30 --require-persistence --json
```

Live probe from this agent: **passed** (`status: healthy`, `startup_source: persisted`, assets smoke ok).

## Merge Criteria

- Related pytest suites green
- Workflow YAML still invokes readiness with `--require-persistence` where required
- No secrets or topology details in the diff

## Operator note

If you hit the timeout again before this lands, re-run with an explicit timeout:

```bash
python scripts/check_hosted_readiness.py "$HOSTED_READINESS_BASE_URL" --timeout 30 --require-persistence
```

Or dispatch `hosted-readiness.yml` with timeout `30`. The target URL itself is currently healthy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raise hosted readiness timeout to 30s to prevent flaky /api/health timeouts during Vercel Python cold starts. Updates the script default, pins 30s in gate workflows, and tightens tests/docs.

- **Bug Fixes**
  - Set default `--timeout` to 30s in `scripts/check_hosted_readiness.py` (help text notes cold starts).
  - Pass `--timeout 30` in `staging-promotion`, `production-promotion`, and `release-evidence-verify`; set `timeout` input default to "30" in `hosted-readiness.yml` and `post-recovery-readiness.yml`.
  - Add tests to lock the 30s timeout across all gate workflows (including post-recovery) and assert the new script default; keep `--require-persistence` checks.
  - Update `AGENTS.md` and `docs/operations/hosted-readiness-evidence-guide.md`; clear Super-linter markdown/terminology warnings.

<sup>Written for commit f095221541a07f076344894ed35c382e7c7a7308. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR raises hosted-readiness request timeouts to 30 seconds across the readiness script and operational workflows, documents the Vercel cold-start guidance, and adds regression coverage for each workflow identified in the previous review.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains in the fix for the previously reported timeout coverage gap.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/check_hosted_readiness.py | Raises the default request timeout from 5 to 30 seconds for hosted cold starts. |
| .github/workflows/staging-promotion.yml | Explicitly applies the 30-second timeout to the persistence-gated staging readiness probe. |
| .github/workflows/production-promotion.yml | Explicitly applies the 30-second timeout to the production readiness probe. |
| .github/workflows/release-evidence-verify.yml | Applies the 30-second timeout when collecting hosted release evidence. |
| .github/workflows/post-recovery-readiness.yml | Changes the manual timeout default to 30 seconds and retains input propagation to the readiness command. |
| tests/integration/test_hp004_db_authz_workflows.py | Adds regression assertions for staging and release-evidence timeout configuration. |
| tests/integration/test_post_recovery_readiness_workflow.py | Locks the post-recovery timeout default and command-line input propagation. |
| tests/integration/test_production_promotion_workflow.py | Locks the production promotion readiness timeout at 30 seconds. |
| tests/integration/test_hosted_readiness_workflow.py | Locks the manually dispatched hosted-readiness timeout default at 30 seconds. |
| tests/unit/test_check_hosted_readiness.py | Verifies that the readiness script defaults to a 30-second timeout. |

<sub>Reviews (3): Last reviewed commit: ["test: lock hosted readiness --timeout 30..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/f095221541a07f076344894ed35c382e7c7a7308) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46580293)</sub>

**Context used:**

- Knowledge Base — [Operational Scripts, CI, and Deployment](https://app.greptile.com/dashfin/-/custom-context/knowledge-base/dashfin-fardb/financial-asset-relationship-db/-/docs/ops-scripts-ci.md)
- Knowledge Base — [Release Governance and Required CI Checks](https://app.greptile.com/dashfin/-/custom-context/knowledge-base/dashfin-fardb/financial-asset-relationship-db/-/docs/release-governance.md)

<!-- /greptile_comment -->