### PR TITLE
feat: ADR 0007 public deny-by-default migrations (H-P0-04)

### DIFF
--- a/.github/linters/.sqlfluff
+++ b/.github/linters/.sqlfluff
@@ -1,0 +1,7 @@
+[sqlfluff]
+dialect = postgres
+templater = raw
+max_line_length = 120
+# Migration SQL uses Postgres role keyword PUBLIC (not a schema identifier) and
+# continuation indents under ALTER DEFAULT PRIVILEGES for readability.
+exclude_rules = CP02, LT02

--- a/.sqlfluff
+++ b/.sqlfluff
@@ -1,0 +1,7 @@
+[sqlfluff]
+dialect = postgres
+templater = raw
+max_line_length = 120
+# Migration SQL uses Postgres role keyword PUBLIC (not a schema identifier) and
+# continuation indents under ALTER DEFAULT PRIVILEGES for readability.
+exclude_rules = CP02, LT02

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -5,8 +5,8 @@
 -- Rollback: restore prior grants/policies from restricted backup only.
 --
 -- Default privileges: revoke for postgres and supabase_admin (hosted grantors).
--- Policy drop is intentional: Data API policies must not survive RLS enablement;
--- FastAPI is the only product ingress (BYPASSRLS / custom policies out of scope).
+-- Policy drop is selective: only policies that apply to anon, authenticated, or
+-- PUBLIC (Data API paths). Custom policies scoped to other roles are retained.
 
 BEGIN;
 
@@ -36,11 +36,12 @@ BEGIN
         );
     END LOOP;
 
-    -- Drop public-schema policies so enabling RLS does not revive Data API paths.
+    -- Drop only policies that grant a Data API / untrusted-role path.
     FOR pol IN
         SELECT policyname, tablename
         FROM pg_policies
         WHERE schemaname = target_schema
+          AND roles && ARRAY['anon', 'authenticated', 'public']::name[]
     LOOP
         EXECUTE format(
             'DROP POLICY IF EXISTS %I ON %I.%I',

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -3,6 +3,9 @@
 -- table, view, sequence, or function authority on the exposed public schema.
 -- Apply through governed migration authority against the target hosted database.
 -- Rollback: restore prior grants/policies from restricted backup only.
+--
+-- Object owners in the hosted target are postgres; DEFAULT PRIVILEGES therefore
+-- use FOR ROLE postgres so future objects keep the deny-by-default posture.
 
 BEGIN;
 
@@ -19,12 +22,15 @@ BEGIN
           AND c.relkind IN ('r', 'p')
           AND NOT c.relrowsecurity
     LOOP
-        EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', rel.table_name);
+        EXECUTE format(
+            'ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY',
+            rel.table_name
+        );
     END LOOP;
 END
 $$;
 
--- Drop existing public-schema policies so enabling RLS does not revive Data API paths.
+-- Drop public-schema policies so enabling RLS does not revive Data API paths.
 DO $$
 DECLARE
     pol record;
@@ -34,29 +40,51 @@ BEGIN
         FROM pg_policies
         WHERE schemaname = 'public'
     LOOP
-        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', pol.policyname, pol.tablename);
+        EXECUTE format(
+            'DROP POLICY IF EXISTS %I ON public.%I',
+            pol.policyname,
+            pol.tablename
+        );
     END LOOP;
 END
 $$;
 
 -- Revoke direct privileges from provider untrusted roles.
+-- Include PUBLIC on functions: Postgres defaults GRANT EXECUTE TO PUBLIC, and
+-- REVOKE FROM anon/authenticated alone does not remove that grant path.
 REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
 REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
 REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM anon, authenticated;
 
--- Explicit revoke for known privileged helper (defense in depth).
--- Postgres defaults GRANT EXECUTE TO PUBLIC on new functions; revoke that too.
-REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM anon, authenticated;
+-- Guarded revoke for known privileged helper overloads (skip cleanly if absent).
+DO $$
+DECLARE
+    fn regprocedure;
+BEGIN
+    FOR fn IN
+        SELECT p.oid::regprocedure
+        FROM pg_proc AS p
+        JOIN pg_namespace AS n ON n.oid = p.pronamespace
+        WHERE n.nspname = 'public'
+          AND p.proname = 'is_requester_admin'
+    LOOP
+        EXECUTE format(
+            'REVOKE ALL PRIVILEGES ON FUNCTION %s FROM PUBLIC, anon, authenticated',
+            fn
+        );
+    END LOOP;
+END
+$$;
 
--- Prevent future objects created by this role from re-granting untrusted access.
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+-- Deny-by-default for future objects created by the public-schema owner role.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
     REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
     REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
     REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
 
 COMMIT;

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -4,8 +4,9 @@
 -- Apply through governed migration authority against the target hosted database.
 -- Rollback: restore prior grants/policies from restricted backup only.
 --
--- Object owners in the hosted target are postgres; DEFAULT PRIVILEGES therefore
--- use FOR ROLE postgres so future objects keep the deny-by-default posture.
+-- Default privileges: revoke for postgres and supabase_admin (hosted grantors).
+-- Policy drop is intentional: Data API policies must not survive RLS enablement;
+-- FastAPI is the only product ingress (BYPASSRLS / custom policies out of scope).
 
 BEGIN;
 
@@ -13,7 +14,8 @@ DO $$
 DECLARE
     target_schema constant text := 'public';
     default_priv_prefix constant text :=
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I ';
+        'ALTER DEFAULT PRIVILEGES FOR ROLE %I IN SCHEMA %I ';
+    owner_role text;
     rel record;
     pol record;
     fn regprocedure;
@@ -82,23 +84,41 @@ BEGIN
         );
     END LOOP;
 
-    -- Deny-by-default for future objects created by the public-schema owner role.
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
-        target_schema
-    );
+    -- Deny-by-default for future objects from known public-schema grantor roles.
+    -- Skip roles the migration runner cannot alter (e.g. hosted supabase_admin).
+    FOREACH owner_role IN ARRAY ARRAY['postgres', 'supabase_admin']
+    LOOP
+        IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = owner_role) THEN
+            CONTINUE;
+        END IF;
+        BEGIN
+            EXECUTE format(
+                default_priv_prefix || 'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
+                owner_role,
+                target_schema
+            );
+            EXECUTE format(
+                default_priv_prefix || 'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
+                owner_role,
+                target_schema
+            );
+            EXECUTE format(
+                default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
+                owner_role,
+                target_schema
+            );
+            EXECUTE format(
+                default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
+                owner_role,
+                target_schema
+            );
+        EXCEPTION
+            WHEN insufficient_privilege THEN
+                RAISE NOTICE
+                    'skip default privileges for role % (insufficient privilege)',
+                    owner_role;
+        END;
+    END LOOP;
 END
 $$;
 

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -1,0 +1,62 @@
+-- ADR 0007 / H-P0-04: deny-by-default for provider untrusted roles on public.
+-- FastAPI remains the only product ingress; anon/authenticated receive no
+-- table, view, sequence, or function authority on the exposed public schema.
+-- Apply through governed migration authority against the target hosted database.
+-- Rollback: restore prior grants/policies from restricted backup only.
+
+BEGIN;
+
+-- Enable RLS on every public base/partitioned table (idempotent).
+DO $$
+DECLARE
+    rel record;
+BEGIN
+    FOR rel IN
+        SELECT c.relname AS table_name
+        FROM pg_class AS c
+        JOIN pg_namespace AS n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'public'
+          AND c.relkind IN ('r', 'p')
+          AND NOT c.relrowsecurity
+    LOOP
+        EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', rel.table_name);
+    END LOOP;
+END
+$$;
+
+-- Drop existing public-schema policies so enabling RLS does not revive Data API paths.
+DO $$
+DECLARE
+    pol record;
+BEGIN
+    FOR pol IN
+        SELECT policyname, tablename
+        FROM pg_policies
+        WHERE schemaname = 'public'
+    LOOP
+        EXECUTE format('DROP POLICY IF EXISTS %I ON public.%I', pol.policyname, pol.tablename);
+    END LOOP;
+END
+$$;
+
+-- Revoke direct privileges from provider untrusted roles.
+REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM anon, authenticated;
+
+-- Explicit revoke for known privileged helper (defense in depth).
+-- Postgres defaults GRANT EXECUTE TO PUBLIC on new functions; revoke that too.
+REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM anon, authenticated;
+
+-- Prevent future objects created by this role from re-granting untrusted access.
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
+
+COMMIT;

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -9,64 +9,69 @@
 
 BEGIN;
 
--- Enable RLS on every public base/partitioned table (idempotent).
 DO $$
 DECLARE
+    target_schema constant text := 'public';
     rel record;
+    pol record;
+    fn regprocedure;
 BEGIN
+    -- Enable RLS on every public base/partitioned table (idempotent).
     FOR rel IN
         SELECT c.relname AS table_name
         FROM pg_class AS c
         JOIN pg_namespace AS n ON n.oid = c.relnamespace
-        WHERE n.nspname = 'public'
+        WHERE n.nspname = target_schema
           AND c.relkind IN ('r', 'p')
           AND NOT c.relrowsecurity
     LOOP
         EXECUTE format(
-            'ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY',
+            'ALTER TABLE %I.%I ENABLE ROW LEVEL SECURITY',
+            target_schema,
             rel.table_name
         );
     END LOOP;
-END
-$$;
 
--- Drop public-schema policies so enabling RLS does not revive Data API paths.
-DO $$
-DECLARE
-    pol record;
-BEGIN
+    -- Drop public-schema policies so enabling RLS does not revive Data API paths.
     FOR pol IN
         SELECT policyname, tablename
         FROM pg_policies
-        WHERE schemaname = 'public'
+        WHERE schemaname = target_schema
     LOOP
         EXECUTE format(
-            'DROP POLICY IF EXISTS %I ON public.%I',
+            'DROP POLICY IF EXISTS %I ON %I.%I',
             pol.policyname,
+            target_schema,
             pol.tablename
         );
     END LOOP;
-END
-$$;
 
--- Revoke direct privileges from provider untrusted roles.
--- Include PUBLIC on functions: Postgres defaults GRANT EXECUTE TO PUBLIC, and
--- REVOKE FROM anon/authenticated alone does not remove that grant path.
-REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM anon, authenticated;
-REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM anon, authenticated;
-REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM anon, authenticated;
+    -- Revoke direct privileges from provider untrusted roles.
+    -- Include PUBLIC on functions: Postgres defaults GRANT EXECUTE TO PUBLIC, and
+    -- REVOKE FROM anon/authenticated alone does not remove that grant path.
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA %I FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA %I FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM PUBLIC',
+        target_schema
+    );
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM anon, authenticated',
+        target_schema
+    );
 
--- Guarded revoke for known privileged helper overloads (skip cleanly if absent).
-DO $$
-DECLARE
-    fn regprocedure;
-BEGIN
+    -- Guarded revoke for known privileged helper overloads (skip if absent).
     FOR fn IN
         SELECT p.oid::regprocedure
         FROM pg_proc AS p
         JOIN pg_namespace AS n ON n.oid = p.pronamespace
-        WHERE n.nspname = 'public'
+        WHERE n.nspname = target_schema
           AND p.proname = 'is_requester_admin'
     LOOP
         EXECUTE format(
@@ -74,17 +79,29 @@ BEGIN
             fn
         );
     END LOOP;
+
+    -- Deny-by-default for future objects created by the public-schema owner role.
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
+        target_schema
+    );
 END
 $$;
-
--- Deny-by-default for future objects created by the public-schema owner role.
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
 
 COMMIT;

--- a/migrations/005_adr0007_public_deny_untrusted_roles.sql
+++ b/migrations/005_adr0007_public_deny_untrusted_roles.sql
@@ -12,6 +12,8 @@ BEGIN;
 DO $$
 DECLARE
     target_schema constant text := 'public';
+    default_priv_prefix constant text :=
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I ';
     rel record;
     pol record;
     fn regprocedure;
@@ -82,23 +84,19 @@ BEGIN
 
     -- Deny-by-default for future objects created by the public-schema owner role.
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
         target_schema
     );
 END

--- a/migrations/006_adr0007_revoke_public_execute_helper.sql
+++ b/migrations/006_adr0007_revoke_public_execute_helper.sql
@@ -6,16 +6,39 @@
 
 BEGIN;
 
-REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM anon, authenticated;
-
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
-    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
+DO $$
+DECLARE
+    target_schema constant text := 'public';
+BEGIN
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM PUBLIC',
+        target_schema
+    );
+    EXECUTE format(
+        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
+        target_schema
+    );
+    EXECUTE format(
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
+        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
+        target_schema
+    );
+END
+$$;
 
 COMMIT;

--- a/migrations/006_adr0007_revoke_public_execute_helper.sql
+++ b/migrations/006_adr0007_revoke_public_execute_helper.sql
@@ -9,6 +9,8 @@ BEGIN;
 DO $$
 DECLARE
     target_schema constant text := 'public';
+    default_priv_prefix constant text :=
+        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I ';
 BEGIN
     EXECUTE format(
         'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM PUBLIC',
@@ -19,23 +21,19 @@ BEGIN
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
         target_schema
     );
     EXECUTE format(
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I '
-        'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
+        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
         target_schema
     );
 END

--- a/migrations/006_adr0007_revoke_public_execute_helper.sql
+++ b/migrations/006_adr0007_revoke_public_execute_helper.sql
@@ -1,42 +1,8 @@
--- ADR 0007 / H-P0-04 follow-up for environments that already applied earlier
--- 005/006 revisions before FOR ROLE postgres and schema-wide PUBLIC function
--- revokes landed in 005.
--- Idempotent: safe when current 005 already contains the same posture.
--- Fresh installs rely on 005; this file exists so already-migrated hosts converge.
+-- ADR 0007 / H-P0-04: version slot only.
+-- Idempotent backfill placeholder for hosts that already applied an earlier
+-- 006 revision. Current deny-by-default posture lives entirely in
+-- 005_adr0007_public_deny_untrusted_roles.sql; this file intentionally has
+-- no privilege statements so adjacent migrations do not duplicate security logic.
 
 BEGIN;
-
-DO $$
-DECLARE
-    target_schema constant text := 'public';
-    default_priv_prefix constant text :=
-        'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA %I ';
-BEGIN
-    EXECUTE format(
-        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM PUBLIC',
-        target_schema
-    );
-    EXECUTE format(
-        'REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA %I FROM anon, authenticated',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC',
-        target_schema
-    );
-    EXECUTE format(
-        default_priv_prefix || 'REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated',
-        target_schema
-    );
-END
-$$;
-
 COMMIT;

--- a/migrations/006_adr0007_revoke_public_execute_helper.sql
+++ b/migrations/006_adr0007_revoke_public_execute_helper.sql
@@ -1,0 +1,12 @@
+-- ADR 0007 / H-P0-04 follow-up: revoke PUBLIC default EXECUTE on privileged helper.
+-- Companion to 005_adr0007_public_deny_untrusted_roles.sql (PUBLIC retained EXECUTE).
+
+BEGIN;
+
+REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM anon, authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
+
+COMMIT;

--- a/migrations/006_adr0007_revoke_public_execute_helper.sql
+++ b/migrations/006_adr0007_revoke_public_execute_helper.sql
@@ -1,12 +1,21 @@
--- ADR 0007 / H-P0-04 follow-up: revoke PUBLIC default EXECUTE on privileged helper.
--- Companion to 005_adr0007_public_deny_untrusted_roles.sql (PUBLIC retained EXECUTE).
+-- ADR 0007 / H-P0-04 follow-up for environments that already applied earlier
+-- 005/006 revisions before FOR ROLE postgres and schema-wide PUBLIC function
+-- revokes landed in 005.
+-- Idempotent: safe when current 005 already contains the same posture.
+-- Fresh installs rely on 005; this file exists so already-migrated hosts converge.
 
 BEGIN;
 
-REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM PUBLIC;
-REVOKE ALL PRIVILEGES ON FUNCTION public.is_requester_admin() FROM anon, authenticated;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC;
+REVOKE ALL PRIVILEGES ON ALL FUNCTIONS IN SCHEMA public FROM anon, authenticated;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON TABLES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON SEQUENCES FROM anon, authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
     REVOKE ALL PRIVILEGES ON FUNCTIONS FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA public
+    REVOKE ALL PRIVILEGES ON FUNCTIONS FROM anon, authenticated;
 
 COMMIT;


### PR DESCRIPTION
## **User description**
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Primary Objective

Record the ADR 0007 / H-P0-04 hosted remediation migrations that deny provider untrusted roles (`anon` / `authenticated`) on the exposed `public` schema while keeping FastAPI as the only product ingress.

## In Scope

- `migrations/005_adr0007_public_deny_untrusted_roles.sql` — full deny-by-default posture (RLS, selective policy drop for anon/authenticated/PUBLIC, PUBLIC/function revokes, guarded helper, default privileges for `postgres` + best-effort `supabase_admin`)
- `migrations/006_adr0007_revoke_public_execute_helper.sql` — no-op version slot for hosts that already applied an earlier 006; no duplicated privilege SQL
- `.github/linters/.sqlfluff` (+ repo-root `.sqlfluff`) — postgres dialect for Super-linter

## Out of Scope

- Marking H-P0-04 Satisfied (still needs workflow `db_authz: PASS|<opaque-ref>`)
- Changing application connection roles / BYPASSRLS
- Publishing restricted topology in docs or CI

## Review fixes

- Schema-wide `REVOKE ... FUNCTIONS ... FROM PUBLIC`
- Existence-guarded `is_requester_admin` revoke
- `FOR ROLE postgres` (+ best-effort `supabase_admin` with privilege skip)
- Selective RLS policy drop (`roles && {anon,authenticated,public}`) — preserves custom non-untrusted policies
- 006 reduced to documented no-op slot
- SQLFluff dialect + Sonar literal dedupe

## Tracker

- https://github.com/DashFin-FarDb/financial-asset-relationship-db/issues/1525
- https://linear.app/dashfin/issue/DAS-61/db-authz-close-adr-0007-h-p0-04-for-staging

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a77a317-4588-4078-8226-3c89355d27d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down the `public` schema per ADR 0007 (H-P0-04) by denying provider-untrusted roles (`anon`, `authenticated`) and keeping FastAPI as the only ingress. Updates migrations to selectively drop only untrusted-role RLS policies and harden default privileges, aligning staging with Linear DAS-61.

- **Migration**
  - Enable RLS on all `public` tables and drop only policies that include `anon`, `authenticated`, or `PUBLIC`.
  - Revoke all table/sequence/function privileges from `anon`, `authenticated`; revoke `EXECUTE` from `PUBLIC` on all `public` functions; guarded revoke on `public.is_requester_admin()` overloads.
  - Set default privileges with `FOR ROLE postgres` and `supabase_admin` (skip on insufficient privilege) to block future grants to `PUBLIC`, `anon`, `authenticated`.
  - Make `006` an idempotent version slot with no privilege statements.

- **Dependencies**
  - Add repo and CI `.sqlfluff` configs with the `postgres` dialect for Super-linter.

<sup>Written for commit bc4ac7473ae997f673c03a0128c7945b4f98efb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Lock down access to the public schema for untrusted roles**

### What Changed
- The public schema now denies direct access from `anon` and `authenticated` roles across tables, sequences, and functions
- Row-level security is enabled on all public tables, and existing public-schema policies are removed so old Data API access paths stay closed
- The privileged `public.is_requester_admin()` helper no longer grants default execute access to everyone or to untrusted roles

### Impact
`✅ Restricted public schema access`
`✅ Fewer unintended Data API paths`
`✅ Safer server-only database access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds operator-applied ADR 0007 database authorization migrations and PostgreSQL SQLFluff configuration.
- Enables RLS across public tables and removes policies granting access to provider-untrusted roles.
- Revokes existing and default privileges from `anon`, `authenticated`, and `PUBLIC`.
- Reserves migration version 006 as a documented no-op compatibility slot.
- Configures repository and Super-linter SQLFluff instances for PostgreSQL syntax.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failure remains in this follow-up review.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| migrations/005_adr0007_public_deny_untrusted_roles.sql | Implements the hosted public-schema deny-by-default remediation for existing and future database objects. |
| migrations/006_adr0007_revoke_public_execute_helper.sql | Preserves migration numbering as an intentional transactional no-op. |
| .sqlfluff | Configures repository SQL linting for PostgreSQL migration syntax. |
| .github/linters/.sqlfluff | Mirrors the PostgreSQL SQLFluff configuration for Super-linter. |

<sub>Reviews (6): Last reviewed commit: ["fix: drop only untrusted-role RLS polici..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/bc4ac7473ae997f673c03a0128c7945b4f98efb2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46588545)</sub>

**Context used:**

- Knowledge Base — [Data Layer](https://app.greptile.com/dashfin/-/custom-context/knowledge-base/dashfin-fardb/financial-asset-relationship-db/-/docs/data-layer.md)

<!-- /greptile_comment -->