### PR TITLE
chore: add CodeScene PR refactoring agent workflow

### DIFF
--- a/.github/workflows/refactoring-agent.yml
+++ b/.github/workflows/refactoring-agent.yml
@@ -18,6 +18,6 @@ jobs:
         with:
           pr_number: ${{ github.event.issue.number }}
           command: ${{ github.event.comment.body }}
-          model: 'openai/gpt-5.1'
+          model: 'openai/gpt-4-turbo'
           codescene_token: ${{ secrets.CODESCENE_ACCESS_TOKEN }}
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}

--- a/.github/workflows/refactoring-agent.yml
+++ b/.github/workflows/refactoring-agent.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: codescene-oss/pr-refactoring-agent@v1.0.8
+      - uses: codescene-oss/pr-refactoring-agent@bbc72fbfb8e514ed2dd0a1ba2dda2e0083abac73 # v1.0.8
         with:
           pr_number: ${{ github.event.issue.number }}
           command: ${{ github.event.comment.body }}

--- a/.github/workflows/refactoring-agent.yml
+++ b/.github/workflows/refactoring-agent.yml
@@ -6,8 +6,11 @@ on:
 
 jobs:
   refactor:
-    # Only run on PR comments that contain /cs-agent
-    if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/cs-agent')
+    # Only run trusted PR comments that contain /cs-agent
+    if: >-
+      github.event.issue.pull_request != null &&
+      contains(github.event.comment.body, '/cs-agent') &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/refactoring-agent.yml
+++ b/.github/workflows/refactoring-agent.yml
@@ -1,0 +1,23 @@
+name: PR Refactoring Agent
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  refactor:
+    # Only run on PR comments that contain /cs-agent
+    if: github.event.issue.pull_request != null && contains(github.event.comment.body, '/cs-agent')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: codescene-oss/pr-refactoring-agent@v1.0.8
+        with:
+          pr_number: ${{ github.event.issue.number }}
+          command: ${{ github.event.comment.body }}
+          model: 'openai/gpt-5.1'
+          codescene_token: ${{ secrets.CODESCENE_ACCESS_TOKEN }}
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}


### PR DESCRIPTION
## Primary Objective
Enable CodeScene PR Refactoring Agent so reviewers can trigger Code Health-guided refactors from PR comments.

## In Scope
- Add `.github/workflows/refactoring-agent.yml` using `codescene-oss/pr-refactoring-agent@v1.0.8`
- Configure OpenAI provider via existing repo secrets (`CODESCENE_ACCESS_TOKEN`, `OPENAI_API_KEY`)
- Model: `openai/gpt-5.1`

## Out of Scope
- Application/runtime code changes
- Changing CodeScene project configuration
- Committing API keys (secrets only)

## Files Expected to Change
- `.github/workflows/refactoring-agent.yml`

## Validation Commands
- Confirm workflow YAML validates (pre-commit `check yaml`)
- After merge: comment `/cs-agent` on a PR to exercise the agent

## Merge Criteria
- Workflow file present and secrets configured on the repository
- No secrets in git history or PR body

## Usage
Comment `/cs-agent` on any pull request (optionally with a skill such as `skill:fix-code-health-degradations`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The workflow can write to the repo and PRs via a third-party action when triggered by a comment; blast radius is limited to opt-in `/cs-agent` use but automated commits still warrant careful secret and permission hygiene.
> 
> **Overview**
> Adds a **GitHub Actions workflow** that runs when someone comments **`/cs-agent`** on a pull request, wiring in **`codescene-oss/pr-refactoring-agent@v1.0.8`** with **`openai/gpt-5.1`** and repo secrets **`CODESCENE_ACCESS_TOKEN`** and **`OPENAI_API_KEY`**.
> 
> The job is gated to PR issue comments only and grants **`contents`**, **`pull-requests`**, and **`issues`** write so the agent can apply refactors on the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0863580ef718cf8e7a344d8a2d4f41bf7c92a3b9. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a GitHub Actions workflow to run the CodeScene PR Refactoring Agent on `/cs-agent` comments from trusted users on a PR. Uses `codescene-oss/pr-refactoring-agent` pinned to v1.0.8 (commit SHA) with `openai/gpt-4-turbo`, configured via `CODESCENE_ACCESS_TOKEN` and `OPENAI_API_KEY`.

- **Migration**
  - Set `CODESCENE_ACCESS_TOKEN` and `OPENAI_API_KEY` in repository secrets.
  - After merge, comment `/cs-agent` on a PR (optionally with a skill); only `OWNER`, `MEMBER`, or `COLLABORATOR` comments trigger the agent.

<sup>Written for commit d697e21d14f6d934f2db3688ee957e2e3d13632d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a comment-triggered CodeScene refactoring workflow.
- Runs for pull-request comments containing `/cs-agent`.
- Restricts invocation to OWNER, MEMBER, or COLLABORATOR associations.
- Pins the CodeScene action to the v1.0.8 commit and configures GPT-4 Turbo with repository secrets.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until invocation is restricted to users who are actually authorized to exercise the workflow's repository write permissions.

The association check prevents arbitrary external commenters from triggering the job, but organization members and read-only collaborators can still satisfy it and invoke the secret-backed action with contents, pull-request, and issue write permissions.

**Files Needing Attention:** .github/workflows/refactoring-agent.yml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/refactoring-agent.yml | Adds the refactoring-agent workflow and an association-based authorization gate, but the previously reported privilege-boundary issue remains because MEMBER and COLLABORATOR do not necessarily imply write access. |

<sub>Reviews (4): Last reviewed commit: ["Restrict refactoring agent trigger (#155..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/d697e21d14f6d934f2db3688ee957e2e3d13632d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47333229)</sub>

<!-- /greptile_comment -->