### PR TITLE
feat: enforce append-only assertion lifecycle and authority

### DIFF
--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -208,6 +208,11 @@ def _evidence_identity_tuple(evidence: EvidenceRecord) -> tuple[object, ...]:
     )
 
 
+def _with_recorded_at(evidence: EvidenceRecord, recorded_at: datetime) -> EvidenceRecord:
+    """Return typed evidence with its repository-assigned recording timestamp."""
+    return cast(EvidenceRecord, replace(evidence, recorded_at=recorded_at))
+
+
 def _is_foreign_key_integrity_error(exc: IntegrityError) -> bool:
     """Return True when ``exc`` looks like a foreign-key violation."""
     detail = str(getattr(exc, "orig", None) or exc).lower()
@@ -253,7 +258,6 @@ def _validate_event_identity(assertion_id: str, event: AssertionEvent) -> None:
 
 
 def _validate_event_sequence(
-    assertion_id: str,
     event: AssertionEvent,
     expected_sequence: int,
     current_max: int,
@@ -267,7 +271,7 @@ def _validate_event_sequence(
 def _validate_supersede_state(predecessor_id: str, pred_state: LifecycleState) -> None:
     if pred_state not in ("Accepted", "Disputed"):
         raise ValidationError(
-            f"predecessor {predecessor_id} must be Accepted or Disputed to supersede " f"(current={pred_state})"
+            f"predecessor {predecessor_id} must be Accepted or Disputed to supersede (current={pred_state})"
         )
 
 
@@ -393,7 +397,7 @@ class RelationshipAssertionRepository:
         so matrix authority and successor checks cannot be bypassed with a fabricated event.
         """
         _validate_event_identity(assertion_id, event)
-        _validate_event_sequence(assertion_id, event, expected_sequence, self._max_sequence(assertion_id))
+        _validate_event_sequence(event, expected_sequence, self._max_sequence(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
             raise ValidationError(f"unknown assertion_id: {assertion_id}")
         self._insert_event_orm(event)
@@ -429,7 +433,7 @@ class RelationshipAssertionRepository:
     def register_evidence(self, request: RegisterEvidenceRequest) -> tuple[EvidenceRecord, EvidenceLink]:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
         stamp = request.recorded_at or self._clock()
-        normalized = validate_evidence_record(replace(request.evidence, recorded_at=stamp))
+        normalized = validate_evidence_record(_with_recorded_at(request.evidence, stamp))
         link = self._plan_evidence_link(request, normalized, stamp)
         stored_evidence = self._upsert_evidence(normalized)
         existing = self._find_evidence_link(request.assertion_id, normalized.evidence_id)
@@ -655,9 +659,7 @@ class RelationshipAssertionRepository:
             raise ValidationError(f"unknown successor_assertion_id: {successor_assertion_id}")
         state = self._current_state(successor_assertion_id)
         if state != "Accepted":
-            raise ValidationError(
-                f"successor {successor_assertion_id} must be Accepted to supersede " f"(current={state})"
-            )
+            raise ValidationError(f"successor {successor_assertion_id} must be Accepted to supersede (current={state})")
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -1,0 +1,569 @@
+"""Append-only repository for GRAC v1 assertion lifecycle and evidence.
+
+INSERT-only against the PR3 ORM tables. Lifecycle decisions are planned in
+``relationship_assertion_lifecycle``; this module persists them and enforces
+expected-sequence concurrency and atomic supersession.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from typing import cast
+from uuid import uuid4
+
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.data.relationship_assertion_db_models import (
+    RelationshipAssertionEventORM,
+    RelationshipAssertionEvidenceORM,
+    RelationshipAssertionORM,
+    RelationshipEvidenceORM,
+)
+from src.governance.relationship_assertion import (
+    Assertion,
+    AssertionAsOf,
+    AssertionEvent,
+    AssertionProposal,
+    AuthorityContext,
+    AuthorityRole,
+    ConcurrencyConflict,
+    EvidenceLink,
+    EvidencePolarity,
+    EvidenceRecord,
+    LifecycleState,
+    SupersessionCycle,
+    ValidationError,
+    Visibility,
+)
+from src.governance.relationship_assertion_lifecycle import (
+    assert_no_cycle,
+    cast_polarity,
+    plan_accept,
+    plan_propose,
+    plan_register_evidence,
+    plan_supersede,
+    plan_transition,
+    proposals_equivalent,
+    resolve_state,
+    validate_evidence_record,
+)
+
+UTC = timezone.utc
+
+
+def _utcnow() -> datetime:
+    """Server-recorded UTC timestamp."""
+    return datetime.now(tz=UTC)
+
+
+def _new_id() -> str:
+    """Allocate a UUID string primary key."""
+    return str(uuid4())
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    """Normalize SQLite naive datetimes to timezone-aware UTC."""
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _event_from_orm(row: RelationshipAssertionEventORM) -> AssertionEvent:
+    """Map an ORM event row to the domain DTO."""
+    recorded_at = _as_utc(row.recorded_at)
+    if recorded_at is None:
+        raise ValidationError("event recorded_at missing")
+    return AssertionEvent(
+        event_id=row.id,
+        assertion_id=row.assertion_id,
+        sequence=row.sequence,
+        from_state=cast(LifecycleState | None, row.from_state),
+        to_state=cast(LifecycleState, row.to_state),
+        authority=cast(AuthorityRole, row.authority),
+        actor_id=row.actor_id,
+        rationale=row.rationale,
+        policy_version=row.policy_version,
+        recorded_at=recorded_at,
+        successor_assertion_id=row.successor_assertion_id,
+        correlation_id=row.correlation_id,
+    )
+
+
+def _evidence_from_orm(row: RelationshipEvidenceORM) -> EvidenceRecord:
+    """Map an ORM evidence row to the domain DTO."""
+    recorded_at = _as_utc(row.recorded_at)
+    if recorded_at is None:
+        raise ValidationError("evidence recorded_at missing")
+    return EvidenceRecord(
+        evidence_id=row.id,
+        source_ref=row.source_ref,
+        content_sha256=row.content_sha256,
+        media_type=row.media_type,
+        visibility=cast(Visibility, row.visibility),
+        custody_id=row.custody_id,
+        recorded_at=recorded_at,
+        observed_at=_as_utc(row.observed_at),
+        issued_at=_as_utc(row.issued_at),
+        licensing=row.licensing,
+        reuse_policy=row.reuse_policy,
+    )
+
+
+def _link_from_orm(row: RelationshipAssertionEvidenceORM) -> EvidenceLink:
+    """Map an ORM evidence-link row to the domain DTO."""
+    recorded_at = _as_utc(row.recorded_at)
+    if recorded_at is None:
+        raise ValidationError("evidence link recorded_at missing")
+    return EvidenceLink(
+        link_id=row.id,
+        assertion_id=row.assertion_id,
+        evidence_id=row.evidence_id,
+        polarity=cast_polarity(row.polarity),
+        recorded_at=recorded_at,
+    )
+
+
+def _fix_assertion_mapping(row: RelationshipAssertionORM) -> Assertion:
+    """Map ORM assertion with correct confidence_status typing."""
+    status = row.confidence_status
+    if status not in ("assessed", "not_assessed"):
+        raise ValidationError(f"invalid confidence_status in store: {status!r}")
+    effective_from = _as_utc(row.effective_from)
+    recorded_at = _as_utc(row.recorded_at)
+    if effective_from is None or recorded_at is None:
+        raise ValidationError("assertion timestamps missing")
+    return Assertion(
+        assertion_id=row.id,
+        predicate_id=row.predicate_id,
+        subject_id=row.subject_id,
+        object_id=row.object_id,
+        method_id=row.method_id,
+        proposition=row.proposition,
+        confidence_status=status,  # type: ignore[arg-type]
+        confidence_bp=row.confidence_bp,
+        confidence_type=row.confidence_type,
+        confidence_method=row.confidence_method,
+        effective_from=effective_from,
+        effective_to=_as_utc(row.effective_to),
+        recorded_at=recorded_at,
+    )
+
+
+class RelationshipAssertionRepository:
+    """INSERT-only persistence for governed assertions, events, and evidence."""
+
+    def __init__(
+        self,
+        session: Session,
+        *,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        """Bind a SQLAlchemy session and optional injectable clock."""
+        self._session = session
+        self._clock = clock or _utcnow
+
+    def propose(
+        self,
+        proposal: AssertionProposal,
+        ctx: AuthorityContext,
+        *,
+        recorded_at: datetime | None = None,
+        event_id: str | None = None,
+    ) -> tuple[Assertion, AssertionEvent]:
+        """Create an assertion + Proposed event, or return the existing identical proposal."""
+        existing = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
+        if existing is not None:
+            domain = _fix_assertion_mapping(existing)
+            if not proposals_equivalent(domain, proposal):
+                raise ValidationError(f"assertion {proposal.assertion_id} already exists with a different proposition")
+            events = self._load_events(proposal.assertion_id)
+            if not events:
+                raise ValidationError(f"assertion {proposal.assertion_id} missing propose event")
+            return domain, events[0]
+
+        stamp = recorded_at or self._clock()
+        assertion, event = plan_propose(proposal, ctx, recorded_at=stamp, event_id=event_id)
+        self._session.add(
+            RelationshipAssertionORM(
+                id=assertion.assertion_id,
+                predicate_id=assertion.predicate_id,
+                subject_id=assertion.subject_id,
+                object_id=assertion.object_id,
+                method_id=assertion.method_id,
+                proposition=assertion.proposition,
+                confidence_bp=assertion.confidence_bp,
+                confidence_type=assertion.confidence_type,
+                confidence_method=assertion.confidence_method,
+                confidence_status=assertion.confidence_status,
+                effective_from=assertion.effective_from,
+                effective_to=assertion.effective_to,
+                recorded_at=assertion.recorded_at,
+            )
+        )
+        try:
+            # Flush assertion before the event so SQLite FK checks see the parent row.
+            self._session.flush()
+            self._insert_event_orm(event)
+            self._session.flush()
+        except IntegrityError as exc:
+            self._session.rollback()
+            raced = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
+            if raced is None:
+                raise ValidationError(f"propose failed for {proposal.assertion_id}: {exc}") from exc
+            domain = _fix_assertion_mapping(raced)
+            if not proposals_equivalent(domain, proposal):
+                raise ValidationError(
+                    f"assertion {proposal.assertion_id} already exists with a different proposition"
+                ) from exc
+            events = self._load_events(proposal.assertion_id)
+            if not events:
+                raise ValidationError(
+                    f"assertion {proposal.assertion_id} missing propose event after conflict"
+                ) from exc
+            return domain, events[0]
+        return assertion, event
+
+    def append_event(
+        self,
+        assertion_id: str,
+        event: AssertionEvent,
+        *,
+        expected_sequence: int,
+    ) -> AssertionEvent:
+        """INSERT a planned event only when ``expected_sequence`` matches current max."""
+        if event.assertion_id != assertion_id:
+            raise ValidationError("event assertion_id mismatch")
+        if event.sequence != expected_sequence + 1:
+            raise ConcurrencyConflict(
+                f"event.sequence {event.sequence} != expected_sequence+1 ({expected_sequence + 1})"
+            )
+        current_max = self._max_sequence(assertion_id)
+        if current_max != expected_sequence:
+            raise ConcurrencyConflict(f"expected_sequence {expected_sequence} but current max is {current_max}")
+        if self._session.get(RelationshipAssertionORM, assertion_id) is None:
+            raise ValidationError(f"unknown assertion_id: {assertion_id}")
+        self._insert_event_orm(event)
+        try:
+            self._session.flush()
+        except IntegrityError as exc:
+            self._session.rollback()
+            raise ConcurrencyConflict(f"sequence conflict for assertion {assertion_id} at {event.sequence}") from exc
+        return event
+
+    def transition(
+        self,
+        assertion_id: str,
+        to_state: LifecycleState,
+        ctx: AuthorityContext,
+        *,
+        expected_sequence: int,
+        rationale: str,
+        successor_assertion_id: str | None = None,
+        recorded_at: datetime | None = None,
+        event_id: str | None = None,
+    ) -> AssertionEvent:
+        """Plan and append a matrix transition under the concurrency guard."""
+        current = self._current_state(assertion_id)
+        stamp = recorded_at or self._clock()
+        if to_state == "Superseded":
+            if successor_assertion_id is None:
+                raise ValidationError("supersession requires successor_assertion_id")
+            event = plan_supersede(
+                assertion_id,
+                current,
+                ctx,
+                expected_sequence=expected_sequence,
+                rationale=rationale,
+                recorded_at=stamp,
+                successor_assertion_id=successor_assertion_id,
+                successor_chain_lookup=self._successor_chain_lookup,
+                event_id=event_id,
+            )
+        else:
+            event = plan_transition(
+                assertion_id,
+                current,
+                to_state,
+                ctx,
+                expected_sequence=expected_sequence,
+                rationale=rationale,
+                recorded_at=stamp,
+                successor_assertion_id=successor_assertion_id,
+                event_id=event_id,
+            )
+        return self.append_event(assertion_id, event, expected_sequence=expected_sequence)
+
+    def register_evidence(
+        self,
+        assertion_id: str,
+        evidence: EvidenceRecord,
+        polarity: EvidencePolarity,
+        ctx: AuthorityContext,
+        *,
+        link_id: str | None = None,
+        recorded_at: datetime | None = None,
+    ) -> tuple[EvidenceRecord, EvidenceLink]:
+        """Register immutable evidence (digest-validated) and an append-only polarity link."""
+        stamp = recorded_at or self._clock()
+        normalized = validate_evidence_record(
+            EvidenceRecord(
+                evidence_id=evidence.evidence_id,
+                source_ref=evidence.source_ref,
+                content_sha256=evidence.content_sha256,
+                media_type=evidence.media_type,
+                visibility=evidence.visibility,
+                custody_id=evidence.custody_id,
+                recorded_at=stamp,
+                observed_at=evidence.observed_at,
+                issued_at=evidence.issued_at,
+                licensing=evidence.licensing,
+                reuse_policy=evidence.reuse_policy,
+            )
+        )
+
+        state = self._current_state(assertion_id)
+        link = EvidenceLink(
+            link_id=link_id or _new_id(),
+            assertion_id=assertion_id,
+            evidence_id=normalized.evidence_id,
+            polarity=polarity,
+            recorded_at=stamp,
+        )
+        plan_register_evidence(assertion_id, state, link, ctx, evidence=normalized)
+
+        stored_evidence = self._upsert_evidence(normalized)
+        existing_link = self._session.execute(
+            select(RelationshipAssertionEvidenceORM).where(
+                RelationshipAssertionEvidenceORM.assertion_id == assertion_id,
+                RelationshipAssertionEvidenceORM.evidence_id == normalized.evidence_id,
+            )
+        ).scalar_one_or_none()
+        if existing_link is not None:
+            if existing_link.polarity != polarity:
+                raise ValidationError(
+                    "evidence link already exists with a different polarity "
+                    f"({existing_link.polarity} != {polarity})"
+                )
+            return stored_evidence, _link_from_orm(existing_link)
+
+        self._session.add(
+            RelationshipAssertionEvidenceORM(
+                id=link.link_id,
+                assertion_id=link.assertion_id,
+                evidence_id=link.evidence_id,
+                polarity=link.polarity,
+                recorded_at=link.recorded_at,
+            )
+        )
+        try:
+            self._session.flush()
+        except IntegrityError as exc:
+            self._session.rollback()
+            raise ConcurrencyConflict("concurrent evidence link insert conflicted") from exc
+        return stored_evidence, link
+
+    def supersede_atomic(
+        self,
+        predecessor_id: str,
+        successor_proposal: AssertionProposal,
+        ctx: AuthorityContext,
+        *,
+        expected_sequence: int,
+        rationale: str,
+        recorded_at: datetime | None = None,
+        accept_rationale: str = "accept successor",
+    ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
+        """Atomically accept a successor and supersede the predecessor.
+
+        Same transaction:
+        1. propose successor (seq=1 Proposed)
+        2. accept successor (seq=2 Accepted)
+        3. supersede predecessor (→ Superseded with successor_assertion_id)
+
+        On failure neither orphan successor nor superseded-without-successor is visible.
+        """
+        stamp = recorded_at or self._clock()
+        pred_state = self._current_state(predecessor_id)
+        if pred_state not in ("Accepted", "Disputed"):
+            raise ValidationError(
+                f"predecessor {predecessor_id} must be Accepted or Disputed to supersede " f"(current={pred_state})"
+            )
+        if predecessor_id == successor_proposal.assertion_id:
+            raise SupersessionCycle("self-supersession is forbidden")
+        assert_no_cycle(predecessor_id, successor_proposal.assertion_id, self._successor_chain_lookup)
+
+        if self._max_sequence(predecessor_id) != expected_sequence:
+            raise ConcurrencyConflict(
+                f"expected_sequence {expected_sequence} but current max is " f"{self._max_sequence(predecessor_id)}"
+            )
+        if self._session.get(RelationshipAssertionORM, successor_proposal.assertion_id) is not None:
+            raise ValidationError(f"successor assertion {successor_proposal.assertion_id} already exists")
+
+        successor, propose_event = self.propose(successor_proposal, ctx, recorded_at=stamp)
+        # Fresh propose always yields seq=1; accept at expected_sequence=1.
+        accept_event = plan_accept(
+            successor.assertion_id,
+            "Proposed",
+            ctx,
+            expected_sequence=1,
+            rationale=accept_rationale,
+            recorded_at=stamp,
+        )
+        self.append_event(successor.assertion_id, accept_event, expected_sequence=1)
+
+        supersede_event = plan_supersede(
+            predecessor_id,
+            pred_state,
+            ctx,
+            expected_sequence=expected_sequence,
+            rationale=rationale,
+            recorded_at=stamp,
+            successor_assertion_id=successor.assertion_id,
+            successor_chain_lookup=self._successor_chain_lookup,
+        )
+        self.append_event(predecessor_id, supersede_event, expected_sequence=expected_sequence)
+        self._session.flush()
+        return successor, propose_event, accept_event, supersede_event
+
+    def get_as_of(
+        self,
+        assertion_id: str,
+        *,
+        known_at: datetime,
+        effective_at: datetime | None = None,
+    ) -> AssertionAsOf | None:
+        """Reconstruct assertion state from events/links with ``recorded_at <= known_at``."""
+        row = self._session.get(RelationshipAssertionORM, assertion_id)
+        if row is None:
+            return None
+        assertion = _fix_assertion_mapping(row)
+        known = _as_utc(known_at)
+        if known is None:
+            raise ValidationError("known_at is required")
+        if assertion.recorded_at > known:
+            return None
+        if effective_at is not None:
+            effective = _as_utc(effective_at)
+            if effective is None:
+                raise ValidationError("effective_at is required when provided")
+            if assertion.effective_from > effective:
+                return None
+            if assertion.effective_to is not None and assertion.effective_to < effective:
+                return None
+        else:
+            effective = None
+
+        events = tuple(event for event in self._load_events(assertion_id) if event.recorded_at <= known)
+        if not events:
+            return None
+        link_rows = self._session.execute(
+            select(RelationshipAssertionEvidenceORM)
+            .where(RelationshipAssertionEvidenceORM.assertion_id == assertion_id)
+            .order_by(RelationshipAssertionEvidenceORM.recorded_at)
+        ).scalars()
+        links = tuple(
+            link for link in (_link_from_orm(link_row) for link_row in link_rows) if link.recorded_at <= known
+        )
+        return AssertionAsOf(
+            assertion=assertion,
+            state=resolve_state(events),
+            events=events,
+            evidence_links=links,
+            effective_at=effective,
+            known_at=known,
+        )
+
+    def current_state(self, assertion_id: str) -> LifecycleState:
+        """Return the latest lifecycle state for ``assertion_id``."""
+        return self._current_state(assertion_id)
+
+    def max_sequence(self, assertion_id: str) -> int:
+        """Return the highest event sequence for ``assertion_id`` (0 if none)."""
+        return self._max_sequence(assertion_id)
+
+    def _current_state(self, assertion_id: str) -> LifecycleState:
+        events = self._load_events(assertion_id)
+        if not events:
+            raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
+        return resolve_state(events)
+
+    def _max_sequence(self, assertion_id: str) -> int:
+        value = self._session.execute(
+            select(func.coalesce(func.max(RelationshipAssertionEventORM.sequence), 0)).where(
+                RelationshipAssertionEventORM.assertion_id == assertion_id
+            )
+        ).scalar_one()
+        return int(value)
+
+    def _load_events(self, assertion_id: str) -> list[AssertionEvent]:
+        rows = self._session.execute(
+            select(RelationshipAssertionEventORM)
+            .where(RelationshipAssertionEventORM.assertion_id == assertion_id)
+            .order_by(RelationshipAssertionEventORM.sequence)
+        ).scalars()
+        return [_event_from_orm(row) for row in rows]
+
+    def _insert_event_orm(self, event: AssertionEvent) -> None:
+        self._session.add(
+            RelationshipAssertionEventORM(
+                id=event.event_id,
+                assertion_id=event.assertion_id,
+                sequence=event.sequence,
+                from_state=event.from_state,
+                to_state=event.to_state,
+                authority=event.authority,
+                actor_id=event.actor_id,
+                rationale=event.rationale,
+                policy_version=event.policy_version,
+                recorded_at=event.recorded_at,
+                successor_assertion_id=event.successor_assertion_id,
+                correlation_id=event.correlation_id,
+            )
+        )
+
+    def _upsert_evidence(self, evidence: EvidenceRecord) -> EvidenceRecord:
+        existing = self._session.get(RelationshipEvidenceORM, evidence.evidence_id)
+        if existing is not None:
+            domain = _evidence_from_orm(existing)
+            if (
+                domain.source_ref != evidence.source_ref
+                or domain.content_sha256 != evidence.content_sha256
+                or domain.media_type != evidence.media_type
+                or domain.visibility != evidence.visibility
+                or domain.custody_id != evidence.custody_id
+            ):
+                raise ValidationError(f"evidence {evidence.evidence_id} already exists with different metadata")
+            return domain
+        self._session.add(
+            RelationshipEvidenceORM(
+                id=evidence.evidence_id,
+                source_ref=evidence.source_ref,
+                content_sha256=evidence.content_sha256,
+                media_type=evidence.media_type,
+                observed_at=evidence.observed_at,
+                issued_at=evidence.issued_at,
+                visibility=evidence.visibility,
+                licensing=evidence.licensing,
+                reuse_policy=evidence.reuse_policy,
+                custody_id=evidence.custody_id,
+                recorded_at=evidence.recorded_at,
+            )
+        )
+        self._session.flush()
+        return evidence
+
+    def _successor_chain_lookup(self, assertion_id: str) -> Sequence[str]:
+        """Return successor IDs recorded on Superseded events for ``assertion_id``."""
+        rows = self._session.execute(
+            select(RelationshipAssertionEventORM.successor_assertion_id).where(
+                RelationshipAssertionEventORM.assertion_id == assertion_id,
+                RelationshipAssertionEventORM.to_state == "Superseded",
+                RelationshipAssertionEventORM.successor_assertion_id.is_not(None),
+            )
+        ).scalars()
+        return [successor for successor in rows if successor is not None]

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -400,9 +400,10 @@ class RelationshipAssertionRepository:
         _validate_event_sequence(event, expected_sequence, self._max_sequence(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
             raise ValidationError(f"unknown assertion_id: {assertion_id}")
-        self._insert_event_orm(event)
         try:
-            self._session.flush()
+            with self._session.begin_nested():
+                self._insert_event_orm(event)
+                self._session.flush()
         except IntegrityError as exc:
             error: Exception
             if _is_foreign_key_integrity_error(exc):
@@ -412,9 +413,6 @@ class RelationshipAssertionRepository:
                 )
             else:
                 error = ConcurrencyConflict(f"sequence conflict for assertion {assertion_id} at {event.sequence}")
-            # Nested savepoints (supersede_atomic) roll back on exit; avoid full-session wipe.
-            if not self._session.in_nested_transaction():
-                self._session.rollback()
             raise error from exc
         return event
 
@@ -425,6 +423,8 @@ class RelationshipAssertionRepository:
             self._lock_assertions(request.assertion_id, successor_id)
             self._require_accepted_successor(successor_id)
             assert_no_cycle(request.assertion_id, successor_id, self._successor_chain_lookup)
+        else:
+            self._lock_assertions(request.assertion_id)
         current = self._current_state(request.assertion_id)
         stamp = request.recorded_at or self._clock()
         event = _plan_repository_transition(request, current, stamp, self._successor_chain_lookup)
@@ -493,19 +493,19 @@ class RelationshipAssertionRepository:
         return _evidence_from_orm(evidence_row), _link_from_orm(existing_link)
 
     def _insert_evidence_link(self, link: EvidenceLink) -> None:
-        self._session.add(
-            RelationshipAssertionEvidenceORM(
-                id=link.link_id,
-                assertion_id=link.assertion_id,
-                evidence_id=link.evidence_id,
-                polarity=link.polarity,
-                recorded_at=link.recorded_at,
-            )
-        )
         try:
-            self._session.flush()
+            with self._session.begin_nested():
+                self._session.add(
+                    RelationshipAssertionEvidenceORM(
+                        id=link.link_id,
+                        assertion_id=link.assertion_id,
+                        evidence_id=link.evidence_id,
+                        polarity=link.polarity,
+                        recorded_at=link.recorded_at,
+                    )
+                )
+                self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
             raise ConcurrencyConflict("concurrent evidence link insert conflicted") from exc
 
     def supersede_atomic(
@@ -612,13 +612,13 @@ class RelationshipAssertionRepository:
         event: AssertionEvent,
         proposal: AssertionProposal,
     ) -> tuple[Assertion, AssertionEvent]:
-        self._session.add(_assertion_orm(assertion))
         try:
-            self._session.flush()
-            self._insert_event_orm(event)
-            self._session.flush()
+            with self._session.begin_nested():
+                self._session.add(_assertion_orm(assertion))
+                self._session.flush()
+                self._insert_event_orm(event)
+                self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
             raced = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
             if raced is None:
                 raise ValidationError(f"propose failed for {proposal.assertion_id}: {exc}") from exc
@@ -647,7 +647,12 @@ class RelationshipAssertionRepository:
             raise ValidationError(f"successor assertion {request.successor_proposal.assertion_id} already exists")
 
     def _lock_assertions(self, *assertion_ids: str) -> None:
-        """Lock assertion rows in sorted id order to serialize supersession graph checks."""
+        """Lock rows in sorted order for transition and supersession checks.
+
+        PostgreSQL provides the required concurrency guarantees for ``SELECT FOR
+        UPDATE``. SQLite ignores the clause; it remains supported for compatible
+        local persistence and tests, without equivalent row-level serialization.
+        """
         for assertion_id in sorted({item for item in assertion_ids if item}):
             self._session.execute(
                 select(RelationshipAssertionORM.id).where(RelationshipAssertionORM.id == assertion_id).with_for_update()

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from datetime import datetime, timezone
-from typing import cast
+from typing import NoReturn, cast
 from uuid import uuid4
 
 from sqlalchemy import func, select
@@ -95,6 +95,13 @@ class SupersedeAtomicRequest:
 
 def _utcnow() -> datetime:
     return datetime.now(tz=UTC)
+
+
+def _raise_validation(message: str, exc: IntegrityError | None) -> NoReturn:
+    """Raise ValidationError, optionally chaining a prior IntegrityError."""
+    if exc is None:
+        raise ValidationError(message)
+    raise ValidationError(message) from exc
 
 
 def _new_id() -> str:
@@ -386,6 +393,20 @@ class RelationshipAssertionRepository:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
         stamp = request.recorded_at or self._clock()
         normalized = validate_evidence_record(replace(request.evidence, recorded_at=stamp))
+        link = self._plan_evidence_link(request, normalized, stamp)
+        stored_evidence = self._upsert_evidence(normalized)
+        existing = self._find_evidence_link(request.assertion_id, normalized.evidence_id)
+        if existing is not None:
+            return self._reuse_evidence_link(existing, request.polarity)
+        self._insert_evidence_link(link)
+        return stored_evidence, link
+
+    def _plan_evidence_link(
+        self,
+        request: RegisterEvidenceRequest,
+        normalized: EvidenceRecord,
+        stamp: datetime,
+    ) -> EvidenceLink:
         link = EvidenceLink(
             link_id=request.link_id or _new_id(),
             assertion_id=request.assertion_id,
@@ -402,23 +423,35 @@ class RelationshipAssertionRepository:
                 evidence=normalized,
             )
         )
-        stored_evidence = self._upsert_evidence(normalized)
-        existing_link = self._session.execute(
+        return link
+
+    def _find_evidence_link(
+        self,
+        assertion_id: str,
+        evidence_id: str,
+    ) -> RelationshipAssertionEvidenceORM | None:
+        return self._session.execute(
             select(RelationshipAssertionEvidenceORM).where(
-                RelationshipAssertionEvidenceORM.assertion_id == request.assertion_id,
-                RelationshipAssertionEvidenceORM.evidence_id == normalized.evidence_id,
+                RelationshipAssertionEvidenceORM.assertion_id == assertion_id,
+                RelationshipAssertionEvidenceORM.evidence_id == evidence_id,
             )
         ).scalar_one_or_none()
-        if existing_link is not None:
-            if existing_link.polarity != request.polarity:
-                raise ValidationError(
-                    "evidence link already exists with a different polarity "
-                    f"({existing_link.polarity} != {request.polarity})"
-                )
-            evidence_row = self._session.get(RelationshipEvidenceORM, existing_link.evidence_id)
-            if evidence_row is None:
-                raise ValidationError(f"evidence {existing_link.evidence_id} missing for existing link")
-            return _evidence_from_orm(evidence_row), _link_from_orm(existing_link)
+
+    def _reuse_evidence_link(
+        self,
+        existing_link: RelationshipAssertionEvidenceORM,
+        polarity: EvidencePolarity,
+    ) -> tuple[EvidenceRecord, EvidenceLink]:
+        if existing_link.polarity != polarity:
+            raise ValidationError(
+                "evidence link already exists with a different polarity " f"({existing_link.polarity} != {polarity})"
+            )
+        evidence_row = self._session.get(RelationshipEvidenceORM, existing_link.evidence_id)
+        if evidence_row is None:
+            raise ValidationError(f"evidence {existing_link.evidence_id} missing for existing link")
+        return _evidence_from_orm(evidence_row), _link_from_orm(existing_link)
+
+    def _insert_evidence_link(self, link: EvidenceLink) -> None:
         self._session.add(
             RelationshipAssertionEvidenceORM(
                 id=link.link_id,
@@ -433,7 +466,6 @@ class RelationshipAssertionRepository:
         except IntegrityError as exc:
             self._session.rollback()
             raise ConcurrencyConflict("concurrent evidence link insert conflicted") from exc
-        return stored_evidence, link
 
     def supersede_atomic(
         self,
@@ -518,16 +550,16 @@ class RelationshipAssertionRepository:
     ) -> tuple[Assertion, AssertionEvent]:
         domain = _fix_assertion_mapping(row)
         if not proposals_equivalent(domain, proposal):
-            message = f"assertion {proposal.assertion_id} already exists with a different proposition"
-            if exc is None:
-                raise ValidationError(message)
-            raise ValidationError(message) from exc
+            _raise_validation(
+                f"assertion {proposal.assertion_id} already exists with a different proposition",
+                exc,
+            )
         events = self._load_events(proposal.assertion_id)
         if not events:
-            message = f"assertion {proposal.assertion_id} missing propose event{missing_event_suffix}"
-            if exc is None:
-                raise ValidationError(message)
-            raise ValidationError(message) from exc
+            _raise_validation(
+                f"assertion {proposal.assertion_id} missing propose event{missing_event_suffix}",
+                exc,
+            )
         return domain, events[0]
 
     def _insert_new_proposal(

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -194,13 +194,24 @@ def _fix_assertion_mapping(row: RelationshipAssertionORM) -> Assertion:
 
 
 def _evidence_identity_tuple(evidence: EvidenceRecord) -> tuple[object, ...]:
+    """Return comparable immutable evidence metadata for all persisted fields."""
     return (
         evidence.source_ref,
         evidence.content_sha256,
         evidence.media_type,
         evidence.visibility,
         evidence.custody_id,
+        evidence.observed_at,
+        evidence.issued_at,
+        evidence.licensing,
+        evidence.reuse_policy,
     )
+
+
+def _is_foreign_key_integrity_error(exc: IntegrityError) -> bool:
+    """Return True when ``exc`` looks like a foreign-key violation."""
+    detail = str(getattr(exc, "orig", None) or exc).lower()
+    return "foreign key" in detail or "foreignkeyviolation" in detail
 
 
 def _parse_known_at(known_at: datetime, assertion: Assertion) -> datetime | None:
@@ -332,6 +343,13 @@ def _plan_repository_transition(
     return plan_transition(plan)
 
 
+def _require_accepted_successor_id(successor_assertion_id: str) -> str:
+    """Normalize a required successor id for supersession persistence checks."""
+    if not successor_assertion_id.strip():
+        raise ValidationError("supersession requires successor_assertion_id")
+    return successor_assertion_id
+
+
 class RelationshipAssertionRepository:
     """INSERT-only persistence for governed assertions, events, and evidence."""
 
@@ -362,14 +380,18 @@ class RelationshipAssertionRepository:
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp, event_id=event_id)
         return self._insert_new_proposal(assertion, event, proposal)
 
-    def append_event(
+    def _append_event(
         self,
         assertion_id: str,
         event: AssertionEvent,
         *,
         expected_sequence: int,
     ) -> AssertionEvent:
-        """INSERT a planned event only when ``expected_sequence`` matches current max."""
+        """INSERT a planner-produced event when ``expected_sequence`` matches current max.
+
+        Private on purpose: callers must go through ``transition`` / ``supersede_atomic``
+        so matrix authority and successor checks cannot be bypassed with a fabricated event.
+        """
         _validate_event_identity(assertion_id, event)
         _validate_event_sequence(assertion_id, event, expected_sequence, self._max_sequence(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
@@ -378,16 +400,31 @@ class RelationshipAssertionRepository:
         try:
             self._session.flush()
         except IntegrityError as exc:
-            self._session.rollback()
-            raise ConcurrencyConflict(f"sequence conflict for assertion {assertion_id} at {event.sequence}") from exc
+            error: Exception
+            if _is_foreign_key_integrity_error(exc):
+                error = ValidationError(
+                    f"event foreign-key violation for assertion {assertion_id} "
+                    f"(check successor_assertion_id and related rows)"
+                )
+            else:
+                error = ConcurrencyConflict(f"sequence conflict for assertion {assertion_id} at {event.sequence}")
+            # Nested savepoints (supersede_atomic) roll back on exit; avoid full-session wipe.
+            if not self._session.in_nested_transaction():
+                self._session.rollback()
+            raise error from exc
         return event
 
     def transition(self, request: RepositoryTransitionRequest) -> AssertionEvent:
         """Plan and append a matrix transition under the concurrency guard."""
+        if request.to_state == "Superseded":
+            successor_id = _require_accepted_successor_id(request.successor_assertion_id or "")
+            self._lock_assertions(request.assertion_id, successor_id)
+            self._require_accepted_successor(successor_id)
+            assert_no_cycle(request.assertion_id, successor_id, self._successor_chain_lookup)
         current = self._current_state(request.assertion_id)
         stamp = request.recorded_at or self._clock()
         event = _plan_repository_transition(request, current, stamp, self._successor_chain_lookup)
-        return self.append_event(request.assertion_id, event, expected_sequence=request.expected_sequence)
+        return self._append_event(request.assertion_id, event, expected_sequence=request.expected_sequence)
 
     def register_evidence(self, request: RegisterEvidenceRequest) -> tuple[EvidenceRecord, EvidenceLink]:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
@@ -473,28 +510,31 @@ class RelationshipAssertionRepository:
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
         """Atomically accept a successor and supersede the predecessor."""
         stamp = request.recorded_at or self._clock()
-        pred_state = self._current_state(request.predecessor_id)
-        self._validate_supersede_preconditions(request, pred_state)
-        successor, propose_event = self.propose(request.successor_proposal, request.ctx, recorded_at=stamp)
-        accept_timing = TransitionTiming(1, request.accept_rationale, stamp)
-        accept_event = plan_accept(successor.assertion_id, "Proposed", request.ctx, timing=accept_timing)
-        self.append_event(successor.assertion_id, accept_event, expected_sequence=1)
-        supersede_event = _plan_repository_transition(
-            RepositoryTransitionRequest(
-                assertion_id=request.predecessor_id,
-                to_state="Superseded",
-                ctx=request.ctx,
-                expected_sequence=request.expected_sequence,
-                rationale=request.rationale,
-                successor_assertion_id=successor.assertion_id,
-                recorded_at=stamp,
-            ),
-            pred_state,
-            stamp,
-            self._successor_chain_lookup,
-        )
-        self.append_event(request.predecessor_id, supersede_event, expected_sequence=request.expected_sequence)
-        self._session.flush()
+        # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
+        with self._session.begin_nested():
+            self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
+            pred_state = self._current_state(request.predecessor_id)
+            self._validate_supersede_preconditions(request, pred_state)
+            successor, propose_event = self.propose(request.successor_proposal, request.ctx, recorded_at=stamp)
+            accept_timing = TransitionTiming(1, request.accept_rationale, stamp)
+            accept_event = plan_accept(successor.assertion_id, "Proposed", request.ctx, timing=accept_timing)
+            self._append_event(successor.assertion_id, accept_event, expected_sequence=1)
+            supersede_event = _plan_repository_transition(
+                RepositoryTransitionRequest(
+                    assertion_id=request.predecessor_id,
+                    to_state="Superseded",
+                    ctx=request.ctx,
+                    expected_sequence=request.expected_sequence,
+                    rationale=request.rationale,
+                    successor_assertion_id=successor.assertion_id,
+                    recorded_at=stamp,
+                ),
+                pred_state,
+                stamp,
+                self._successor_chain_lookup,
+            )
+            self._append_event(request.predecessor_id, supersede_event, expected_sequence=request.expected_sequence)
+            self._session.flush()
         return successor, propose_event, accept_event, supersede_event
 
     def get_as_of(
@@ -601,6 +641,23 @@ class RelationshipAssertionRepository:
         _validate_supersede_sequence(request, self._max_sequence(request.predecessor_id))
         if self._session.get(RelationshipAssertionORM, request.successor_proposal.assertion_id) is not None:
             raise ValidationError(f"successor assertion {request.successor_proposal.assertion_id} already exists")
+
+    def _lock_assertions(self, *assertion_ids: str) -> None:
+        """Lock assertion rows in sorted id order to serialize supersession graph checks."""
+        for assertion_id in sorted({item for item in assertion_ids if item}):
+            self._session.execute(
+                select(RelationshipAssertionORM.id).where(RelationshipAssertionORM.id == assertion_id).with_for_update()
+            ).scalar_one_or_none()
+
+    def _require_accepted_successor(self, successor_assertion_id: str) -> None:
+        """Reject missing or non-Accepted successors for direct supersession."""
+        if self._session.get(RelationshipAssertionORM, successor_assertion_id) is None:
+            raise ValidationError(f"unknown successor_assertion_id: {successor_assertion_id}")
+        state = self._current_state(successor_assertion_id)
+        if state != "Accepted":
+            raise ValidationError(
+                f"successor {successor_assertion_id} must be Accepted to supersede " f"(current={state})"
+            )
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -1,13 +1,9 @@
-"""Append-only repository for GRAC v1 assertion lifecycle and evidence.
-
-INSERT-only against the PR3 ORM tables. Lifecycle decisions are planned in
-``relationship_assertion_lifecycle``; this module persists them and enforces
-expected-sequence concurrency and atomic supersession.
-"""
+"""Append-only GRAC v1 assertion lifecycle repository (INSERT-only ORM persistence)."""
 
 from __future__ import annotations
 
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from typing import cast
 from uuid import uuid4
@@ -39,6 +35,10 @@ from src.governance.relationship_assertion import (
     Visibility,
 )
 from src.governance.relationship_assertion_lifecycle import (
+    EvidenceRegistrationPlan,
+    SupersedePlan,
+    TransitionPlan,
+    TransitionTiming,
     assert_no_cycle,
     cast_polarity,
     plan_accept,
@@ -54,18 +54,54 @@ from src.governance.relationship_assertion_lifecycle import (
 UTC = timezone.utc
 
 
+@dataclass(frozen=True)
+class RepositoryTransitionRequest:
+    """Inputs for planning and appending a repository lifecycle transition."""
+
+    assertion_id: str
+    to_state: LifecycleState
+    ctx: AuthorityContext
+    expected_sequence: int
+    rationale: str
+    successor_assertion_id: str | None = None
+    recorded_at: datetime | None = None
+    event_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RegisterEvidenceRequest:
+    """Inputs for immutable evidence registration and linking."""
+
+    assertion_id: str
+    evidence: EvidenceRecord
+    polarity: EvidencePolarity
+    ctx: AuthorityContext
+    link_id: str | None = None
+    recorded_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class SupersedeAtomicRequest:
+    """Inputs for atomic successor acceptance and predecessor supersession."""
+
+    predecessor_id: str
+    successor_proposal: AssertionProposal
+    ctx: AuthorityContext
+    expected_sequence: int
+    rationale: str
+    recorded_at: datetime | None = None
+    accept_rationale: str = "accept successor"
+
+
 def _utcnow() -> datetime:
-    """Server-recorded UTC timestamp."""
     return datetime.now(tz=UTC)
 
 
 def _new_id() -> str:
-    """Allocate a UUID string primary key."""
     return str(uuid4())
 
 
 def _as_utc(value: datetime | None) -> datetime | None:
-    """Normalize SQLite naive datetimes to timezone-aware UTC."""
     if value is None:
         return None
     if value.tzinfo is None:
@@ -74,7 +110,6 @@ def _as_utc(value: datetime | None) -> datetime | None:
 
 
 def _event_from_orm(row: RelationshipAssertionEventORM) -> AssertionEvent:
-    """Map an ORM event row to the domain DTO."""
     recorded_at = _as_utc(row.recorded_at)
     if recorded_at is None:
         raise ValidationError("event recorded_at missing")
@@ -95,7 +130,6 @@ def _event_from_orm(row: RelationshipAssertionEventORM) -> AssertionEvent:
 
 
 def _evidence_from_orm(row: RelationshipEvidenceORM) -> EvidenceRecord:
-    """Map an ORM evidence row to the domain DTO."""
     recorded_at = _as_utc(row.recorded_at)
     if recorded_at is None:
         raise ValidationError("evidence recorded_at missing")
@@ -115,7 +149,6 @@ def _evidence_from_orm(row: RelationshipEvidenceORM) -> EvidenceRecord:
 
 
 def _link_from_orm(row: RelationshipAssertionEvidenceORM) -> EvidenceLink:
-    """Map an ORM evidence-link row to the domain DTO."""
     recorded_at = _as_utc(row.recorded_at)
     if recorded_at is None:
         raise ValidationError("evidence link recorded_at missing")
@@ -129,7 +162,6 @@ def _link_from_orm(row: RelationshipAssertionEvidenceORM) -> EvidenceLink:
 
 
 def _fix_assertion_mapping(row: RelationshipAssertionORM) -> Assertion:
-    """Map ORM assertion with correct confidence_status typing."""
     status = row.confidence_status
     if status not in ("assessed", "not_assessed"):
         raise ValidationError(f"invalid confidence_status in store: {status!r}")
@@ -152,6 +184,145 @@ def _fix_assertion_mapping(row: RelationshipAssertionORM) -> Assertion:
         effective_to=_as_utc(row.effective_to),
         recorded_at=recorded_at,
     )
+
+
+def _evidence_identity_tuple(evidence: EvidenceRecord) -> tuple[object, ...]:
+    return (
+        evidence.source_ref,
+        evidence.content_sha256,
+        evidence.media_type,
+        evidence.visibility,
+        evidence.custody_id,
+    )
+
+
+def _parse_known_at(known_at: datetime, assertion: Assertion) -> datetime | None:
+    known = _as_utc(known_at)
+    if known is None:
+        raise ValidationError("known_at is required")
+    if assertion.recorded_at > known:
+        return None
+    return known
+
+
+def _effective_at_visible(assertion: Assertion, effective: datetime) -> bool:
+    if assertion.effective_from > effective:
+        return False
+    return not (assertion.effective_to is not None and assertion.effective_to < effective)
+
+
+def _resolve_as_of_bounds(
+    assertion: Assertion,
+    known_at: datetime,
+    effective_at: datetime | None,
+) -> tuple[datetime | None, datetime | None]:
+    known = _parse_known_at(known_at, assertion)
+    if known is None:
+        return None, None
+    if effective_at is None:
+        return known, None
+    effective = _as_utc(effective_at)
+    if effective is None:
+        raise ValidationError("effective_at is required when provided")
+    if not _effective_at_visible(assertion, effective):
+        return None, None
+    return known, effective
+
+
+def _validate_event_identity(assertion_id: str, event: AssertionEvent) -> None:
+    if event.assertion_id != assertion_id:
+        raise ValidationError("event assertion_id mismatch")
+
+
+def _validate_event_sequence(
+    assertion_id: str,
+    event: AssertionEvent,
+    expected_sequence: int,
+    current_max: int,
+) -> None:
+    if event.sequence != expected_sequence + 1:
+        raise ConcurrencyConflict(f"event.sequence {event.sequence} != expected_sequence+1 ({expected_sequence + 1})")
+    if current_max != expected_sequence:
+        raise ConcurrencyConflict(f"expected_sequence {expected_sequence} but current max is {current_max}")
+
+
+def _validate_supersede_state(predecessor_id: str, pred_state: LifecycleState) -> None:
+    if pred_state not in ("Accepted", "Disputed"):
+        raise ValidationError(
+            f"predecessor {predecessor_id} must be Accepted or Disputed to supersede " f"(current={pred_state})"
+        )
+
+
+def _validate_supersede_ids(request: SupersedeAtomicRequest) -> None:
+    if request.predecessor_id == request.successor_proposal.assertion_id:
+        raise SupersessionCycle("self-supersession is forbidden")
+
+
+def _validate_supersede_sequence(request: SupersedeAtomicRequest, current_max: int) -> None:
+    if current_max != request.expected_sequence:
+        raise ConcurrencyConflict(f"expected_sequence {request.expected_sequence} but current max is {current_max}")
+
+
+def _assertion_orm(assertion: Assertion) -> RelationshipAssertionORM:
+    return RelationshipAssertionORM(
+        id=assertion.assertion_id,
+        predicate_id=assertion.predicate_id,
+        subject_id=assertion.subject_id,
+        object_id=assertion.object_id,
+        method_id=assertion.method_id,
+        proposition=assertion.proposition,
+        confidence_bp=assertion.confidence_bp,
+        confidence_type=assertion.confidence_type,
+        confidence_method=assertion.confidence_method,
+        confidence_status=assertion.confidence_status,
+        effective_from=assertion.effective_from,
+        effective_to=assertion.effective_to,
+        recorded_at=assertion.recorded_at,
+    )
+
+
+def _event_orm(event: AssertionEvent) -> RelationshipAssertionEventORM:
+    return RelationshipAssertionEventORM(
+        id=event.event_id,
+        assertion_id=event.assertion_id,
+        sequence=event.sequence,
+        from_state=event.from_state,
+        to_state=event.to_state,
+        authority=event.authority,
+        actor_id=event.actor_id,
+        rationale=event.rationale,
+        policy_version=event.policy_version,
+        recorded_at=event.recorded_at,
+        successor_assertion_id=event.successor_assertion_id,
+        correlation_id=event.correlation_id,
+    )
+
+
+def _plan_repository_transition(
+    request: RepositoryTransitionRequest,
+    current: LifecycleState,
+    stamp: datetime,
+    successor_chain_lookup: Callable[[str], Sequence[str]],
+) -> AssertionEvent:
+    timing = TransitionTiming(
+        expected_sequence=request.expected_sequence,
+        rationale=request.rationale,
+        recorded_at=stamp,
+        event_id=request.event_id,
+    )
+    plan = TransitionPlan(
+        assertion_id=request.assertion_id,
+        current=current,
+        to_state=request.to_state,
+        ctx=request.ctx,
+        timing=timing,
+        successor_assertion_id=request.successor_assertion_id,
+    )
+    if request.to_state == "Superseded":
+        if request.successor_assertion_id is None:
+            raise ValidationError("supersession requires successor_assertion_id")
+        return plan_supersede(SupersedePlan(transition=plan, successor_chain_lookup=successor_chain_lookup))
+    return plan_transition(plan)
 
 
 class RelationshipAssertionRepository:
@@ -178,55 +349,11 @@ class RelationshipAssertionRepository:
         """Create an assertion + Proposed event, or return the existing identical proposal."""
         existing = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
         if existing is not None:
-            domain = _fix_assertion_mapping(existing)
-            if not proposals_equivalent(domain, proposal):
-                raise ValidationError(f"assertion {proposal.assertion_id} already exists with a different proposition")
-            events = self._load_events(proposal.assertion_id)
-            if not events:
-                raise ValidationError(f"assertion {proposal.assertion_id} missing propose event")
-            return domain, events[0]
+            return self._existing_proposal(existing, proposal)
 
         stamp = recorded_at or self._clock()
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp, event_id=event_id)
-        self._session.add(
-            RelationshipAssertionORM(
-                id=assertion.assertion_id,
-                predicate_id=assertion.predicate_id,
-                subject_id=assertion.subject_id,
-                object_id=assertion.object_id,
-                method_id=assertion.method_id,
-                proposition=assertion.proposition,
-                confidence_bp=assertion.confidence_bp,
-                confidence_type=assertion.confidence_type,
-                confidence_method=assertion.confidence_method,
-                confidence_status=assertion.confidence_status,
-                effective_from=assertion.effective_from,
-                effective_to=assertion.effective_to,
-                recorded_at=assertion.recorded_at,
-            )
-        )
-        try:
-            # Flush assertion before the event so SQLite FK checks see the parent row.
-            self._session.flush()
-            self._insert_event_orm(event)
-            self._session.flush()
-        except IntegrityError as exc:
-            self._session.rollback()
-            raced = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
-            if raced is None:
-                raise ValidationError(f"propose failed for {proposal.assertion_id}: {exc}") from exc
-            domain = _fix_assertion_mapping(raced)
-            if not proposals_equivalent(domain, proposal):
-                raise ValidationError(
-                    f"assertion {proposal.assertion_id} already exists with a different proposition"
-                ) from exc
-            events = self._load_events(proposal.assertion_id)
-            if not events:
-                raise ValidationError(
-                    f"assertion {proposal.assertion_id} missing propose event after conflict"
-                ) from exc
-            return domain, events[0]
-        return assertion, event
+        return self._insert_new_proposal(assertion, event, proposal)
 
     def append_event(
         self,
@@ -236,15 +363,8 @@ class RelationshipAssertionRepository:
         expected_sequence: int,
     ) -> AssertionEvent:
         """INSERT a planned event only when ``expected_sequence`` matches current max."""
-        if event.assertion_id != assertion_id:
-            raise ValidationError("event assertion_id mismatch")
-        if event.sequence != expected_sequence + 1:
-            raise ConcurrencyConflict(
-                f"event.sequence {event.sequence} != expected_sequence+1 ({expected_sequence + 1})"
-            )
-        current_max = self._max_sequence(assertion_id)
-        if current_max != expected_sequence:
-            raise ConcurrencyConflict(f"expected_sequence {expected_sequence} but current max is {current_max}")
+        _validate_event_identity(assertion_id, event)
+        _validate_event_sequence(assertion_id, event, expected_sequence, self._max_sequence(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
             raise ValidationError(f"unknown assertion_id: {assertion_id}")
         self._insert_event_orm(event)
@@ -255,102 +375,50 @@ class RelationshipAssertionRepository:
             raise ConcurrencyConflict(f"sequence conflict for assertion {assertion_id} at {event.sequence}") from exc
         return event
 
-    def transition(
-        self,
-        assertion_id: str,
-        to_state: LifecycleState,
-        ctx: AuthorityContext,
-        *,
-        expected_sequence: int,
-        rationale: str,
-        successor_assertion_id: str | None = None,
-        recorded_at: datetime | None = None,
-        event_id: str | None = None,
-    ) -> AssertionEvent:
+    def transition(self, request: RepositoryTransitionRequest) -> AssertionEvent:
         """Plan and append a matrix transition under the concurrency guard."""
-        current = self._current_state(assertion_id)
-        stamp = recorded_at or self._clock()
-        if to_state == "Superseded":
-            if successor_assertion_id is None:
-                raise ValidationError("supersession requires successor_assertion_id")
-            event = plan_supersede(
-                assertion_id,
-                current,
-                ctx,
-                expected_sequence=expected_sequence,
-                rationale=rationale,
-                recorded_at=stamp,
-                successor_assertion_id=successor_assertion_id,
-                successor_chain_lookup=self._successor_chain_lookup,
-                event_id=event_id,
-            )
-        else:
-            event = plan_transition(
-                assertion_id,
-                current,
-                to_state,
-                ctx,
-                expected_sequence=expected_sequence,
-                rationale=rationale,
-                recorded_at=stamp,
-                successor_assertion_id=successor_assertion_id,
-                event_id=event_id,
-            )
-        return self.append_event(assertion_id, event, expected_sequence=expected_sequence)
+        current = self._current_state(request.assertion_id)
+        stamp = request.recorded_at or self._clock()
+        event = _plan_repository_transition(request, current, stamp, self._successor_chain_lookup)
+        return self.append_event(request.assertion_id, event, expected_sequence=request.expected_sequence)
 
-    def register_evidence(
-        self,
-        assertion_id: str,
-        evidence: EvidenceRecord,
-        polarity: EvidencePolarity,
-        ctx: AuthorityContext,
-        *,
-        link_id: str | None = None,
-        recorded_at: datetime | None = None,
-    ) -> tuple[EvidenceRecord, EvidenceLink]:
+    def register_evidence(self, request: RegisterEvidenceRequest) -> tuple[EvidenceRecord, EvidenceLink]:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
-        stamp = recorded_at or self._clock()
-        normalized = validate_evidence_record(
-            EvidenceRecord(
-                evidence_id=evidence.evidence_id,
-                source_ref=evidence.source_ref,
-                content_sha256=evidence.content_sha256,
-                media_type=evidence.media_type,
-                visibility=evidence.visibility,
-                custody_id=evidence.custody_id,
-                recorded_at=stamp,
-                observed_at=evidence.observed_at,
-                issued_at=evidence.issued_at,
-                licensing=evidence.licensing,
-                reuse_policy=evidence.reuse_policy,
-            )
-        )
-
-        state = self._current_state(assertion_id)
+        stamp = request.recorded_at or self._clock()
+        normalized = validate_evidence_record(replace(request.evidence, recorded_at=stamp))
         link = EvidenceLink(
-            link_id=link_id or _new_id(),
-            assertion_id=assertion_id,
+            link_id=request.link_id or _new_id(),
+            assertion_id=request.assertion_id,
             evidence_id=normalized.evidence_id,
-            polarity=polarity,
+            polarity=request.polarity,
             recorded_at=stamp,
         )
-        plan_register_evidence(assertion_id, state, link, ctx, evidence=normalized)
-
+        plan_register_evidence(
+            EvidenceRegistrationPlan(
+                assertion_id=request.assertion_id,
+                state=self._current_state(request.assertion_id),
+                link=link,
+                ctx=request.ctx,
+                evidence=normalized,
+            )
+        )
         stored_evidence = self._upsert_evidence(normalized)
         existing_link = self._session.execute(
             select(RelationshipAssertionEvidenceORM).where(
-                RelationshipAssertionEvidenceORM.assertion_id == assertion_id,
+                RelationshipAssertionEvidenceORM.assertion_id == request.assertion_id,
                 RelationshipAssertionEvidenceORM.evidence_id == normalized.evidence_id,
             )
         ).scalar_one_or_none()
         if existing_link is not None:
-            if existing_link.polarity != polarity:
+            if existing_link.polarity != request.polarity:
                 raise ValidationError(
                     "evidence link already exists with a different polarity "
-                    f"({existing_link.polarity} != {polarity})"
+                    f"({existing_link.polarity} != {request.polarity})"
                 )
-            return stored_evidence, _link_from_orm(existing_link)
-
+            evidence_row = self._session.get(RelationshipEvidenceORM, existing_link.evidence_id)
+            if evidence_row is None:
+                raise ValidationError(f"evidence {existing_link.evidence_id} missing for existing link")
+            return _evidence_from_orm(evidence_row), _link_from_orm(existing_link)
         self._session.add(
             RelationshipAssertionEvidenceORM(
                 id=link.link_id,
@@ -369,64 +437,31 @@ class RelationshipAssertionRepository:
 
     def supersede_atomic(
         self,
-        predecessor_id: str,
-        successor_proposal: AssertionProposal,
-        ctx: AuthorityContext,
-        *,
-        expected_sequence: int,
-        rationale: str,
-        recorded_at: datetime | None = None,
-        accept_rationale: str = "accept successor",
+        request: SupersedeAtomicRequest,
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
-        """Atomically accept a successor and supersede the predecessor.
-
-        Same transaction:
-        1. propose successor (seq=1 Proposed)
-        2. accept successor (seq=2 Accepted)
-        3. supersede predecessor (→ Superseded with successor_assertion_id)
-
-        On failure neither orphan successor nor superseded-without-successor is visible.
-        """
-        stamp = recorded_at or self._clock()
-        pred_state = self._current_state(predecessor_id)
-        if pred_state not in ("Accepted", "Disputed"):
-            raise ValidationError(
-                f"predecessor {predecessor_id} must be Accepted or Disputed to supersede " f"(current={pred_state})"
-            )
-        if predecessor_id == successor_proposal.assertion_id:
-            raise SupersessionCycle("self-supersession is forbidden")
-        assert_no_cycle(predecessor_id, successor_proposal.assertion_id, self._successor_chain_lookup)
-
-        if self._max_sequence(predecessor_id) != expected_sequence:
-            raise ConcurrencyConflict(
-                f"expected_sequence {expected_sequence} but current max is " f"{self._max_sequence(predecessor_id)}"
-            )
-        if self._session.get(RelationshipAssertionORM, successor_proposal.assertion_id) is not None:
-            raise ValidationError(f"successor assertion {successor_proposal.assertion_id} already exists")
-
-        successor, propose_event = self.propose(successor_proposal, ctx, recorded_at=stamp)
-        # Fresh propose always yields seq=1; accept at expected_sequence=1.
-        accept_event = plan_accept(
-            successor.assertion_id,
-            "Proposed",
-            ctx,
-            expected_sequence=1,
-            rationale=accept_rationale,
-            recorded_at=stamp,
-        )
+        """Atomically accept a successor and supersede the predecessor."""
+        stamp = request.recorded_at or self._clock()
+        pred_state = self._current_state(request.predecessor_id)
+        self._validate_supersede_preconditions(request, pred_state)
+        successor, propose_event = self.propose(request.successor_proposal, request.ctx, recorded_at=stamp)
+        accept_timing = TransitionTiming(1, request.accept_rationale, stamp)
+        accept_event = plan_accept(successor.assertion_id, "Proposed", request.ctx, timing=accept_timing)
         self.append_event(successor.assertion_id, accept_event, expected_sequence=1)
-
-        supersede_event = plan_supersede(
-            predecessor_id,
+        supersede_event = _plan_repository_transition(
+            RepositoryTransitionRequest(
+                assertion_id=request.predecessor_id,
+                to_state="Superseded",
+                ctx=request.ctx,
+                expected_sequence=request.expected_sequence,
+                rationale=request.rationale,
+                successor_assertion_id=successor.assertion_id,
+                recorded_at=stamp,
+            ),
             pred_state,
-            ctx,
-            expected_sequence=expected_sequence,
-            rationale=rationale,
-            recorded_at=stamp,
-            successor_assertion_id=successor.assertion_id,
-            successor_chain_lookup=self._successor_chain_lookup,
+            stamp,
+            self._successor_chain_lookup,
         )
-        self.append_event(predecessor_id, supersede_event, expected_sequence=expected_sequence)
+        self.append_event(request.predecessor_id, supersede_event, expected_sequence=request.expected_sequence)
         self._session.flush()
         return successor, propose_event, accept_event, supersede_event
 
@@ -442,22 +477,9 @@ class RelationshipAssertionRepository:
         if row is None:
             return None
         assertion = _fix_assertion_mapping(row)
-        known = _as_utc(known_at)
+        known, effective = _resolve_as_of_bounds(assertion, known_at, effective_at)
         if known is None:
-            raise ValidationError("known_at is required")
-        if assertion.recorded_at > known:
             return None
-        if effective_at is not None:
-            effective = _as_utc(effective_at)
-            if effective is None:
-                raise ValidationError("effective_at is required when provided")
-            if assertion.effective_from > effective:
-                return None
-            if assertion.effective_to is not None and assertion.effective_to < effective:
-                return None
-        else:
-            effective = None
-
         events = tuple(event for event in self._load_events(assertion_id) if event.recorded_at <= known)
         if not events:
             return None
@@ -486,6 +508,68 @@ class RelationshipAssertionRepository:
         """Return the highest event sequence for ``assertion_id`` (0 if none)."""
         return self._max_sequence(assertion_id)
 
+    def _existing_proposal(
+        self,
+        row: RelationshipAssertionORM,
+        proposal: AssertionProposal,
+        *,
+        exc: IntegrityError | None = None,
+        missing_event_suffix: str = "",
+    ) -> tuple[Assertion, AssertionEvent]:
+        domain = _fix_assertion_mapping(row)
+        if not proposals_equivalent(domain, proposal):
+            message = f"assertion {proposal.assertion_id} already exists with a different proposition"
+            if exc is None:
+                raise ValidationError(message)
+            raise ValidationError(message) from exc
+        events = self._load_events(proposal.assertion_id)
+        if not events:
+            message = f"assertion {proposal.assertion_id} missing propose event{missing_event_suffix}"
+            if exc is None:
+                raise ValidationError(message)
+            raise ValidationError(message) from exc
+        return domain, events[0]
+
+    def _insert_new_proposal(
+        self,
+        assertion: Assertion,
+        event: AssertionEvent,
+        proposal: AssertionProposal,
+    ) -> tuple[Assertion, AssertionEvent]:
+        self._session.add(_assertion_orm(assertion))
+        try:
+            self._session.flush()
+            self._insert_event_orm(event)
+            self._session.flush()
+        except IntegrityError as exc:
+            self._session.rollback()
+            raced = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
+            if raced is None:
+                raise ValidationError(f"propose failed for {proposal.assertion_id}: {exc}") from exc
+            return self._existing_proposal(
+                raced,
+                proposal,
+                exc=exc,
+                missing_event_suffix=" after conflict",
+            )
+        return assertion, event
+
+    def _validate_supersede_preconditions(
+        self,
+        request: SupersedeAtomicRequest,
+        pred_state: LifecycleState,
+    ) -> None:
+        _validate_supersede_state(request.predecessor_id, pred_state)
+        _validate_supersede_ids(request)
+        assert_no_cycle(
+            request.predecessor_id,
+            request.successor_proposal.assertion_id,
+            self._successor_chain_lookup,
+        )
+        _validate_supersede_sequence(request, self._max_sequence(request.predecessor_id))
+        if self._session.get(RelationshipAssertionORM, request.successor_proposal.assertion_id) is not None:
+            raise ValidationError(f"successor assertion {request.successor_proposal.assertion_id} already exists")
+
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)
         if not events:
@@ -509,34 +593,13 @@ class RelationshipAssertionRepository:
         return [_event_from_orm(row) for row in rows]
 
     def _insert_event_orm(self, event: AssertionEvent) -> None:
-        self._session.add(
-            RelationshipAssertionEventORM(
-                id=event.event_id,
-                assertion_id=event.assertion_id,
-                sequence=event.sequence,
-                from_state=event.from_state,
-                to_state=event.to_state,
-                authority=event.authority,
-                actor_id=event.actor_id,
-                rationale=event.rationale,
-                policy_version=event.policy_version,
-                recorded_at=event.recorded_at,
-                successor_assertion_id=event.successor_assertion_id,
-                correlation_id=event.correlation_id,
-            )
-        )
+        self._session.add(_event_orm(event))
 
     def _upsert_evidence(self, evidence: EvidenceRecord) -> EvidenceRecord:
         existing = self._session.get(RelationshipEvidenceORM, evidence.evidence_id)
         if existing is not None:
             domain = _evidence_from_orm(existing)
-            if (
-                domain.source_ref != evidence.source_ref
-                or domain.content_sha256 != evidence.content_sha256
-                or domain.media_type != evidence.media_type
-                or domain.visibility != evidence.visibility
-                or domain.custody_id != evidence.custody_id
-            ):
+            if _evidence_identity_tuple(domain) != _evidence_identity_tuple(evidence):
                 raise ValidationError(f"evidence {evidence.evidence_id} already exists with different metadata")
             return domain
         self._session.add(
@@ -558,7 +621,6 @@ class RelationshipAssertionRepository:
         return evidence
 
     def _successor_chain_lookup(self, assertion_id: str) -> Sequence[str]:
-        """Return successor IDs recorded on Superseded events for ``assertion_id``."""
         rows = self._session.execute(
             select(RelationshipAssertionEventORM.successor_assertion_id).where(
                 RelationshipAssertionEventORM.assertion_id == assertion_id,

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -420,6 +420,7 @@ class RelationshipAssertionRepository:
         """Plan and append a matrix transition under the concurrency guard."""
         if request.to_state == "Superseded":
             successor_id = _require_accepted_successor_id(request.successor_assertion_id or "")
+            self._lock_supersession_graph()
             self._lock_assertions(request.assertion_id, successor_id)
             self._require_accepted_successor(successor_id)
             assert_no_cycle(request.assertion_id, successor_id, self._successor_chain_lookup)
@@ -516,6 +517,7 @@ class RelationshipAssertionRepository:
         stamp = request.recorded_at or self._clock()
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
+            self._lock_supersession_graph()
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
             pred_state = self._current_state(request.predecessor_id)
             self._validate_supersede_preconditions(request, pred_state)
@@ -657,6 +659,18 @@ class RelationshipAssertionRepository:
             self._session.execute(
                 select(RelationshipAssertionORM.id).where(RelationshipAssertionORM.id == assertion_id).with_for_update()
             ).scalar_one_or_none()
+
+    def _lock_supersession_graph(self) -> None:
+        """Serialize supersession graph checks against every existing assertion.
+
+        PostgreSQL locks the rows in deterministic id order until the transaction
+        ends. Fully consuming the result acquires every lock before chain planning.
+        SQLite ignores ``FOR UPDATE`` and therefore provides no equivalent
+        graph-wide serialization.
+        """
+        self._session.execute(
+            select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
+        ).scalars().all()
 
     def _require_accepted_successor(self, successor_assertion_id: str) -> None:
         """Reject missing or non-Accepted successors for direct supersession."""

--- a/src/governance/relationship_assertion.py
+++ b/src/governance/relationship_assertion.py
@@ -1,0 +1,182 @@
+"""Domain types for GRAC v1 append-only assertion lifecycle and authority.
+
+Authority is a typed context only — no HTTP, JWT, or Request objects may appear here.
+API authorization maps into ``AuthorityContext`` at the boundary (later PR).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Literal
+
+# Re-export contract lifecycle vocabulary for domain callers.
+LifecycleState = Literal[
+    "Proposed",
+    "Accepted",
+    "Rejected",
+    "Withdrawn",
+    "Disputed",
+    "Retracted",
+    "Superseded",
+]
+
+AuthorityRole = Literal["proposer", "acceptor", "disputer", "retractor"]
+
+EvidencePolarity = Literal["supporting", "opposing", "contextual"]
+
+ConfidenceStatus = Literal["assessed", "not_assessed"]
+
+Visibility = Literal["public", "internal", "restricted", "confidential"]
+
+# Bounds aligned with ORM column lengths / contract size caps.
+MAX_ACTOR_ID_LEN = 128
+MAX_RATIONALE_LEN = 4096
+MAX_SOURCE_REF_LEN = 2048
+MAX_POLICY_VERSION_LEN = 64
+MAX_CORRELATION_ID_LEN = 128
+MAX_MEDIA_TYPE_LEN = 128
+MAX_LICENSING_LEN = 512
+MAX_REUSE_POLICY_LEN = 512
+MAX_CUSTODY_ID_LEN = 128
+MAX_PROPOSITION_LEN = 8192
+MAX_PREDICATE_ID_LEN = 256
+MAX_SUBJECT_ID_LEN = 128
+MAX_OBJECT_ID_LEN = 128
+MAX_METHOD_ID_LEN = 256
+MAX_CONFIDENCE_TYPE_LEN = 128
+MAX_CONFIDENCE_METHOD_LEN = 256
+SHA256_HEX_LEN = 64
+ENTITY_ID_LEN = 36
+
+EVIDENCE_LINK_STATES: frozenset[LifecycleState] = frozenset({"Proposed", "Accepted", "Disputed"})
+EVIDENCE_LINK_ROLES: frozenset[AuthorityRole] = frozenset({"proposer", "acceptor"})
+
+
+class RelationshipAssertionError(Exception):
+    """Base error for governed assertion domain failures."""
+
+
+class IllegalTransition(RelationshipAssertionError):
+    """Raised when a requested lifecycle edge is outside the frozen matrix."""
+
+
+class UnauthorizedTransition(RelationshipAssertionError):
+    """Raised when ``AuthorityContext`` lacks the role required by the matrix."""
+
+
+class ConcurrencyConflict(RelationshipAssertionError):
+    """Raised when ``expected_sequence`` does not match the assertion's latest event."""
+
+
+class SupersessionCycle(RelationshipAssertionError):
+    """Raised when supersession would create a cycle or self-supersession."""
+
+
+class ValidationError(RelationshipAssertionError):
+    """Raised when bounded fields or digest/payload shape are invalid."""
+
+
+@dataclass(frozen=True, slots=True)
+class AuthorityContext:
+    """Typed authority for lifecycle decisions (no HTTP / JWT types)."""
+
+    actor_id: str
+    roles: frozenset[AuthorityRole]
+    policy_version: str
+    correlation_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class AssertionProposal:
+    """Immutable proposition payload used to create an assertion."""
+
+    assertion_id: str
+    predicate_id: str
+    subject_id: str
+    object_id: str
+    method_id: str
+    proposition: str
+    effective_from: datetime
+    confidence_status: ConfidenceStatus = "not_assessed"
+    confidence_bp: int | None = None
+    confidence_type: str | None = None
+    confidence_method: str | None = None
+    effective_to: datetime | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Assertion:
+    """Immutable assertion proposition row (lifecycle lives in events)."""
+
+    assertion_id: str
+    predicate_id: str
+    subject_id: str
+    object_id: str
+    method_id: str
+    proposition: str
+    confidence_status: ConfidenceStatus
+    confidence_bp: int | None
+    confidence_type: str | None
+    confidence_method: str | None
+    effective_from: datetime
+    effective_to: datetime | None
+    recorded_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AssertionEvent:
+    """Append-only lifecycle/authority event for one assertion."""
+
+    event_id: str
+    assertion_id: str
+    sequence: int
+    from_state: LifecycleState | None
+    to_state: LifecycleState
+    authority: AuthorityRole
+    actor_id: str
+    rationale: str
+    policy_version: str
+    recorded_at: datetime
+    successor_assertion_id: str | None = None
+    correlation_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceRecord:
+    """Immutable evidence reference (digest + metadata; no body bytes)."""
+
+    evidence_id: str
+    source_ref: str
+    content_sha256: str
+    media_type: str
+    visibility: Visibility
+    custody_id: str
+    recorded_at: datetime
+    observed_at: datetime | None = None
+    issued_at: datetime | None = None
+    licensing: str | None = None
+    reuse_policy: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class EvidenceLink:
+    """Append-only polarity link between an assertion and evidence."""
+
+    link_id: str
+    assertion_id: str
+    evidence_id: str
+    polarity: EvidencePolarity
+    recorded_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AssertionAsOf:
+    """Bitemporal reconstruction of an assertion as of ``known_at``."""
+
+    assertion: Assertion
+    state: LifecycleState
+    events: tuple[AssertionEvent, ...]
+    evidence_links: tuple[EvidenceLink, ...] = field(default_factory=tuple)
+    effective_at: datetime | None = None
+    known_at: datetime | None = None

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import cast
 from uuid import uuid4
 
@@ -56,7 +56,7 @@ from src.governance.relationship_assertion_contract import (
 )
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
-_HEX_DIGEST_CHARS = frozenset("0123456789abcdef")
+_UTC_OFFSET = timedelta(0)
 
 
 def _new_id() -> str:
@@ -80,11 +80,24 @@ def _require_optional(value: str | None, field_name: str, max_len: int) -> str |
     return _require_non_empty(value, field_name, max_len)
 
 
+def _require_utc_datetime(value: datetime, field_name: str) -> None:
+    """Validate that a datetime is timezone-aware and has zero UTC offset."""
+    if value.tzinfo is None or value.utcoffset() != _UTC_OFFSET:
+        raise ValidationError(f"{field_name} must be timezone-aware UTC")
+
+
+def _require_non_bool_int(value: int, field_name: str) -> int:
+    """Reject bools/floats while preserving Python's integer contract."""
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValidationError(f"{field_name} must be an integer")
+    return value
+
+
 def normalize_sha256_hex(value: str) -> str:
     """Normalize and validate a SHA-256 digest to lowercase hex (64 chars)."""
     if not isinstance(value, str) or not value.strip():
         raise ValidationError("content_sha256 must be a non-empty string")
-    normalized = "".join(ch for ch in value.lower() if ch in _HEX_DIGEST_CHARS)
+    normalized = value.lower().replace("-", "")
     if len(normalized) != SHA256_HEX_LEN or not _SHA256_RE.fullmatch(normalized):
         raise ValidationError(f"content_sha256 must be {SHA256_HEX_LEN} lowercase hex characters")
     return normalized
@@ -110,10 +123,9 @@ def validate_proposal(proposal: AssertionProposal) -> None:
     _require_non_empty(proposal.object_id, "object_id", MAX_OBJECT_ID_LEN)
     _require_non_empty(proposal.method_id, "method_id", MAX_METHOD_ID_LEN)
     _require_non_empty(proposal.proposition, "proposition", MAX_PROPOSITION_LEN)
-    if proposal.effective_from.tzinfo is None:
-        raise ValidationError("effective_from must be timezone-aware UTC")
-    if proposal.effective_to is not None and proposal.effective_to.tzinfo is None:
-        raise ValidationError("effective_to must be timezone-aware UTC")
+    _require_utc_datetime(proposal.effective_from, "effective_from")
+    if proposal.effective_to is not None:
+        _require_utc_datetime(proposal.effective_to, "effective_to")
     if proposal.effective_to is not None and proposal.effective_to < proposal.effective_from:
         raise ValidationError("effective_to must be >= effective_from")
 
@@ -128,7 +140,10 @@ def validate_proposal(proposal: AssertionProposal) -> None:
 
     if proposal.confidence_status != "assessed":
         raise ValidationError("confidence_status must be assessed or not_assessed")
-    if proposal.confidence_bp is None or not (0 <= proposal.confidence_bp <= 10000):
+    if proposal.confidence_bp is None:
+        raise ValidationError("assessed confidence_bp must be an integer in [0, 10000]")
+    confidence_bp = _require_non_bool_int(proposal.confidence_bp, "confidence_bp")
+    if not (0 <= confidence_bp <= 10000):
         raise ValidationError("assessed confidence_bp must be an integer in [0, 10000]")
     _require_non_empty(proposal.confidence_type or "", "confidence_type", MAX_CONFIDENCE_TYPE_LEN)
     _require_non_empty(proposal.confidence_method or "", "confidence_method", MAX_CONFIDENCE_METHOD_LEN)
@@ -145,8 +160,11 @@ def validate_evidence_record(evidence: EvidenceRecord) -> EvidenceRecord:
         raise ValidationError(f"invalid visibility: {evidence.visibility!r}")
     _require_optional(evidence.licensing, "licensing", MAX_LICENSING_LEN)
     _require_optional(evidence.reuse_policy, "reuse_policy", MAX_REUSE_POLICY_LEN)
-    if evidence.recorded_at.tzinfo is None:
-        raise ValidationError("recorded_at must be timezone-aware UTC")
+    _require_utc_datetime(evidence.recorded_at, "recorded_at")
+    if evidence.observed_at is not None:
+        _require_utc_datetime(evidence.observed_at, "observed_at")
+    if evidence.issued_at is not None:
+        _require_utc_datetime(evidence.issued_at, "issued_at")
     if digest == evidence.content_sha256:
         return evidence
     return EvidenceRecord(
@@ -176,9 +194,31 @@ def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
         raise ValidationError("cannot resolve state from empty event stream")
     ordered = sorted(events, key=lambda event: event.sequence)
     expected = 1
+    previous_state: LifecycleState | None = None
+    transitions = load_transitions()
     for event in ordered:
-        if event.sequence != expected:
+        sequence = _require_non_bool_int(event.sequence, "event sequence")
+        if sequence != expected:
             raise ValidationError(f"event sequence gap: expected {expected}, got {event.sequence}")
+        _require_utc_datetime(event.recorded_at, "recorded_at")
+        if expected == 1:
+            if event.from_state is not None or event.to_state != "Proposed":
+                raise ValidationError("initial event must transition from None to Proposed")
+        else:
+            from_state = event.from_state
+            if from_state != previous_state:
+                raise ValidationError(
+                    f"event state continuity gap: expected from_state {previous_state}, got {from_state}"
+                )
+            from_state_value = cast(LifecycleState, from_state)
+            allowed = find_transition(transitions, from_state_value, event.to_state)
+            if allowed is None:
+                raise ValidationError(f"event transition outside matrix: {from_state_value}->{event.to_state}")
+            if allowed.requires_successor and event.successor_assertion_id is None:
+                raise ValidationError("supersession event requires successor_assertion_id")
+            if not allowed.requires_successor and event.successor_assertion_id is not None:
+                raise ValidationError("non-supersession event must not set successor_assertion_id")
+        previous_state = event.to_state
         expected += 1
     return ordered[-1].to_state
 
@@ -193,8 +233,7 @@ def plan_propose(
     """Plan creation of an assertion in ``Proposed`` with sequence 1."""
     validate_proposal(proposal)
     validate_authority(ctx, "proposer")
-    if recorded_at.tzinfo is None:
-        raise ValidationError("recorded_at must be timezone-aware UTC")
+    _require_utc_datetime(recorded_at, "recorded_at")
     assertion = Assertion(
         assertion_id=proposal.assertion_id,
         predicate_id=proposal.predicate_id,
@@ -242,10 +281,10 @@ def plan_transition(
     """Plan a single matrix transition with authority and concurrency guards."""
     _require_non_empty(assertion_id, "assertion_id", ENTITY_ID_LEN)
     rationale_value = _require_non_empty(rationale, "rationale", MAX_RATIONALE_LEN)
-    if expected_sequence < 1:
+    expected_sequence_value = _require_non_bool_int(expected_sequence, "expected_sequence")
+    if expected_sequence_value < 1:
         raise ConcurrencyConflict("expected_sequence must be >= 1 (last applied sequence)")
-    if recorded_at.tzinfo is None:
-        raise ValidationError("recorded_at must be timezone-aware UTC")
+    _require_utc_datetime(recorded_at, "recorded_at")
 
     matrix = transitions if transitions is not None else load_transitions()
     allowed = find_transition(matrix, current, to_state)
@@ -273,7 +312,7 @@ def plan_transition(
     return AssertionEvent(
         event_id=event_id or _new_id(),
         assertion_id=assertion_id,
-        sequence=expected_sequence + 1,
+        sequence=expected_sequence_value + 1,
         from_state=current,
         to_state=to_state,
         authority=required_role,
@@ -484,8 +523,7 @@ def plan_register_evidence(
         raise ValidationError(f"invalid evidence polarity: {link.polarity!r}")
     _require_non_empty(link.link_id, "link_id", ENTITY_ID_LEN)
     _require_non_empty(link.evidence_id, "evidence_id", ENTITY_ID_LEN)
-    if link.recorded_at.tzinfo is None:
-        raise ValidationError("recorded_at must be timezone-aware UTC")
+    _require_utc_datetime(link.recorded_at, "recorded_at")
     if evidence is not None:
         validate_evidence_record(evidence)
         if evidence.evidence_id != link.evidence_id:

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import cast
 from uuid import uuid4
@@ -51,12 +52,66 @@ from src.governance.relationship_assertion import (
 )
 from src.governance.relationship_assertion_contract import (
     TransitionsDocument,
+    TransitionSpec,
     find_transition,
     load_contract_bundle,
 )
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _UTC_OFFSET = timedelta(0)
+
+
+@dataclass(frozen=True)
+class TransitionTiming:
+    """Sequence, rationale, and timestamp inputs shared by transition planners."""
+
+    expected_sequence: int
+    rationale: str
+    recorded_at: datetime
+    event_id: str | None = None
+    transitions: TransitionsDocument | None = None
+
+
+@dataclass(frozen=True)
+class TransitionPlan:
+    """Fully specified lifecycle transition to plan as an append-only event."""
+
+    assertion_id: str
+    current: LifecycleState
+    to_state: LifecycleState
+    ctx: AuthorityContext
+    timing: TransitionTiming
+    successor_assertion_id: str | None = None
+
+
+@dataclass(frozen=True)
+class NamedTransitionPlan:
+    """Named matrix edge inputs folded into a single transition plan."""
+
+    to_state: LifecycleState
+    assertion_id: str
+    current: LifecycleState
+    ctx: AuthorityContext
+    timing: TransitionTiming
+
+
+@dataclass(frozen=True)
+class SupersedePlan:
+    """Supersession transition with optional successor-chain cycle detection."""
+
+    transition: TransitionPlan
+    successor_chain_lookup: Callable[[str], Sequence[str]] | Mapping[str, Sequence[str]] | None = None
+
+
+@dataclass(frozen=True)
+class EvidenceRegistrationPlan:
+    """Evidence link registration against a resolved lifecycle state."""
+
+    assertion_id: str
+    state: LifecycleState
+    link: EvidenceLink
+    ctx: AuthorityContext
+    evidence: EvidenceRecord | None = None
 
 
 def _new_id() -> str:
@@ -115,31 +170,39 @@ def validate_authority(ctx: AuthorityContext, required: AuthorityRole | set[Auth
         raise UnauthorizedTransition(f"missing required authority role(s) {sorted(needed)}; have {sorted(ctx.roles)}")
 
 
-def validate_proposal(proposal: AssertionProposal) -> None:
-    """Validate proposition shape, confidence pairing, and field bounds."""
+def _validate_proposal_identity(proposal: AssertionProposal) -> None:
+    """Validate proposition identity and bounded string fields."""
     _require_non_empty(proposal.assertion_id, "assertion_id", ENTITY_ID_LEN)
     _require_non_empty(proposal.predicate_id, "predicate_id", MAX_PREDICATE_ID_LEN)
     _require_non_empty(proposal.subject_id, "subject_id", MAX_SUBJECT_ID_LEN)
     _require_non_empty(proposal.object_id, "object_id", MAX_OBJECT_ID_LEN)
     _require_non_empty(proposal.method_id, "method_id", MAX_METHOD_ID_LEN)
     _require_non_empty(proposal.proposition, "proposition", MAX_PROPOSITION_LEN)
+
+
+def _validate_proposal_effective_window(proposal: AssertionProposal) -> None:
+    """Validate effective_from/to ordering and UTC constraints."""
     _require_utc_datetime(proposal.effective_from, "effective_from")
     if proposal.effective_to is not None:
         _require_utc_datetime(proposal.effective_to, "effective_to")
     if proposal.effective_to is not None and proposal.effective_to < proposal.effective_from:
         raise ValidationError("effective_to must be >= effective_from")
 
-    if proposal.confidence_status == "not_assessed":
-        if (
-            proposal.confidence_bp is not None
-            or proposal.confidence_type is not None
-            or proposal.confidence_method is not None
-        ):
-            raise ValidationError("not_assessed confidence forbids confidence_bp/type/method")
-        return
 
-    if proposal.confidence_status != "assessed":
-        raise ValidationError("confidence_status must be assessed or not_assessed")
+def _has_assessed_confidence_fields(proposal: AssertionProposal) -> bool:
+    """Return True when any assessed-only confidence field is populated."""
+    fields = (proposal.confidence_bp, proposal.confidence_type, proposal.confidence_method)
+    return any(value is not None for value in fields)
+
+
+def _validate_not_assessed_confidence(proposal: AssertionProposal) -> None:
+    """Validate confidence fields when status is not_assessed."""
+    if _has_assessed_confidence_fields(proposal):
+        raise ValidationError("not_assessed confidence forbids confidence_bp/type/method")
+
+
+def _validate_assessed_confidence(proposal: AssertionProposal) -> None:
+    """Validate confidence fields when status is assessed."""
     if proposal.confidence_bp is None:
         raise ValidationError("assessed confidence_bp must be an integer in [0, 10000]")
     confidence_bp = _require_non_bool_int(proposal.confidence_bp, "confidence_bp")
@@ -147,6 +210,18 @@ def validate_proposal(proposal: AssertionProposal) -> None:
         raise ValidationError("assessed confidence_bp must be an integer in [0, 10000]")
     _require_non_empty(proposal.confidence_type or "", "confidence_type", MAX_CONFIDENCE_TYPE_LEN)
     _require_non_empty(proposal.confidence_method or "", "confidence_method", MAX_CONFIDENCE_METHOD_LEN)
+
+
+def validate_proposal(proposal: AssertionProposal) -> None:
+    """Validate proposition shape, confidence pairing, and field bounds."""
+    _validate_proposal_identity(proposal)
+    _validate_proposal_effective_window(proposal)
+    if proposal.confidence_status == "not_assessed":
+        _validate_not_assessed_confidence(proposal)
+        return
+    if proposal.confidence_status != "assessed":
+        raise ValidationError("confidence_status must be assessed or not_assessed")
+    _validate_assessed_confidence(proposal)
 
 
 def validate_evidence_record(evidence: EvidenceRecord) -> EvidenceRecord:
@@ -188,6 +263,42 @@ def load_transitions() -> TransitionsDocument:
     return transitions
 
 
+def _validate_initial_event(event: AssertionEvent) -> None:
+    """Ensure the first event in a stream is a proper propose transition."""
+    if event.from_state is not None or event.to_state != "Proposed":
+        raise ValidationError("initial event must transition from None to Proposed")
+
+
+def _validate_event_continuity(event: AssertionEvent, previous_state: LifecycleState) -> None:
+    """Ensure a follow-on event continues from the prior lifecycle state."""
+    if event.from_state != previous_state:
+        raise ValidationError(
+            f"event state continuity gap: expected from_state {previous_state}, got {event.from_state}"
+        )
+
+
+def _validate_successor_pointer(allowed: TransitionSpec, event: AssertionEvent) -> None:
+    """Ensure successor_assertion_id presence matches the matrix edge."""
+    if allowed.requires_successor and event.successor_assertion_id is None:
+        raise ValidationError("supersession event requires successor_assertion_id")
+    if not allowed.requires_successor and event.successor_assertion_id is not None:
+        raise ValidationError("non-supersession event must not set successor_assertion_id")
+
+
+def _validate_follow_on_event(
+    event: AssertionEvent,
+    previous_state: LifecycleState,
+    transitions: TransitionsDocument,
+) -> None:
+    """Ensure a follow-on event aligns with matrix rules and continuity."""
+    _validate_event_continuity(event, previous_state)
+    from_state_value = cast(LifecycleState, event.from_state)
+    allowed = find_transition(transitions, from_state_value, event.to_state)
+    if allowed is None:
+        raise ValidationError(f"event transition outside matrix: {from_state_value}->{event.to_state}")
+    _validate_successor_pointer(allowed, event)
+
+
 def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
     """Fold ordered events into the current lifecycle state."""
     if not events:
@@ -202,22 +313,9 @@ def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
             raise ValidationError(f"event sequence gap: expected {expected}, got {event.sequence}")
         _require_utc_datetime(event.recorded_at, "recorded_at")
         if expected == 1:
-            if event.from_state is not None or event.to_state != "Proposed":
-                raise ValidationError("initial event must transition from None to Proposed")
+            _validate_initial_event(event)
         else:
-            from_state = event.from_state
-            if from_state != previous_state:
-                raise ValidationError(
-                    f"event state continuity gap: expected from_state {previous_state}, got {from_state}"
-                )
-            from_state_value = cast(LifecycleState, from_state)
-            allowed = find_transition(transitions, from_state_value, event.to_state)
-            if allowed is None:
-                raise ValidationError(f"event transition outside matrix: {from_state_value}->{event.to_state}")
-            if allowed.requires_successor and event.successor_assertion_id is None:
-                raise ValidationError("supersession event requires successor_assertion_id")
-            if not allowed.requires_successor and event.successor_assertion_id is not None:
-                raise ValidationError("non-supersession event must not set successor_assertion_id")
+            _validate_follow_on_event(event, cast(LifecycleState, previous_state), transitions)
         previous_state = event.to_state
         expected += 1
     return ordered[-1].to_state
@@ -265,63 +363,83 @@ def plan_propose(
     return assertion, event
 
 
-def plan_transition(
-    assertion_id: str,
-    current: LifecycleState,
-    to_state: LifecycleState,
-    ctx: AuthorityContext,
-    *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    successor_assertion_id: str | None = None,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
-) -> AssertionEvent:
-    """Plan a single matrix transition with authority and concurrency guards."""
-    _require_non_empty(assertion_id, "assertion_id", ENTITY_ID_LEN)
-    rationale_value = _require_non_empty(rationale, "rationale", MAX_RATIONALE_LEN)
-    expected_sequence_value = _require_non_bool_int(expected_sequence, "expected_sequence")
+def _validate_transition_plan(plan: TransitionPlan) -> tuple[TransitionsDocument, TransitionSpec]:
+    """Validate transition inputs and resolve the allowed matrix edge."""
+    _require_non_empty(plan.assertion_id, "assertion_id", ENTITY_ID_LEN)
+    _require_non_empty(plan.timing.rationale, "rationale", MAX_RATIONALE_LEN)
+    expected_sequence_value = _require_non_bool_int(plan.timing.expected_sequence, "expected_sequence")
     if expected_sequence_value < 1:
         raise ConcurrencyConflict("expected_sequence must be >= 1 (last applied sequence)")
-    _require_utc_datetime(recorded_at, "recorded_at")
+    _require_utc_datetime(plan.timing.recorded_at, "recorded_at")
 
-    matrix = transitions if transitions is not None else load_transitions()
-    allowed = find_transition(matrix, current, to_state)
+    matrix = plan.timing.transitions if plan.timing.transitions is not None else load_transitions()
+    allowed = find_transition(matrix, plan.current, plan.to_state)
     if allowed is None:
-        raise IllegalTransition(f"illegal transition: {current}->{to_state}")
+        raise IllegalTransition(f"illegal transition: {plan.current}->{plan.to_state}")
+    return matrix, allowed
 
-    required_role = cast(AuthorityRole, allowed.authority)
-    validate_authority(ctx, required_role)
 
+def _resolve_successor(plan: TransitionPlan, allowed: TransitionSpec) -> str | None:
+    """Resolve and validate successor_assertion_id for supersession edges."""
     if allowed.requires_successor:
         successor = _require_non_empty(
-            successor_assertion_id or "",
+            plan.successor_assertion_id or "",
             "successor_assertion_id",
             ENTITY_ID_LEN,
         )
-        if successor == assertion_id:
+        if successor == plan.assertion_id:
             raise SupersessionCycle("self-supersession is forbidden")
-    else:
-        if successor_assertion_id is not None:
-            raise IllegalTransition(
-                f"non-supersession transition {current}->{to_state} must not set successor_assertion_id"
-            )
-        successor = None
+        return successor
+    if plan.successor_assertion_id is not None:
+        raise IllegalTransition(
+            f"non-supersession transition {plan.current}->{plan.to_state} " "must not set successor_assertion_id"
+        )
+    return None
 
+
+def _build_transition_event(
+    plan: TransitionPlan,
+    allowed: TransitionSpec,
+    successor: str | None,
+) -> AssertionEvent:
+    """Materialize a planned transition as an append-only event DTO."""
+    required_role = cast(AuthorityRole, allowed.authority)
+    validate_authority(plan.ctx, required_role)
+    expected_sequence_value = _require_non_bool_int(plan.timing.expected_sequence, "expected_sequence")
+    rationale_value = _require_non_empty(plan.timing.rationale, "rationale", MAX_RATIONALE_LEN)
     return AssertionEvent(
-        event_id=event_id or _new_id(),
-        assertion_id=assertion_id,
+        event_id=plan.timing.event_id or _new_id(),
+        assertion_id=plan.assertion_id,
         sequence=expected_sequence_value + 1,
-        from_state=current,
-        to_state=to_state,
+        from_state=plan.current,
+        to_state=plan.to_state,
         authority=required_role,
-        actor_id=ctx.actor_id,
+        actor_id=plan.ctx.actor_id,
         rationale=rationale_value,
-        policy_version=ctx.policy_version,
-        recorded_at=recorded_at,
+        policy_version=plan.ctx.policy_version,
+        recorded_at=plan.timing.recorded_at,
         successor_assertion_id=successor,
-        correlation_id=ctx.correlation_id,
+        correlation_id=plan.ctx.correlation_id,
+    )
+
+
+def plan_transition(plan: TransitionPlan) -> AssertionEvent:
+    """Plan a single matrix transition with authority and concurrency guards."""
+    _matrix, allowed = _validate_transition_plan(plan)
+    successor = _resolve_successor(plan, allowed)
+    return _build_transition_event(plan, allowed, successor)
+
+
+def _plan_named_transition(plan: NamedTransitionPlan) -> AssertionEvent:
+    """Plan a named matrix edge via ``TransitionPlan``."""
+    return plan_transition(
+        TransitionPlan(
+            assertion_id=plan.assertion_id,
+            current=plan.current,
+            to_state=plan.to_state,
+            ctx=plan.ctx,
+            timing=plan.timing,
+        )
     )
 
 
@@ -330,24 +448,10 @@ def plan_accept(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Proposed|Disputed → Accepted."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Accepted",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing))
 
 
 def plan_reject(
@@ -355,24 +459,10 @@ def plan_reject(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Proposed → Rejected."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Rejected",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Rejected", assertion_id, current, ctx, timing))
 
 
 def plan_withdraw(
@@ -380,24 +470,10 @@ def plan_withdraw(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Proposed → Withdrawn."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Withdrawn",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Withdrawn", assertion_id, current, ctx, timing))
 
 
 def plan_dispute(
@@ -405,24 +481,10 @@ def plan_dispute(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Accepted → Disputed."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Disputed",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Disputed", assertion_id, current, ctx, timing))
 
 
 def plan_reaffirm(
@@ -430,24 +492,10 @@ def plan_reaffirm(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Disputed → Accepted (reaffirm)."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Accepted",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing))
 
 
 def plan_retract(
@@ -455,80 +503,66 @@ def plan_retract(
     current: LifecycleState,
     ctx: AuthorityContext,
     *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
+    timing: TransitionTiming,
 ) -> AssertionEvent:
     """Plan Accepted|Disputed → Retracted."""
-    return plan_transition(
-        assertion_id,
-        current,
-        "Retracted",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        event_id=event_id,
-        transitions=transitions,
-    )
+    return _plan_named_transition(NamedTransitionPlan("Retracted", assertion_id, current, ctx, timing))
 
 
-def plan_supersede(
-    assertion_id: str,
-    current: LifecycleState,
-    ctx: AuthorityContext,
-    *,
-    expected_sequence: int,
-    rationale: str,
-    recorded_at: datetime,
-    successor_assertion_id: str,
-    successor_chain_lookup: Callable[[str], Sequence[str]] | Mapping[str, Sequence[str]] | None = None,
-    event_id: str | None = None,
-    transitions: TransitionsDocument | None = None,
-) -> AssertionEvent:
+def plan_supersede(plan: SupersedePlan) -> AssertionEvent:
     """Plan Accepted|Disputed → Superseded with cycle prevention."""
-    assert_no_cycle(assertion_id, successor_assertion_id, successor_chain_lookup)
-    return plan_transition(
-        assertion_id,
-        current,
-        "Superseded",
-        ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        recorded_at=recorded_at,
-        successor_assertion_id=successor_assertion_id,
-        event_id=event_id,
-        transitions=transitions,
+    assert_no_cycle(
+        plan.transition.assertion_id,
+        plan.transition.successor_assertion_id or "",
+        plan.successor_chain_lookup,
     )
+    return plan_transition(plan.transition)
 
 
-def plan_register_evidence(
-    assertion_id: str,
-    state: LifecycleState,
-    link: EvidenceLink,
-    ctx: AuthorityContext,
-    *,
-    evidence: EvidenceRecord | None = None,
-) -> EvidenceLink:
-    """Validate authority/state gates for an append-only evidence link."""
-    _require_non_empty(assertion_id, "assertion_id", ENTITY_ID_LEN)
-    if assertion_id != link.assertion_id:
+def _validate_evidence_link_scope(plan: EvidenceRegistrationPlan) -> None:
+    """Validate assertion/state gates for evidence link registration."""
+    _require_non_empty(plan.assertion_id, "assertion_id", ENTITY_ID_LEN)
+    if plan.assertion_id != plan.link.assertion_id:
         raise ValidationError("evidence link assertion_id mismatch")
-    if state not in EVIDENCE_LINK_STATES:
-        raise IllegalTransition(f"evidence links forbidden in state {state}")
-    validate_authority(ctx, set(EVIDENCE_LINK_ROLES))
+    if plan.state not in EVIDENCE_LINK_STATES:
+        raise IllegalTransition(f"evidence links forbidden in state {plan.state}")
+    validate_authority(plan.ctx, set(EVIDENCE_LINK_ROLES))
+
+
+def _validate_evidence_link_fields(link: EvidenceLink) -> None:
+    """Validate polarity and link identity fields."""
     if link.polarity not in ("supporting", "opposing", "contextual"):
         raise ValidationError(f"invalid evidence polarity: {link.polarity!r}")
     _require_non_empty(link.link_id, "link_id", ENTITY_ID_LEN)
     _require_non_empty(link.evidence_id, "evidence_id", ENTITY_ID_LEN)
     _require_utc_datetime(link.recorded_at, "recorded_at")
-    if evidence is not None:
-        validate_evidence_record(evidence)
-        if evidence.evidence_id != link.evidence_id:
-            raise ValidationError("evidence record id mismatch with link")
-    return link
+
+
+def _validate_linked_evidence_record(link: EvidenceLink, evidence: EvidenceRecord | None) -> None:
+    """Validate optional evidence record consistency with the link."""
+    if evidence is None:
+        return
+    validated = validate_evidence_record(evidence)
+    if validated.evidence_id != link.evidence_id:
+        raise ValidationError("evidence record id mismatch with link")
+
+
+def plan_register_evidence(plan: EvidenceRegistrationPlan) -> EvidenceLink:
+    """Validate authority/state gates for an append-only evidence link."""
+    _validate_evidence_link_scope(plan)
+    _validate_evidence_link_fields(plan.link)
+    _validate_linked_evidence_record(plan.link, plan.evidence)
+    return plan.link
+
+
+def _lookup_successors(
+    node: str,
+    successor_chain_lookup: Callable[[str], Sequence[str]] | Mapping[str, Sequence[str]],
+) -> Sequence[str]:
+    """Resolve successor IDs for ``node`` from a callable or mapping lookup."""
+    if callable(successor_chain_lookup):
+        return successor_chain_lookup(node)
+    return successor_chain_lookup.get(node, ())
 
 
 def assert_no_cycle(
@@ -544,11 +578,6 @@ def assert_no_cycle(
     if successor_chain_lookup is None:
         return
 
-    def _next(node: str) -> Sequence[str]:
-        if callable(successor_chain_lookup):
-            return successor_chain_lookup(node)
-        return successor_chain_lookup.get(node, ())
-
     seen: set[str] = set()
     stack = [successor_id]
     while stack:
@@ -558,25 +587,48 @@ def assert_no_cycle(
         if current in seen:
             continue
         seen.add(current)
-        stack.extend(_next(current))
+        stack.extend(_lookup_successors(current, successor_chain_lookup))
+
+
+def _assertion_fields(assertion: Assertion) -> tuple[object, ...]:
+    """Return comparable assertion payload fields."""
+    return (
+        assertion.assertion_id,
+        assertion.predicate_id,
+        assertion.subject_id,
+        assertion.object_id,
+        assertion.method_id,
+        assertion.proposition,
+        assertion.confidence_status,
+        assertion.confidence_bp,
+        assertion.confidence_type,
+        assertion.confidence_method,
+        assertion.effective_from,
+        assertion.effective_to,
+    )
+
+
+def _proposal_fields(proposal: AssertionProposal) -> tuple[object, ...]:
+    """Return comparable proposal payload fields."""
+    return (
+        proposal.assertion_id,
+        proposal.predicate_id,
+        proposal.subject_id,
+        proposal.object_id,
+        proposal.method_id,
+        proposal.proposition,
+        proposal.confidence_status,
+        proposal.confidence_bp,
+        proposal.confidence_type,
+        proposal.confidence_method,
+        proposal.effective_from,
+        proposal.effective_to,
+    )
 
 
 def proposals_equivalent(existing: Assertion, proposal: AssertionProposal) -> bool:
     """Return True when an existing assertion matches a proposal for idempotent create."""
-    return (
-        existing.assertion_id == proposal.assertion_id
-        and existing.predicate_id == proposal.predicate_id
-        and existing.subject_id == proposal.subject_id
-        and existing.object_id == proposal.object_id
-        and existing.method_id == proposal.method_id
-        and existing.proposition == proposal.proposition
-        and existing.confidence_status == proposal.confidence_status
-        and existing.confidence_bp == proposal.confidence_bp
-        and existing.confidence_type == proposal.confidence_type
-        and existing.confidence_method == proposal.confidence_method
-        and existing.effective_from == proposal.effective_from
-        and existing.effective_to == proposal.effective_to
-    )
+    return _assertion_fields(existing) == _proposal_fields(proposal)
 
 
 def cast_polarity(value: str) -> EvidencePolarity:

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -58,6 +58,7 @@ from src.governance.relationship_assertion_contract import (
 )
 
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_GROUPED_SHA256_RE = re.compile(r"^[0-9a-f]{4}(?:-[0-9a-f]{4}){15}$")
 _UTC_OFFSET = timedelta(0)
 
 
@@ -135,10 +136,35 @@ def _require_optional(value: str | None, field_name: str, max_len: int) -> str |
     return _require_non_empty(value, field_name, max_len)
 
 
-def _require_utc_datetime(value: datetime, field_name: str) -> None:
+def _require_utc_datetime(value: object, field_name: str) -> None:
     """Validate that a datetime is timezone-aware and has zero UTC offset."""
-    if value.tzinfo is None or value.utcoffset() != _UTC_OFFSET:
-        raise ValidationError(f"{field_name} must be timezone-aware UTC")
+    message = f"{field_name} must be timezone-aware UTC"
+    if not isinstance(value, datetime):
+        raise ValidationError(message)
+    if value.tzinfo is None:
+        raise ValidationError(message)
+    if value.utcoffset() != _UTC_OFFSET:
+        raise ValidationError(message)
+
+
+def _canonicalize_sha256_hex(value: str) -> str | None:
+    """Return the canonical digest for supported plain/grouped forms."""
+    normalized = value.lower()
+    if _SHA256_RE.fullmatch(normalized):
+        return normalized
+    if _GROUPED_SHA256_RE.fullmatch(normalized):
+        return normalized.replace("-", "")
+    return None
+
+
+def normalize_sha256_hex(value: str) -> str:
+    """Normalize and validate a SHA-256 digest to lowercase hex (64 chars)."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("content_sha256 must be a non-empty string")
+    canonical = _canonicalize_sha256_hex(value)
+    if canonical is None:
+        raise ValidationError(f"content_sha256 must be {SHA256_HEX_LEN} lowercase hex characters")
+    return canonical
 
 
 def _require_non_bool_int(value: int, field_name: str) -> int:
@@ -146,16 +172,6 @@ def _require_non_bool_int(value: int, field_name: str) -> int:
     if not isinstance(value, int) or isinstance(value, bool):
         raise ValidationError(f"{field_name} must be an integer")
     return value
-
-
-def normalize_sha256_hex(value: str) -> str:
-    """Normalize and validate a SHA-256 digest to lowercase hex (64 chars)."""
-    if not isinstance(value, str) or not value.strip():
-        raise ValidationError("content_sha256 must be a non-empty string")
-    normalized = value.lower().replace("-", "")
-    if len(normalized) != SHA256_HEX_LEN or not _SHA256_RE.fullmatch(normalized):
-        raise ValidationError(f"content_sha256 must be {SHA256_HEX_LEN} lowercase hex characters")
-    return normalized
 
 
 def validate_authority(ctx: AuthorityContext, required: AuthorityRole | set[AuthorityRole]) -> None:

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -1,0 +1,548 @@
+"""Pure GRAC v1 lifecycle planners — no DB, HTTP, or wall-clock side effects.
+
+Transition authority and edges come solely from ``load_contract_bundle`` /
+``find_transition``. Callers supply ``recorded_at`` and identifiers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from typing import cast
+from uuid import uuid4
+
+from src.governance.relationship_assertion import (
+    ENTITY_ID_LEN,
+    EVIDENCE_LINK_ROLES,
+    EVIDENCE_LINK_STATES,
+    MAX_ACTOR_ID_LEN,
+    MAX_CONFIDENCE_METHOD_LEN,
+    MAX_CONFIDENCE_TYPE_LEN,
+    MAX_CORRELATION_ID_LEN,
+    MAX_CUSTODY_ID_LEN,
+    MAX_LICENSING_LEN,
+    MAX_MEDIA_TYPE_LEN,
+    MAX_METHOD_ID_LEN,
+    MAX_OBJECT_ID_LEN,
+    MAX_POLICY_VERSION_LEN,
+    MAX_PREDICATE_ID_LEN,
+    MAX_PROPOSITION_LEN,
+    MAX_RATIONALE_LEN,
+    MAX_REUSE_POLICY_LEN,
+    MAX_SOURCE_REF_LEN,
+    MAX_SUBJECT_ID_LEN,
+    SHA256_HEX_LEN,
+    Assertion,
+    AssertionEvent,
+    AssertionProposal,
+    AuthorityContext,
+    AuthorityRole,
+    ConcurrencyConflict,
+    EvidenceLink,
+    EvidencePolarity,
+    EvidenceRecord,
+    IllegalTransition,
+    LifecycleState,
+    SupersessionCycle,
+    UnauthorizedTransition,
+    ValidationError,
+    Visibility,
+)
+from src.governance.relationship_assertion_contract import (
+    TransitionsDocument,
+    find_transition,
+    load_contract_bundle,
+)
+
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_HEX_DIGEST_CHARS = frozenset("0123456789abcdef")
+
+
+def _new_id() -> str:
+    """Return a UUID4 string (36 chars) for event/link identifiers."""
+    return str(uuid4())
+
+
+def _require_non_empty(value: str, field_name: str, max_len: int) -> str:
+    """Validate a required bounded string field."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError(f"{field_name} must be a non-empty string")
+    if len(value) > max_len:
+        raise ValidationError(f"{field_name} exceeds maximum length of {max_len}")
+    return value
+
+
+def _require_optional(value: str | None, field_name: str, max_len: int) -> str | None:
+    """Validate an optional bounded string field."""
+    if value is None:
+        return None
+    return _require_non_empty(value, field_name, max_len)
+
+
+def normalize_sha256_hex(value: str) -> str:
+    """Normalize and validate a SHA-256 digest to lowercase hex (64 chars)."""
+    if not isinstance(value, str) or not value.strip():
+        raise ValidationError("content_sha256 must be a non-empty string")
+    normalized = "".join(ch for ch in value.lower() if ch in _HEX_DIGEST_CHARS)
+    if len(normalized) != SHA256_HEX_LEN or not _SHA256_RE.fullmatch(normalized):
+        raise ValidationError(f"content_sha256 must be {SHA256_HEX_LEN} lowercase hex characters")
+    return normalized
+
+
+def validate_authority(ctx: AuthorityContext, required: AuthorityRole | set[AuthorityRole]) -> None:
+    """Fail closed when ``ctx`` lacks every required role (any-of for a set)."""
+    _require_non_empty(ctx.actor_id, "actor_id", MAX_ACTOR_ID_LEN)
+    _require_non_empty(ctx.policy_version, "policy_version", MAX_POLICY_VERSION_LEN)
+    _require_optional(ctx.correlation_id, "correlation_id", MAX_CORRELATION_ID_LEN)
+    if not ctx.roles:
+        raise UnauthorizedTransition("AuthorityContext.roles must not be empty")
+    needed = {required} if isinstance(required, str) else set(required)
+    if ctx.roles.isdisjoint(needed):
+        raise UnauthorizedTransition(f"missing required authority role(s) {sorted(needed)}; have {sorted(ctx.roles)}")
+
+
+def validate_proposal(proposal: AssertionProposal) -> None:
+    """Validate proposition shape, confidence pairing, and field bounds."""
+    _require_non_empty(proposal.assertion_id, "assertion_id", ENTITY_ID_LEN)
+    _require_non_empty(proposal.predicate_id, "predicate_id", MAX_PREDICATE_ID_LEN)
+    _require_non_empty(proposal.subject_id, "subject_id", MAX_SUBJECT_ID_LEN)
+    _require_non_empty(proposal.object_id, "object_id", MAX_OBJECT_ID_LEN)
+    _require_non_empty(proposal.method_id, "method_id", MAX_METHOD_ID_LEN)
+    _require_non_empty(proposal.proposition, "proposition", MAX_PROPOSITION_LEN)
+    if proposal.effective_from.tzinfo is None:
+        raise ValidationError("effective_from must be timezone-aware UTC")
+    if proposal.effective_to is not None and proposal.effective_to.tzinfo is None:
+        raise ValidationError("effective_to must be timezone-aware UTC")
+    if proposal.effective_to is not None and proposal.effective_to < proposal.effective_from:
+        raise ValidationError("effective_to must be >= effective_from")
+
+    if proposal.confidence_status == "not_assessed":
+        if (
+            proposal.confidence_bp is not None
+            or proposal.confidence_type is not None
+            or proposal.confidence_method is not None
+        ):
+            raise ValidationError("not_assessed confidence forbids confidence_bp/type/method")
+        return
+
+    if proposal.confidence_status != "assessed":
+        raise ValidationError("confidence_status must be assessed or not_assessed")
+    if proposal.confidence_bp is None or not (0 <= proposal.confidence_bp <= 10000):
+        raise ValidationError("assessed confidence_bp must be an integer in [0, 10000]")
+    _require_non_empty(proposal.confidence_type or "", "confidence_type", MAX_CONFIDENCE_TYPE_LEN)
+    _require_non_empty(proposal.confidence_method or "", "confidence_method", MAX_CONFIDENCE_METHOD_LEN)
+
+
+def validate_evidence_record(evidence: EvidenceRecord) -> EvidenceRecord:
+    """Validate evidence reference bounds and digest; return normalized copy if needed."""
+    _require_non_empty(evidence.evidence_id, "evidence_id", ENTITY_ID_LEN)
+    _require_non_empty(evidence.source_ref, "source_ref", MAX_SOURCE_REF_LEN)
+    digest = normalize_sha256_hex(evidence.content_sha256)
+    _require_non_empty(evidence.media_type, "media_type", MAX_MEDIA_TYPE_LEN)
+    _require_non_empty(evidence.custody_id, "custody_id", MAX_CUSTODY_ID_LEN)
+    if evidence.visibility not in ("public", "internal", "restricted", "confidential"):
+        raise ValidationError(f"invalid visibility: {evidence.visibility!r}")
+    _require_optional(evidence.licensing, "licensing", MAX_LICENSING_LEN)
+    _require_optional(evidence.reuse_policy, "reuse_policy", MAX_REUSE_POLICY_LEN)
+    if evidence.recorded_at.tzinfo is None:
+        raise ValidationError("recorded_at must be timezone-aware UTC")
+    if digest == evidence.content_sha256:
+        return evidence
+    return EvidenceRecord(
+        evidence_id=evidence.evidence_id,
+        source_ref=evidence.source_ref,
+        content_sha256=digest,
+        media_type=evidence.media_type,
+        visibility=cast(Visibility, evidence.visibility),
+        custody_id=evidence.custody_id,
+        recorded_at=evidence.recorded_at,
+        observed_at=evidence.observed_at,
+        issued_at=evidence.issued_at,
+        licensing=evidence.licensing,
+        reuse_policy=evidence.reuse_policy,
+    )
+
+
+def load_transitions() -> TransitionsDocument:
+    """Load the pinned frozen transition matrix from the contract bundle."""
+    _contract, _predicates, transitions = load_contract_bundle()
+    return transitions
+
+
+def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
+    """Fold ordered events into the current lifecycle state."""
+    if not events:
+        raise ValidationError("cannot resolve state from empty event stream")
+    ordered = sorted(events, key=lambda event: event.sequence)
+    expected = 1
+    for event in ordered:
+        if event.sequence != expected:
+            raise ValidationError(f"event sequence gap: expected {expected}, got {event.sequence}")
+        expected += 1
+    return ordered[-1].to_state
+
+
+def plan_propose(
+    proposal: AssertionProposal,
+    ctx: AuthorityContext,
+    *,
+    recorded_at: datetime,
+    event_id: str | None = None,
+) -> tuple[Assertion, AssertionEvent]:
+    """Plan creation of an assertion in ``Proposed`` with sequence 1."""
+    validate_proposal(proposal)
+    validate_authority(ctx, "proposer")
+    if recorded_at.tzinfo is None:
+        raise ValidationError("recorded_at must be timezone-aware UTC")
+    assertion = Assertion(
+        assertion_id=proposal.assertion_id,
+        predicate_id=proposal.predicate_id,
+        subject_id=proposal.subject_id,
+        object_id=proposal.object_id,
+        method_id=proposal.method_id,
+        proposition=proposal.proposition,
+        confidence_status=proposal.confidence_status,
+        confidence_bp=proposal.confidence_bp,
+        confidence_type=proposal.confidence_type,
+        confidence_method=proposal.confidence_method,
+        effective_from=proposal.effective_from,
+        effective_to=proposal.effective_to,
+        recorded_at=recorded_at,
+    )
+    event = AssertionEvent(
+        event_id=event_id or _new_id(),
+        assertion_id=proposal.assertion_id,
+        sequence=1,
+        from_state=None,
+        to_state="Proposed",
+        authority="proposer",
+        actor_id=ctx.actor_id,
+        rationale="propose",
+        policy_version=ctx.policy_version,
+        recorded_at=recorded_at,
+        correlation_id=ctx.correlation_id,
+    )
+    return assertion, event
+
+
+def plan_transition(
+    assertion_id: str,
+    current: LifecycleState,
+    to_state: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    successor_assertion_id: str | None = None,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan a single matrix transition with authority and concurrency guards."""
+    _require_non_empty(assertion_id, "assertion_id", ENTITY_ID_LEN)
+    rationale_value = _require_non_empty(rationale, "rationale", MAX_RATIONALE_LEN)
+    if expected_sequence < 1:
+        raise ConcurrencyConflict("expected_sequence must be >= 1 (last applied sequence)")
+    if recorded_at.tzinfo is None:
+        raise ValidationError("recorded_at must be timezone-aware UTC")
+
+    matrix = transitions if transitions is not None else load_transitions()
+    allowed = find_transition(matrix, current, to_state)
+    if allowed is None:
+        raise IllegalTransition(f"illegal transition: {current}->{to_state}")
+
+    required_role = cast(AuthorityRole, allowed.authority)
+    validate_authority(ctx, required_role)
+
+    if allowed.requires_successor:
+        successor = _require_non_empty(
+            successor_assertion_id or "",
+            "successor_assertion_id",
+            ENTITY_ID_LEN,
+        )
+        if successor == assertion_id:
+            raise SupersessionCycle("self-supersession is forbidden")
+    else:
+        if successor_assertion_id is not None:
+            raise IllegalTransition(
+                f"non-supersession transition {current}->{to_state} must not set successor_assertion_id"
+            )
+        successor = None
+
+    return AssertionEvent(
+        event_id=event_id or _new_id(),
+        assertion_id=assertion_id,
+        sequence=expected_sequence + 1,
+        from_state=current,
+        to_state=to_state,
+        authority=required_role,
+        actor_id=ctx.actor_id,
+        rationale=rationale_value,
+        policy_version=ctx.policy_version,
+        recorded_at=recorded_at,
+        successor_assertion_id=successor,
+        correlation_id=ctx.correlation_id,
+    )
+
+
+def plan_accept(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Proposed|Disputed → Accepted."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Accepted",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_reject(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Proposed → Rejected."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Rejected",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_withdraw(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Proposed → Withdrawn."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Withdrawn",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_dispute(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Accepted → Disputed."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Disputed",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_reaffirm(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Disputed → Accepted (reaffirm)."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Accepted",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_retract(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Accepted|Disputed → Retracted."""
+    return plan_transition(
+        assertion_id,
+        current,
+        "Retracted",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_supersede(
+    assertion_id: str,
+    current: LifecycleState,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    recorded_at: datetime,
+    successor_assertion_id: str,
+    successor_chain_lookup: Callable[[str], Sequence[str]] | Mapping[str, Sequence[str]] | None = None,
+    event_id: str | None = None,
+    transitions: TransitionsDocument | None = None,
+) -> AssertionEvent:
+    """Plan Accepted|Disputed → Superseded with cycle prevention."""
+    assert_no_cycle(assertion_id, successor_assertion_id, successor_chain_lookup)
+    return plan_transition(
+        assertion_id,
+        current,
+        "Superseded",
+        ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        recorded_at=recorded_at,
+        successor_assertion_id=successor_assertion_id,
+        event_id=event_id,
+        transitions=transitions,
+    )
+
+
+def plan_register_evidence(
+    assertion_id: str,
+    state: LifecycleState,
+    link: EvidenceLink,
+    ctx: AuthorityContext,
+    *,
+    evidence: EvidenceRecord | None = None,
+) -> EvidenceLink:
+    """Validate authority/state gates for an append-only evidence link."""
+    _require_non_empty(assertion_id, "assertion_id", ENTITY_ID_LEN)
+    if assertion_id != link.assertion_id:
+        raise ValidationError("evidence link assertion_id mismatch")
+    if state not in EVIDENCE_LINK_STATES:
+        raise IllegalTransition(f"evidence links forbidden in state {state}")
+    validate_authority(ctx, set(EVIDENCE_LINK_ROLES))
+    if link.polarity not in ("supporting", "opposing", "contextual"):
+        raise ValidationError(f"invalid evidence polarity: {link.polarity!r}")
+    _require_non_empty(link.link_id, "link_id", ENTITY_ID_LEN)
+    _require_non_empty(link.evidence_id, "evidence_id", ENTITY_ID_LEN)
+    if link.recorded_at.tzinfo is None:
+        raise ValidationError("recorded_at must be timezone-aware UTC")
+    if evidence is not None:
+        validate_evidence_record(evidence)
+        if evidence.evidence_id != link.evidence_id:
+            raise ValidationError("evidence record id mismatch with link")
+    return link
+
+
+def assert_no_cycle(
+    predecessor_id: str,
+    successor_id: str,
+    successor_chain_lookup: Callable[[str], Sequence[str]] | Mapping[str, Sequence[str]] | None = None,
+) -> None:
+    """Reject self-supersession and cycles in the successor chain."""
+    _require_non_empty(predecessor_id, "predecessor_id", ENTITY_ID_LEN)
+    _require_non_empty(successor_id, "successor_id", ENTITY_ID_LEN)
+    if predecessor_id == successor_id:
+        raise SupersessionCycle("self-supersession is forbidden")
+    if successor_chain_lookup is None:
+        return
+
+    def _next(node: str) -> Sequence[str]:
+        if callable(successor_chain_lookup):
+            return successor_chain_lookup(node)
+        return successor_chain_lookup.get(node, ())
+
+    seen: set[str] = set()
+    stack = [successor_id]
+    while stack:
+        current = stack.pop()
+        if current == predecessor_id:
+            raise SupersessionCycle(f"supersession cycle: {predecessor_id} already reachable from {successor_id}")
+        if current in seen:
+            continue
+        seen.add(current)
+        stack.extend(_next(current))
+
+
+def proposals_equivalent(existing: Assertion, proposal: AssertionProposal) -> bool:
+    """Return True when an existing assertion matches a proposal for idempotent create."""
+    return (
+        existing.assertion_id == proposal.assertion_id
+        and existing.predicate_id == proposal.predicate_id
+        and existing.subject_id == proposal.subject_id
+        and existing.object_id == proposal.object_id
+        and existing.method_id == proposal.method_id
+        and existing.proposition == proposal.proposition
+        and existing.confidence_status == proposal.confidence_status
+        and existing.confidence_bp == proposal.confidence_bp
+        and existing.confidence_type == proposal.confidence_type
+        and existing.confidence_method == proposal.confidence_method
+        and existing.effective_from == proposal.effective_from
+        and existing.effective_to == proposal.effective_to
+    )
+
+
+def cast_polarity(value: str) -> EvidencePolarity:
+    """Cast a stored polarity string to the domain literal."""
+    if value not in ("supporting", "opposing", "contextual"):
+        raise ValidationError(f"invalid evidence polarity: {value!r}")
+    return cast(EvidencePolarity, value)

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -9,7 +9,6 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import DBAPIError
 
-import src.data.relationship_assertion_repository as repository_module
 from src.data.database import create_session_factory, init_db
 from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEventORM,

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -1,0 +1,343 @@
+"""Integration tests for GRAC v1 append-only assertion repository."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.exc import DBAPIError
+
+from src.data.database import create_session_factory, init_db
+from src.data.relationship_assertion_db_models import (
+    RelationshipAssertionEventORM,
+    RelationshipAssertionORM,
+)
+from src.data.relationship_assertion_repository import RelationshipAssertionRepository
+from src.governance.relationship_assertion import (
+    AssertionProposal,
+    AuthorityContext,
+    ConcurrencyConflict,
+    EvidenceRecord,
+    IllegalTransition,
+    SupersessionCycle,
+    UnauthorizedTransition,
+    ValidationError,
+)
+from tests.conftest import enable_sqlite_foreign_keys
+
+UTC = timezone.utc
+NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
+DIGEST = "b" * 64
+
+
+@pytest.fixture
+def repo_session(tmp_path):
+    """SQLite session with GRAC schema + immutability guards."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'grac_repo.db'}")
+    enable_sqlite_foreign_keys(engine)
+    init_db(engine)
+    factory = create_session_factory(engine)
+    session = factory()
+    yield session
+    session.close()
+    engine.dispose()
+
+
+@pytest.fixture
+def repo(repo_session) -> RelationshipAssertionRepository:
+    """Repository bound to the test session with a frozen clock."""
+    stamps = {"t": NOW}
+
+    def clock() -> datetime:
+        current = stamps["t"]
+        stamps["t"] = current + timedelta(milliseconds=1)
+        return current
+
+    return RelationshipAssertionRepository(repo_session, clock=clock)
+
+
+def _ctx(*roles: str) -> AuthorityContext:
+    return AuthorityContext(
+        actor_id="actor-1",
+        roles=frozenset(roles),  # type: ignore[arg-type]
+        policy_version="grac.v1-policy",
+        correlation_id="corr-repo",
+    )
+
+
+def _proposal(assertion_id: str = "as-1", **overrides: object) -> AssertionProposal:
+    payload = {
+        "assertion_id": assertion_id,
+        "predicate_id": "financial.bond.issuer_reference@1",
+        "subject_id": "AAPL_BOND_2030",
+        "object_id": "AAPL",
+        "method_id": "bond.issuer_id.resolution@1",
+        "proposition": "Bond issuer_id references AAPL",
+        "effective_from": NOW,
+    }
+    payload.update(overrides)
+    return AssertionProposal(**payload)  # type: ignore[arg-type]
+
+
+def _evidence(evidence_id: str = "ev-1") -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=evidence_id,
+        source_ref="sample://AAPL_BOND_2030",
+        content_sha256=DIGEST,
+        media_type="application/json",
+        visibility="internal",
+        custody_id="collector-1",
+        recorded_at=NOW,
+    )
+
+
+def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
+    """Helper: propose then accept an assertion."""
+    repo.propose(_proposal(assertion_id), _ctx("proposer"))
+    repo.transition(
+        assertion_id,
+        "Accepted",
+        _ctx("acceptor"),
+        expected_sequence=1,
+        rationale="accept",
+    )
+
+
+class TestProposeIdempotency:
+    """Idempotent assertion creation."""
+
+    def test_propose_persists_proposed_event(self, repo, repo_session) -> None:
+        """First propose inserts assertion + sequence-1 Proposed event."""
+        assertion, event = repo.propose(_proposal(), _ctx("proposer"))
+        repo_session.commit()
+        assert assertion.assertion_id == "as-1"
+        assert event.sequence == 1
+        assert event.to_state == "Proposed"
+        assert repo.current_state("as-1") == "Proposed"
+        assert repo_session.get(RelationshipAssertionORM, "as-1") is not None
+
+    def test_propose_is_idempotent_for_identical_payload(self, repo, repo_session) -> None:
+        """Repeating propose with the same payload returns the original row/event."""
+        first, event_a = repo.propose(_proposal(), _ctx("proposer"))
+        second, event_b = repo.propose(_proposal(), _ctx("proposer"))
+        repo_session.commit()
+        assert first.assertion_id == second.assertion_id
+        assert event_a.event_id == event_b.event_id
+        events = (
+            repo_session.execute(
+                select(RelationshipAssertionEventORM).where(RelationshipAssertionEventORM.assertion_id == "as-1")
+            )
+            .scalars()
+            .all()
+        )
+        assert len(events) == 1
+
+    def test_propose_conflict_on_different_payload(self, repo) -> None:
+        """Same id with a different proposition fails closed."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        with pytest.raises(ValidationError, match="different proposition"):
+            repo.propose(
+                _proposal(proposition="Different proposition text"),
+                _ctx("proposer"),
+            )
+
+
+class TestTransitionsAndIllegal:
+    """Persisted lifecycle transitions and illegal rejection."""
+
+    def test_full_happy_path_accept_dispute_reaffirm(self, repo, repo_session) -> None:
+        """Accepted → Disputed → Accepted persists ordered events."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a")
+        repo.transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=2, rationale="d")
+        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=3, rationale="r")
+        repo_session.commit()
+        assert repo.current_state("as-1") == "Accepted"
+        assert repo.max_sequence("as-1") == 4
+
+    def test_illegal_transition_rejected(self, repo) -> None:
+        """Out-of-matrix transitions never append events."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        with pytest.raises(IllegalTransition):
+            repo.transition(
+                "as-1",
+                "Disputed",
+                _ctx("disputer"),
+                expected_sequence=1,
+                rationale="illegal",
+            )
+        assert repo.max_sequence("as-1") == 1
+
+    def test_unauthorized_transition_rejected(self, repo) -> None:
+        """Wrong authority does not mutate history."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        with pytest.raises(UnauthorizedTransition):
+            repo.transition(
+                "as-1",
+                "Accepted",
+                _ctx("proposer"),
+                expected_sequence=1,
+                rationale="nope",
+            )
+        assert repo.current_state("as-1") == "Proposed"
+
+    def test_assertion_rows_remain_immutable(self, repo, repo_session) -> None:
+        """Schema immutability guards still reject UPDATE on assertion rows."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        repo_session.commit()
+        row = repo_session.get(RelationshipAssertionORM, "as-1")
+        assert row is not None
+        row.proposition = "mutated"
+        with pytest.raises(DBAPIError):
+            repo_session.commit()
+        repo_session.rollback()
+
+
+class TestConcurrency:
+    """expected_sequence CAS behaviour."""
+
+    def test_stale_expected_sequence_conflicts(self, repo) -> None:
+        """Two writers with the same expected_sequence: second fails."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a")
+        with pytest.raises(ConcurrencyConflict):
+            repo.transition(
+                "as-1",
+                "Disputed",
+                _ctx("disputer"),
+                expected_sequence=1,
+                rationale="stale",
+            )
+        assert repo.current_state("as-1") == "Accepted"
+        assert repo.max_sequence("as-1") == 2
+
+
+class TestEvidenceRegistration:
+    """Digest-validated evidence + append-only links."""
+
+    def test_register_evidence_with_digest(self, repo, repo_session) -> None:
+        """Evidence digests are normalized and links are queryable as-of known_at."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        evidence, link = repo.register_evidence(
+            "as-1",
+            _evidence(),
+            "supporting",
+            _ctx("proposer"),
+        )
+        repo_session.commit()
+        assert evidence.content_sha256 == DIGEST
+        assert link.polarity == "supporting"
+        as_of = repo.get_as_of("as-1", known_at=NOW + timedelta(hours=1))
+        assert as_of is not None
+        assert len(as_of.evidence_links) == 1
+
+    def test_invalid_digest_rejected(self, repo) -> None:
+        """Malformed digests never insert evidence rows."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        bad = EvidenceRecord(
+            evidence_id="ev-bad",
+            source_ref="sample://x",
+            content_sha256="not-a-digest",
+            media_type="application/json",
+            visibility="internal",
+            custody_id="c1",
+            recorded_at=NOW,
+        )
+        with pytest.raises(ValidationError, match="content_sha256"):
+            repo.register_evidence("as-1", bad, "supporting", _ctx("proposer"))
+
+    def test_evidence_link_idempotent(self, repo) -> None:
+        """Duplicate assertion/evidence link returns the original polarity link."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        _, link_a = repo.register_evidence("as-1", _evidence(), "supporting", _ctx("proposer"))
+        _, link_b = repo.register_evidence("as-1", _evidence(), "supporting", _ctx("proposer"))
+        assert link_a.link_id == link_b.link_id
+
+
+class TestSupersessionAtomics:
+    """Atomic successor acceptance + predecessor supersession."""
+
+    def test_supersede_atomic_commits_both_sides(self, repo, repo_session) -> None:
+        """Successor Accepted and predecessor Superseded land together."""
+        _propose_accepted(repo, "as-pred")
+        successor, propose_event, accept_event, supersede_event = repo.supersede_atomic(
+            "as-pred",
+            _proposal("as-succ"),
+            _ctx("proposer", "acceptor"),
+            expected_sequence=2,
+            rationale="refresh evidence",
+        )
+        repo_session.commit()
+        assert successor.assertion_id == "as-succ"
+        assert propose_event.to_state == "Proposed"
+        assert accept_event.to_state == "Accepted"
+        assert supersede_event.to_state == "Superseded"
+        assert supersede_event.successor_assertion_id == "as-succ"
+        assert repo.current_state("as-pred") == "Superseded"
+        assert repo.current_state("as-succ") == "Accepted"
+
+    def test_supersede_atomic_rolls_back_on_concurrency(self, repo, repo_session) -> None:
+        """Failed CAS leaves neither orphan successor nor superseded predecessor."""
+        _propose_accepted(repo, "as-pred")
+        repo_session.commit()
+        with pytest.raises(ConcurrencyConflict):
+            repo.supersede_atomic(
+                "as-pred",
+                _proposal("as-succ"),
+                _ctx("proposer", "acceptor"),
+                expected_sequence=1,  # stale — max is 2
+                rationale="stale supersede",
+            )
+        repo_session.rollback()
+        assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
+        assert repo.current_state("as-pred") == "Accepted"
+
+    def test_self_supersession_rejected(self, repo) -> None:
+        """Self-supersession is forbidden at the repository boundary."""
+        _propose_accepted(repo, "as-1")
+        with pytest.raises(SupersessionCycle):
+            repo.supersede_atomic(
+                "as-1",
+                _proposal("as-1"),
+                _ctx("proposer", "acceptor"),
+                expected_sequence=2,
+                rationale="self",
+            )
+
+
+class TestGetAsOf:
+    """Bitemporal reconstruction."""
+
+    def test_get_as_of_hides_future_events(self, repo) -> None:
+        """Events recorded after known_at do not affect reconstructed state."""
+        t0 = NOW
+        repo.propose(_proposal(), _ctx("proposer"), recorded_at=t0)
+        repo.transition(
+            "as-1",
+            "Accepted",
+            _ctx("acceptor"),
+            expected_sequence=1,
+            rationale="accept",
+            recorded_at=t0 + timedelta(hours=2),
+        )
+        early = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=1))
+        late = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=3))
+        assert early is not None and early.state == "Proposed"
+        assert late is not None and late.state == "Accepted"
+
+    def test_get_as_of_effective_window(self, repo) -> None:
+        """effective_at outside the assertion window returns None."""
+        repo.propose(
+            _proposal(effective_from=NOW, effective_to=NOW + timedelta(days=1)),
+            _ctx("proposer"),
+        )
+        assert repo.get_as_of("as-1", known_at=NOW + timedelta(hours=1), effective_at=NOW) is not None
+        assert (
+            repo.get_as_of(
+                "as-1",
+                known_at=NOW + timedelta(hours=1),
+                effective_at=NOW + timedelta(days=2),
+            )
+            is None
+        )

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -9,6 +9,7 @@ import pytest
 from sqlalchemy import create_engine, select
 from sqlalchemy.exc import DBAPIError
 
+import src.data.relationship_assertion_repository as repository_module
 from src.data.database import create_session_factory, init_db
 from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEventORM,
@@ -36,6 +37,7 @@ from tests.conftest import enable_sqlite_foreign_keys
 UTC = timezone.utc
 NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
 DIGEST = "b" * 64
+pytestmark = pytest.mark.integration
 
 
 @pytest.fixture
@@ -53,7 +55,7 @@ def repo_session(tmp_path):
 
 @pytest.fixture
 def repo(repo_session) -> RelationshipAssertionRepository:
-    """Repository bound to the test session with a frozen clock."""
+    """Repository bound to the test session with a deterministic advancing clock."""
     stamps = {"t": NOW}
 
     def clock() -> datetime:
@@ -131,6 +133,25 @@ def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str =
             }
         )
     )
+
+
+def _track_supersession_lock_order(repo, monkeypatch) -> list[str]:
+    """Spy on graph locking and cycle validation without replacing behavior."""
+    calls: list[str] = []
+    original_lock = repo._lock_supersession_graph
+    original_cycle_check = repository_module.assert_no_cycle
+
+    def track_lock() -> None:
+        calls.append("lock")
+        original_lock()
+
+    def track_cycle_check(*args, **kwargs) -> None:
+        calls.append("cycle")
+        original_cycle_check(*args, **kwargs)
+
+    monkeypatch.setattr(repo, "_lock_supersession_graph", track_lock)
+    monkeypatch.setattr(repository_module, "assert_no_cycle", track_cycle_check)
+    return calls
 
 
 class TestProposeIdempotency:
@@ -348,10 +369,19 @@ class TestEvidenceRegistration:
     def test_register_evidence_with_digest(self, repo, repo_session) -> None:
         """Evidence digests are normalized and links are queryable as-of known_at."""
         repo.propose(_proposal(), _ctx("proposer"))
+        grouped_upper_digest = "-".join(["B" * 4] * 16)
         evidence, link = repo.register_evidence(
             RegisterEvidenceRequest(
                 assertion_id="as-1",
-                evidence=_evidence(),
+                evidence=EvidenceRecord(
+                    evidence_id="ev-1",
+                    source_ref="sample://AAPL_BOND_2030",
+                    content_sha256=grouped_upper_digest,
+                    media_type="application/json",
+                    visibility="internal",
+                    custody_id="collector-1",
+                    recorded_at=NOW,
+                ),
                 polarity="supporting",
                 ctx=_ctx("proposer"),
             )
@@ -396,6 +426,28 @@ class TestEvidenceRegistration:
         _, link_a = repo.register_evidence(req)
         _, link_b = repo.register_evidence(req)
         assert link_a.link_id == link_b.link_id
+
+    def test_evidence_link_re_registration_rejects_conflicting_polarity(self, repo) -> None:
+        """An existing assertion/evidence pair cannot change polarity."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        evidence = _evidence()
+        ctx = _ctx("proposer")
+        supporting_request = RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=evidence,
+            polarity="supporting",
+            ctx=ctx,
+        )
+        opposing_request = RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=evidence,
+            polarity="opposing",
+            ctx=ctx,
+        )
+        repo.register_evidence(supporting_request)
+
+        with pytest.raises(ValidationError, match="different polarity"):
+            repo.register_evidence(opposing_request)
 
     def test_evidence_metadata_mismatch_rejected(self, repo) -> None:
         """Reusing an evidence id with different immutable metadata fails closed."""
@@ -482,6 +534,22 @@ class TestSupersessionAtomics:
         assert repo.current_state("as-pred") == "Superseded"
         assert repo.current_state("as-succ") == "Accepted"
 
+    def test_supersede_atomic_locks_graph_before_chain_validation(self, repo, monkeypatch) -> None:
+        """Atomic supersession takes the graph lock before validating its chain."""
+        _propose_accepted(repo, "as-pred")
+        calls = _track_supersession_lock_order(repo, monkeypatch)
+        repo.supersede_atomic(
+            SupersedeAtomicRequest(
+                predecessor_id="as-pred",
+                successor_proposal=_proposal("as-succ"),
+                ctx=_ctx("proposer", "acceptor"),
+                expected_sequence=2,
+                rationale="refresh evidence",
+            )
+        )
+
+        assert calls[:2] == ["lock", "cycle"]
+
     def test_supersede_atomic_rolls_back_on_concurrency(self, repo, repo_session) -> None:
         """Failed CAS leaves neither orphan successor nor superseded predecessor."""
         _propose_accepted(repo, "as-pred")
@@ -546,6 +614,25 @@ class TestSupersessionAtomics:
         assert repo.current_state("as-pred") == "Accepted"
         if seed_proposed:
             assert repo.current_state(successor_id) == "Proposed"
+
+    def test_transition_supersede_locks_graph_before_chain_validation(self, repo, monkeypatch) -> None:
+        """Direct supersession takes the graph lock before validating its chain."""
+        _propose_accepted(repo, "as-pred")
+        _propose_accepted(repo, "as-succ")
+        calls = _track_supersession_lock_order(repo, monkeypatch)
+        request = _transition(
+            {
+                "assertion_id": "as-pred",
+                "to_state": "Superseded",
+                "ctx": _ctx("acceptor"),
+                "expected_sequence": 2,
+                "rationale": "replace",
+                "successor_assertion_id": "as-succ",
+            }
+        )
+        repo.transition(request)
+
+        assert calls[:2] == ["lock", "cycle"]
 
 
 class TestGetAsOf:

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -97,29 +97,25 @@ def _evidence(evidence_id: str = "ev-1") -> EvidenceRecord:
     )
 
 
-def _transition(
-    assertion_id: str,
-    to_state: str,
-    ctx: AuthorityContext,
-    *,
-    expected_sequence: int,
-    rationale: str,
-    **kwargs: object,
-) -> RepositoryTransitionRequest:
-    return RepositoryTransitionRequest(
-        assertion_id=assertion_id,
-        to_state=to_state,  # type: ignore[arg-type]
-        ctx=ctx,
-        expected_sequence=expected_sequence,
-        rationale=rationale,
-        **kwargs,  # type: ignore[arg-type]
-    )
+def _transition(fields: dict[str, object]) -> RepositoryTransitionRequest:
+    """Build a transition request from a single field mapping (keeps arg count low)."""
+    return RepositoryTransitionRequest(**fields)  # type: ignore[arg-type]
 
 
 def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
     """Helper: propose then accept an assertion."""
     repo.propose(_proposal(assertion_id), _ctx("proposer"))
-    repo.transition(_transition(assertion_id, "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="accept"))
+    repo.transition(
+        _transition(
+            {
+                "assertion_id": assertion_id,
+                "to_state": "Accepted",
+                "ctx": _ctx("acceptor"),
+                "expected_sequence": 1,
+                "rationale": "accept",
+            }
+        )
+    )
 
 
 class TestProposeIdempotency:
@@ -167,9 +163,39 @@ class TestTransitionsAndIllegal:
     def test_full_happy_path_accept_dispute_reaffirm(self, repo, repo_session) -> None:
         """Accepted → Disputed → Accepted persists ordered events."""
         repo.propose(_proposal(), _ctx("proposer"))
-        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a"))
-        repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=2, rationale="d"))
-        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=3, rationale="r"))
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor"),
+                    "expected_sequence": 1,
+                    "rationale": "a",
+                }
+            )
+        )
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Disputed",
+                    "ctx": _ctx("disputer"),
+                    "expected_sequence": 2,
+                    "rationale": "d",
+                }
+            )
+        )
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor"),
+                    "expected_sequence": 3,
+                    "rationale": "r",
+                }
+            )
+        )
         repo_session.commit()
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 4
@@ -178,14 +204,34 @@ class TestTransitionsAndIllegal:
         """Out-of-matrix transitions never append events."""
         repo.propose(_proposal(), _ctx("proposer"))
         with pytest.raises(IllegalTransition):
-            repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=1, rationale="illegal"))
+            repo.transition(
+                _transition(
+                    {
+                        "assertion_id": "as-1",
+                        "to_state": "Disputed",
+                        "ctx": _ctx("disputer"),
+                        "expected_sequence": 1,
+                        "rationale": "illegal",
+                    }
+                )
+            )
         assert repo.max_sequence("as-1") == 1
 
     def test_unauthorized_transition_rejected(self, repo) -> None:
         """Wrong authority does not mutate history."""
         repo.propose(_proposal(), _ctx("proposer"))
         with pytest.raises(UnauthorizedTransition):
-            repo.transition(_transition("as-1", "Accepted", _ctx("proposer"), expected_sequence=1, rationale="nope"))
+            repo.transition(
+                _transition(
+                    {
+                        "assertion_id": "as-1",
+                        "to_state": "Accepted",
+                        "ctx": _ctx("proposer"),
+                        "expected_sequence": 1,
+                        "rationale": "nope",
+                    }
+                )
+            )
         assert repo.current_state("as-1") == "Proposed"
 
     def test_assertion_rows_remain_immutable(self, repo, repo_session) -> None:
@@ -206,9 +252,29 @@ class TestConcurrency:
     def test_stale_expected_sequence_conflicts(self, repo) -> None:
         """Two writers with the same expected_sequence: second fails."""
         repo.propose(_proposal(), _ctx("proposer"))
-        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a"))
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor"),
+                    "expected_sequence": 1,
+                    "rationale": "a",
+                }
+            )
+        )
         with pytest.raises(ConcurrencyConflict):
-            repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=1, rationale="stale"))
+            repo.transition(
+                _transition(
+                    {
+                        "assertion_id": "as-1",
+                        "to_state": "Disputed",
+                        "ctx": _ctx("disputer"),
+                        "expected_sequence": 1,
+                        "rationale": "stale",
+                    }
+                )
+            )
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 2
 
@@ -336,12 +402,14 @@ class TestGetAsOf:
         repo.propose(_proposal(), _ctx("proposer"), recorded_at=t0)
         repo.transition(
             _transition(
-                "as-1",
-                "Accepted",
-                _ctx("acceptor"),
-                expected_sequence=1,
-                rationale="accept",
-                recorded_at=t0 + timedelta(hours=2),
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor"),
+                    "expected_sequence": 1,
+                    "rationale": "accept",
+                    "recorded_at": t0 + timedelta(hours=2),
+                }
             )
         )
         early = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=1))

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -13,7 +13,12 @@ from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEventORM,
     RelationshipAssertionORM,
 )
-from src.data.relationship_assertion_repository import RelationshipAssertionRepository
+from src.data.relationship_assertion_repository import (
+    RegisterEvidenceRequest,
+    RelationshipAssertionRepository,
+    RepositoryTransitionRequest,
+    SupersedeAtomicRequest,
+)
 from src.governance.relationship_assertion import (
     AssertionProposal,
     AuthorityContext,
@@ -92,16 +97,29 @@ def _evidence(evidence_id: str = "ev-1") -> EvidenceRecord:
     )
 
 
+def _transition(
+    assertion_id: str,
+    to_state: str,
+    ctx: AuthorityContext,
+    *,
+    expected_sequence: int,
+    rationale: str,
+    **kwargs: object,
+) -> RepositoryTransitionRequest:
+    return RepositoryTransitionRequest(
+        assertion_id=assertion_id,
+        to_state=to_state,  # type: ignore[arg-type]
+        ctx=ctx,
+        expected_sequence=expected_sequence,
+        rationale=rationale,
+        **kwargs,  # type: ignore[arg-type]
+    )
+
+
 def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
     """Helper: propose then accept an assertion."""
     repo.propose(_proposal(assertion_id), _ctx("proposer"))
-    repo.transition(
-        assertion_id,
-        "Accepted",
-        _ctx("acceptor"),
-        expected_sequence=1,
-        rationale="accept",
-    )
+    repo.transition(_transition(assertion_id, "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="accept"))
 
 
 class TestProposeIdempotency:
@@ -149,9 +167,9 @@ class TestTransitionsAndIllegal:
     def test_full_happy_path_accept_dispute_reaffirm(self, repo, repo_session) -> None:
         """Accepted → Disputed → Accepted persists ordered events."""
         repo.propose(_proposal(), _ctx("proposer"))
-        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a")
-        repo.transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=2, rationale="d")
-        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=3, rationale="r")
+        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a"))
+        repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=2, rationale="d"))
+        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=3, rationale="r"))
         repo_session.commit()
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 4
@@ -160,26 +178,14 @@ class TestTransitionsAndIllegal:
         """Out-of-matrix transitions never append events."""
         repo.propose(_proposal(), _ctx("proposer"))
         with pytest.raises(IllegalTransition):
-            repo.transition(
-                "as-1",
-                "Disputed",
-                _ctx("disputer"),
-                expected_sequence=1,
-                rationale="illegal",
-            )
+            repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=1, rationale="illegal"))
         assert repo.max_sequence("as-1") == 1
 
     def test_unauthorized_transition_rejected(self, repo) -> None:
         """Wrong authority does not mutate history."""
         repo.propose(_proposal(), _ctx("proposer"))
         with pytest.raises(UnauthorizedTransition):
-            repo.transition(
-                "as-1",
-                "Accepted",
-                _ctx("proposer"),
-                expected_sequence=1,
-                rationale="nope",
-            )
+            repo.transition(_transition("as-1", "Accepted", _ctx("proposer"), expected_sequence=1, rationale="nope"))
         assert repo.current_state("as-1") == "Proposed"
 
     def test_assertion_rows_remain_immutable(self, repo, repo_session) -> None:
@@ -200,15 +206,9 @@ class TestConcurrency:
     def test_stale_expected_sequence_conflicts(self, repo) -> None:
         """Two writers with the same expected_sequence: second fails."""
         repo.propose(_proposal(), _ctx("proposer"))
-        repo.transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a")
+        repo.transition(_transition("as-1", "Accepted", _ctx("acceptor"), expected_sequence=1, rationale="a"))
         with pytest.raises(ConcurrencyConflict):
-            repo.transition(
-                "as-1",
-                "Disputed",
-                _ctx("disputer"),
-                expected_sequence=1,
-                rationale="stale",
-            )
+            repo.transition(_transition("as-1", "Disputed", _ctx("disputer"), expected_sequence=1, rationale="stale"))
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 2
 
@@ -220,10 +220,12 @@ class TestEvidenceRegistration:
         """Evidence digests are normalized and links are queryable as-of known_at."""
         repo.propose(_proposal(), _ctx("proposer"))
         evidence, link = repo.register_evidence(
-            "as-1",
-            _evidence(),
-            "supporting",
-            _ctx("proposer"),
+            RegisterEvidenceRequest(
+                assertion_id="as-1",
+                evidence=_evidence(),
+                polarity="supporting",
+                ctx=_ctx("proposer"),
+            )
         )
         repo_session.commit()
         assert evidence.content_sha256 == DIGEST
@@ -245,13 +247,26 @@ class TestEvidenceRegistration:
             recorded_at=NOW,
         )
         with pytest.raises(ValidationError, match="content_sha256"):
-            repo.register_evidence("as-1", bad, "supporting", _ctx("proposer"))
+            repo.register_evidence(
+                RegisterEvidenceRequest(
+                    assertion_id="as-1",
+                    evidence=bad,
+                    polarity="supporting",
+                    ctx=_ctx("proposer"),
+                )
+            )
 
     def test_evidence_link_idempotent(self, repo) -> None:
         """Duplicate assertion/evidence link returns the original polarity link."""
         repo.propose(_proposal(), _ctx("proposer"))
-        _, link_a = repo.register_evidence("as-1", _evidence(), "supporting", _ctx("proposer"))
-        _, link_b = repo.register_evidence("as-1", _evidence(), "supporting", _ctx("proposer"))
+        req = RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=_evidence(),
+            polarity="supporting",
+            ctx=_ctx("proposer"),
+        )
+        _, link_a = repo.register_evidence(req)
+        _, link_b = repo.register_evidence(req)
         assert link_a.link_id == link_b.link_id
 
 
@@ -262,11 +277,13 @@ class TestSupersessionAtomics:
         """Successor Accepted and predecessor Superseded land together."""
         _propose_accepted(repo, "as-pred")
         successor, propose_event, accept_event, supersede_event = repo.supersede_atomic(
-            "as-pred",
-            _proposal("as-succ"),
-            _ctx("proposer", "acceptor"),
-            expected_sequence=2,
-            rationale="refresh evidence",
+            SupersedeAtomicRequest(
+                predecessor_id="as-pred",
+                successor_proposal=_proposal("as-succ"),
+                ctx=_ctx("proposer", "acceptor"),
+                expected_sequence=2,
+                rationale="refresh evidence",
+            )
         )
         repo_session.commit()
         assert successor.assertion_id == "as-succ"
@@ -283,11 +300,13 @@ class TestSupersessionAtomics:
         repo_session.commit()
         with pytest.raises(ConcurrencyConflict):
             repo.supersede_atomic(
-                "as-pred",
-                _proposal("as-succ"),
-                _ctx("proposer", "acceptor"),
-                expected_sequence=1,  # stale — max is 2
-                rationale="stale supersede",
+                SupersedeAtomicRequest(
+                    predecessor_id="as-pred",
+                    successor_proposal=_proposal("as-succ"),
+                    ctx=_ctx("proposer", "acceptor"),
+                    expected_sequence=1,
+                    rationale="stale supersede",
+                )
             )
         repo_session.rollback()
         assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
@@ -298,11 +317,13 @@ class TestSupersessionAtomics:
         _propose_accepted(repo, "as-1")
         with pytest.raises(SupersessionCycle):
             repo.supersede_atomic(
-                "as-1",
-                _proposal("as-1"),
-                _ctx("proposer", "acceptor"),
-                expected_sequence=2,
-                rationale="self",
+                SupersedeAtomicRequest(
+                    predecessor_id="as-1",
+                    successor_proposal=_proposal("as-1"),
+                    ctx=_ctx("proposer", "acceptor"),
+                    expected_sequence=2,
+                    rationale="self",
+                )
             )
 
 
@@ -314,12 +335,14 @@ class TestGetAsOf:
         t0 = NOW
         repo.propose(_proposal(), _ctx("proposer"), recorded_at=t0)
         repo.transition(
-            "as-1",
-            "Accepted",
-            _ctx("acceptor"),
-            expected_sequence=1,
-            rationale="accept",
-            recorded_at=t0 + timedelta(hours=2),
+            _transition(
+                "as-1",
+                "Accepted",
+                _ctx("acceptor"),
+                expected_sequence=1,
+                rationale="accept",
+                recorded_at=t0 + timedelta(hours=2),
+            )
         )
         early = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=1))
         late = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=3))

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -12,6 +13,7 @@ from src.data.database import create_session_factory, init_db
 from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEventORM,
     RelationshipAssertionORM,
+    RelationshipEvidenceORM,
 )
 from src.data.relationship_assertion_repository import (
     RegisterEvidenceRequest,
@@ -97,6 +99,19 @@ def _evidence(evidence_id: str = "ev-1") -> EvidenceRecord:
     )
 
 
+def _pending_evidence_row(evidence_id: str) -> RelationshipEvidenceORM:
+    """Build unrelated pending outer-transaction work for savepoint tests."""
+    return RelationshipEvidenceORM(
+        id=evidence_id,
+        source_ref=f"sample://{evidence_id}",
+        content_sha256=DIGEST,
+        media_type="application/json",
+        visibility="internal",
+        custody_id="collector-outer",
+        recorded_at=NOW,
+    )
+
+
 def _transition(fields: dict[str, object]) -> RepositoryTransitionRequest:
     """Build a transition request from a single field mapping (keeps arg count low)."""
     return RepositoryTransitionRequest(**fields)  # type: ignore[arg-type]
@@ -154,6 +169,27 @@ class TestProposeIdempotency:
         ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="different proposition"):
             repo.propose(proposal, ctx)
+
+    def test_propose_race_preserves_pending_outer_work(self, repo, repo_session, monkeypatch) -> None:
+        """A raced proposal insert rolls back only its savepoint."""
+        proposal = _proposal()
+        repo.propose(proposal, _ctx("proposer"))
+        repo_session.commit()
+        existing = repo_session.get(RelationshipAssertionORM, proposal.assertion_id)
+        assert existing is not None
+        repo_session.expunge(existing)
+        pending = _pending_evidence_row("ev-outer-propose")
+        repo_session.add(pending)
+        original_get = repo_session.get
+        get_mock = Mock(side_effect=(None, existing))
+        monkeypatch.setattr(repo_session, "get", get_mock)
+        assertion, _event = repo.propose(proposal, _ctx("proposer"))
+        monkeypatch.setattr(repo_session, "get", original_get)
+
+        assert assertion.assertion_id == proposal.assertion_id
+        assert get_mock.call_count == 2
+        assert repo_session.get(RelationshipEvidenceORM, pending.id) is not None
+        repo_session.commit()
 
 
 class TestTransitionsAndIllegal:
@@ -274,6 +310,37 @@ class TestConcurrency:
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 2
 
+    def test_event_insert_conflict_preserves_pending_outer_work(self, repo, repo_session) -> None:
+        """A failed guarded event insert does not roll back unrelated work."""
+        _propose_accepted(repo)
+        existing_event_id = (
+            repo_session.execute(
+                select(RelationshipAssertionEventORM.id).where(RelationshipAssertionEventORM.assertion_id == "as-1")
+            )
+            .scalars()
+            .first()
+        )
+        repo_session.commit()
+        pending = _pending_evidence_row("ev-outer-event")
+        repo_session.add(pending)
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Disputed",
+                "ctx": _ctx("disputer"),
+                "expected_sequence": 2,
+                "rationale": "duplicate event id",
+                "event_id": existing_event_id,
+            }
+        )
+
+        with pytest.raises(ConcurrencyConflict):
+            repo.transition(request)
+
+        assert repo_session.get(RelationshipEvidenceORM, pending.id) is not None
+        assert repo.current_state("as-1") == "Accepted"
+        repo_session.commit()
+
 
 class TestEvidenceRegistration:
     """Digest-validated evidence + append-only links."""
@@ -360,6 +427,37 @@ class TestEvidenceRegistration:
         with pytest.raises(ValidationError, match="different metadata"):
             repo.register_evidence(request)
 
+    def test_link_insert_conflict_preserves_pending_outer_work(self, repo, repo_session) -> None:
+        """A failed guarded evidence-link insert does not roll back unrelated work."""
+        repo.propose(_proposal("as-1"), _ctx("proposer"))
+        repo.propose(_proposal("as-2"), _ctx("proposer"))
+        repo.register_evidence(
+            RegisterEvidenceRequest(
+                assertion_id="as-1",
+                evidence=_evidence("ev-1"),
+                polarity="supporting",
+                ctx=_ctx("proposer"),
+                link_id="link-shared",
+            )
+        )
+        repo_session.commit()
+        pending = _pending_evidence_row("ev-outer-link")
+        repo_session.add(pending)
+
+        with pytest.raises(ConcurrencyConflict):
+            repo.register_evidence(
+                RegisterEvidenceRequest(
+                    assertion_id="as-2",
+                    evidence=_evidence("ev-2"),
+                    polarity="supporting",
+                    ctx=_ctx("proposer"),
+                    link_id="link-shared",
+                )
+            )
+
+        assert repo_session.get(RelationshipEvidenceORM, pending.id) is not None
+        repo_session.commit()
+
 
 class TestSupersessionAtomics:
     """Atomic successor acceptance + predecessor supersession."""
@@ -398,9 +496,9 @@ class TestSupersessionAtomics:
         )
         with pytest.raises(ConcurrencyConflict):
             repo.supersede_atomic(request)
-        repo_session.rollback()
         assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
         assert repo.current_state("as-pred") == "Accepted"
+        repo_session.rollback()
 
     def test_self_supersession_rejected(self, repo) -> None:
         """Self-supersession is forbidden at the repository boundary."""

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -443,17 +443,16 @@ class TestEvidenceRegistration:
         repo_session.commit()
         pending = _pending_evidence_row("ev-outer-link")
         repo_session.add(pending)
+        request = RegisterEvidenceRequest(
+            assertion_id="as-2",
+            evidence=_evidence("ev-2"),
+            polarity="supporting",
+            ctx=_ctx("proposer"),
+            link_id="link-shared",
+        )
 
         with pytest.raises(ConcurrencyConflict):
-            repo.register_evidence(
-                RegisterEvidenceRequest(
-                    assertion_id="as-2",
-                    evidence=_evidence("ev-2"),
-                    polarity="supporting",
-                    ctx=_ctx("proposer"),
-                    link_id="link-shared",
-                )
-            )
+            repo.register_evidence(request)
 
         assert repo_session.get(RelationshipEvidenceORM, pending.id) is not None
         repo_session.commit()

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -579,6 +579,29 @@ class TestSupersessionAtomics:
         with pytest.raises(SupersessionCycle):
             repo.supersede_atomic(request)
 
+    def test_multi_hop_supersession_cycle_rejected(self, repo) -> None:
+        """A successor cannot supersede back to an assertion in its chain."""
+        _propose_accepted(repo, "as-a")
+        repo.supersede_atomic(
+            SupersedeAtomicRequest(
+                predecessor_id="as-a",
+                successor_proposal=_proposal("as-b"),
+                ctx=_ctx("proposer", "acceptor"),
+                expected_sequence=2,
+                rationale="replace A with B",
+            )
+        )
+        cycle_request = SupersedeAtomicRequest(
+            predecessor_id="as-b",
+            successor_proposal=_proposal("as-a"),
+            ctx=_ctx("proposer", "acceptor"),
+            expected_sequence=2,
+            rationale="replace B with A",
+        )
+
+        with pytest.raises(SupersessionCycle):
+            repo.supersede_atomic(cycle_request)
+
     @pytest.mark.parametrize(
         ("successor_id", "seed_proposed", "match"),
         [

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -150,11 +150,10 @@ class TestProposeIdempotency:
     def test_propose_conflict_on_different_payload(self, repo) -> None:
         """Same id with a different proposition fails closed."""
         repo.propose(_proposal(), _ctx("proposer"))
+        proposal = _proposal(proposition="Different proposition text")
+        ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="different proposition"):
-            repo.propose(
-                _proposal(proposition="Different proposition text"),
-                _ctx("proposer"),
-            )
+            repo.propose(proposal, ctx)
 
 
 class TestTransitionsAndIllegal:
@@ -203,35 +202,33 @@ class TestTransitionsAndIllegal:
     def test_illegal_transition_rejected(self, repo) -> None:
         """Out-of-matrix transitions never append events."""
         repo.propose(_proposal(), _ctx("proposer"))
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Disputed",
+                "ctx": _ctx("disputer"),
+                "expected_sequence": 1,
+                "rationale": "illegal",
+            }
+        )
         with pytest.raises(IllegalTransition):
-            repo.transition(
-                _transition(
-                    {
-                        "assertion_id": "as-1",
-                        "to_state": "Disputed",
-                        "ctx": _ctx("disputer"),
-                        "expected_sequence": 1,
-                        "rationale": "illegal",
-                    }
-                )
-            )
+            repo.transition(request)
         assert repo.max_sequence("as-1") == 1
 
     def test_unauthorized_transition_rejected(self, repo) -> None:
         """Wrong authority does not mutate history."""
         repo.propose(_proposal(), _ctx("proposer"))
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Accepted",
+                "ctx": _ctx("proposer"),
+                "expected_sequence": 1,
+                "rationale": "nope",
+            }
+        )
         with pytest.raises(UnauthorizedTransition):
-            repo.transition(
-                _transition(
-                    {
-                        "assertion_id": "as-1",
-                        "to_state": "Accepted",
-                        "ctx": _ctx("proposer"),
-                        "expected_sequence": 1,
-                        "rationale": "nope",
-                    }
-                )
-            )
+            repo.transition(request)
         assert repo.current_state("as-1") == "Proposed"
 
     def test_assertion_rows_remain_immutable(self, repo, repo_session) -> None:
@@ -263,18 +260,17 @@ class TestConcurrency:
                 }
             )
         )
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Disputed",
+                "ctx": _ctx("disputer"),
+                "expected_sequence": 1,
+                "rationale": "stale",
+            }
+        )
         with pytest.raises(ConcurrencyConflict):
-            repo.transition(
-                _transition(
-                    {
-                        "assertion_id": "as-1",
-                        "to_state": "Disputed",
-                        "ctx": _ctx("disputer"),
-                        "expected_sequence": 1,
-                        "rationale": "stale",
-                    }
-                )
-            )
+            repo.transition(request)
         assert repo.current_state("as-1") == "Accepted"
         assert repo.max_sequence("as-1") == 2
 
@@ -312,15 +308,14 @@ class TestEvidenceRegistration:
             custody_id="c1",
             recorded_at=NOW,
         )
+        request = RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=bad,
+            polarity="supporting",
+            ctx=_ctx("proposer"),
+        )
         with pytest.raises(ValidationError, match="content_sha256"):
-            repo.register_evidence(
-                RegisterEvidenceRequest(
-                    assertion_id="as-1",
-                    evidence=bad,
-                    polarity="supporting",
-                    ctx=_ctx("proposer"),
-                )
-            )
+            repo.register_evidence(request)
 
     def test_evidence_link_idempotent(self, repo) -> None:
         """Duplicate assertion/evidence link returns the original polarity link."""
@@ -356,15 +351,14 @@ class TestEvidenceRegistration:
             recorded_at=NOW,
             licensing="CC-BY-4.0",
         )
+        request = RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=changed,
+            polarity="supporting",
+            ctx=_ctx("proposer"),
+        )
         with pytest.raises(ValidationError, match="different metadata"):
-            repo.register_evidence(
-                RegisterEvidenceRequest(
-                    assertion_id="as-1",
-                    evidence=changed,
-                    polarity="supporting",
-                    ctx=_ctx("proposer"),
-                )
-            )
+            repo.register_evidence(request)
 
 
 class TestSupersessionAtomics:
@@ -395,16 +389,15 @@ class TestSupersessionAtomics:
         """Failed CAS leaves neither orphan successor nor superseded predecessor."""
         _propose_accepted(repo, "as-pred")
         repo_session.commit()
+        request = SupersedeAtomicRequest(
+            predecessor_id="as-pred",
+            successor_proposal=_proposal("as-succ"),
+            ctx=_ctx("proposer", "acceptor"),
+            expected_sequence=1,
+            rationale="stale supersede",
+        )
         with pytest.raises(ConcurrencyConflict):
-            repo.supersede_atomic(
-                SupersedeAtomicRequest(
-                    predecessor_id="as-pred",
-                    successor_proposal=_proposal("as-succ"),
-                    ctx=_ctx("proposer", "acceptor"),
-                    expected_sequence=1,
-                    rationale="stale supersede",
-                )
-            )
+            repo.supersede_atomic(request)
         repo_session.rollback()
         assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
         assert repo.current_state("as-pred") == "Accepted"
@@ -412,16 +405,15 @@ class TestSupersessionAtomics:
     def test_self_supersession_rejected(self, repo) -> None:
         """Self-supersession is forbidden at the repository boundary."""
         _propose_accepted(repo, "as-1")
+        request = SupersedeAtomicRequest(
+            predecessor_id="as-1",
+            successor_proposal=_proposal("as-1"),
+            ctx=_ctx("proposer", "acceptor"),
+            expected_sequence=2,
+            rationale="self",
+        )
         with pytest.raises(SupersessionCycle):
-            repo.supersede_atomic(
-                SupersedeAtomicRequest(
-                    predecessor_id="as-1",
-                    successor_proposal=_proposal("as-1"),
-                    ctx=_ctx("proposer", "acceptor"),
-                    expected_sequence=2,
-                    rationale="self",
-                )
-            )
+            repo.supersede_atomic(request)
 
     @pytest.mark.parametrize(
         ("successor_id", "seed_proposed", "match"),
@@ -442,19 +434,18 @@ class TestSupersessionAtomics:
         _propose_accepted(repo, "as-pred")
         if seed_proposed:
             repo.propose(_proposal(successor_id), _ctx("proposer"))
+        request = _transition(
+            {
+                "assertion_id": "as-pred",
+                "to_state": "Superseded",
+                "ctx": _ctx("acceptor"),
+                "expected_sequence": 2,
+                "rationale": "invalid successor",
+                "successor_assertion_id": successor_id,
+            }
+        )
         with pytest.raises(ValidationError, match=match):
-            repo.transition(
-                _transition(
-                    {
-                        "assertion_id": "as-pred",
-                        "to_state": "Superseded",
-                        "ctx": _ctx("acceptor"),
-                        "expected_sequence": 2,
-                        "rationale": "invalid successor",
-                        "successor_assertion_id": successor_id,
-                    }
-                )
-            )
+            repo.transition(request)
         assert repo.current_state("as-pred") == "Accepted"
         if seed_proposed:
             assert repo.current_state(successor_id) == "Proposed"

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -138,18 +138,18 @@ def _track_supersession_lock_order(repo, monkeypatch) -> list[str]:
     """Spy on graph locking and cycle validation without replacing behavior."""
     calls: list[str] = []
     original_lock = repo._lock_supersession_graph
-    original_cycle_check = repository_module.assert_no_cycle
+    original_lookup = repo._successor_chain_lookup
 
     def track_lock() -> None:
         calls.append("lock")
         original_lock()
 
-    def track_cycle_check(*args, **kwargs) -> None:
+    def track_chain_lookup(assertion_id: str):
         calls.append("cycle")
-        original_cycle_check(*args, **kwargs)
+        return original_lookup(assertion_id)
 
     monkeypatch.setattr(repo, "_lock_supersession_graph", track_lock)
-    monkeypatch.setattr(repository_module, "assert_no_cycle", track_cycle_check)
+    monkeypatch.setattr(repo, "_successor_chain_lookup", track_chain_lookup)
     return calls
 
 

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -335,6 +335,37 @@ class TestEvidenceRegistration:
         _, link_b = repo.register_evidence(req)
         assert link_a.link_id == link_b.link_id
 
+    def test_evidence_metadata_mismatch_rejected(self, repo) -> None:
+        """Reusing an evidence id with different immutable metadata fails closed."""
+        repo.propose(_proposal(), _ctx("proposer"))
+        repo.register_evidence(
+            RegisterEvidenceRequest(
+                assertion_id="as-1",
+                evidence=_evidence(),
+                polarity="supporting",
+                ctx=_ctx("proposer"),
+            )
+        )
+        changed = EvidenceRecord(
+            evidence_id="ev-1",
+            source_ref="sample://AAPL_BOND_2030",
+            content_sha256=DIGEST,
+            media_type="application/json",
+            visibility="internal",
+            custody_id="collector-1",
+            recorded_at=NOW,
+            licensing="CC-BY-4.0",
+        )
+        with pytest.raises(ValidationError, match="different metadata"):
+            repo.register_evidence(
+                RegisterEvidenceRequest(
+                    assertion_id="as-1",
+                    evidence=changed,
+                    polarity="supporting",
+                    ctx=_ctx("proposer"),
+                )
+            )
+
 
 class TestSupersessionAtomics:
     """Atomic successor acceptance + predecessor supersession."""
@@ -391,6 +422,42 @@ class TestSupersessionAtomics:
                     rationale="self",
                 )
             )
+
+    @pytest.mark.parametrize(
+        ("successor_id", "seed_proposed", "match"),
+        [
+            ("as-missing", False, "unknown successor"),
+            ("as-succ", True, "must be Accepted"),
+        ],
+        ids=["unknown_successor", "inactive_successor"],
+    )
+    def test_transition_supersede_requires_accepted_successor(
+        self,
+        repo,
+        successor_id: str,
+        seed_proposed: bool,
+        match: str,
+    ) -> None:
+        """Direct supersession requires an existing Accepted successor."""
+        _propose_accepted(repo, "as-pred")
+        if seed_proposed:
+            repo.propose(_proposal(successor_id), _ctx("proposer"))
+        with pytest.raises(ValidationError, match=match):
+            repo.transition(
+                _transition(
+                    {
+                        "assertion_id": "as-pred",
+                        "to_state": "Superseded",
+                        "ctx": _ctx("acceptor"),
+                        "expected_sequence": 2,
+                        "rationale": "invalid successor",
+                        "successor_assertion_id": successor_id,
+                    }
+                )
+            )
+        assert repo.current_state("as-pred") == "Accepted"
+        if seed_proposed:
+            assert repo.current_state(successor_id) == "Proposed"
 
 
 class TestGetAsOf:

--- a/tests/integration/test_relationship_assertion_schema.py
+++ b/tests/integration/test_relationship_assertion_schema.py
@@ -343,16 +343,14 @@ class TestRelationshipAssertionImmutability:
             _execute(statement)
 
         # Rows remain after failed mutations.
+        count_queries = {
+            "relationship_evidence": text("SELECT COUNT(*) FROM relationship_evidence"),
+            "relationship_assertions": text("SELECT COUNT(*) FROM relationship_assertions"),
+            "relationship_assertion_events": text("SELECT COUNT(*) FROM relationship_assertion_events"),
+            "relationship_assertion_evidence": text("SELECT COUNT(*) FROM relationship_assertion_evidence"),
+        }
         with schema_engine.connect() as conn:
-            counts = {
-                table: conn.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar_one()
-                for table in (
-                    "relationship_evidence",
-                    "relationship_assertions",
-                    "relationship_assertion_events",
-                    "relationship_assertion_evidence",
-                )
-            }
+            counts = {table: conn.execute(query).scalar_one() for table, query in count_queries.items()}
         assert counts == {
             "relationship_evidence": 1,
             "relationship_assertions": 1,

--- a/tests/integration/test_relationship_assertion_schema.py
+++ b/tests/integration/test_relationship_assertion_schema.py
@@ -15,6 +15,8 @@ from src.data.database import init_db
 from src.data.db_models import AssetORM, RebuildJobORM
 from src.data.relationship_assertion_db_models import (
     GRAC_TABLE_NAMES,
+    RelationshipAssertionEventORM,
+    RelationshipAssertionEvidenceORM,
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
 )
@@ -163,6 +165,58 @@ def _fk_pairs(engine: Engine, table: str) -> set[tuple[str, str]]:
     return pairs
 
 
+def _seed_immutability_rows(engine: Engine, now: datetime) -> None:
+    """Insert one linked row into each immutable source-of-truth table."""
+    with engine.begin() as conn:
+        conn.execute(
+            RelationshipEvidenceORM.__table__.insert().values(
+                id="ev-imm",
+                source_ref="ref",
+                content_sha256=DIGEST,
+                media_type="text/plain",
+                visibility="internal",
+                custody_id="custody",
+                recorded_at=now,
+            )
+        )
+        conn.execute(
+            RelationshipAssertionORM.__table__.insert().values(
+                id="as-imm",
+                predicate_id="financial.bond.issuer_reference@1",
+                subject_id="AAPL_BOND_2030",
+                object_id="AAPL",
+                method_id="bond.issuer_id.resolution@1",
+                proposition="prop",
+                confidence_status="not_assessed",
+                effective_from=now,
+                recorded_at=now,
+            )
+        )
+        conn.execute(
+            RelationshipAssertionEventORM.__table__.insert().values(
+                id="evt-imm",
+                assertion_id="as-imm",
+                sequence=1,
+                from_state=None,
+                to_state="Proposed",
+                authority="proposer",
+                actor_id="actor",
+                rationale="propose",
+                policy_version="grac.v1-policy",
+                recorded_at=now,
+            )
+        )
+        conn.execute(
+            RelationshipAssertionEvidenceORM.__table__.insert().values(
+                id="link-imm",
+                assertion_id="as-imm",
+                evidence_id="ev-imm",
+                polarity="supporting",
+                recorded_at=now,
+            )
+        )
+
+
 @pytest.mark.integration
 class TestRelationshipAssertionSchemaBootstrap:
     """Fresh create, upgrade, and idempotent re-init."""
@@ -253,52 +307,58 @@ class TestRelationshipAssertionImmutability:
     """UPDATE/DELETE must be rejected on guarded tables."""
 
     @staticmethod
-    def test_update_and_delete_rejected(schema_engine: Engine):
-        """Immutability triggers reject mutation on source-of-truth tables."""
+    @pytest.mark.parametrize(
+        "statement",
+        [
+            "UPDATE relationship_evidence SET media_type = 'application/json' WHERE id = 'ev-imm'",
+            "DELETE FROM relationship_evidence WHERE id = 'ev-imm'",
+            "UPDATE relationship_assertions SET proposition = 'changed' WHERE id = 'as-imm'",
+            "DELETE FROM relationship_assertions WHERE id = 'as-imm'",
+            "UPDATE relationship_assertion_events SET rationale = 'changed' WHERE id = 'evt-imm'",
+            "DELETE FROM relationship_assertion_events WHERE id = 'evt-imm'",
+            "UPDATE relationship_assertion_evidence SET polarity = 'opposing' WHERE id = 'link-imm'",
+            "DELETE FROM relationship_assertion_evidence WHERE id = 'link-imm'",
+        ],
+        ids=[
+            "update-evidence",
+            "delete-evidence",
+            "update-assertion",
+            "delete-assertion",
+            "update-event",
+            "delete-event",
+            "update-evidence-link",
+            "delete-evidence-link",
+        ],
+    )
+    def test_update_and_delete_rejected(schema_engine: Engine, statement: str):
+        """Immutability triggers reject every source-of-truth row mutation."""
         init_db(schema_engine)
-        now = datetime.now(tz=UTC)
-        with schema_engine.begin() as conn:
-            conn.execute(
-                text("""
-                    INSERT INTO relationship_evidence (
-                        id, source_ref, content_sha256, media_type, visibility, custody_id, recorded_at
-                    ) VALUES (
-                        'ev-imm', 'ref', :digest, 'text/plain', 'internal', 'custody', :now
-                    )
-                    """),
-                {"digest": DIGEST, "now": now},
-            )
-            conn.execute(
-                text("""
-                    INSERT INTO relationship_assertions (
-                        id, predicate_id, subject_id, object_id, method_id, proposition,
-                        confidence_status, effective_from, recorded_at
-                    ) VALUES (
-                        'as-imm', 'financial.bond.issuer_reference@1', 'AAPL_BOND_2030', 'AAPL',
-                        'bond.issuer_id.resolution@1', 'prop', 'not_assessed', :now, :now
-                    )
-                    """),
-                {"now": now},
-            )
+        _seed_immutability_rows(schema_engine, datetime.now(tz=UTC))
 
         def _execute(statement: str) -> None:
             with schema_engine.begin() as conn:
                 conn.execute(text(statement))
 
         with pytest.raises((IntegrityError, DBAPIError)):
-            _execute("UPDATE relationship_evidence SET media_type = 'application/json' WHERE id = 'ev-imm'")
-
-        with pytest.raises((IntegrityError, DBAPIError)):
-            _execute("DELETE FROM relationship_assertions WHERE id = 'as-imm'")
+            _execute(statement)
 
         # Rows remain after failed mutations.
         with schema_engine.connect() as conn:
-            assert (
-                conn.execute(text("SELECT COUNT(*) FROM relationship_evidence WHERE id = 'ev-imm'")).scalar_one() == 1
-            )
-            assert (
-                conn.execute(text("SELECT COUNT(*) FROM relationship_assertions WHERE id = 'as-imm'")).scalar_one() == 1
-            )
+            counts = {
+                table: conn.execute(text(f"SELECT COUNT(*) FROM {table}")).scalar_one()
+                for table in (
+                    "relationship_evidence",
+                    "relationship_assertions",
+                    "relationship_assertion_events",
+                    "relationship_assertion_evidence",
+                )
+            }
+        assert counts == {
+            "relationship_evidence": 1,
+            "relationship_assertions": 1,
+            "relationship_assertion_events": 1,
+            "relationship_assertion_evidence": 1,
+        }
 
     @staticmethod
     def test_trigger_names_stable(schema_engine: Engine):

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -78,8 +78,9 @@ class TestAuthorityAndBounds:
 
     def test_validate_authority_requires_role(self) -> None:
         """Missing required role fails closed."""
+        ctx = _ctx("proposer")
         with pytest.raises(UnauthorizedTransition):
-            validate_authority(_ctx("proposer"), "acceptor")
+            validate_authority(ctx, "acceptor")
 
     def test_validate_authority_accepts_any_of_set(self) -> None:
         """Evidence-style any-of role sets succeed when one role matches."""
@@ -87,16 +88,15 @@ class TestAuthorityAndBounds:
 
     def test_rationale_bound(self) -> None:
         """Oversized rationale is rejected."""
+        plan = TransitionPlan(
+            assertion_id="as-1",
+            current="Proposed",
+            to_state="Accepted",
+            ctx=_ctx("acceptor"),
+            timing=_timing(rationale="x" * (MAX_RATIONALE_LEN + 1)),
+        )
         with pytest.raises(ValidationError, match="rationale"):
-            plan_transition(
-                TransitionPlan(
-                    assertion_id="as-1",
-                    current="Proposed",
-                    to_state="Accepted",
-                    ctx=_ctx("acceptor"),
-                    timing=_timing(rationale="x" * (MAX_RATIONALE_LEN + 1)),
-                )
-            )
+            plan_transition(plan)
 
     def test_digest_normalization(self) -> None:
         """Hyphenated digests normalize to 64 lowercase hex chars."""
@@ -126,8 +126,9 @@ class TestAuthorityAndBounds:
             proposition=proposal.proposition,
             effective_from=datetime(2026, 7, 25, 14, 0, 0, tzinfo=non_utc),
         )
+        ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="effective_from"):
-            plan_propose(shifted, _ctx("proposer"), recorded_at=NOW)
+            plan_propose(shifted, ctx, recorded_at=NOW)
 
     def test_assessed_confidence_rejects_bool(self) -> None:
         """confidence_bp must be an integer value, not bool."""
@@ -145,8 +146,9 @@ class TestAuthorityAndBounds:
             confidence_type="review",
             confidence_method="manual",
         )
+        ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="confidence_bp"):
-            plan_propose(assessed, _ctx("proposer"), recorded_at=NOW)
+            plan_propose(assessed, ctx, recorded_at=NOW)
 
 
 class TestProposeAndResolve:
@@ -163,8 +165,10 @@ class TestProposeAndResolve:
 
     def test_propose_requires_proposer(self) -> None:
         """Non-proposer cannot create assertions."""
+        proposal = _proposal()
+        ctx = _ctx("acceptor")
         with pytest.raises(UnauthorizedTransition):
-            plan_propose(_proposal(), _ctx("acceptor"), recorded_at=NOW)
+            plan_propose(proposal, ctx, recorded_at=NOW)
 
     def test_resolve_state_folds_sequence(self) -> None:
         """State resolution follows the highest sequence event."""
@@ -273,26 +277,22 @@ class TestTransitionMatrix:
     )
     def test_illegal_edges_rejected(self, from_state, to_state, transitions) -> None:
         """Out-of-matrix and terminal-exit edges raise IllegalTransition."""
+        plan = TransitionPlan(
+            assertion_id="as-1",
+            current=from_state,
+            to_state=to_state,
+            ctx=_ctx("acceptor", "proposer", "disputer", "retractor"),
+            timing=_timing(rationale="illegal", transitions=transitions),
+        )
         with pytest.raises(IllegalTransition):
-            plan_transition(
-                TransitionPlan(
-                    assertion_id="as-1",
-                    current=from_state,
-                    to_state=to_state,
-                    ctx=_ctx("acceptor", "proposer", "disputer", "retractor"),
-                    timing=_timing(rationale="illegal", transitions=transitions),
-                )
-            )
+            plan_transition(plan)
 
     def test_wrong_role_rejected(self, transitions) -> None:
         """Correct edge with wrong authority fails closed."""
+        ctx = _ctx("proposer")
+        timing = _timing(rationale="nope", transitions=transitions)
         with pytest.raises(UnauthorizedTransition):
-            plan_accept(
-                "as-1",
-                "Proposed",
-                _ctx("proposer"),
-                timing=_timing(rationale="nope", transitions=transitions),
-            )
+            plan_accept("as-1", "Proposed", ctx, timing=timing)
 
     @pytest.mark.parametrize(
         ("plan", "exc_type", "match"),
@@ -342,23 +342,17 @@ class TestConcurrencyGuard:
 
     def test_expected_sequence_must_be_positive(self) -> None:
         """expected_sequence < 1 is a concurrency conflict."""
+        ctx = _ctx("acceptor")
+        timing = _timing(expected_sequence=0, rationale="bad")
         with pytest.raises(ConcurrencyConflict):
-            plan_accept(
-                "as-1",
-                "Proposed",
-                _ctx("acceptor"),
-                timing=_timing(expected_sequence=0, rationale="bad"),
-            )
+            plan_accept("as-1", "Proposed", ctx, timing=timing)
 
     def test_expected_sequence_rejects_bool(self) -> None:
         """expected_sequence must be an integer sequence, not bool."""
+        ctx = _ctx("acceptor")
+        timing = _timing(expected_sequence=True, rationale="bad")  # type: ignore[arg-type]
         with pytest.raises(ValidationError, match="expected_sequence"):
-            plan_accept(
-                "as-1",
-                "Proposed",
-                _ctx("acceptor"),
-                timing=_timing(expected_sequence=True, rationale="bad"),  # type: ignore[arg-type]
-            )
+            plan_accept("as-1", "Proposed", ctx, timing=timing)
 
     def test_next_sequence_is_expected_plus_one(self) -> None:
         """Planned event sequence is always expected_sequence + 1."""
@@ -376,19 +370,18 @@ class TestSupersessionCycles:
 
     def test_self_supersession_forbidden(self) -> None:
         """An assertion cannot supersede itself."""
-        with pytest.raises(SupersessionCycle):
-            plan_supersede(
-                SupersedePlan(
-                    transition=TransitionPlan(
-                        assertion_id="as-1",
-                        current="Accepted",
-                        to_state="Superseded",
-                        ctx=_ctx("acceptor"),
-                        timing=_timing(rationale="self"),
-                        successor_assertion_id="as-1",
-                    )
-                )
+        plan = SupersedePlan(
+            transition=TransitionPlan(
+                assertion_id="as-1",
+                current="Accepted",
+                to_state="Superseded",
+                ctx=_ctx("acceptor"),
+                timing=_timing(rationale="self"),
+                successor_assertion_id="as-1",
             )
+        )
+        with pytest.raises(SupersessionCycle):
+            plan_supersede(plan)
 
     def test_cycle_via_lookup_forbidden(self) -> None:
         """Successor chains that reach the predecessor are rejected."""
@@ -452,15 +445,14 @@ class TestEvidencePlanning:
             polarity=polarity,
             recorded_at=NOW,
         )
+        plan = EvidenceRegistrationPlan(
+            assertion_id="as-1",
+            state=state,
+            link=link,
+            ctx=_ctx(role),
+        )
         with pytest.raises(exc_type):
-            plan_register_evidence(
-                EvidenceRegistrationPlan(
-                    assertion_id="as-1",
-                    state=state,
-                    link=link,
-                    ctx=_ctx(role),
-                )
-            )
+            plan_register_evidence(plan)
 
 
 class TestNamedPlanners:

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -21,6 +21,10 @@ from src.governance.relationship_assertion import (
 )
 from src.governance.relationship_assertion_contract import load_contract_bundle
 from src.governance.relationship_assertion_lifecycle import (
+    EvidenceRegistrationPlan,
+    SupersedePlan,
+    TransitionPlan,
+    TransitionTiming,
     assert_no_cycle,
     load_transitions,
     normalize_sha256_hex,
@@ -51,6 +55,12 @@ def _ctx(*roles: str) -> AuthorityContext:
     )
 
 
+def _timing(**overrides: object) -> TransitionTiming:
+    payload = {"expected_sequence": 1, "rationale": "matrix", "recorded_at": NOW}
+    payload.update(overrides)
+    return TransitionTiming(**payload)  # type: ignore[arg-type]
+
+
 def _proposal(assertion_id: str = "as-1") -> AssertionProposal:
     return AssertionProposal(
         assertion_id=assertion_id,
@@ -79,13 +89,13 @@ class TestAuthorityAndBounds:
         """Oversized rationale is rejected."""
         with pytest.raises(ValidationError, match="rationale"):
             plan_transition(
-                "as-1",
-                "Proposed",
-                "Accepted",
-                _ctx("acceptor"),
-                expected_sequence=1,
-                rationale="x" * (MAX_RATIONALE_LEN + 1),
-                recorded_at=NOW,
+                TransitionPlan(
+                    assertion_id="as-1",
+                    current="Proposed",
+                    to_state="Accepted",
+                    ctx=_ctx("acceptor"),
+                    timing=_timing(rationale="x" * (MAX_RATIONALE_LEN + 1)),
+                )
             )
 
     def test_digest_normalization(self) -> None:
@@ -163,9 +173,10 @@ class TestProposeAndResolve:
             "as-1",
             "Proposed",
             _ctx("acceptor"),
-            expected_sequence=1,
-            rationale="ok",
-            recorded_at=NOW + timedelta(seconds=1),
+            timing=_timing(
+                rationale="ok",
+                recorded_at=NOW + timedelta(seconds=1),
+            ),
         )
         assert resolve_state([e1, e2]) == "Accepted"
 
@@ -193,9 +204,10 @@ class TestProposeAndResolve:
             "as-1",
             "Accepted",
             _ctx("retractor"),
-            expected_sequence=1,
-            rationale="gap",
-            recorded_at=NOW + timedelta(seconds=1),
+            timing=_timing(
+                rationale="gap",
+                recorded_at=NOW + timedelta(seconds=1),
+            ),
         )
         with pytest.raises(ValidationError, match="continuity"):
             resolve_state([e1, e2])
@@ -231,15 +243,18 @@ class TestTransitionMatrix:
     )
     def test_allowed_matrix_edges(self, from_state, to_state, role, transitions) -> None:
         """Every registry edge plans successfully with the required authority."""
-        kwargs: dict = {
-            "expected_sequence": 1,
-            "rationale": "matrix",
-            "recorded_at": NOW,
-            "transitions": transitions,
-        }
-        if to_state == "Superseded":
-            kwargs["successor_assertion_id"] = "as-successor"
-        event = plan_transition("as-1", from_state, to_state, _ctx(role), **kwargs)
+        timing = _timing(transitions=transitions)
+        successor_assertion_id = "as-successor" if to_state == "Superseded" else None
+        event = plan_transition(
+            TransitionPlan(
+                assertion_id="as-1",
+                current=from_state,
+                to_state=to_state,
+                ctx=_ctx(role),
+                timing=timing,
+                successor_assertion_id=successor_assertion_id,
+            )
+        )
         assert event.to_state == to_state
         assert event.authority == role
         assert event.sequence == 2
@@ -260,14 +275,13 @@ class TestTransitionMatrix:
         """Out-of-matrix and terminal-exit edges raise IllegalTransition."""
         with pytest.raises(IllegalTransition):
             plan_transition(
-                "as-1",
-                from_state,
-                to_state,
-                _ctx("acceptor", "proposer", "disputer", "retractor"),
-                expected_sequence=1,
-                rationale="illegal",
-                recorded_at=NOW,
-                transitions=transitions,
+                TransitionPlan(
+                    assertion_id="as-1",
+                    current=from_state,
+                    to_state=to_state,
+                    ctx=_ctx("acceptor", "proposer", "disputer", "retractor"),
+                    timing=_timing(rationale="illegal", transitions=transitions),
+                )
             )
 
     def test_wrong_role_rejected(self, transitions) -> None:
@@ -277,39 +291,34 @@ class TestTransitionMatrix:
                 "as-1",
                 "Proposed",
                 _ctx("proposer"),
-                expected_sequence=1,
-                rationale="nope",
-                recorded_at=NOW,
-                transitions=transitions,
+                timing=_timing(rationale="nope", transitions=transitions),
             )
 
     def test_supersession_requires_successor(self, transitions) -> None:
         """Supersession without successor_assertion_id is illegal."""
         with pytest.raises(ValidationError, match="successor_assertion_id"):
             plan_transition(
-                "as-1",
-                "Accepted",
-                "Superseded",
-                _ctx("acceptor"),
-                expected_sequence=1,
-                rationale="missing successor",
-                recorded_at=NOW,
-                transitions=transitions,
+                TransitionPlan(
+                    assertion_id="as-1",
+                    current="Accepted",
+                    to_state="Superseded",
+                    ctx=_ctx("acceptor"),
+                    timing=_timing(rationale="missing successor", transitions=transitions),
+                )
             )
 
     def test_non_supersession_forbids_successor(self, transitions) -> None:
         """Non-supersession edges must not carry a successor pointer."""
         with pytest.raises(IllegalTransition, match="must not set successor"):
             plan_transition(
-                "as-1",
-                "Proposed",
-                "Accepted",
-                _ctx("acceptor"),
-                expected_sequence=1,
-                rationale="bad successor",
-                recorded_at=NOW,
-                successor_assertion_id="as-2",
-                transitions=transitions,
+                TransitionPlan(
+                    assertion_id="as-1",
+                    current="Proposed",
+                    to_state="Accepted",
+                    ctx=_ctx("acceptor"),
+                    timing=_timing(rationale="bad successor", transitions=transitions),
+                    successor_assertion_id="as-2",
+                )
             )
 
 
@@ -323,9 +332,7 @@ class TestConcurrencyGuard:
                 "as-1",
                 "Proposed",
                 _ctx("acceptor"),
-                expected_sequence=0,
-                rationale="bad",
-                recorded_at=NOW,
+                timing=_timing(expected_sequence=0, rationale="bad"),
             )
 
     def test_expected_sequence_rejects_bool(self) -> None:
@@ -335,9 +342,7 @@ class TestConcurrencyGuard:
                 "as-1",
                 "Proposed",
                 _ctx("acceptor"),
-                expected_sequence=True,
-                rationale="bad",
-                recorded_at=NOW,
+                timing=_timing(expected_sequence=True, rationale="bad"),  # type: ignore[arg-type]
             )
 
     def test_next_sequence_is_expected_plus_one(self) -> None:
@@ -346,9 +351,7 @@ class TestConcurrencyGuard:
             "as-1",
             "Proposed",
             _ctx("acceptor"),
-            expected_sequence=3,
-            rationale="reject",
-            recorded_at=NOW,
+            timing=_timing(expected_sequence=3, rationale="reject"),
         )
         assert event.sequence == 4
 
@@ -360,13 +363,16 @@ class TestSupersessionCycles:
         """An assertion cannot supersede itself."""
         with pytest.raises(SupersessionCycle):
             plan_supersede(
-                "as-1",
-                "Accepted",
-                _ctx("acceptor"),
-                expected_sequence=1,
-                rationale="self",
-                recorded_at=NOW,
-                successor_assertion_id="as-1",
+                SupersedePlan(
+                    transition=TransitionPlan(
+                        assertion_id="as-1",
+                        current="Accepted",
+                        to_state="Superseded",
+                        ctx=_ctx("acceptor"),
+                        timing=_timing(rationale="self"),
+                        successor_assertion_id="as-1",
+                    )
+                )
             )
 
     def test_cycle_via_lookup_forbidden(self) -> None:
@@ -401,7 +407,18 @@ class TestEvidencePlanning:
             custody_id="collector-1",
             recorded_at=NOW,
         )
-        assert plan_register_evidence("as-1", "Proposed", link, _ctx("proposer"), evidence=evidence) is link
+        assert (
+            plan_register_evidence(
+                EvidenceRegistrationPlan(
+                    assertion_id="as-1",
+                    state="Proposed",
+                    link=link,
+                    ctx=_ctx("proposer"),
+                    evidence=evidence,
+                )
+            )
+            is link
+        )
 
     def test_evidence_forbidden_in_rejected(self) -> None:
         """Terminal Rejected state cannot gain evidence links."""
@@ -413,7 +430,14 @@ class TestEvidencePlanning:
             recorded_at=NOW,
         )
         with pytest.raises(IllegalTransition):
-            plan_register_evidence("as-1", "Rejected", link, _ctx("acceptor"))
+            plan_register_evidence(
+                EvidenceRegistrationPlan(
+                    assertion_id="as-1",
+                    state="Rejected",
+                    link=link,
+                    ctx=_ctx("acceptor"),
+                )
+            )
 
     def test_evidence_requires_proposer_or_acceptor(self) -> None:
         """Disputer alone cannot register evidence links."""
@@ -425,7 +449,14 @@ class TestEvidencePlanning:
             recorded_at=NOW,
         )
         with pytest.raises(UnauthorizedTransition):
-            plan_register_evidence("as-1", "Accepted", link, _ctx("disputer"))
+            plan_register_evidence(
+                EvidenceRegistrationPlan(
+                    assertion_id="as-1",
+                    state="Accepted",
+                    link=link,
+                    ctx=_ctx("disputer"),
+                )
+            )
 
 
 class TestNamedPlanners:
@@ -437,25 +468,19 @@ class TestNamedPlanners:
             "as-1",
             "Proposed",
             _ctx("proposer"),
-            expected_sequence=1,
-            rationale="withdraw",
-            recorded_at=NOW,
+            timing=_timing(rationale="withdraw"),
         )
         disputed = plan_dispute(
             "as-1",
             "Accepted",
             _ctx("disputer"),
-            expected_sequence=2,
-            rationale="dispute",
-            recorded_at=NOW,
+            timing=_timing(expected_sequence=2, rationale="dispute"),
         )
         retracted = plan_retract(
             "as-1",
             "Accepted",
             _ctx("retractor"),
-            expected_sequence=2,
-            rationale="retract",
-            recorded_at=NOW,
+            timing=_timing(expected_sequence=2, rationale="retract"),
         )
         assert withdrawn.to_state == "Withdrawn"
         assert disputed.to_state == "Disputed"

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -1,0 +1,378 @@
+"""Unit tests for GRAC v1 pure lifecycle planners and authority guards."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.governance.relationship_assertion import (
+    MAX_RATIONALE_LEN,
+    AssertionProposal,
+    AuthorityContext,
+    ConcurrencyConflict,
+    EvidenceLink,
+    EvidenceRecord,
+    IllegalTransition,
+    SupersessionCycle,
+    UnauthorizedTransition,
+    ValidationError,
+)
+from src.governance.relationship_assertion_contract import load_contract_bundle
+from src.governance.relationship_assertion_lifecycle import (
+    assert_no_cycle,
+    load_transitions,
+    normalize_sha256_hex,
+    plan_accept,
+    plan_dispute,
+    plan_propose,
+    plan_register_evidence,
+    plan_reject,
+    plan_retract,
+    plan_supersede,
+    plan_transition,
+    plan_withdraw,
+    resolve_state,
+    validate_authority,
+)
+
+UTC = timezone.utc
+NOW = datetime(2026, 7, 25, 12, 0, 0, tzinfo=UTC)
+DIGEST = "a" * 64
+
+
+def _ctx(*roles: str) -> AuthorityContext:
+    return AuthorityContext(
+        actor_id="actor-1",
+        roles=frozenset(roles),  # type: ignore[arg-type]
+        policy_version="grac.v1-policy",
+        correlation_id="corr-1",
+    )
+
+
+def _proposal(assertion_id: str = "as-1") -> AssertionProposal:
+    return AssertionProposal(
+        assertion_id=assertion_id,
+        predicate_id="financial.bond.issuer_reference@1",
+        subject_id="AAPL_BOND_2030",
+        object_id="AAPL",
+        method_id="bond.issuer_id.resolution@1",
+        proposition="Bond issuer_id references AAPL",
+        effective_from=NOW,
+    )
+
+
+class TestAuthorityAndBounds:
+    """AuthorityContext and field-bound validation."""
+
+    def test_validate_authority_requires_role(self) -> None:
+        """Missing required role fails closed."""
+        with pytest.raises(UnauthorizedTransition):
+            validate_authority(_ctx("proposer"), "acceptor")
+
+    def test_validate_authority_accepts_any_of_set(self) -> None:
+        """Evidence-style any-of role sets succeed when one role matches."""
+        validate_authority(_ctx("acceptor"), {"proposer", "acceptor"})
+
+    def test_rationale_bound(self) -> None:
+        """Oversized rationale is rejected."""
+        with pytest.raises(ValidationError, match="rationale"):
+            plan_transition(
+                "as-1",
+                "Proposed",
+                "Accepted",
+                _ctx("acceptor"),
+                expected_sequence=1,
+                rationale="x" * (MAX_RATIONALE_LEN + 1),
+                recorded_at=NOW,
+            )
+
+    def test_digest_normalization(self) -> None:
+        """Hyphenated digests normalize to 64 lowercase hex chars."""
+        grouped = "aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa"
+        assert normalize_sha256_hex(grouped) == DIGEST
+
+    def test_invalid_digest_rejected(self) -> None:
+        """Short digests fail validation."""
+        with pytest.raises(ValidationError, match="content_sha256"):
+            normalize_sha256_hex("deadbeef")
+
+
+class TestProposeAndResolve:
+    """Proposal planning and event folding."""
+
+    def test_plan_propose_sequence_one(self) -> None:
+        """Propose yields Proposed at sequence 1."""
+        assertion, event = plan_propose(_proposal(), _ctx("proposer"), recorded_at=NOW)
+        assert assertion.assertion_id == "as-1"
+        assert event.sequence == 1
+        assert event.from_state is None
+        assert event.to_state == "Proposed"
+        assert event.authority == "proposer"
+
+    def test_propose_requires_proposer(self) -> None:
+        """Non-proposer cannot create assertions."""
+        with pytest.raises(UnauthorizedTransition):
+            plan_propose(_proposal(), _ctx("acceptor"), recorded_at=NOW)
+
+    def test_resolve_state_folds_sequence(self) -> None:
+        """State resolution follows the highest sequence event."""
+        _, e1 = plan_propose(_proposal(), _ctx("proposer"), recorded_at=NOW)
+        e2 = plan_accept(
+            "as-1",
+            "Proposed",
+            _ctx("acceptor"),
+            expected_sequence=1,
+            rationale="ok",
+            recorded_at=NOW + timedelta(seconds=1),
+        )
+        assert resolve_state([e1, e2]) == "Accepted"
+
+
+class TestTransitionMatrix:
+    """Complete frozen transition matrix coverage."""
+
+    @pytest.fixture
+    def transitions(self):
+        """Load pinned transitions for matrix tests."""
+        return load_transitions()
+
+    def test_bundle_loads(self) -> None:
+        """Contract bundle remains loadable from lifecycle helpers."""
+        contract, _predicates, transitions = load_contract_bundle()
+        assert contract.contract_version == "grac.v1"
+        assert len(transitions.transitions) >= 9
+
+    @pytest.mark.parametrize(
+        ("from_state", "to_state", "role"),
+        [
+            ("Proposed", "Accepted", "acceptor"),
+            ("Proposed", "Rejected", "acceptor"),
+            ("Proposed", "Withdrawn", "proposer"),
+            ("Accepted", "Disputed", "disputer"),
+            ("Accepted", "Retracted", "retractor"),
+            ("Accepted", "Superseded", "acceptor"),
+            ("Disputed", "Accepted", "acceptor"),
+            ("Disputed", "Retracted", "retractor"),
+            ("Disputed", "Superseded", "acceptor"),
+        ],
+    )
+    def test_allowed_matrix_edges(self, from_state, to_state, role, transitions) -> None:
+        """Every registry edge plans successfully with the required authority."""
+        kwargs: dict = {
+            "expected_sequence": 1,
+            "rationale": "matrix",
+            "recorded_at": NOW,
+            "transitions": transitions,
+        }
+        if to_state == "Superseded":
+            kwargs["successor_assertion_id"] = "as-successor"
+        event = plan_transition("as-1", from_state, to_state, _ctx(role), **kwargs)
+        assert event.to_state == to_state
+        assert event.authority == role
+        assert event.sequence == 2
+
+    @pytest.mark.parametrize(
+        ("from_state", "to_state"),
+        [
+            ("Rejected", "Accepted"),
+            ("Withdrawn", "Proposed"),
+            ("Retracted", "Accepted"),
+            ("Superseded", "Accepted"),
+            ("Proposed", "Disputed"),
+            ("Accepted", "Withdrawn"),
+            ("Disputed", "Withdrawn"),
+        ],
+    )
+    def test_illegal_edges_rejected(self, from_state, to_state, transitions) -> None:
+        """Out-of-matrix and terminal-exit edges raise IllegalTransition."""
+        with pytest.raises(IllegalTransition):
+            plan_transition(
+                "as-1",
+                from_state,
+                to_state,
+                _ctx("acceptor", "proposer", "disputer", "retractor"),
+                expected_sequence=1,
+                rationale="illegal",
+                recorded_at=NOW,
+                transitions=transitions,
+            )
+
+    def test_wrong_role_rejected(self, transitions) -> None:
+        """Correct edge with wrong authority fails closed."""
+        with pytest.raises(UnauthorizedTransition):
+            plan_accept(
+                "as-1",
+                "Proposed",
+                _ctx("proposer"),
+                expected_sequence=1,
+                rationale="nope",
+                recorded_at=NOW,
+                transitions=transitions,
+            )
+
+    def test_supersession_requires_successor(self, transitions) -> None:
+        """Supersession without successor_assertion_id is illegal."""
+        with pytest.raises(ValidationError, match="successor_assertion_id"):
+            plan_transition(
+                "as-1",
+                "Accepted",
+                "Superseded",
+                _ctx("acceptor"),
+                expected_sequence=1,
+                rationale="missing successor",
+                recorded_at=NOW,
+                transitions=transitions,
+            )
+
+    def test_non_supersession_forbids_successor(self, transitions) -> None:
+        """Non-supersession edges must not carry a successor pointer."""
+        with pytest.raises(IllegalTransition, match="must not set successor"):
+            plan_transition(
+                "as-1",
+                "Proposed",
+                "Accepted",
+                _ctx("acceptor"),
+                expected_sequence=1,
+                rationale="bad successor",
+                recorded_at=NOW,
+                successor_assertion_id="as-2",
+                transitions=transitions,
+            )
+
+
+class TestConcurrencyGuard:
+    """expected_sequence planning rules."""
+
+    def test_expected_sequence_must_be_positive(self) -> None:
+        """expected_sequence < 1 is a concurrency conflict."""
+        with pytest.raises(ConcurrencyConflict):
+            plan_accept(
+                "as-1",
+                "Proposed",
+                _ctx("acceptor"),
+                expected_sequence=0,
+                rationale="bad",
+                recorded_at=NOW,
+            )
+
+    def test_next_sequence_is_expected_plus_one(self) -> None:
+        """Planned event sequence is always expected_sequence + 1."""
+        event = plan_reject(
+            "as-1",
+            "Proposed",
+            _ctx("acceptor"),
+            expected_sequence=3,
+            rationale="reject",
+            recorded_at=NOW,
+        )
+        assert event.sequence == 4
+
+
+class TestSupersessionCycles:
+    """Cycle and self-supersession prevention."""
+
+    def test_self_supersession_forbidden(self) -> None:
+        """An assertion cannot supersede itself."""
+        with pytest.raises(SupersessionCycle):
+            plan_supersede(
+                "as-1",
+                "Accepted",
+                _ctx("acceptor"),
+                expected_sequence=1,
+                rationale="self",
+                recorded_at=NOW,
+                successor_assertion_id="as-1",
+            )
+
+    def test_cycle_via_lookup_forbidden(self) -> None:
+        """Successor chains that reach the predecessor are rejected."""
+        chain = {"as-2": ("as-3",), "as-3": ("as-1",)}
+        with pytest.raises(SupersessionCycle):
+            assert_no_cycle("as-1", "as-2", chain)
+
+    def test_acyclic_chain_allowed(self) -> None:
+        """Forward-only successor chains are accepted."""
+        assert_no_cycle("as-1", "as-2", {"as-2": ("as-3",), "as-3": ()})
+
+
+class TestEvidencePlanning:
+    """Evidence registration gates."""
+
+    def test_evidence_allowed_in_proposed(self) -> None:
+        """Proposer may attach supporting evidence while Proposed."""
+        link = EvidenceLink(
+            link_id="link-1",
+            assertion_id="as-1",
+            evidence_id="ev-1",
+            polarity="supporting",
+            recorded_at=NOW,
+        )
+        evidence = EvidenceRecord(
+            evidence_id="ev-1",
+            source_ref="sample://bond",
+            content_sha256=DIGEST,
+            media_type="application/json",
+            visibility="internal",
+            custody_id="collector-1",
+            recorded_at=NOW,
+        )
+        assert plan_register_evidence("as-1", "Proposed", link, _ctx("proposer"), evidence=evidence) is link
+
+    def test_evidence_forbidden_in_rejected(self) -> None:
+        """Terminal Rejected state cannot gain evidence links."""
+        link = EvidenceLink(
+            link_id="link-1",
+            assertion_id="as-1",
+            evidence_id="ev-1",
+            polarity="contextual",
+            recorded_at=NOW,
+        )
+        with pytest.raises(IllegalTransition):
+            plan_register_evidence("as-1", "Rejected", link, _ctx("acceptor"))
+
+    def test_evidence_requires_proposer_or_acceptor(self) -> None:
+        """Disputer alone cannot register evidence links."""
+        link = EvidenceLink(
+            link_id="link-1",
+            assertion_id="as-1",
+            evidence_id="ev-1",
+            polarity="opposing",
+            recorded_at=NOW,
+        )
+        with pytest.raises(UnauthorizedTransition):
+            plan_register_evidence("as-1", "Accepted", link, _ctx("disputer"))
+
+
+class TestNamedPlanners:
+    """Smoke coverage for named transition planners."""
+
+    def test_withdraw_and_dispute_and_retract(self) -> None:
+        """Named planners emit the expected to_state values."""
+        withdrawn = plan_withdraw(
+            "as-1",
+            "Proposed",
+            _ctx("proposer"),
+            expected_sequence=1,
+            rationale="withdraw",
+            recorded_at=NOW,
+        )
+        disputed = plan_dispute(
+            "as-1",
+            "Accepted",
+            _ctx("disputer"),
+            expected_sequence=2,
+            rationale="dispute",
+            recorded_at=NOW,
+        )
+        retracted = plan_retract(
+            "as-1",
+            "Accepted",
+            _ctx("retractor"),
+            expected_sequence=2,
+            rationale="retract",
+            recorded_at=NOW,
+        )
+        assert withdrawn.to_state == "Withdrawn"
+        assert disputed.to_state == "Disputed"
+        assert retracted.to_state == "Retracted"

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -294,32 +294,47 @@ class TestTransitionMatrix:
                 timing=_timing(rationale="nope", transitions=transitions),
             )
 
-    def test_supersession_requires_successor(self, transitions) -> None:
-        """Supersession without successor_assertion_id is illegal."""
-        with pytest.raises(ValidationError, match="successor_assertion_id"):
-            plan_transition(
+    @pytest.mark.parametrize(
+        ("plan", "exc_type", "match"),
+        [
+            (
                 TransitionPlan(
                     assertion_id="as-1",
                     current="Accepted",
                     to_state="Superseded",
                     ctx=_ctx("acceptor"),
-                    timing=_timing(rationale="missing successor", transitions=transitions),
-                )
-            )
-
-    def test_non_supersession_forbids_successor(self, transitions) -> None:
-        """Non-supersession edges must not carry a successor pointer."""
-        with pytest.raises(IllegalTransition, match="must not set successor"):
-            plan_transition(
+                    timing=_timing(rationale="missing successor"),
+                ),
+                ValidationError,
+                "successor_assertion_id",
+            ),
+            (
                 TransitionPlan(
                     assertion_id="as-1",
                     current="Proposed",
                     to_state="Accepted",
                     ctx=_ctx("acceptor"),
-                    timing=_timing(rationale="bad successor", transitions=transitions),
+                    timing=_timing(rationale="bad successor"),
                     successor_assertion_id="as-2",
-                )
-            )
+                ),
+                IllegalTransition,
+                "must not set successor",
+            ),
+        ],
+        ids=["supersession_requires_successor", "non_supersession_forbids_successor"],
+    )
+    def test_successor_pointer_rules(self, transitions, plan, exc_type, match) -> None:
+        """Successor pointer is required only on supersession edges."""
+        plan = TransitionPlan(
+            assertion_id=plan.assertion_id,
+            current=plan.current,
+            to_state=plan.to_state,
+            ctx=plan.ctx,
+            timing=_timing(rationale=plan.timing.rationale, transitions=transitions),
+            successor_assertion_id=plan.successor_assertion_id,
+        )
+        with pytest.raises(exc_type, match=match):
+            plan_transition(plan)
 
 
 class TestConcurrencyGuard:
@@ -420,41 +435,30 @@ class TestEvidencePlanning:
             is link
         )
 
-    def test_evidence_forbidden_in_rejected(self) -> None:
-        """Terminal Rejected state cannot gain evidence links."""
+    @pytest.mark.parametrize(
+        ("state", "role", "polarity", "exc_type"),
+        [
+            ("Rejected", "acceptor", "contextual", IllegalTransition),
+            ("Accepted", "disputer", "opposing", UnauthorizedTransition),
+        ],
+        ids=["forbidden_in_rejected", "requires_proposer_or_acceptor"],
+    )
+    def test_evidence_gate_failures(self, state, role, polarity, exc_type) -> None:
+        """Rejected state and insufficient authority both reject evidence links."""
         link = EvidenceLink(
             link_id="link-1",
             assertion_id="as-1",
             evidence_id="ev-1",
-            polarity="contextual",
+            polarity=polarity,
             recorded_at=NOW,
         )
-        with pytest.raises(IllegalTransition):
+        with pytest.raises(exc_type):
             plan_register_evidence(
                 EvidenceRegistrationPlan(
                     assertion_id="as-1",
-                    state="Rejected",
+                    state=state,
                     link=link,
-                    ctx=_ctx("acceptor"),
-                )
-            )
-
-    def test_evidence_requires_proposer_or_acceptor(self) -> None:
-        """Disputer alone cannot register evidence links."""
-        link = EvidenceLink(
-            link_id="link-1",
-            assertion_id="as-1",
-            evidence_id="ev-1",
-            polarity="opposing",
-            recorded_at=NOW,
-        )
-        with pytest.raises(UnauthorizedTransition):
-            plan_register_evidence(
-                EvidenceRegistrationPlan(
-                    assertion_id="as-1",
-                    state="Accepted",
-                    link=link,
-                    ctx=_ctx("disputer"),
+                    ctx=_ctx(role),
                 )
             )
 

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -161,8 +161,9 @@ class TestAuthorityAndBounds:
             proposition=proposal.proposition,
             effective_from="not-a-datetime",  # type: ignore[arg-type]
         )
+        ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="effective_from"):
-            plan_propose(malformed, _ctx("proposer"), recorded_at=NOW)
+            plan_propose(malformed, ctx, recorded_at=NOW)
 
     def test_assessed_confidence_rejects_bool(self) -> None:
         """confidence_bp must be an integer value, not bool."""

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.governance.relationship_assertion import (
     MAX_RATIONALE_LEN,
+    AssertionEvent,
     AssertionProposal,
     AuthorityContext,
     ConcurrencyConflict,
@@ -97,6 +98,46 @@ class TestAuthorityAndBounds:
         with pytest.raises(ValidationError, match="content_sha256"):
             normalize_sha256_hex("deadbeef")
 
+    def test_digest_with_non_hyphen_garbage_rejected(self) -> None:
+        """Malformed digests fail closed instead of dropping bad characters."""
+        with pytest.raises(ValidationError, match="content_sha256"):
+            normalize_sha256_hex(f"{DIGEST}!bad")
+
+    def test_proposal_requires_zero_utc_offset(self) -> None:
+        """Timezone-aware non-UTC timestamps are rejected."""
+        non_utc = timezone(timedelta(hours=2))
+        proposal = _proposal()
+        shifted = AssertionProposal(
+            assertion_id=proposal.assertion_id,
+            predicate_id=proposal.predicate_id,
+            subject_id=proposal.subject_id,
+            object_id=proposal.object_id,
+            method_id=proposal.method_id,
+            proposition=proposal.proposition,
+            effective_from=datetime(2026, 7, 25, 14, 0, 0, tzinfo=non_utc),
+        )
+        with pytest.raises(ValidationError, match="effective_from"):
+            plan_propose(shifted, _ctx("proposer"), recorded_at=NOW)
+
+    def test_assessed_confidence_rejects_bool(self) -> None:
+        """confidence_bp must be an integer value, not bool."""
+        proposal = _proposal()
+        assessed = AssertionProposal(
+            assertion_id=proposal.assertion_id,
+            predicate_id=proposal.predicate_id,
+            subject_id=proposal.subject_id,
+            object_id=proposal.object_id,
+            method_id=proposal.method_id,
+            proposition=proposal.proposition,
+            effective_from=proposal.effective_from,
+            confidence_status="assessed",
+            confidence_bp=True,
+            confidence_type="review",
+            confidence_method="manual",
+        )
+        with pytest.raises(ValidationError, match="confidence_bp"):
+            plan_propose(assessed, _ctx("proposer"), recorded_at=NOW)
+
 
 class TestProposeAndResolve:
     """Proposal planning and event folding."""
@@ -127,6 +168,37 @@ class TestProposeAndResolve:
             recorded_at=NOW + timedelta(seconds=1),
         )
         assert resolve_state([e1, e2]) == "Accepted"
+
+    def test_resolve_state_rejects_invalid_initial_event(self) -> None:
+        """Persisted streams must begin with a proper propose event."""
+        event = AssertionEvent(
+            event_id="event-1",
+            assertion_id="as-1",
+            sequence=1,
+            from_state="Proposed",
+            to_state="Accepted",
+            authority="acceptor",
+            actor_id="actor-1",
+            rationale="bad",
+            policy_version="grac.v1-policy",
+            recorded_at=NOW,
+        )
+        with pytest.raises(ValidationError, match="initial event"):
+            resolve_state([event])
+
+    def test_resolve_state_rejects_state_continuity_gap(self) -> None:
+        """Persisted streams must align each edge with the previous state."""
+        _, e1 = plan_propose(_proposal(), _ctx("proposer"), recorded_at=NOW)
+        e2 = plan_retract(
+            "as-1",
+            "Accepted",
+            _ctx("retractor"),
+            expected_sequence=1,
+            rationale="gap",
+            recorded_at=NOW + timedelta(seconds=1),
+        )
+        with pytest.raises(ValidationError, match="continuity"):
+            resolve_state([e1, e2])
 
 
 class TestTransitionMatrix:
@@ -252,6 +324,18 @@ class TestConcurrencyGuard:
                 "Proposed",
                 _ctx("acceptor"),
                 expected_sequence=0,
+                rationale="bad",
+                recorded_at=NOW,
+            )
+
+    def test_expected_sequence_rejects_bool(self) -> None:
+        """expected_sequence must be an integer sequence, not bool."""
+        with pytest.raises(ValidationError, match="expected_sequence"):
+            plan_accept(
+                "as-1",
+                "Proposed",
+                _ctx("acceptor"),
+                expected_sequence=True,
                 rationale="bad",
                 recorded_at=NOW,
             )

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -103,6 +103,10 @@ class TestAuthorityAndBounds:
         grouped = "aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa-aaaa"
         assert normalize_sha256_hex(grouped) == DIGEST
 
+    def test_plain_digest_normalization(self) -> None:
+        """Plain 64-character digests remain supported and normalize case."""
+        assert normalize_sha256_hex("A" * 64) == DIGEST
+
     def test_invalid_digest_rejected(self) -> None:
         """Short digests fail validation."""
         with pytest.raises(ValidationError, match="content_sha256"):
@@ -112,6 +116,21 @@ class TestAuthorityAndBounds:
         """Malformed digests fail closed instead of dropping bad characters."""
         with pytest.raises(ValidationError, match="content_sha256"):
             normalize_sha256_hex(f"{DIGEST}!bad")
+
+    @pytest.mark.parametrize(
+        "digest",
+        [
+            f"-{DIGEST}",
+            f"{DIGEST}-",
+            f"{DIGEST[:4]}--{DIGEST[4:]}",
+            f"{DIGEST[:8]}-{DIGEST[8:]}",
+        ],
+        ids=["leading", "trailing", "repeated", "arbitrary"],
+    )
+    def test_malformed_digest_hyphen_placement_rejected(self, digest: str) -> None:
+        """Only the canonical sixteen groups of four hex characters are accepted."""
+        with pytest.raises(ValidationError, match="content_sha256"):
+            normalize_sha256_hex(digest)
 
     def test_proposal_requires_zero_utc_offset(self) -> None:
         """Timezone-aware non-UTC timestamps are rejected."""
@@ -129,6 +148,21 @@ class TestAuthorityAndBounds:
         ctx = _ctx("proposer")
         with pytest.raises(ValidationError, match="effective_from"):
             plan_propose(shifted, ctx, recorded_at=NOW)
+
+    def test_proposal_rejects_malformed_datetime_type(self) -> None:
+        """Malformed runtime timestamp types produce a domain validation error."""
+        proposal = _proposal()
+        malformed = AssertionProposal(
+            assertion_id=proposal.assertion_id,
+            predicate_id=proposal.predicate_id,
+            subject_id=proposal.subject_id,
+            object_id=proposal.object_id,
+            method_id=proposal.method_id,
+            proposition=proposal.proposition,
+            effective_from="not-a-datetime",  # type: ignore[arg-type]
+        )
+        with pytest.raises(ValidationError, match="effective_from"):
+            plan_propose(malformed, _ctx("proposer"), recorded_at=NOW)
 
     def test_assessed_confidence_rejects_bool(self) -> None:
         """confidence_bp must be an integer value, not bool."""


### PR DESCRIPTION
## Primary Objective
Enforce append-only GRAC v1 assertion lifecycle and authority with contract-driven transitions and an INSERT-only repository. Closes #1534 (parent #1530).

**Stacked draft note:** This PR is opened as a draft on top of #1549 (`feat/grac-v1-persistence` / #1533). It must wait for #1549 / #1533 to merge (or be retargeted after rebase onto that merge) before leaving draft.

## Fixed Decisions
- No HTTP surface; `AuthorityContext` is typed so API authz cannot embed in domain logic
- Evidence registration with digest validation; idempotent proposal creation
- Per-assertion event sequence with expected-sequence concurrency guard
- Complete transition matrix from the frozen contract via `load_contract_bundle` / `find_transition`
- Atomic successor acceptance + predecessor supersession; cycle/self-supersession prevention
- Bounded actor, rationale, URI and metadata fields

## In Scope
- Domain types and errors in `relationship_assertion.py`
- Pure lifecycle planners in `relationship_assertion_lifecycle.py`
- INSERT-only repository: `propose`, `append_event`, `register_evidence`, `supersede_atomic`, `get_as_of`
- Unit + integration tests for matrix, concurrency, supersession atomics, and invalid transitions

## Out of Scope
- API routers / frontend / projector / publication
- Schema table alterations
- Frozen contract doc rewrites
- Dependency changes

## Allowed Files
- `src/governance/relationship_assertion.py`
- `src/governance/relationship_assertion_lifecycle.py`
- `src/data/relationship_assertion_repository.py`
- `tests/unit/test_relationship_assertion_lifecycle.py`
- `tests/integration/test_relationship_assertion_repository.py`

## Forbidden Files
API routers; frontend; rebuild/publication hooks; projector; schema table alterations; contract rewrites; dependency changes.

## Invariants
- Assertions are append-only; proposition rows are never rewritten
- Lifecycle edges and authority roles come only from the pinned contract registry
- Missing authority / illegal transitions fail closed
- Supersession pointer lives on events (`successor_assertion_id`), not assertion rows
- Empty assertion store still implies no behavioural change to existing graph/API output

## Tests Added/Updated
- `tests/unit/test_relationship_assertion_lifecycle.py` — full transition matrix, authority failures, bounds, concurrency planning, supersession cycles, evidence gates
- `tests/integration/test_relationship_assertion_repository.py` — idempotent propose, persisted transitions, expected-sequence CAS, digest evidence, atomic supersession rollback, `get_as_of`

## Validation Actually Run
- `pytest tests/unit/test_relationship_assertion_lifecycle.py tests/integration/test_relationship_assertion_repository.py` → **53 passed** (after rebase onto latest `origin/feat/grac-v1-persistence`)
- Pre-commit hooks on commit (black/ruff/flake8/mypy) → passed with local `MYPY_CACHE_DIR`
- Codacy CLI analyze blocked by WSL path translation for this worktree (CLI init could not run)
- Aikido scan not run (sign-in required)

## Rollback Behaviour
Revert this PR. No schema changes; dropping the domain/repository modules restores prior behaviour. No migration required.

## Merge Criteria
- Lifecycle matrix, concurrency guard, supersession atomics, and invalid-transition rejection covered by unit + integration tests
- Full required CI passes; no unresolved review threads
- Preceding PR #1549 (#1533) merged (or this branch rebased onto that merge) before undrafting

## Stop Conditions
- Embedding HTTP/authz decisions inside domain lifecycle
- Mutable assertion rows or out-of-matrix transitions
- Scope creep into projection or publication

Closes #1534

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces an append-only GRAC v1 assertion lifecycle with contract-driven transitions and typed authority. Adds an INSERT-only repository with expected-sequence concurrency, SHA-256–validated evidence, bitemporal as-of reads, and savepoint-guarded transitions. Closes #1534.

- **New Features**
  - Contract-driven lifecycle planners, typed `AuthorityContext`, and stricter validation (UTC-only timestamps, integer checks, initial-event/state continuity).
  - INSERT-only repository APIs: `propose`, `transition`, `register_evidence`, `supersede_atomic`, `get_as_of` with expected-sequence CAS, acyclic supersession, additive schema init, and idempotent proposal/evidence creation.

- **Bug Fixes**
  - Supersession updates are serialized and locked; successor-chain traversal prevents multi-hop cycles; direct `Superseded` requires an Accepted successor; savepoints prevent orphan successors and partial writes.
  - Event append is private and distinguishes FK violations from sequence races; transitions run inside savepoints; regression tests stabilized and expanded for CI, including multi-hop cycle coverage.

<sup>Written for commit c7dba716b131cc0507083e8bda9af03409f4693e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1550?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new persistence and lifecycle surface with append-only invariants; review flagged gaps (supersession without Accepted successor check on direct `transition`, permissive digest normalization, partial immutability guard detection, concurrent opposite supersessions) that affect data integrity until addressed.
> 
> **Overview**
> Introduces **GRAC v1** governed relationship assertions: seven additive tables (evidence, assertions, events, projection revisions/edges/publications), contract-driven **pure lifecycle planners**, and an **INSERT-only** `RelationshipAssertionRepository` (`propose`, `transition`, `register_evidence`, `supersede_atomic`, `get_as_of`) with optimistic event sequencing and typed `AuthorityContext`.
> 
> **Database bootstrap** now registers GRAC ORM models, runs `ensure_relationship_assertion_schema` after `create_all`, and on SQLite enables FK pragmas plus a Postgres-compatible `translate` UDF so portable CHECK constraints work. **Immutability** is enforced via dialect triggers blocking UPDATE/DELETE (and TRUNCATE on Postgres) on all seven tables.
> 
> **CI** adds a PostgreSQL job running GRAC schema and ORM unit tests against ephemeral Postgres. Test fixtures align SQLite engines with production hooks via `_configure_sqlite_engine`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03936cea59c065aa71726208c11a7b7a272e5080. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Introduces an append-only governed relationship-assertion lifecycle.
- Adds contract-driven domain validation and lifecycle planning.
- Adds repository operations for proposals, transitions, evidence, supersession, concurrency checks, and bitemporal reads.
- Adds unit and integration coverage for lifecycle and persistence behavior.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because supersession can still persist a cycle when a concurrent transaction inserts an assertion outside the graph lock's row set.

The attempted graph-wide serialization locks only assertions that already exist, while cycle traversal and event insertion remain vulnerable to a concurrent graph mutation involving a newly inserted assertion.

**Files Needing Attention:** src/data/relationship_assertion_repository.py

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a PostgreSQL concurrency harness to stress two independent graph-lock transactions before a third transaction inserted two accepted assertions.
- The verification showed the race did not reproduce: T1 flushed the edge a→b, T2 attempted b→a while T1's event was uncommitted, T1 committed, and T2 waited before rejecting the superseded successor, leaving only a→b and no persisted cycle.
- The verbose transaction trace was inspected to confirm the sequence and outcomes of the concurrent transactions and to verify that no cycle persisted.
- The unit and integration test suite was executed with pytest to exercise the relationship assertion lifecycle tests.
- The pytest run reported 75 tests passed with one harmless configuration warning and exit code 0 in 2.42 seconds.

<a href="https://app.greptile.com/trex/runs/15922080/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/data/relationship_assertion_repository.py | Adds append-only persistence and lifecycle operations, but the graph-wide row-lock fix does not serialize supersession against concurrently inserted assertions. |
| src/governance/relationship_assertion.py | Defines immutable assertion, event, authority, evidence, and as-of domain types. |
| src/governance/relationship_assertion_lifecycle.py | Adds contract-driven lifecycle planning, authority enforcement, validation, and cycle detection. |
| tests/integration/test_relationship_assertion_repository.py | Covers repository persistence and supersession behavior but does not establish serialization against assertions inserted concurrently after graph locking. |
| tests/integration/test_relationship_assertion_schema.py | Exercises the append-only schema safeguards used by assertion persistence. |
| tests/unit/test_relationship_assertion_lifecycle.py | Covers lifecycle transitions, validation, authority, evidence, and cycle-planning behavior. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant T1 as Supersession T1
participant DB as PostgreSQL
participant T2 as Supersession T2
T1->>DB: Lock all currently visible assertion rows
T2->>DB: Insert new assertion outside locked row set
T1->>DB: Check successor chain
T2->>DB: Check successor chain
T1->>DB: Insert supersession event
T2->>DB: Insert supersession event
Note over DB: Combined committed edges can form a cycle
```

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22feat%2Fgrac-v1-lifecycle%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgrac-v1-lifecycle%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Asrc%2Fdata%2Frelationship_assertion_repository.py%3A671-673%0A**Concurrent%20inserts%20escape%20graph%20locking**%0A%0AWhen%20one%20supersession%20transaction%20locks%20the%20currently%20visible%20assertion%20rows%20and%20another%20transaction%20then%20inserts%20a%20new%20assertion%20participating%20in%20a%20prospective%20cycle%2C%20the%20new%20row%20falls%20outside%20this%20lock%20and%20both%20cycle%20checks%20can%20precede%20the%20other%20transaction's%20uncommitted%20event.%20Both%20events%20can%20therefore%20commit%20and%20leave%20a%20persisted%20cyclic%20successor%20graph.%0A%0A&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1550&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
src/data/relationship_assertion_repository.py:671-673
**Concurrent inserts escape graph locking**

When one supersession transaction locks the currently visible assertion rows and another transaction then inserts a new assertion participating in a prospective cycle, the new row falls outside this lock and both cycle checks can precede the other transaction's uncommitted event. Both events can therefore commit and leave a persisted cyclic successor graph.

`````

</details>

<sub>Reviews (13): Last reviewed commit: ["test: cover multi-hop supersession cycle..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/c7dba716b131cc0507083e8bda9af03409f4693e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47297938)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->