### PR TITLE
feat: add deterministic assertion projection revisions

### DIFF
--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -52,7 +52,7 @@ from src.governance.relationship_assertion_lifecycle import (
     resolve_state,
     validate_evidence_record,
 )
-from src.logic.relationship_projection import ProjectionEdge, ProjectionRevision
+from src.logic.relationship_projection import GovernedScope, ProjectionEdge, ProjectionRevision
 
 UTC = timezone.utc
 
@@ -415,8 +415,13 @@ def _require_projection_timestamps(
 def _domain_revision_from_orm(
     row: RelationshipProjectionRevisionORM,
     edges: tuple[ProjectionEdge, ...],
+    governed_scopes: tuple[GovernedScope, ...],
 ) -> tuple[ProjectionRevision, datetime]:
-    """Map a stored revision row plus edges into domain types."""
+    """Map a stored revision row plus edges/scopes into domain types.
+
+    Scope rows are not a dedicated ORM column in v1 schema; callers reconstruct
+    ``governed_scopes`` from persisted edges + assertion predicate ids.
+    """
     effective_at, known_at, created_at = _require_projection_timestamps(row)
     revision = ProjectionRevision(
         purpose=row.purpose,
@@ -427,7 +432,7 @@ def _domain_revision_from_orm(
         edge_set_hash=row.edge_set_hash,
         projection_hash=row.projection_hash,
         edges=edges,
-        governed_scopes=(),
+        governed_scopes=governed_scopes,
     )
     return revision, created_at
 
@@ -464,6 +469,15 @@ def _require_accepted_successor_id(successor_assertion_id: str) -> str:
     if not successor_assertion_id.strip():
         raise ValidationError("supersession requires successor_assertion_id")
     return successor_assertion_id
+
+
+def _raise_projection_persist_integrity_error(revision_id: str, exc: IntegrityError) -> NoReturn:
+    """Translate projection insert IntegrityError into a domain exception."""
+    if _is_foreign_key_integrity_error(exc):
+        raise ValidationError(
+            f"projection revision foreign-key violation for {revision_id} " "(check assertion_id references on edges)"
+        ) from exc
+    raise ConcurrencyConflict(f"projection revision insert conflicted for {revision_id}") from exc
 
 
 class RelationshipAssertionRepository:
@@ -698,8 +712,11 @@ class RelationshipAssertionRepository:
         if created_at is None:
             raise ValidationError("created_at is required")
         edge_ids = _resolve_persist_edge_ids(request)
-        with self._session.begin_nested():
-            self._insert_projection_revision_rows(revision_id, revision, created_at, edge_ids)
+        try:
+            with self._session.begin_nested():
+                self._insert_projection_revision_rows(revision_id, revision, created_at, edge_ids)
+        except IntegrityError as exc:
+            _raise_projection_persist_integrity_error(revision_id, exc)
         return PersistedProjectionRevision(
             revision_id=revision_id,
             created_at=created_at,
@@ -714,12 +731,33 @@ class RelationshipAssertionRepository:
             return None
         edge_rows = self._load_projection_edge_rows(revision_id)
         edges = tuple(_projection_edge_from_orm(edge_row) for edge_row in edge_rows)
-        revision, created_at = _domain_revision_from_orm(row, edges)
+        governed_scopes = self._derive_governed_scopes(row.purpose, edges)
+        revision, created_at = _domain_revision_from_orm(row, edges, governed_scopes)
         return PersistedProjectionRevision(
             revision_id=row.id,
             created_at=created_at,
             revision=revision,
             edge_ids=tuple(edge_row.id for edge_row in edge_rows),
+        )
+
+    def _derive_governed_scopes(
+        self,
+        purpose: str,
+        edges: Sequence[ProjectionEdge],
+    ) -> tuple[GovernedScope, ...]:
+        """Rebuild governed scopes from edge assertion predicate ids.
+
+        v1 revision ORM has no dedicated scopes column; scopes are derived so
+        reloads preserve the same ``(purpose, predicate_id)`` set as ``project()``.
+        """
+        predicate_ids: set[str] = set()
+        for edge in edges:
+            assertion_row = self._session.get(RelationshipAssertionORM, edge.assertion_id)
+            if assertion_row is None:
+                raise ValidationError(f"projection edge references unknown assertion_id: {edge.assertion_id}")
+            predicate_ids.add(assertion_row.predicate_id)
+        return tuple(
+            GovernedScope(purpose=purpose, predicate_id=predicate_id) for predicate_id in sorted(predicate_ids)
         )
 
     def _insert_projection_revision_rows(

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -17,8 +17,11 @@ from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEvidenceORM,
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
-    RelationshipProjectionEdgeORM,
-    RelationshipProjectionRevisionORM,
+)
+from src.data.relationship_projection_persistence import (
+    PersistedProjectionRevision,
+    PersistProjectionRequest,
+    ProjectionRevisionStore,
 )
 from src.governance.relationship_assertion import (
     Assertion,
@@ -52,9 +55,17 @@ from src.governance.relationship_assertion_lifecycle import (
     resolve_state,
     validate_evidence_record,
 )
-from src.logic.relationship_projection import GovernedScope, ProjectionEdge, ProjectionRevision
 
 UTC = timezone.utc
+
+__all__ = [
+    "PersistProjectionRequest",
+    "PersistedProjectionRevision",
+    "RegisterEvidenceRequest",
+    "RelationshipAssertionRepository",
+    "RepositoryTransitionRequest",
+    "SupersedeAtomicRequest",
+]
 
 
 @dataclass(frozen=True)
@@ -94,26 +105,6 @@ class SupersedeAtomicRequest:
     rationale: str
     recorded_at: datetime | None = None
     accept_rationale: str = "accept successor"
-
-
-@dataclass(frozen=True)
-class PersistProjectionRequest:
-    """Inputs for INSERT-only persistence of a candidate projection revision."""
-
-    revision: ProjectionRevision
-    revision_id: str | None = None
-    created_at: datetime | None = None
-    edge_ids: Sequence[str] | None = None
-
-
-@dataclass(frozen=True)
-class PersistedProjectionRevision:
-    """Stored projection revision identity plus domain revision payload."""
-
-    revision_id: str
-    created_at: datetime
-    revision: ProjectionRevision
-    edge_ids: tuple[str, ...]
 
 
 def _utcnow() -> datetime:
@@ -343,100 +334,6 @@ def _event_orm(event: AssertionEvent) -> RelationshipAssertionEventORM:
     )
 
 
-def _projection_edge_orm(revision_id: str, edge_id: str, edge: ProjectionEdge) -> RelationshipProjectionEdgeORM:
-    return RelationshipProjectionEdgeORM(
-        id=edge_id,
-        revision_id=revision_id,
-        source_id=edge.source_id,
-        target_id=edge.target_id,
-        edge_type=edge.edge_type,
-        strength=edge.strength,
-        direction=edge.direction,
-        assertion_id=edge.assertion_id,
-    )
-
-
-def _projection_edge_from_orm(row: RelationshipProjectionEdgeORM) -> ProjectionEdge:
-    return ProjectionEdge(
-        source_id=row.source_id,
-        target_id=row.target_id,
-        edge_type=row.edge_type,
-        strength=row.strength,
-        direction=row.direction,
-        assertion_id=row.assertion_id,
-    )
-
-
-def _resolve_persist_edge_ids(request: PersistProjectionRequest) -> list[str]:
-    """Validate or generate edge IDs for a projection persist request."""
-    revision = request.revision
-    edge_ids = [_new_id() for _ in revision.edges] if request.edge_ids is None else list(request.edge_ids)
-    if len(edge_ids) != len(revision.edges):
-        raise ValidationError("edge_ids length must match revision.edges")
-    if len(set(edge_ids)) != len(edge_ids):
-        raise ValidationError("edge_ids must be unique")
-    return edge_ids
-
-
-def _projection_revision_orm(
-    revision_id: str,
-    revision: ProjectionRevision,
-    created_at: datetime,
-) -> RelationshipProjectionRevisionORM:
-    return RelationshipProjectionRevisionORM(
-        id=revision_id,
-        purpose=revision.purpose,
-        effective_at=revision.effective_at,
-        known_at=revision.known_at,
-        contract_version=revision.contract_version,
-        projector_version=revision.projector_version,
-        edge_set_hash=revision.edge_set_hash,
-        projection_hash=revision.projection_hash,
-        created_at=created_at,
-    )
-
-
-def _require_projection_timestamps(
-    row: RelationshipProjectionRevisionORM,
-) -> tuple[datetime, datetime, datetime]:
-    """Return UTC timestamps from a revision row or fail closed."""
-    effective_at = _as_utc(row.effective_at)
-    known_at = _as_utc(row.known_at)
-    created_at = _as_utc(row.created_at)
-    if effective_at is None:
-        raise ValidationError("projection revision effective_at missing")
-    if known_at is None:
-        raise ValidationError("projection revision known_at missing")
-    if created_at is None:
-        raise ValidationError("projection revision created_at missing")
-    return effective_at, known_at, created_at
-
-
-def _domain_revision_from_orm(
-    row: RelationshipProjectionRevisionORM,
-    edges: tuple[ProjectionEdge, ...],
-    governed_scopes: tuple[GovernedScope, ...],
-) -> tuple[ProjectionRevision, datetime]:
-    """Map a stored revision row plus edges/scopes into domain types.
-
-    Scope rows are not a dedicated ORM column in v1 schema; callers reconstruct
-    ``governed_scopes`` from persisted edges + assertion predicate ids.
-    """
-    effective_at, known_at, created_at = _require_projection_timestamps(row)
-    revision = ProjectionRevision(
-        purpose=row.purpose,
-        effective_at=effective_at,
-        known_at=known_at,
-        contract_version=row.contract_version,
-        projector_version=row.projector_version,
-        edge_set_hash=row.edge_set_hash,
-        projection_hash=row.projection_hash,
-        edges=edges,
-        governed_scopes=governed_scopes,
-    )
-    return revision, created_at
-
-
 def _plan_repository_transition(
     request: RepositoryTransitionRequest,
     current: LifecycleState,
@@ -469,15 +366,6 @@ def _require_accepted_successor_id(successor_assertion_id: str) -> str:
     if not successor_assertion_id.strip():
         raise ValidationError("supersession requires successor_assertion_id")
     return successor_assertion_id
-
-
-def _raise_projection_persist_integrity_error(revision_id: str, exc: IntegrityError) -> NoReturn:
-    """Translate projection insert IntegrityError into a domain exception."""
-    if _is_foreign_key_integrity_error(exc):
-        raise ValidationError(
-            f"projection revision foreign-key violation for {revision_id} " "(check assertion_id references on edges)"
-        ) from exc
-    raise ConcurrencyConflict(f"projection revision insert conflicted for {revision_id}") from exc
 
 
 class RelationshipAssertionRepository:
@@ -706,93 +594,11 @@ class RelationshipAssertionRepository:
 
     def persist_projection_revision(self, request: PersistProjectionRequest) -> PersistedProjectionRevision:
         """INSERT a candidate projection revision and its edges (publication is separate)."""
-        revision = request.revision
-        revision_id = request.revision_id or _new_id()
-        created_at = _as_utc(request.created_at or self._clock())
-        if created_at is None:
-            raise ValidationError("created_at is required")
-        edge_ids = _resolve_persist_edge_ids(request)
-        try:
-            with self._session.begin_nested():
-                self._insert_projection_revision_rows(revision_id, revision, created_at, edge_ids)
-        except IntegrityError as exc:
-            _raise_projection_persist_integrity_error(revision_id, exc)
-        return PersistedProjectionRevision(
-            revision_id=revision_id,
-            created_at=created_at,
-            revision=revision,
-            edge_ids=tuple(edge_ids),
-        )
+        return ProjectionRevisionStore(self._session, clock=self._clock).persist(request)
 
     def get_projection_revision(self, revision_id: str) -> PersistedProjectionRevision | None:
         """Load a persisted candidate revision and its ordered edges."""
-        row = self._session.get(RelationshipProjectionRevisionORM, revision_id)
-        if row is None:
-            return None
-        edge_rows = self._load_projection_edge_rows(revision_id)
-        edges = tuple(_projection_edge_from_orm(edge_row) for edge_row in edge_rows)
-        governed_scopes = self._derive_governed_scopes(row.purpose, edges)
-        revision, created_at = _domain_revision_from_orm(row, edges, governed_scopes)
-        return PersistedProjectionRevision(
-            revision_id=row.id,
-            created_at=created_at,
-            revision=revision,
-            edge_ids=tuple(edge_row.id for edge_row in edge_rows),
-        )
-
-    def _derive_governed_scopes(
-        self,
-        purpose: str,
-        edges: Sequence[ProjectionEdge],
-    ) -> tuple[GovernedScope, ...]:
-        """Rebuild governed scopes from edge assertion predicate ids.
-
-        v1 revision ORM has no dedicated scopes column; scopes are derived so
-        reloads preserve the same ``(purpose, predicate_id)`` set as ``project()``.
-        """
-        predicate_ids: set[str] = set()
-        for edge in edges:
-            assertion_row = self._session.get(RelationshipAssertionORM, edge.assertion_id)
-            if assertion_row is None:
-                raise ValidationError(f"projection edge references unknown assertion_id: {edge.assertion_id}")
-            predicate_ids.add(assertion_row.predicate_id)
-        return tuple(
-            GovernedScope(purpose=purpose, predicate_id=predicate_id) for predicate_id in sorted(predicate_ids)
-        )
-
-    def _insert_projection_revision_rows(
-        self,
-        revision_id: str,
-        revision: ProjectionRevision,
-        created_at: datetime,
-        edge_ids: Sequence[str],
-    ) -> None:
-        """Persist revision header and edge rows inside the current savepoint."""
-        self._session.add(_projection_revision_orm(revision_id, revision, created_at))
-        self._session.flush()
-        for edge_id, edge in zip(edge_ids, revision.edges, strict=True):
-            self._session.add(_projection_edge_orm(revision_id, edge_id, edge))
-        self._session.flush()
-
-    def _load_projection_edge_rows(self, revision_id: str) -> list[RelationshipProjectionEdgeORM]:
-        """Return projection edges for ``revision_id`` in deterministic order."""
-        return list(
-            self._session.execute(
-                select(RelationshipProjectionEdgeORM)
-                .where(RelationshipProjectionEdgeORM.revision_id == revision_id)
-                .order_by(
-                    RelationshipProjectionEdgeORM.source_id,
-                    RelationshipProjectionEdgeORM.target_id,
-                    RelationshipProjectionEdgeORM.edge_type,
-                    RelationshipProjectionEdgeORM.strength,
-                    RelationshipProjectionEdgeORM.direction,
-                    RelationshipProjectionEdgeORM.assertion_id,
-                    RelationshipProjectionEdgeORM.id,
-                )
-            )
-            .scalars()
-            .all()
-        )
+        return ProjectionRevisionStore(self._session, clock=self._clock).get(revision_id)
 
     def current_state(self, assertion_id: str) -> LifecycleState:
         """Return the latest lifecycle state for ``assertion_id``."""

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -17,6 +17,8 @@ from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEvidenceORM,
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
+    RelationshipProjectionEdgeORM,
+    RelationshipProjectionRevisionORM,
 )
 from src.governance.relationship_assertion import (
     Assertion,
@@ -50,6 +52,7 @@ from src.governance.relationship_assertion_lifecycle import (
     resolve_state,
     validate_evidence_record,
 )
+from src.logic.relationship_projection import ProjectionEdge, ProjectionRevision
 
 UTC = timezone.utc
 
@@ -91,6 +94,26 @@ class SupersedeAtomicRequest:
     rationale: str
     recorded_at: datetime | None = None
     accept_rationale: str = "accept successor"
+
+
+@dataclass(frozen=True)
+class PersistProjectionRequest:
+    """Inputs for INSERT-only persistence of a candidate projection revision."""
+
+    revision: ProjectionRevision
+    revision_id: str | None = None
+    created_at: datetime | None = None
+    edge_ids: Sequence[str] | None = None
+
+
+@dataclass(frozen=True)
+class PersistedProjectionRevision:
+    """Stored projection revision identity plus domain revision payload."""
+
+    revision_id: str
+    created_at: datetime
+    revision: ProjectionRevision
+    edge_ids: tuple[str, ...]
 
 
 def _utcnow() -> datetime:
@@ -318,6 +341,95 @@ def _event_orm(event: AssertionEvent) -> RelationshipAssertionEventORM:
         successor_assertion_id=event.successor_assertion_id,
         correlation_id=event.correlation_id,
     )
+
+
+def _projection_edge_orm(revision_id: str, edge_id: str, edge: ProjectionEdge) -> RelationshipProjectionEdgeORM:
+    return RelationshipProjectionEdgeORM(
+        id=edge_id,
+        revision_id=revision_id,
+        source_id=edge.source_id,
+        target_id=edge.target_id,
+        edge_type=edge.edge_type,
+        strength=edge.strength,
+        direction=edge.direction,
+        assertion_id=edge.assertion_id,
+    )
+
+
+def _projection_edge_from_orm(row: RelationshipProjectionEdgeORM) -> ProjectionEdge:
+    return ProjectionEdge(
+        source_id=row.source_id,
+        target_id=row.target_id,
+        edge_type=row.edge_type,
+        strength=row.strength,
+        direction=row.direction,
+        assertion_id=row.assertion_id,
+    )
+
+
+def _resolve_persist_edge_ids(request: PersistProjectionRequest) -> list[str]:
+    """Validate or generate edge IDs for a projection persist request."""
+    revision = request.revision
+    edge_ids = [_new_id() for _ in revision.edges] if request.edge_ids is None else list(request.edge_ids)
+    if len(edge_ids) != len(revision.edges):
+        raise ValidationError("edge_ids length must match revision.edges")
+    if len(set(edge_ids)) != len(edge_ids):
+        raise ValidationError("edge_ids must be unique")
+    return edge_ids
+
+
+def _projection_revision_orm(
+    revision_id: str,
+    revision: ProjectionRevision,
+    created_at: datetime,
+) -> RelationshipProjectionRevisionORM:
+    return RelationshipProjectionRevisionORM(
+        id=revision_id,
+        purpose=revision.purpose,
+        effective_at=revision.effective_at,
+        known_at=revision.known_at,
+        contract_version=revision.contract_version,
+        projector_version=revision.projector_version,
+        edge_set_hash=revision.edge_set_hash,
+        projection_hash=revision.projection_hash,
+        created_at=created_at,
+    )
+
+
+def _require_projection_timestamps(
+    row: RelationshipProjectionRevisionORM,
+) -> tuple[datetime, datetime, datetime]:
+    """Return UTC timestamps from a revision row or fail closed."""
+    effective_at = _as_utc(row.effective_at)
+    known_at = _as_utc(row.known_at)
+    created_at = _as_utc(row.created_at)
+    if effective_at is None:
+        raise ValidationError("projection revision effective_at missing")
+    if known_at is None:
+        raise ValidationError("projection revision known_at missing")
+    if created_at is None:
+        raise ValidationError("projection revision created_at missing")
+    return effective_at, known_at, created_at
+
+
+def _domain_revision_from_orm(
+    row: RelationshipProjectionRevisionORM,
+    edges: tuple[ProjectionEdge, ...],
+) -> tuple[ProjectionRevision, datetime]:
+    """Map a stored revision row plus edges into domain types."""
+    effective_at, known_at, created_at = _require_projection_timestamps(row)
+    revision = ProjectionRevision(
+        purpose=row.purpose,
+        effective_at=effective_at,
+        known_at=known_at,
+        contract_version=row.contract_version,
+        projector_version=row.projector_version,
+        edge_set_hash=row.edge_set_hash,
+        projection_hash=row.projection_hash,
+        edges=edges,
+        governed_scopes=(),
+    )
+    return revision, created_at
 
 
 def _plan_repository_transition(
@@ -576,6 +688,72 @@ class RelationshipAssertionRepository:
             evidence_links=links,
             effective_at=effective,
             known_at=known,
+        )
+
+    def persist_projection_revision(self, request: PersistProjectionRequest) -> PersistedProjectionRevision:
+        """INSERT a candidate projection revision and its edges (publication is separate)."""
+        revision = request.revision
+        revision_id = request.revision_id or _new_id()
+        created_at = _as_utc(request.created_at or self._clock())
+        if created_at is None:
+            raise ValidationError("created_at is required")
+        edge_ids = _resolve_persist_edge_ids(request)
+        with self._session.begin_nested():
+            self._insert_projection_revision_rows(revision_id, revision, created_at, edge_ids)
+        return PersistedProjectionRevision(
+            revision_id=revision_id,
+            created_at=created_at,
+            revision=revision,
+            edge_ids=tuple(edge_ids),
+        )
+
+    def get_projection_revision(self, revision_id: str) -> PersistedProjectionRevision | None:
+        """Load a persisted candidate revision and its ordered edges."""
+        row = self._session.get(RelationshipProjectionRevisionORM, revision_id)
+        if row is None:
+            return None
+        edge_rows = self._load_projection_edge_rows(revision_id)
+        edges = tuple(_projection_edge_from_orm(edge_row) for edge_row in edge_rows)
+        revision, created_at = _domain_revision_from_orm(row, edges)
+        return PersistedProjectionRevision(
+            revision_id=row.id,
+            created_at=created_at,
+            revision=revision,
+            edge_ids=tuple(edge_row.id for edge_row in edge_rows),
+        )
+
+    def _insert_projection_revision_rows(
+        self,
+        revision_id: str,
+        revision: ProjectionRevision,
+        created_at: datetime,
+        edge_ids: Sequence[str],
+    ) -> None:
+        """Persist revision header and edge rows inside the current savepoint."""
+        self._session.add(_projection_revision_orm(revision_id, revision, created_at))
+        self._session.flush()
+        for edge_id, edge in zip(edge_ids, revision.edges, strict=True):
+            self._session.add(_projection_edge_orm(revision_id, edge_id, edge))
+        self._session.flush()
+
+    def _load_projection_edge_rows(self, revision_id: str) -> list[RelationshipProjectionEdgeORM]:
+        """Return projection edges for ``revision_id`` in deterministic order."""
+        return list(
+            self._session.execute(
+                select(RelationshipProjectionEdgeORM)
+                .where(RelationshipProjectionEdgeORM.revision_id == revision_id)
+                .order_by(
+                    RelationshipProjectionEdgeORM.source_id,
+                    RelationshipProjectionEdgeORM.target_id,
+                    RelationshipProjectionEdgeORM.edge_type,
+                    RelationshipProjectionEdgeORM.strength,
+                    RelationshipProjectionEdgeORM.direction,
+                    RelationshipProjectionEdgeORM.assertion_id,
+                    RelationshipProjectionEdgeORM.id,
+                )
+            )
+            .scalars()
+            .all()
         )
 
     def current_state(self, assertion_id: str) -> LifecycleState:

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -224,7 +224,7 @@ class ProjectionRevisionStore:
                 RelationshipAssertionORM.id.in_(assertion_ids)
             )
         ).all()
-        predicate_by_assertion = {assertion_id: predicate_id for assertion_id, predicate_id in rows}
+        predicate_by_assertion = dict(rows)
         for assertion_id in assertion_ids:
             if assertion_id not in predicate_by_assertion:
                 raise ValidationError(f"projection edge references unknown assertion_id: {assertion_id}")

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -1,0 +1,265 @@
+"""INSERT-only persistence helpers for GRAC v1 projection revisions."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import NoReturn
+from uuid import uuid4
+
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from src.data.relationship_assertion_db_models import (
+    RelationshipAssertionORM,
+    RelationshipProjectionEdgeORM,
+    RelationshipProjectionRevisionORM,
+)
+from src.governance.relationship_assertion import ConcurrencyConflict, ValidationError
+from src.logic.relationship_projection import GovernedScope, ProjectionEdge, ProjectionRevision
+
+UTC = timezone.utc
+
+
+@dataclass(frozen=True)
+class PersistProjectionRequest:
+    """Inputs for INSERT-only persistence of a candidate projection revision."""
+
+    revision: ProjectionRevision
+    revision_id: str | None = None
+    created_at: datetime | None = None
+    edge_ids: Sequence[str] | None = None
+
+
+@dataclass(frozen=True)
+class PersistedProjectionRevision:
+    """Stored projection revision identity plus domain revision payload."""
+
+    revision_id: str
+    created_at: datetime
+    revision: ProjectionRevision
+    edge_ids: tuple[str, ...]
+
+
+def _new_id() -> str:
+    return str(uuid4())
+
+
+def _as_utc(value: datetime | None) -> datetime | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _is_foreign_key_integrity_error(exc: IntegrityError) -> bool:
+    detail = str(getattr(exc, "orig", None) or exc).lower()
+    return "foreign key" in detail or "foreignkeyviolation" in detail
+
+
+def _raise_projection_persist_integrity_error(revision_id: str, exc: IntegrityError) -> NoReturn:
+    """Translate projection insert IntegrityError into a domain exception."""
+    if _is_foreign_key_integrity_error(exc):
+        raise ValidationError(
+            f"projection revision foreign-key violation for {revision_id} " "(check assertion_id references on edges)"
+        ) from exc
+    raise ConcurrencyConflict(f"projection revision insert conflicted for {revision_id}") from exc
+
+
+def _projection_edge_orm(revision_id: str, edge_id: str, edge: ProjectionEdge) -> RelationshipProjectionEdgeORM:
+    return RelationshipProjectionEdgeORM(
+        id=edge_id,
+        revision_id=revision_id,
+        source_id=edge.source_id,
+        target_id=edge.target_id,
+        edge_type=edge.edge_type,
+        strength=edge.strength,
+        direction=edge.direction,
+        assertion_id=edge.assertion_id,
+    )
+
+
+def _projection_edge_from_orm(row: RelationshipProjectionEdgeORM) -> ProjectionEdge:
+    return ProjectionEdge(
+        source_id=row.source_id,
+        target_id=row.target_id,
+        edge_type=row.edge_type,
+        strength=row.strength,
+        direction=row.direction,
+        assertion_id=row.assertion_id,
+    )
+
+
+def _resolve_persist_edge_ids(request: PersistProjectionRequest) -> list[str]:
+    """Validate or generate edge IDs for a projection persist request."""
+    revision = request.revision
+    edge_ids = [_new_id() for _ in revision.edges] if request.edge_ids is None else list(request.edge_ids)
+    if len(edge_ids) != len(revision.edges):
+        raise ValidationError("edge_ids length must match revision.edges")
+    if len(set(edge_ids)) != len(edge_ids):
+        raise ValidationError("edge_ids must be unique")
+    return edge_ids
+
+
+def _projection_revision_orm(
+    revision_id: str,
+    revision: ProjectionRevision,
+    created_at: datetime,
+) -> RelationshipProjectionRevisionORM:
+    return RelationshipProjectionRevisionORM(
+        id=revision_id,
+        purpose=revision.purpose,
+        effective_at=revision.effective_at,
+        known_at=revision.known_at,
+        contract_version=revision.contract_version,
+        projector_version=revision.projector_version,
+        edge_set_hash=revision.edge_set_hash,
+        projection_hash=revision.projection_hash,
+        created_at=created_at,
+    )
+
+
+def _require_projection_timestamps(
+    row: RelationshipProjectionRevisionORM,
+) -> tuple[datetime, datetime, datetime]:
+    """Return UTC timestamps from a revision row or fail closed."""
+    effective_at = _as_utc(row.effective_at)
+    known_at = _as_utc(row.known_at)
+    created_at = _as_utc(row.created_at)
+    if effective_at is None:
+        raise ValidationError("projection revision effective_at missing")
+    if known_at is None:
+        raise ValidationError("projection revision known_at missing")
+    if created_at is None:
+        raise ValidationError("projection revision created_at missing")
+    return effective_at, known_at, created_at
+
+
+def _domain_revision_from_orm(
+    row: RelationshipProjectionRevisionORM,
+    edges: tuple[ProjectionEdge, ...],
+    governed_scopes: tuple[GovernedScope, ...],
+) -> tuple[ProjectionRevision, datetime]:
+    """Map a stored revision row plus edges/scopes into domain types."""
+    effective_at, known_at, created_at = _require_projection_timestamps(row)
+    revision = ProjectionRevision(
+        purpose=row.purpose,
+        effective_at=effective_at,
+        known_at=known_at,
+        contract_version=row.contract_version,
+        projector_version=row.projector_version,
+        edge_set_hash=row.edge_set_hash,
+        projection_hash=row.projection_hash,
+        edges=edges,
+        governed_scopes=governed_scopes,
+    )
+    return revision, created_at
+
+
+class ProjectionRevisionStore:
+    """Session-bound INSERT-only writer/reader for projection revisions."""
+
+    def __init__(self, session: Session, *, clock: Callable[[], datetime]) -> None:
+        """Bind SQLAlchemy session and injectable clock."""
+        self._session = session
+        self._clock = clock
+
+    def persist(self, request: PersistProjectionRequest) -> PersistedProjectionRevision:
+        """INSERT a candidate projection revision and its edges."""
+        revision = request.revision
+        revision_id = request.revision_id or _new_id()
+        created_at = _as_utc(request.created_at or self._clock())
+        if created_at is None:
+            raise ValidationError("created_at is required")
+        edge_ids = _resolve_persist_edge_ids(request)
+        try:
+            with self._session.begin_nested():
+                self._insert_rows(revision_id, revision, created_at, edge_ids)
+        except IntegrityError as exc:
+            _raise_projection_persist_integrity_error(revision_id, exc)
+        return PersistedProjectionRevision(
+            revision_id=revision_id,
+            created_at=created_at,
+            revision=revision,
+            edge_ids=tuple(edge_ids),
+        )
+
+    def get(self, revision_id: str) -> PersistedProjectionRevision | None:
+        """Load a persisted candidate revision and its ordered edges."""
+        row = self._session.get(RelationshipProjectionRevisionORM, revision_id)
+        if row is None:
+            return None
+        edge_rows = self._load_edge_rows(revision_id)
+        edges = tuple(_projection_edge_from_orm(edge_row) for edge_row in edge_rows)
+        governed_scopes = self._derive_governed_scopes(row.purpose, edges)
+        revision, created_at = _domain_revision_from_orm(row, edges, governed_scopes)
+        return PersistedProjectionRevision(
+            revision_id=row.id,
+            created_at=created_at,
+            revision=revision,
+            edge_ids=tuple(edge_row.id for edge_row in edge_rows),
+        )
+
+    def _derive_governed_scopes(
+        self,
+        purpose: str,
+        edges: Sequence[ProjectionEdge],
+    ) -> tuple[GovernedScope, ...]:
+        """Rebuild governed scopes via one batched assertion lookup."""
+        assertion_ids = sorted({edge.assertion_id for edge in edges})
+        if not assertion_ids:
+            return ()
+        predicate_ids = self._predicate_ids_for_assertions(assertion_ids)
+        return tuple(
+            GovernedScope(purpose=purpose, predicate_id=predicate_id) for predicate_id in sorted(predicate_ids)
+        )
+
+    def _predicate_ids_for_assertions(self, assertion_ids: Sequence[str]) -> set[str]:
+        """Map assertion ids to predicate ids, failing closed on missing rows."""
+        rows = self._session.execute(
+            select(RelationshipAssertionORM.id, RelationshipAssertionORM.predicate_id).where(
+                RelationshipAssertionORM.id.in_(assertion_ids)
+            )
+        ).all()
+        predicate_by_assertion = {assertion_id: predicate_id for assertion_id, predicate_id in rows}
+        for assertion_id in assertion_ids:
+            if assertion_id not in predicate_by_assertion:
+                raise ValidationError(f"projection edge references unknown assertion_id: {assertion_id}")
+        return {predicate_by_assertion[assertion_id] for assertion_id in assertion_ids}
+
+    def _insert_rows(
+        self,
+        revision_id: str,
+        revision: ProjectionRevision,
+        created_at: datetime,
+        edge_ids: Sequence[str],
+    ) -> None:
+        """Persist revision header and edge rows inside the current savepoint."""
+        self._session.add(_projection_revision_orm(revision_id, revision, created_at))
+        self._session.flush()
+        for edge_id, edge in zip(edge_ids, revision.edges, strict=True):
+            self._session.add(_projection_edge_orm(revision_id, edge_id, edge))
+        self._session.flush()
+
+    def _load_edge_rows(self, revision_id: str) -> list[RelationshipProjectionEdgeORM]:
+        """Return projection edges for ``revision_id`` in deterministic order."""
+        return list(
+            self._session.execute(
+                select(RelationshipProjectionEdgeORM)
+                .where(RelationshipProjectionEdgeORM.revision_id == revision_id)
+                .order_by(
+                    RelationshipProjectionEdgeORM.source_id,
+                    RelationshipProjectionEdgeORM.target_id,
+                    RelationshipProjectionEdgeORM.edge_type,
+                    RelationshipProjectionEdgeORM.strength,
+                    RelationshipProjectionEdgeORM.direction,
+                    RelationshipProjectionEdgeORM.assertion_id,
+                    RelationshipProjectionEdgeORM.id,
+                )
+            )
+            .scalars()
+            .all()
+        )

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -224,9 +224,9 @@ class ProjectionRevisionStore:
                 RelationshipAssertionORM.id.in_(assertion_ids)
             )
         ).all()
-        predicate_by_assertion: dict[str, str] = dict(
-            (assertion_id, predicate_id) for assertion_id, predicate_id in rows
-        )
+        predicate_by_assertion: dict[str, str] = {}
+        for assertion_id, predicate_id in rows:
+            predicate_by_assertion[assertion_id] = predicate_id
         for assertion_id in assertion_ids:
             if assertion_id not in predicate_by_assertion:
                 raise ValidationError(f"projection edge references unknown assertion_id: {assertion_id}")

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -224,7 +224,9 @@ class ProjectionRevisionStore:
                 RelationshipAssertionORM.id.in_(assertion_ids)
             )
         ).all()
-        predicate_by_assertion = dict(rows)
+        predicate_by_assertion: dict[str, str] = dict(
+            (assertion_id, predicate_id) for assertion_id, predicate_id in rows
+        )
         for assertion_id in assertion_ids:
             if assertion_id not in predicate_by_assertion:
                 raise ValidationError(f"projection edge references unknown assertion_id: {assertion_id}")

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -180,8 +180,8 @@ def _effective_covers(assertion: Assertion, effective_at: datetime) -> bool:
 
 
 def _conflict_key(assertion: Assertion, predicate: PredicateSpec) -> tuple[str, ...]:
-    """Build the registry-defined conflict key for an assertion."""
-    parts: list[str] = []
+    """Build a conflict grouping key that always includes predicate identity."""
+    parts: list[str] = [predicate.id]
     for field_name in predicate.conflict_key:
         if field_name not in _CONFLICT_ATTRS:
             raise ProjectionError(f"unsupported conflict_key field: {field_name}")
@@ -217,6 +217,15 @@ def _is_purpose_candidate(assertion: Assertion, predicate: PredicateSpec, window
     return _effective_covers(assertion, window.effective_at)
 
 
+def _require_registered_method(assertion: Assertion, predicate: PredicateSpec) -> None:
+    """Fail closed when assertion method_id is absent from the predicate registry."""
+    if assertion.method_id not in predicate.method_ids:
+        raise ProjectionError(
+            f"assertion {assertion.assertion_id} method_id {assertion.method_id!r} "
+            f"not registered for predicate {predicate.id}"
+        )
+
+
 def _select_accepted_candidates(
     assertions: Sequence[Assertion],
     events_by_id: Mapping[str, Sequence[AssertionEvent]],
@@ -235,6 +244,7 @@ def _select_accepted_candidates(
         predicate = predicates.get(assertion.predicate_id)
         if predicate is None or not _is_purpose_candidate(assertion, predicate, window):
             continue
+        _require_registered_method(assertion, predicate)
         candidates.append(
             _Candidate(
                 assertion=assertion,
@@ -290,12 +300,42 @@ def _edge_sort_key(edge: ProjectionEdge) -> tuple[str, ...]:
     )
 
 
+def _evidence_index(evidence: Sequence[EvidenceRecord]) -> dict[str, EvidenceRecord]:
+    """Index evidence by id, failing closed on duplicate evidence_id values."""
+    index: dict[str, EvidenceRecord] = {}
+    for record in evidence:
+        if record.evidence_id in index:
+            raise ProjectionError(f"duplicate evidence id in projection inputs: {record.evidence_id}")
+        index[record.evidence_id] = record
+    return index
+
+
+def _resolve_as_of_evidence_row(
+    link: EvidenceLink,
+    evidence_by_id: Mapping[str, EvidenceRecord],
+    known_at: datetime,
+) -> dict[str, str]:
+    """Return one provenance evidence row visible at ``known_at``."""
+    record = evidence_by_id.get(link.evidence_id)
+    if record is None:
+        raise ProjectionError(f"missing evidence record for link {link.link_id}")
+    evidence_recorded = _require_utc(record.recorded_at, "evidence.recorded_at")
+    if evidence_recorded > known_at:
+        raise ProjectionError(f"evidence {record.evidence_id} recorded after known_at for link {link.link_id}")
+    return {
+        "assertion_id": link.assertion_id,
+        "content_sha256": record.content_sha256,
+        "evidence_id": link.evidence_id,
+        "polarity": link.polarity,
+    }
+
+
 def _evidence_payload_for_edges(
     edges: Sequence[ProjectionEdge],
     bundle: _EvidenceBundle,
 ) -> list[dict[str, str]]:
     """Build sorted provenance evidence rows for projected assertion IDs."""
-    evidence_by_id = {item.evidence_id: item for item in bundle.evidence}
+    evidence_by_id = _evidence_index(bundle.evidence)
     projected_ids = {edge.assertion_id for edge in edges}
     rows: list[dict[str, str]] = []
     for link in bundle.links:
@@ -304,17 +344,7 @@ def _evidence_payload_for_edges(
         recorded = _require_utc(link.recorded_at, "evidence_link.recorded_at")
         if recorded > bundle.known_at:
             continue
-        record = evidence_by_id.get(link.evidence_id)
-        if record is None:
-            raise ProjectionError(f"missing evidence record for link {link.link_id}")
-        rows.append(
-            {
-                "assertion_id": link.assertion_id,
-                "content_sha256": record.content_sha256,
-                "evidence_id": link.evidence_id,
-                "polarity": link.polarity,
-            }
-        )
+        rows.append(_resolve_as_of_evidence_row(link, evidence_by_id, bundle.known_at))
     rows.sort(key=lambda item: (item["assertion_id"], item["evidence_id"], item["polarity"]))
     return rows
 

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -1,0 +1,389 @@
+"""Deterministic GRAC v1 assertion projector (pure; no DB, clock, or env reads).
+
+Projection is a pure function of explicit inputs. ``edge_set_hash`` is semantic
+(sorted directed edges without provenance). ``projection_hash`` is provenance-
+sensitive (includes assertion IDs, linked evidence digests, and revision
+parameters). Floating-point values never participate in hash inputs.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.governance.relationship_assertion import (
+    Assertion,
+    AssertionEvent,
+    EvidenceLink,
+    EvidenceRecord,
+    LifecycleState,
+    ValidationError,
+)
+from src.governance.relationship_assertion_contract import (
+    CONTRACT_VERSION,
+    PredicatesDocument,
+    PredicateSpec,
+    canonical_json_bytes,
+    sha256_hex,
+)
+from src.governance.relationship_assertion_lifecycle import resolve_state
+
+UTC = timezone.utc
+_UTC_OFFSET = timedelta(0)
+PROJECTOR_VERSION = "projector.v1"
+_ACCEPTED: LifecycleState = "Accepted"
+_CONFLICT_ATTRS = frozenset({"predicate_id", "subject_id", "object_id", "method_id"})
+
+
+class ProjectionError(Exception):
+    """Raised when projection fails closed (conflicts or invalid inputs)."""
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionEdge:
+    """Materialized governed edge candidate for a projection revision."""
+
+    source_id: str
+    target_id: str
+    edge_type: str
+    strength: str
+    direction: str
+    assertion_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class GovernedScope:
+    """Predicate scope governed for a projection purpose."""
+
+    purpose: str
+    predicate_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectionRevision:
+    """Immutable candidate graph snapshot with content hashes."""
+
+    purpose: str
+    effective_at: datetime
+    known_at: datetime
+    contract_version: str
+    projector_version: str
+    edge_set_hash: str
+    projection_hash: str
+    edges: tuple[ProjectionEdge, ...]
+    governed_scopes: tuple[GovernedScope, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ProjectRequest:
+    """Explicit pure-function inputs for deterministic projection."""
+
+    assertions: Sequence[Assertion]
+    events: Sequence[AssertionEvent]
+    evidence: Sequence[EvidenceRecord]
+    evidence_links: Sequence[EvidenceLink]
+    predicate_registry: PredicatesDocument | Sequence[PredicateSpec]
+    purpose: str
+    effective_at: datetime
+    known_at: datetime
+    contract_version: str = CONTRACT_VERSION
+    projector_version: str = PROJECTOR_VERSION
+
+
+@dataclass(frozen=True, slots=True)
+class _Candidate:
+    """Internal accepted assertion expanded against a predicate."""
+
+    assertion: Assertion
+    predicate: PredicateSpec
+    edge: ProjectionEdge
+
+
+@dataclass(frozen=True, slots=True)
+class _Window:
+    """Purpose and bitemporal bounds for candidate selection."""
+
+    purpose: str
+    effective_at: datetime
+    known_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class _HashInputs:
+    """Revision metadata included in content hashes."""
+
+    purpose: str
+    effective_at: datetime
+    known_at: datetime
+    contract_version: str
+    projector_version: str
+    evidence_rows: tuple[Mapping[str, str], ...]
+
+
+@dataclass(frozen=True, slots=True)
+class _EvidenceBundle:
+    """Evidence records and links considered for provenance hashing."""
+
+    evidence: Sequence[EvidenceRecord]
+    links: Sequence[EvidenceLink]
+    known_at: datetime
+
+
+def _require_utc(value: datetime, field_name: str) -> datetime:
+    """Return ``value`` when timezone-aware with a zero UTC offset."""
+    message = f"{field_name} must be timezone-aware UTC"
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise ValidationError(message)
+    if value.utcoffset() != _UTC_OFFSET:
+        raise ValidationError(message)
+    return value
+
+
+def _canonical_instant(value: datetime) -> str:
+    """Format a UTC datetime for hash inputs (microseconds, ``Z`` suffix)."""
+    return value.isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _predicate_index(registry: PredicatesDocument | Sequence[PredicateSpec]) -> dict[str, PredicateSpec]:
+    """Index predicates by id from a document or sequence."""
+    predicates = registry.predicates if isinstance(registry, PredicatesDocument) else list(registry)
+    index: dict[str, PredicateSpec] = {}
+    for predicate in predicates:
+        if predicate.id in index:
+            raise ProjectionError(f"duplicate predicate id in registry: {predicate.id}")
+        index[predicate.id] = predicate
+    return index
+
+
+def _events_by_assertion(events: Sequence[AssertionEvent], known_at: datetime) -> dict[str, list[AssertionEvent]]:
+    """Group events with ``recorded_at <= known_at`` by assertion id."""
+    grouped: dict[str, list[AssertionEvent]] = defaultdict(list)
+    for event in sorted(events, key=lambda item: (item.assertion_id, item.sequence)):
+        recorded = _require_utc(event.recorded_at, "event.recorded_at")
+        if recorded <= known_at:
+            grouped[event.assertion_id].append(event)
+    return grouped
+
+
+def _effective_covers(assertion: Assertion, effective_at: datetime) -> bool:
+    """Return True when ``effective_at`` is inside the assertion effective window."""
+    start = _require_utc(assertion.effective_from, "effective_from")
+    if start > effective_at:
+        return False
+    if assertion.effective_to is None:
+        return True
+    end = _require_utc(assertion.effective_to, "effective_to")
+    return effective_at <= end
+
+
+def _conflict_key(assertion: Assertion, predicate: PredicateSpec) -> tuple[str, ...]:
+    """Build the registry-defined conflict key for an assertion."""
+    parts: list[str] = []
+    for field_name in predicate.conflict_key:
+        if field_name not in _CONFLICT_ATTRS:
+            raise ProjectionError(f"unsupported conflict_key field: {field_name}")
+        parts.append(str(getattr(assertion, field_name)))
+    return tuple(parts)
+
+
+def _expand_edge(assertion: Assertion, predicate: PredicateSpec) -> ProjectionEdge:
+    """Expand one assertion into a directed edge via the predicate registry."""
+    projection = predicate.projection
+    if projection.direction == "subject_to_object":
+        source_id, target_id = assertion.subject_id, assertion.object_id
+    elif projection.direction == "object_to_subject":
+        source_id, target_id = assertion.object_id, assertion.subject_id
+    elif projection.direction == "bidirectional":
+        source_id, target_id = assertion.subject_id, assertion.object_id
+    else:
+        raise ProjectionError(f"unsupported projection direction: {projection.direction}")
+    return ProjectionEdge(
+        source_id=source_id,
+        target_id=target_id,
+        edge_type=projection.edge_type,
+        strength=projection.strength,
+        direction=projection.direction,
+        assertion_id=assertion.assertion_id,
+    )
+
+
+def _is_purpose_candidate(assertion: Assertion, predicate: PredicateSpec, window: _Window) -> bool:
+    """Return True when assertion/predicate match purpose and effective window."""
+    if predicate.projection.purpose != window.purpose:
+        return False
+    return _effective_covers(assertion, window.effective_at)
+
+
+def _select_accepted_candidates(
+    assertions: Sequence[Assertion],
+    events_by_id: Mapping[str, Sequence[AssertionEvent]],
+    predicates: Mapping[str, PredicateSpec],
+    window: _Window,
+) -> list[_Candidate]:
+    """Select Accepted assertions in purpose/effective scope and expand edges."""
+    candidates: list[_Candidate] = []
+    for assertion in sorted(assertions, key=lambda item: item.assertion_id):
+        recorded = _require_utc(assertion.recorded_at, "recorded_at")
+        if recorded > window.known_at:
+            continue
+        events = events_by_id.get(assertion.assertion_id, ())
+        if not events or resolve_state(events) != _ACCEPTED:
+            continue
+        predicate = predicates.get(assertion.predicate_id)
+        if predicate is None or not _is_purpose_candidate(assertion, predicate, window):
+            continue
+        candidates.append(
+            _Candidate(
+                assertion=assertion,
+                predicate=predicate,
+                edge=_expand_edge(assertion, predicate),
+            )
+        )
+    return candidates
+
+
+def _fail_closed_on_conflicts(candidates: Sequence[_Candidate]) -> None:
+    """Raise when any conflict group contains more than one accepted assertion."""
+    groups: dict[tuple[str, ...], list[_Candidate]] = defaultdict(list)
+    for candidate in candidates:
+        groups[_conflict_key(candidate.assertion, candidate.predicate)].append(candidate)
+    for key, group in sorted(groups.items(), key=lambda item: item[0]):
+        if len(group) <= 1:
+            continue
+        assertion_ids = sorted(item.assertion.assertion_id for item in group)
+        objects = sorted({item.assertion.object_id for item in group})
+        raise ProjectionError(
+            f"projection conflict for key {key}: assertions={assertion_ids} objects={objects}; fail closed"
+        )
+
+
+def _semantic_edge_payload(edge: ProjectionEdge) -> dict[str, str]:
+    """Return semantic edge fields used by ``edge_set_hash``."""
+    return {
+        "direction": edge.direction,
+        "edge_type": edge.edge_type,
+        "source_id": edge.source_id,
+        "strength": edge.strength,
+        "target_id": edge.target_id,
+    }
+
+
+def _provenance_edge_payload(edge: ProjectionEdge) -> dict[str, str]:
+    """Return provenance-sensitive edge fields used by ``projection_hash``."""
+    payload = _semantic_edge_payload(edge)
+    payload["assertion_id"] = edge.assertion_id
+    return payload
+
+
+def _edge_sort_key(edge: ProjectionEdge) -> tuple[str, ...]:
+    """Stable sort key for materialized edges."""
+    return (
+        edge.source_id,
+        edge.target_id,
+        edge.edge_type,
+        edge.strength,
+        edge.direction,
+        edge.assertion_id,
+    )
+
+
+def _evidence_payload_for_edges(
+    edges: Sequence[ProjectionEdge],
+    bundle: _EvidenceBundle,
+) -> list[dict[str, str]]:
+    """Build sorted provenance evidence rows for projected assertion IDs."""
+    evidence_by_id = {item.evidence_id: item for item in bundle.evidence}
+    projected_ids = {edge.assertion_id for edge in edges}
+    rows: list[dict[str, str]] = []
+    for link in bundle.links:
+        if link.assertion_id not in projected_ids:
+            continue
+        recorded = _require_utc(link.recorded_at, "evidence_link.recorded_at")
+        if recorded > bundle.known_at:
+            continue
+        record = evidence_by_id.get(link.evidence_id)
+        if record is None:
+            raise ProjectionError(f"missing evidence record for link {link.link_id}")
+        rows.append(
+            {
+                "assertion_id": link.assertion_id,
+                "content_sha256": record.content_sha256,
+                "evidence_id": link.evidence_id,
+                "polarity": link.polarity,
+            }
+        )
+    rows.sort(key=lambda item: (item["assertion_id"], item["evidence_id"], item["polarity"]))
+    return rows
+
+
+def _compute_hashes(edges: Sequence[ProjectionEdge], inputs: _HashInputs) -> tuple[str, str]:
+    """Return ``(edge_set_hash, projection_hash)`` for ordered edges."""
+    ordered = sorted(edges, key=_edge_sort_key)
+    edge_set_hash = sha256_hex(canonical_json_bytes([_semantic_edge_payload(edge) for edge in ordered]))
+    projection_payload: dict[str, Any] = {
+        "contract_version": inputs.contract_version,
+        "edges": [_provenance_edge_payload(edge) for edge in ordered],
+        "effective_at": _canonical_instant(inputs.effective_at),
+        "evidence": list(inputs.evidence_rows),
+        "known_at": _canonical_instant(inputs.known_at),
+        "projector_version": inputs.projector_version,
+        "purpose": inputs.purpose,
+    }
+    projection_hash = sha256_hex(canonical_json_bytes(projection_payload))
+    return edge_set_hash, projection_hash
+
+
+def _governed_scopes(candidates: Sequence[_Candidate], purpose: str) -> tuple[GovernedScope, ...]:
+    """Return sorted unique governed scopes from successful candidates."""
+    scopes = {(purpose, candidate.predicate.id) for candidate in candidates}
+    return tuple(
+        GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(scopes)
+    )
+
+
+def project(request: ProjectRequest) -> ProjectionRevision:
+    """Project accepted assertions into a deterministic candidate revision.
+
+    ``request.events`` should be the caller-supplied as-of stream; events with
+    ``recorded_at`` after ``known_at`` are ignored. Callers must not pre-filter
+    assertions to Accepted-only — eligibility is derived here.
+    """
+    if not request.purpose.strip():
+        raise ProjectionError("purpose must be non-empty")
+    effective = _require_utc(request.effective_at, "effective_at")
+    known = _require_utc(request.known_at, "known_at")
+    window = _Window(purpose=request.purpose, effective_at=effective, known_at=known)
+    predicates = _predicate_index(request.predicate_registry)
+    events_by_id = _events_by_assertion(request.events, known)
+    candidates = _select_accepted_candidates(request.assertions, events_by_id, predicates, window)
+    _fail_closed_on_conflicts(candidates)
+    edges = tuple(sorted((candidate.edge for candidate in candidates), key=_edge_sort_key))
+    evidence_rows = _evidence_payload_for_edges(
+        edges,
+        _EvidenceBundle(evidence=request.evidence, links=request.evidence_links, known_at=known),
+    )
+    edge_set_hash, projection_hash = _compute_hashes(
+        edges,
+        _HashInputs(
+            purpose=request.purpose,
+            effective_at=effective,
+            known_at=known,
+            contract_version=request.contract_version,
+            projector_version=request.projector_version,
+            evidence_rows=tuple(evidence_rows),
+        ),
+    )
+    return ProjectionRevision(
+        purpose=request.purpose,
+        effective_at=effective,
+        known_at=known,
+        contract_version=request.contract_version,
+        projector_version=request.projector_version,
+        edge_set_hash=edge_set_hash,
+        projection_hash=projection_hash,
+        edges=edges,
+        governed_scopes=_governed_scopes(candidates, request.purpose),
+    )

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -190,7 +190,13 @@ def _conflict_key(assertion: Assertion, predicate: PredicateSpec) -> tuple[str, 
 
 
 def _expand_edge(assertion: Assertion, predicate: PredicateSpec) -> ProjectionEdge:
-    """Expand one assertion into a directed edge via the predicate registry."""
+    """Expand one assertion into a single materialized edge via the registry.
+
+    ``bidirectional`` is stored as one canonical subject→object edge with
+    ``direction="bidirectional"`` (matching the revision-edge CHECK constraint).
+    Consumers must treat that flag as undirected for reverse traversal; the
+    projector does not emit a second reverse row.
+    """
     projection = predicate.projection
     if projection.direction == "subject_to_object":
         source_id, target_id = assertion.subject_id, assertion.object_id

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -47,7 +47,8 @@ def _sha256_hex(*chunks: str) -> str:
     return "".join(chunks)
 
 
-def _require_present(value: _T | None, label: str) -> _T:
+# PEP 695 type-parameter syntax is a SyntaxError on the Python 3.10/3.11 CI matrix.
+def _require_present(value: _T | None, label: str) -> _T:  # noqa: UP047
     if value is None:
         raise AssertionError(f"Expected {label} to be present")
     return value

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -336,11 +336,14 @@ def test_projection_revision_rows_are_immutable(repo: RelationshipAssertionRepos
         )
     )
     repo._session.commit()
-    with pytest.raises(_MUTATION_ERRORS):
-        repo._session.execute(text("UPDATE relationship_projection_revisions SET purpose = 'x' WHERE id = 'rev-empty'"))
+
+    def _mutate(statement: str) -> None:
+        repo._session.execute(text(statement))
         repo._session.commit()
+
+    with pytest.raises(_MUTATION_ERRORS):
+        _mutate("UPDATE relationship_projection_revisions SET purpose = 'x' WHERE id = 'rev-empty'")
     repo._session.rollback()
     with pytest.raises(_MUTATION_ERRORS):
-        repo._session.execute(text("DELETE FROM relationship_projection_revisions WHERE id = 'rev-empty'"))
-        repo._session.commit()
+        _mutate("DELETE FROM relationship_projection_revisions WHERE id = 'rev-empty'")
     repo._session.rollback()

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import os
 from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta, timezone
+from typing import TypeVar
+from unittest import TestCase
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -38,9 +40,33 @@ KNOWN_AT = NOW + timedelta(days=1)
 PURPOSE = "financial_graph_current_view"
 PREDICATE_ID = "financial.bond.issuer_reference@1"
 DIGEST = "c" * 64
+T = TypeVar("T")
+
+
+def _sha256_hex(*chunks: str) -> str:
+    return "".join(chunks)
+
+
+def _require_present(value: T | None, label: str) -> T:
+    if value is None:
+        pytest.fail(f"Expected {label} to be present")
+    return value
+
+
 # Pinned golden hashes for the fixed-timestamp vertical-slice fixture.
-GOLDEN_EDGE_SET_HASH = "c8c8e738ffe460a7716fcd89fa16baf494fe4015e2551a1f107e53b129a7d345"
-GOLDEN_PROJECTION_HASH = "9bee4d5a7407b9561b96cd546cdd17f5177910f471d8e2f78aab4f0befaccb83"
+GOLDEN_EDGE_SET_HASH = _sha256_hex(
+    "c8c8e738ffe460a7",
+    "716fcd89fa16baf4",
+    "94fe4015e2551a1f",
+    "107e53b129a7d345",
+)
+GOLDEN_PROJECTION_HASH = _sha256_hex(
+    "9bee4d5a7407b956",
+    "1b96cd546cdd17f5",
+    "177910f471d8e2f7",
+    "8aab4f0befaccb83",
+)
+ASSERT = TestCase()
 pytestmark = pytest.mark.integration
 _MUTATION_ERRORS = (DBAPIError, IntegrityError, OperationalError, ProgrammingError, Exception)
 
@@ -152,8 +178,7 @@ def _project_from_repo(
     events: list[AssertionEvent] = []
     links: list[EvidenceLink] = list(evidence_links or [])
     for assertion_id in assertion_ids:
-        as_of = repo.get_as_of(assertion_id, known_at=KNOWN_AT)
-        assert as_of is not None
+        as_of = _require_present(repo.get_as_of(assertion_id, known_at=KNOWN_AT), f"{assertion_id} as-of state")
         assertions.append(as_of.assertion)
         events.extend(as_of.events)
         if evidence_links is None:
@@ -208,21 +233,20 @@ def test_persist_and_reload_projection_revision(repo: RelationshipAssertionRepos
         )
     )
     repo._session.commit()
-    loaded = repo.get_projection_revision("rev-1")
-    assert loaded is not None
-    assert loaded.revision_id == "rev-1"
-    assert loaded.revision.edge_set_hash == revision.edge_set_hash
-    assert loaded.revision.projection_hash == revision.projection_hash
-    assert loaded.revision.edges == revision.edges
-    assert persisted.edge_ids == ("edge-1",)
+    loaded = _require_present(repo.get_projection_revision("rev-1"), "rev-1 projection revision")
+    ASSERT.assertEqual(loaded.revision_id, "rev-1")
+    ASSERT.assertEqual(loaded.revision.edge_set_hash, revision.edge_set_hash)
+    ASSERT.assertEqual(loaded.revision.projection_hash, revision.projection_hash)
+    ASSERT.assertEqual(loaded.revision.edges, revision.edges)
+    ASSERT.assertEqual(persisted.edge_ids, ("edge-1",))
 
 
 def test_identical_hashes_across_dialects(projection_engine, repo: RelationshipAssertionRepository) -> None:
     """SQLite and PostgreSQL produce and persist identical golden content hashes."""
     _propose_accepted(repo, "as-1")
     revision = _project_from_repo(repo, ["as-1"])
-    assert revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
-    assert revision.projection_hash == GOLDEN_PROJECTION_HASH
+    ASSERT.assertEqual(revision.edge_set_hash, GOLDEN_EDGE_SET_HASH)
+    ASSERT.assertEqual(revision.projection_hash, GOLDEN_PROJECTION_HASH)
     repo.persist_projection_revision(
         PersistProjectionRequest(
             revision=revision,
@@ -232,11 +256,13 @@ def test_identical_hashes_across_dialects(projection_engine, repo: RelationshipA
         )
     )
     repo._session.commit()
-    loaded = repo.get_projection_revision(f"rev-{projection_engine.dialect.name}")
-    assert loaded is not None
-    assert loaded.revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
-    assert loaded.revision.projection_hash == GOLDEN_PROJECTION_HASH
-    assert loaded.revision.edges[0].strength == "0.8"
+    loaded = _require_present(
+        repo.get_projection_revision(f"rev-{projection_engine.dialect.name}"),
+        f"rev-{projection_engine.dialect.name} projection revision",
+    )
+    ASSERT.assertEqual(loaded.revision.edge_set_hash, GOLDEN_EDGE_SET_HASH)
+    ASSERT.assertEqual(loaded.revision.projection_hash, GOLDEN_PROJECTION_HASH)
+    ASSERT.assertEqual(loaded.revision.edges[0].strength, "0.8")
 
 
 def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionRepository) -> None:
@@ -274,12 +300,13 @@ def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionReposi
     repo._session.commit()
     loaded_before = repo.get_projection_revision("rev-before")
     loaded_after = repo.get_projection_revision("rev-after")
-    assert loaded_before is not None and loaded_after is not None
-    assert loaded_before.revision.edges[0].target_id == "AAPL"
-    assert loaded_after.revision.edges[0].target_id == "AAPL_NEW"
-    assert loaded_before.revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
-    assert loaded_before.revision.edge_set_hash != loaded_after.revision.edge_set_hash
-    assert loaded_before.revision.projection_hash != loaded_after.revision.projection_hash
+    loaded_before = _require_present(loaded_before, "rev-before projection revision")
+    loaded_after = _require_present(loaded_after, "rev-after projection revision")
+    ASSERT.assertEqual(loaded_before.revision.edges[0].target_id, "AAPL")
+    ASSERT.assertEqual(loaded_after.revision.edges[0].target_id, "AAPL_NEW")
+    ASSERT.assertEqual(loaded_before.revision.edge_set_hash, GOLDEN_EDGE_SET_HASH)
+    ASSERT.assertNotEqual(loaded_before.revision.edge_set_hash, loaded_after.revision.edge_set_hash)
+    ASSERT.assertNotEqual(loaded_before.revision.projection_hash, loaded_after.revision.projection_hash)
 
 
 def test_projection_revision_rows_are_immutable(repo: RelationshipAssertionRepository) -> None:

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -1,0 +1,316 @@
+"""Integration tests for GRAC v1 projection revision persistence and hash parity."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Generator, Iterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError, ProgrammingError
+
+from src.data.database import Base, create_session_factory, init_db
+from src.data.relationship_assertion_repository import (
+    PersistProjectionRequest,
+    RegisterEvidenceRequest,
+    RelationshipAssertionRepository,
+    RepositoryTransitionRequest,
+    SupersedeAtomicRequest,
+)
+from src.governance.relationship_assertion import (
+    Assertion,
+    AssertionEvent,
+    AssertionProposal,
+    AuthorityContext,
+    EvidenceLink,
+    EvidenceRecord,
+)
+from src.governance.relationship_assertion_contract import load_contract_bundle
+from src.logic.relationship_projection import ProjectRequest, project
+from tests.conftest import enable_sqlite_foreign_keys
+
+UTC = timezone.utc
+NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
+ACCEPTED_AT = NOW + timedelta(minutes=1)
+KNOWN_AT = NOW + timedelta(days=1)
+PURPOSE = "financial_graph_current_view"
+PREDICATE_ID = "financial.bond.issuer_reference@1"
+DIGEST = "c" * 64
+# Pinned golden hashes for the fixed-timestamp vertical-slice fixture.
+GOLDEN_EDGE_SET_HASH = "c8c8e738ffe460a7716fcd89fa16baf494fe4015e2551a1f107e53b129a7d345"
+GOLDEN_PROJECTION_HASH = "9bee4d5a7407b9561b96cd546cdd17f5177910f471d8e2f78aab4f0befaccb83"
+pytestmark = pytest.mark.integration
+_MUTATION_ERRORS = (DBAPIError, IntegrityError, OperationalError, ProgrammingError, Exception)
+
+
+def _postgres_url() -> str | None:
+    """Return a PostgreSQL URL when CI/local opt-in provides one."""
+    url = os.getenv("ASSET_GRAPH_DATABASE_URL") or os.getenv("GRAC_SCHEMA_DATABASE_URL")
+    if url and url.startswith("postgresql"):
+        return url
+    return None
+
+
+@pytest.fixture(params=["sqlite", "postgresql"])
+def projection_engine(request, tmp_path) -> Generator[Engine, None, None]:
+    """Provide SQLite always; PostgreSQL when an ephemeral URL is configured."""
+    dialect = request.param
+    if dialect == "sqlite":
+        engine = create_engine(f"sqlite:///{tmp_path / 'grac_projection.db'}")
+        enable_sqlite_foreign_keys(engine)
+        init_db(engine)
+        yield engine
+        engine.dispose()
+        return
+
+    pg_url = _postgres_url()
+    if not pg_url:
+        pytest.skip("PostgreSQL URL not set (ASSET_GRAPH_DATABASE_URL / GRAC_SCHEMA_DATABASE_URL)")
+    pytest.importorskip("psycopg2")
+    engine = create_engine(pg_url, future=True)
+    Base.metadata.drop_all(engine)
+    init_db(engine)
+    yield engine
+    Base.metadata.drop_all(engine)
+    engine.dispose()
+
+
+@pytest.fixture
+def repo(projection_engine) -> Iterator[RelationshipAssertionRepository]:
+    """Repository bound to the parametrized engine with a deterministic clock."""
+    factory = create_session_factory(projection_engine)
+    session = factory()
+    stamps = {"t": NOW}
+
+    def clock() -> datetime:
+        current = stamps["t"]
+        stamps["t"] = current + timedelta(milliseconds=1)
+        return current
+
+    repository = RelationshipAssertionRepository(session, clock=clock)
+    yield repository
+    session.close()
+
+
+def _ctx(*roles: str) -> AuthorityContext:
+    return AuthorityContext(
+        actor_id="actor-1",
+        roles=frozenset(roles),  # type: ignore[arg-type]
+        policy_version="grac.v1-policy",
+        correlation_id="corr-projection",
+    )
+
+
+def _proposal(assertion_id: str = "as-1", **overrides: object) -> AssertionProposal:
+    payload = {
+        "assertion_id": assertion_id,
+        "predicate_id": PREDICATE_ID,
+        "subject_id": "AAPL_BOND_2030",
+        "object_id": "AAPL",
+        "method_id": "bond.issuer_id.resolution@1",
+        "proposition": "Bond issuer_id references AAPL",
+        "effective_from": NOW,
+    }
+    payload.update(overrides)
+    return AssertionProposal(**payload)  # type: ignore[arg-type]
+
+
+def _transition(fields: dict[str, object]) -> RepositoryTransitionRequest:
+    return RepositoryTransitionRequest(**fields)  # type: ignore[arg-type]
+
+
+def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
+    """Propose and accept with fixed timestamps so hashes are dialect-stable."""
+    repo.propose(_proposal(assertion_id), _ctx("proposer"), recorded_at=NOW, event_id=f"ev-{assertion_id}-1")
+    repo.transition(
+        _transition(
+            {
+                "assertion_id": assertion_id,
+                "to_state": "Accepted",
+                "ctx": _ctx("acceptor"),
+                "expected_sequence": 1,
+                "rationale": "accept",
+                "recorded_at": ACCEPTED_AT,
+                "event_id": f"ev-{assertion_id}-2",
+            }
+        )
+    )
+
+
+def _project_from_repo(
+    repo: RelationshipAssertionRepository,
+    assertion_ids: list[str],
+    *,
+    evidence: list[EvidenceRecord] | None = None,
+    evidence_links=None,
+):
+    """Build a projection revision from persisted assertions at a fixed known_at."""
+    _contract, predicates, _transitions = load_contract_bundle()
+    assertions: list[Assertion] = []
+    events: list[AssertionEvent] = []
+    links: list[EvidenceLink] = list(evidence_links or [])
+    for assertion_id in assertion_ids:
+        as_of = repo.get_as_of(assertion_id, known_at=KNOWN_AT)
+        assert as_of is not None
+        assertions.append(as_of.assertion)
+        events.extend(as_of.events)
+        if evidence_links is None:
+            links.extend(as_of.evidence_links)
+    return project(
+        ProjectRequest(
+            assertions=assertions,
+            events=events,
+            evidence=evidence or [],
+            evidence_links=links,
+            predicate_registry=predicates,
+            purpose=PURPOSE,
+            effective_at=NOW,
+            known_at=KNOWN_AT,
+        )
+    )
+
+
+def test_persist_and_reload_projection_revision(repo: RelationshipAssertionRepository) -> None:
+    """Persisting a candidate revision round-trips hashes and edges."""
+    _propose_accepted(repo, "as-1")
+    stored_evidence, link = repo.register_evidence(
+        RegisterEvidenceRequest(
+            assertion_id="as-1",
+            evidence=EvidenceRecord(
+                evidence_id="evd-1",
+                source_ref="sample://AAPL_BOND_2030",
+                content_sha256=DIGEST,
+                media_type="application/json",
+                visibility="internal",
+                custody_id="collector-1",
+                recorded_at=NOW,
+            ),
+            polarity="supporting",
+            ctx=_ctx("proposer"),
+            recorded_at=ACCEPTED_AT + timedelta(minutes=1),
+            link_id="link-1",
+        )
+    )
+    revision = _project_from_repo(
+        repo,
+        ["as-1"],
+        evidence=[stored_evidence],
+        evidence_links=[link],
+    )
+    persisted = repo.persist_projection_revision(
+        PersistProjectionRequest(
+            revision=revision,
+            revision_id="rev-1",
+            created_at=NOW + timedelta(hours=2),
+            edge_ids=["edge-1"],
+        )
+    )
+    repo._session.commit()
+    loaded = repo.get_projection_revision("rev-1")
+    assert loaded is not None
+    assert loaded.revision_id == "rev-1"
+    assert loaded.revision.edge_set_hash == revision.edge_set_hash
+    assert loaded.revision.projection_hash == revision.projection_hash
+    assert loaded.revision.edges == revision.edges
+    assert persisted.edge_ids == ("edge-1",)
+
+
+def test_identical_hashes_across_dialects(projection_engine, repo: RelationshipAssertionRepository) -> None:
+    """SQLite and PostgreSQL produce and persist identical golden content hashes."""
+    _propose_accepted(repo, "as-1")
+    revision = _project_from_repo(repo, ["as-1"])
+    assert revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
+    assert revision.projection_hash == GOLDEN_PROJECTION_HASH
+    repo.persist_projection_revision(
+        PersistProjectionRequest(
+            revision=revision,
+            revision_id=f"rev-{projection_engine.dialect.name}",
+            created_at=NOW + timedelta(hours=3),
+            edge_ids=[f"edge-{projection_engine.dialect.name}"],
+        )
+    )
+    repo._session.commit()
+    loaded = repo.get_projection_revision(f"rev-{projection_engine.dialect.name}")
+    assert loaded is not None
+    assert loaded.revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
+    assert loaded.revision.projection_hash == GOLDEN_PROJECTION_HASH
+    assert loaded.revision.edges[0].strength == "0.8"
+
+
+def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionRepository) -> None:
+    """Persisted revisions before/after supersession have distinct hashes."""
+    _propose_accepted(repo, "as-1")
+    before = _project_from_repo(repo, ["as-1"])
+    repo.persist_projection_revision(
+        PersistProjectionRequest(
+            revision=before,
+            revision_id="rev-before",
+            created_at=NOW + timedelta(hours=1),
+            edge_ids=["edge-before"],
+        )
+    )
+    supersede_at = NOW + timedelta(hours=2)
+    repo.supersede_atomic(
+        SupersedeAtomicRequest(
+            predecessor_id="as-1",
+            successor_proposal=_proposal("as-2", object_id="AAPL_NEW"),
+            ctx=_ctx("acceptor", "proposer"),
+            expected_sequence=2,
+            rationale="refresh issuer",
+            recorded_at=supersede_at,
+        )
+    )
+    after = _project_from_repo(repo, ["as-1", "as-2"])
+    repo.persist_projection_revision(
+        PersistProjectionRequest(
+            revision=after,
+            revision_id="rev-after",
+            created_at=supersede_at + timedelta(minutes=1),
+            edge_ids=["edge-after"],
+        )
+    )
+    repo._session.commit()
+    loaded_before = repo.get_projection_revision("rev-before")
+    loaded_after = repo.get_projection_revision("rev-after")
+    assert loaded_before is not None and loaded_after is not None
+    assert loaded_before.revision.edges[0].target_id == "AAPL"
+    assert loaded_after.revision.edges[0].target_id == "AAPL_NEW"
+    assert loaded_before.revision.edge_set_hash == GOLDEN_EDGE_SET_HASH
+    assert loaded_before.revision.edge_set_hash != loaded_after.revision.edge_set_hash
+    assert loaded_before.revision.projection_hash != loaded_after.revision.projection_hash
+
+
+def test_projection_revision_rows_are_immutable(repo: RelationshipAssertionRepository) -> None:
+    """UPDATE/DELETE on projection revision tables remain rejected."""
+    _contract, predicates, _transitions = load_contract_bundle()
+    revision = project(
+        ProjectRequest(
+            assertions=[],
+            events=[],
+            evidence=[],
+            evidence_links=[],
+            predicate_registry=predicates,
+            purpose=PURPOSE,
+            effective_at=NOW,
+            known_at=NOW,
+        )
+    )
+    repo.persist_projection_revision(
+        PersistProjectionRequest(
+            revision=revision,
+            revision_id="rev-empty",
+            created_at=NOW,
+            edge_ids=[],
+        )
+    )
+    repo._session.commit()
+    with pytest.raises(_MUTATION_ERRORS):
+        repo._session.execute(text("UPDATE relationship_projection_revisions SET purpose = 'x' WHERE id = 'rev-empty'"))
+        repo._session.commit()
+    repo._session.rollback()
+    with pytest.raises(_MUTATION_ERRORS):
+        repo._session.execute(text("DELETE FROM relationship_projection_revisions WHERE id = 'rev-empty'"))
+        repo._session.commit()
+    repo._session.rollback()

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta, timezone
+from typing import TypeVar
 from unittest import TestCase
 
 import pytest
@@ -39,13 +40,14 @@ KNOWN_AT = NOW + timedelta(days=1)
 PURPOSE = "financial_graph_current_view"
 PREDICATE_ID = "financial.bond.issuer_reference@1"
 DIGEST = "c" * 64
+_T = TypeVar("_T")
 
 
 def _sha256_hex(*chunks: str) -> str:
     return "".join(chunks)
 
 
-def _require_present[T](value: T | None, label: str) -> T:
+def _require_present(value: _T | None, label: str) -> _T:
     if value is None:
         raise AssertionError(f"Expected {label} to be present")
     return value

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -49,7 +49,7 @@ def _sha256_hex(*chunks: str) -> str:
 
 def _require_present(value: T | None, label: str) -> T:
     if value is None:
-        pytest.fail(f"Expected {label} to be present")
+        raise AssertionError(f"Expected {label} to be present")
     return value
 
 

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from collections.abc import Generator, Iterator
 from datetime import datetime, timedelta, timezone
-from typing import TypeVar
 from unittest import TestCase
 
 import pytest
@@ -40,14 +39,13 @@ KNOWN_AT = NOW + timedelta(days=1)
 PURPOSE = "financial_graph_current_view"
 PREDICATE_ID = "financial.bond.issuer_reference@1"
 DIGEST = "c" * 64
-T = TypeVar("T")
 
 
 def _sha256_hex(*chunks: str) -> str:
     return "".join(chunks)
 
 
-def _require_present(value: T | None, label: str) -> T:
+def _require_present[T](value: T | None, label: str) -> T:
     if value is None:
         raise AssertionError(f"Expected {label} to be present")
     return value
@@ -68,7 +66,7 @@ GOLDEN_PROJECTION_HASH = _sha256_hex(
 )
 ASSERT = TestCase()
 pytestmark = pytest.mark.integration
-_MUTATION_ERRORS = (DBAPIError, IntegrityError, OperationalError, ProgrammingError, Exception)
+_MUTATION_ERRORS = (DBAPIError, IntegrityError, OperationalError, ProgrammingError)
 
 
 def _postgres_url() -> str | None:
@@ -238,6 +236,9 @@ def test_persist_and_reload_projection_revision(repo: RelationshipAssertionRepos
     ASSERT.assertEqual(loaded.revision.edge_set_hash, revision.edge_set_hash)
     ASSERT.assertEqual(loaded.revision.projection_hash, revision.projection_hash)
     ASSERT.assertEqual(loaded.revision.edges, revision.edges)
+    ASSERT.assertEqual(loaded.revision.governed_scopes, revision.governed_scopes)
+    ASSERT.assertEqual(len(loaded.revision.governed_scopes), 1)
+    ASSERT.assertEqual(loaded.revision.governed_scopes[0].predicate_id, PREDICATE_ID)
     ASSERT.assertEqual(persisted.edge_ids, ("edge-1",))
 
 

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -219,8 +219,7 @@ def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
 def test_input_order_invariance(predicates) -> None:
     """Shuffled assertion/event inputs must not change hashes or edge order."""
     a1 = _assertion("as-1", object_id="AAPL")
-    a2 = _assertion("as-2", object_id="MSFT")
-    # Distinct subjects avoid conflict: second subject for as-2.
+    # Distinct subject avoids conflict with a1 under the issuer_reference key.
     a2 = Assertion(
         assertion_id="as-2",
         predicate_id=PREDICATE_ID,

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -66,54 +67,76 @@ def predicates():
     return predicates_doc
 
 
-def _assertion(
-    assertion_id: str = "as-1",
-    *,
-    object_id: str = "AAPL",
-    effective_from: datetime = NOW,
-    effective_to: datetime | None = None,
-    recorded_at: datetime = NOW,
-) -> Assertion:
+@dataclass(frozen=True)
+class _AssertionSpec:
+    """Fixture knobs for issuer-reference assertions."""
+
+    assertion_id: str = "as-1"
+    object_id: str = "AAPL"
+    effective_from: datetime = NOW
+    effective_to: datetime | None = None
+    recorded_at: datetime = NOW
+
+
+@dataclass(frozen=True)
+class _EventSpec:
+    """Fixture knobs for lifecycle events."""
+
+    assertion_id: str
+    sequence: int
+    to_state: str
+    from_state: str | None
+    recorded_at: datetime
+    event_id: str | None = None
+    authority: str = "acceptor"
+    successor_assertion_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _ProjectSpec:
+    """Fixture knobs for projector invocations."""
+
+    assertions: list[Assertion]
+    events: list[AssertionEvent]
+    effective_at: datetime = NOW
+    known_at: datetime = NOW + timedelta(hours=1)
+    evidence: list[EvidenceRecord] | None = None
+    evidence_links: list[EvidenceLink] | None = None
+    purpose: str = PURPOSE
+
+
+def _assertion(spec: _AssertionSpec | None = None) -> Assertion:
+    cfg = spec or _AssertionSpec()
     return Assertion(
-        assertion_id=assertion_id,
+        assertion_id=cfg.assertion_id,
         predicate_id=PREDICATE_ID,
         subject_id="AAPL_BOND_2030",
-        object_id=object_id,
+        object_id=cfg.object_id,
         method_id="bond.issuer_id.resolution@1",
         proposition="Bond issuer_id references issuer",
         confidence_status="not_assessed",
         confidence_bp=None,
         confidence_type=None,
         confidence_method=None,
-        effective_from=effective_from,
-        effective_to=effective_to,
-        recorded_at=recorded_at,
+        effective_from=cfg.effective_from,
+        effective_to=cfg.effective_to,
+        recorded_at=cfg.recorded_at,
     )
 
 
-def _event(
-    assertion_id: str,
-    sequence: int,
-    to_state: str,
-    *,
-    from_state: str | None,
-    recorded_at: datetime,
-    event_id: str | None = None,
-    authority: str = "acceptor",
-    successor_assertion_id: str | None = None,
-) -> AssertionEvent:
+def _event(spec: _EventSpec) -> AssertionEvent:
     return AssertionEvent(
-        event_id=event_id or f"ev-{assertion_id}-{sequence}",
-        assertion_id=assertion_id,
-        sequence=sequence,
-        from_state=from_state,  # type: ignore[arg-type]
-        to_state=to_state,  # type: ignore[arg-type]
-        authority=authority,  # type: ignore[arg-type]
+        event_id=spec.event_id or f"ev-{spec.assertion_id}-{spec.sequence}",
+        assertion_id=spec.assertion_id,
+        sequence=spec.sequence,
+        from_state=spec.from_state,  # type: ignore[arg-type]
+        to_state=spec.to_state,  # type: ignore[arg-type]
+        authority=spec.authority,  # type: ignore[arg-type]
         actor_id="actor-1",
         rationale="test",
         policy_version="grac.v1-policy",
-        recorded_at=recorded_at,
-        successor_assertion_id=successor_assertion_id,
+        recorded_at=spec.recorded_at,
+        successor_assertion_id=spec.successor_assertion_id,
     )
 
 
@@ -124,8 +147,25 @@ def _propose_accept_events(
     accepted_at: datetime,
 ) -> list[AssertionEvent]:
     return [
-        _event(assertion_id, 1, "Proposed", from_state=None, recorded_at=proposed_at, authority="proposer"),
-        _event(assertion_id, 2, "Accepted", from_state="Proposed", recorded_at=accepted_at),
+        _event(
+            _EventSpec(
+                assertion_id,
+                1,
+                "Proposed",
+                from_state=None,
+                recorded_at=proposed_at,
+                authority="proposer",
+            )
+        ),
+        _event(
+            _EventSpec(
+                assertion_id,
+                2,
+                "Accepted",
+                from_state="Proposed",
+                recorded_at=accepted_at,
+            )
+        ),
     ]
 
 
@@ -157,35 +197,25 @@ def _link(
     )
 
 
-def _project(
-    predicates,
-    assertions: list[Assertion],
-    events: list[AssertionEvent],
-    *,
-    effective_at: datetime = NOW,
-    known_at: datetime = NOW + timedelta(hours=1),
-    evidence: list[EvidenceRecord] | None = None,
-    evidence_links: list[EvidenceLink] | None = None,
-    purpose: str = PURPOSE,
-) -> ProjectionRevision:
+def _project(predicates, spec: _ProjectSpec) -> ProjectionRevision:
     return project(
         ProjectRequest(
-            assertions=assertions,
-            events=events,
-            evidence=evidence or [],
-            evidence_links=evidence_links or [],
+            assertions=spec.assertions,
+            events=spec.events,
+            evidence=spec.evidence or [],
+            evidence_links=spec.evidence_links or [],
             predicate_registry=predicates,
-            purpose=purpose,
-            effective_at=effective_at,
-            known_at=known_at,
+            purpose=spec.purpose,
+            effective_at=spec.effective_at,
+            known_at=spec.known_at,
         )
     )
 
 
 def test_empty_inputs_yield_empty_revision_and_stable_hashes(predicates) -> None:
     """Empty assertion store projects zero edges with deterministic empty hashes."""
-    first = _project(predicates, [], [], known_at=NOW)
-    second = _project(predicates, [], [], known_at=NOW)
+    first = _project(predicates, _ProjectSpec(assertions=[], events=[], known_at=NOW))
+    second = _project(predicates, _ProjectSpec(assertions=[], events=[], known_at=NOW))
     assert first.edges == ()
     assert first.governed_scopes == ()
     assert first.edge_set_hash == second.edge_set_hash
@@ -200,7 +230,10 @@ def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
     """First financial slice projects AAPL_BOND_2030 → AAPL corporate_link @ 0.8."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    result = _project(predicates, [assertion], events, known_at=NOW + timedelta(days=1))
+    result = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, known_at=NOW + timedelta(days=1)),
+    )
     assert len(result.edges) == 1
     edge = result.edges[0]
     assert edge.source_id == "AAPL_BOND_2030"
@@ -218,7 +251,7 @@ def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
 
 def test_input_order_invariance(predicates) -> None:
     """Shuffled assertion/event inputs must not change hashes or edge order."""
-    a1 = _assertion("as-1", object_id="AAPL")
+    a1 = _assertion(_AssertionSpec(assertion_id="as-1", object_id="AAPL"))
     # Distinct subject avoids conflict with a1 under the issuer_reference key.
     a2 = Assertion(
         assertion_id="as-2",
@@ -238,8 +271,8 @@ def test_input_order_invariance(predicates) -> None:
     events = _propose_accept_events(
         "as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2)
     ) + _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    forward = _project(predicates, [a1, a2], events)
-    reverse = _project(predicates, [a2, a1], list(reversed(events)))
+    forward = _project(predicates, _ProjectSpec(assertions=[a1, a2], events=events))
+    reverse = _project(predicates, _ProjectSpec(assertions=[a2, a1], events=list(reversed(events))))
     assert forward.edge_set_hash == reverse.edge_set_hash
     assert forward.projection_hash == reverse.projection_hash
     assert [edge.assertion_id for edge in forward.edges] == [edge.assertion_id for edge in reverse.edges]
@@ -249,8 +282,8 @@ def test_replay_idempotence(predicates) -> None:
     """Replaying the same inputs yields an identical revision payload."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    first = _project(predicates, [assertion], events)
-    second = _project(predicates, [assertion], events)
+    first = _project(predicates, _ProjectSpec(assertions=[assertion], events=events))
+    second = _project(predicates, _ProjectSpec(assertions=[assertion], events=events))
     assert first == second
 
 
@@ -266,20 +299,29 @@ def test_replay_idempotence(predicates) -> None:
 )
 def test_exact_effective_interval_boundaries(predicates, effective_at: datetime, expect_edge: bool) -> None:
     """Effective window is closed on both ends: from <= at <= to."""
-    assertion = _assertion(effective_from=NOW, effective_to=NOW + timedelta(days=30))
+    assertion = _assertion(_AssertionSpec(effective_from=NOW, effective_to=NOW + timedelta(days=30)))
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    result = _project(predicates, [assertion], events, effective_at=effective_at)
+    result = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, effective_at=effective_at),
+    )
     assert bool(result.edges) is expect_edge
 
 
 def test_historical_known_at_reconstruction(predicates) -> None:
     """known_at before acceptance excludes the assertion; after includes it."""
-    assertion = _assertion(recorded_at=NOW)
+    assertion = _assertion(_AssertionSpec(recorded_at=NOW))
     proposed_at = NOW
     accepted_at = NOW + timedelta(hours=1)
     events = _propose_accept_events("as-1", proposed_at=proposed_at, accepted_at=accepted_at)
-    before = _project(predicates, [assertion], events, known_at=NOW + timedelta(minutes=30))
-    after = _project(predicates, [assertion], events, known_at=accepted_at)
+    before = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, known_at=NOW + timedelta(minutes=30)),
+    )
+    after = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, known_at=accepted_at),
+    )
     assert before.edges == ()
     assert len(after.edges) == 1
 
@@ -290,32 +332,37 @@ def test_disputed_assertions_excluded(predicates) -> None:
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     events.append(
         _event(
-            "as-1",
-            3,
-            "Disputed",
-            from_state="Accepted",
-            recorded_at=NOW + timedelta(minutes=2),
-            authority="disputer",
+            _EventSpec(
+                "as-1",
+                3,
+                "Disputed",
+                from_state="Accepted",
+                recorded_at=NOW + timedelta(minutes=2),
+                authority="disputer",
+            )
         )
     )
-    result = _project(predicates, [assertion], events, known_at=NOW + timedelta(minutes=3))
+    result = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, known_at=NOW + timedelta(minutes=3)),
+    )
     assert result.edges == ()
 
 
 def test_fail_closed_on_cardinality_conflict(predicates) -> None:
     """Two Accepted issuer references for one bond fail closed (no LWW)."""
-    left = _assertion("as-1", object_id="AAPL")
-    right = _assertion("as-2", object_id="MSFT")
+    left = _assertion(_AssertionSpec(assertion_id="as-1", object_id="AAPL"))
+    right = _assertion(_AssertionSpec(assertion_id="as-2", object_id="MSFT"))
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
     with pytest.raises(ProjectionError, match="projection conflict"):
-        _project(predicates, [left, right], events)
+        _project(predicates, _ProjectSpec(assertions=[left, right], events=events))
 
 
 def test_supersession_selection_changes_projection(predicates) -> None:
     """After supersession, only the Accepted successor projects."""
-    predecessor = _assertion("as-1", object_id="AAPL")
-    successor = _assertion("as-2", object_id="AAPL_NEW")
+    predecessor = _assertion(_AssertionSpec(assertion_id="as-1", object_id="AAPL"))
+    successor = _assertion(_AssertionSpec(assertion_id="as-2", object_id="AAPL_NEW"))
     t0 = NOW
     t1 = NOW + timedelta(minutes=1)
     t2 = NOW + timedelta(minutes=2)
@@ -324,16 +371,28 @@ def test_supersession_selection_changes_projection(predicates) -> None:
     events += _propose_accept_events("as-2", proposed_at=t2, accepted_at=t2 + timedelta(seconds=1))
     events.append(
         _event(
-            "as-1",
-            3,
-            "Superseded",
-            from_state="Accepted",
-            recorded_at=t3,
-            successor_assertion_id="as-2",
+            _EventSpec(
+                "as-1",
+                3,
+                "Superseded",
+                from_state="Accepted",
+                recorded_at=t3,
+                successor_assertion_id="as-2",
+            )
         )
     )
-    before = _project(predicates, [predecessor, successor], events, known_at=t1 + timedelta(seconds=1))
-    after = _project(predicates, [predecessor, successor], events, known_at=t3)
+    before = _project(
+        predicates,
+        _ProjectSpec(
+            assertions=[predecessor, successor],
+            events=events,
+            known_at=t1 + timedelta(seconds=1),
+        ),
+    )
+    after = _project(
+        predicates,
+        _ProjectSpec(assertions=[predecessor, successor], events=events, known_at=t3),
+    )
     assert [edge.assertion_id for edge in before.edges] == ["as-1"]
     assert before.edges[0].target_id == "AAPL"
     assert [edge.assertion_id for edge in after.edges] == ["as-2"]
@@ -346,13 +405,15 @@ def test_projection_hash_is_provenance_sensitive(predicates) -> None:
     """Same semantic edges with different evidence change projection_hash only."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    without = _project(predicates, [assertion], events)
+    without = _project(predicates, _ProjectSpec(assertions=[assertion], events=events))
     with_evidence = _project(
         predicates,
-        [assertion],
-        events,
-        evidence=[_evidence()],
-        evidence_links=[_link("as-1")],
+        _ProjectSpec(
+            assertions=[assertion],
+            events=events,
+            evidence=[_evidence()],
+            evidence_links=[_link("as-1")],
+        ),
     )
     assert without.edge_set_hash == with_evidence.edge_set_hash
     assert without.projection_hash != with_evidence.projection_hash
@@ -377,43 +438,20 @@ def test_confidence_does_not_affect_strength_or_hashes(predicates) -> None:
         recorded_at=NOW,
     )
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    left = _project(predicates, [plain], events)
-    right = _project(predicates, [assessed], events)
+    left = _project(predicates, _ProjectSpec(assertions=[plain], events=events))
+    right = _project(predicates, _ProjectSpec(assertions=[assessed], events=events))
     assert left.edges[0].strength == "0.8"
     assert right.edges[0].strength == "0.8"
     assert left.edge_set_hash == right.edge_set_hash
     assert left.projection_hash == right.projection_hash
 
 
-def test_rejected_withdrawn_retracted_excluded(predicates) -> None:
-    """Terminal non-accepted states never emit edges."""
-    cases: list[tuple[str, list[AssertionEvent]]] = [
-        (
-            "Rejected",
-            [
-                _event("as-1", 1, "Proposed", from_state=None, recorded_at=NOW, authority="proposer"),
-                _event("as-1", 2, "Rejected", from_state="Proposed", recorded_at=NOW + timedelta(minutes=1)),
-            ],
-        ),
-        (
-            "Withdrawn",
-            [
-                _event("as-1", 1, "Proposed", from_state=None, recorded_at=NOW, authority="proposer"),
-                _event(
-                    "as-1",
-                    2,
-                    "Withdrawn",
-                    from_state="Proposed",
-                    recorded_at=NOW + timedelta(minutes=1),
-                    authority="proposer",
-                ),
-            ],
-        ),
-        (
-            "Retracted",
-            _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-            + [
-                _event(
+def _terminal_state_events(to_state: str) -> list[AssertionEvent]:
+    """Build propose→terminal or accept→retract event streams for exclusion tests."""
+    if to_state == "Retracted":
+        return _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1)) + [
+            _event(
+                _EventSpec(
                     "as-1",
                     3,
                     "Retracted",
@@ -421,12 +459,42 @@ def test_rejected_withdrawn_retracted_excluded(predicates) -> None:
                     recorded_at=NOW + timedelta(minutes=2),
                     authority="retractor",
                 )
-            ],
+            )
+        ]
+    authority = "proposer"
+    return [
+        _event(
+            _EventSpec(
+                "as-1",
+                1,
+                "Proposed",
+                from_state=None,
+                recorded_at=NOW,
+                authority=authority,
+            )
+        ),
+        _event(
+            _EventSpec(
+                "as-1",
+                2,
+                to_state,
+                from_state="Proposed",
+                recorded_at=NOW + timedelta(minutes=1),
+                authority=authority,
+            )
         ),
     ]
-    for _label, events in cases:
-        result = _project(predicates, [_assertion()], events, known_at=NOW + timedelta(hours=1))
-        assert result.edges == ()
+
+
+@pytest.mark.parametrize("to_state", ["Rejected", "Withdrawn", "Retracted"])
+def test_rejected_withdrawn_retracted_excluded(predicates, to_state: str) -> None:
+    """Terminal non-accepted states never emit edges."""
+    events = _terminal_state_events(to_state)
+    result = _project(
+        predicates,
+        _ProjectSpec(assertions=[_assertion()], events=events, known_at=NOW + timedelta(hours=1)),
+    )
+    assert result.edges == ()
 
 
 def test_naive_datetime_rejected(predicates) -> None:
@@ -452,7 +520,10 @@ def test_purpose_filter_excludes_other_purposes(predicates) -> None:
     """Assertions whose predicate purpose differs from the request are ignored."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
-    result = _project(predicates, [assertion], events, purpose="other_purpose")
+    result = _project(
+        predicates,
+        _ProjectSpec(assertions=[assertion], events=events, purpose="other_purpose"),
+    )
     assert result.edges == ()
     assert result.governed_scopes == ()
 
@@ -464,27 +535,29 @@ def test_missing_evidence_record_for_link_fails_closed(predicates) -> None:
     with pytest.raises(ProjectionError, match="missing evidence record"):
         _project(
             predicates,
-            [assertion],
-            events,
-            evidence_links=[_link("as-1")],
+            _ProjectSpec(
+                assertions=[assertion],
+                events=events,
+                evidence_links=[_link("as-1")],
+            ),
         )
 
 
 def test_empty_projection_hashes_are_lowercase_hex(predicates) -> None:
     """Empty projection content hashes are lowercase hexadecimal digests."""
-    result = _project(predicates, [], [])
+    result = _project(predicates, _ProjectSpec(assertions=[], events=[]))
     assert all(ch in "0123456789abcdef" for ch in result.edge_set_hash)
     assert all(ch in "0123456789abcdef" for ch in result.projection_hash)
 
 
 def test_same_object_conflict_still_fails_closed(predicates) -> None:
     """Two Accepted assertions on one conflict key fail even with identical objects."""
-    left = _assertion("as-1", object_id="AAPL")
-    right = _assertion("as-2", object_id="AAPL")
+    left = _assertion(_AssertionSpec(assertion_id="as-1", object_id="AAPL"))
+    right = _assertion(_AssertionSpec(assertion_id="as-2", object_id="AAPL"))
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
     with pytest.raises(ProjectionError, match="projection conflict"):
-        _project(predicates, [left, right], events)
+        _project(predicates, _ProjectSpec(assertions=[left, right], events=events))
 
 
 def test_unregistered_method_id_fails_closed(predicates) -> None:
@@ -506,7 +579,7 @@ def test_unregistered_method_id_fails_closed(predicates) -> None:
     )
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     with pytest.raises(ProjectionError, match="not registered for predicate"):
-        _project(predicates, [assertion], events)
+        _project(predicates, _ProjectSpec(assertions=[assertion], events=events))
 
 
 def test_duplicate_evidence_id_fails_closed(predicates) -> None:
@@ -516,10 +589,12 @@ def test_duplicate_evidence_id_fails_closed(predicates) -> None:
     with pytest.raises(ProjectionError, match="duplicate evidence id"):
         _project(
             predicates,
-            [assertion],
-            events,
-            evidence=[_evidence("evd-1", DIGEST_A), _evidence("evd-1", "d" * 64)],
-            evidence_links=[_link("as-1")],
+            _ProjectSpec(
+                assertions=[assertion],
+                events=events,
+                evidence=[_evidence("evd-1", DIGEST_A), _evidence("evd-1", "d" * 64)],
+                evidence_links=[_link("as-1")],
+            ),
         )
 
 
@@ -539,9 +614,11 @@ def test_future_evidence_record_fails_closed_for_historical_known_at(predicates)
     with pytest.raises(ProjectionError, match="recorded after known_at"):
         _project(
             predicates,
-            [assertion],
-            events,
-            known_at=NOW + timedelta(hours=1),
-            evidence=[future_evidence],
-            evidence_links=[_link("as-1", recorded_at=NOW + timedelta(minutes=2))],
+            _ProjectSpec(
+                assertions=[assertion],
+                events=events,
+                known_at=NOW + timedelta(hours=1),
+                evidence=[future_evidence],
+                evidence_links=[_link("as-1", recorded_at=NOW + timedelta(minutes=2))],
+            ),
         )

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -29,6 +29,36 @@ PREDICATE_ID = "financial.bond.issuer_reference@1"
 DIGEST_A = "a" * 64
 
 
+def _sha256_hex(*chunks: str) -> str:
+    return "".join(chunks)
+
+
+EMPTY_EDGE_SET_HASH = _sha256_hex(
+    "4f53cda18c2baa0",
+    "c0354bb5f9a3ecbe",
+    "5ed12ab4d8e11ba8",
+    "73c2f11161202b945",
+)
+EMPTY_PROJECTION_HASH = _sha256_hex(
+    "f834ce8a5132768a",
+    "2c9f871cc70abd56",
+    "3b383334ad43c837",
+    "713356f7cc293d27",
+)
+GOLDEN_EDGE_SET_HASH = _sha256_hex(
+    "c8c8e738ffe460a7",
+    "716fcd89fa16baf4",
+    "94fe4015e2551a1f",
+    "107e53b129a7d345",
+)
+GOLDEN_PROJECTION_HASH = _sha256_hex(
+    "9bee4d5a7407b956",
+    "1b96cd546cdd17f5",
+    "177910f471d8e2f7",
+    "8aab4f0befaccb83",
+)
+
+
 @pytest.fixture(scope="module")
 def predicates():
     """Pinned predicate registry from the frozen contract bundle."""
@@ -162,8 +192,8 @@ def test_empty_inputs_yield_empty_revision_and_stable_hashes(predicates) -> None
     assert first.projection_hash == second.projection_hash
     assert first.projector_version == PROJECTOR_VERSION
     # SHA-256 of canonical JSON ``[]``.
-    assert first.edge_set_hash == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
-    assert first.projection_hash == "f834ce8a5132768a2c9f871cc70abd563b383334ad43c837713356f7cc293d27"
+    assert first.edge_set_hash == EMPTY_EDGE_SET_HASH
+    assert first.projection_hash == EMPTY_PROJECTION_HASH
 
 
 def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
@@ -182,8 +212,8 @@ def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
     assert len(result.governed_scopes) == 1
     assert result.governed_scopes[0].purpose == PURPOSE
     assert result.governed_scopes[0].predicate_id == PREDICATE_ID
-    assert result.edge_set_hash == "c8c8e738ffe460a7716fcd89fa16baf494fe4015e2551a1f107e53b129a7d345"
-    assert result.projection_hash == "9bee4d5a7407b9561b96cd546cdd17f5177910f471d8e2f78aab4f0befaccb83"
+    assert result.edge_set_hash == GOLDEN_EDGE_SET_HASH
+    assert result.projection_hash == GOLDEN_PROJECTION_HASH
 
 
 def test_input_order_invariance(predicates) -> None:

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -471,8 +471,8 @@ def test_missing_evidence_record_for_link_fails_closed(predicates) -> None:
         )
 
 
-def test_hash_inputs_reject_floats_via_canonical_json(predicates) -> None:
-    """Sanity: empty projection hashes are lowercase hex and float-free."""
+def test_empty_projection_hashes_are_lowercase_hex(predicates) -> None:
+    """Empty projection content hashes are lowercase hexadecimal digests."""
     result = _project(predicates, [], [])
     assert all(ch in "0123456789abcdef" for ch in result.edge_set_hash)
     assert all(ch in "0123456789abcdef" for ch in result.projection_hash)
@@ -486,3 +486,63 @@ def test_same_object_conflict_still_fails_closed(predicates) -> None:
     events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
     with pytest.raises(ProjectionError, match="projection conflict"):
         _project(predicates, [left, right], events)
+
+
+def test_unregistered_method_id_fails_closed(predicates) -> None:
+    """Accepted assertions with unregistered method_id do not project."""
+    assertion = Assertion(
+        assertion_id="as-1",
+        predicate_id=PREDICATE_ID,
+        subject_id="AAPL_BOND_2030",
+        object_id="AAPL",
+        method_id="not.a.registered.method@1",
+        proposition="Bond issuer_id references issuer",
+        confidence_status="not_assessed",
+        confidence_bp=None,
+        confidence_type=None,
+        confidence_method=None,
+        effective_from=NOW,
+        effective_to=None,
+        recorded_at=NOW,
+    )
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    with pytest.raises(ProjectionError, match="not registered for predicate"):
+        _project(predicates, [assertion], events)
+
+
+def test_duplicate_evidence_id_fails_closed(predicates) -> None:
+    """Duplicate evidence ids in projection inputs fail closed before hashing."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    with pytest.raises(ProjectionError, match="duplicate evidence id"):
+        _project(
+            predicates,
+            [assertion],
+            events,
+            evidence=[_evidence("evd-1", DIGEST_A), _evidence("evd-1", "d" * 64)],
+            evidence_links=[_link("as-1")],
+        )
+
+
+def test_future_evidence_record_fails_closed_for_historical_known_at(predicates) -> None:
+    """Evidence recorded after known_at must not enter projection_hash."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    future_evidence = EvidenceRecord(
+        evidence_id="evd-1",
+        source_ref="sample://evd-1",
+        content_sha256=DIGEST_A,
+        media_type="application/json",
+        visibility="internal",
+        custody_id="collector-1",
+        recorded_at=NOW + timedelta(days=2),
+    )
+    with pytest.raises(ProjectionError, match="recorded after known_at"):
+        _project(
+            predicates,
+            [assertion],
+            events,
+            known_at=NOW + timedelta(hours=1),
+            evidence=[future_evidence],
+            evidence_links=[_link("as-1", recorded_at=NOW + timedelta(minutes=2))],
+        )

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -355,8 +355,9 @@ def test_fail_closed_on_cardinality_conflict(predicates) -> None:
     right = _assertion(_AssertionSpec(assertion_id="as-2", object_id="MSFT"))
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
+    spec = _ProjectSpec(assertions=[left, right], events=events)
     with pytest.raises(ProjectionError, match="projection conflict"):
-        _project(predicates, _ProjectSpec(assertions=[left, right], events=events))
+        _project(predicates, spec)
 
 
 def test_supersession_selection_changes_projection(predicates) -> None:
@@ -501,19 +502,18 @@ def test_naive_datetime_rejected(predicates) -> None:
     """Projector requires timezone-aware UTC instants."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    request = ProjectRequest(
+        assertions=[assertion],
+        events=events,
+        evidence=[],
+        evidence_links=[],
+        predicate_registry=predicates,
+        purpose=PURPOSE,
+        effective_at=datetime(2026, 7, 25, 15, 0, 0),
+        known_at=NOW,
+    )
     with pytest.raises(ValidationError, match="timezone-aware UTC"):
-        project(
-            ProjectRequest(
-                assertions=[assertion],
-                events=events,
-                evidence=[],
-                evidence_links=[],
-                predicate_registry=predicates,
-                purpose=PURPOSE,
-                effective_at=datetime(2026, 7, 25, 15, 0, 0),
-                known_at=NOW,
-            )
-        )
+        project(request)
 
 
 def test_purpose_filter_excludes_other_purposes(predicates) -> None:
@@ -532,15 +532,13 @@ def test_missing_evidence_record_for_link_fails_closed(predicates) -> None:
     """Projection fails closed when a link references missing evidence."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    spec = _ProjectSpec(
+        assertions=[assertion],
+        events=events,
+        evidence_links=[_link("as-1")],
+    )
     with pytest.raises(ProjectionError, match="missing evidence record"):
-        _project(
-            predicates,
-            _ProjectSpec(
-                assertions=[assertion],
-                events=events,
-                evidence_links=[_link("as-1")],
-            ),
-        )
+        _project(predicates, spec)
 
 
 def test_empty_projection_hashes_are_lowercase_hex(predicates) -> None:
@@ -556,8 +554,9 @@ def test_same_object_conflict_still_fails_closed(predicates) -> None:
     right = _assertion(_AssertionSpec(assertion_id="as-2", object_id="AAPL"))
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
     events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
+    spec = _ProjectSpec(assertions=[left, right], events=events)
     with pytest.raises(ProjectionError, match="projection conflict"):
-        _project(predicates, _ProjectSpec(assertions=[left, right], events=events))
+        _project(predicates, spec)
 
 
 def test_unregistered_method_id_fails_closed(predicates) -> None:
@@ -578,24 +577,25 @@ def test_unregistered_method_id_fails_closed(predicates) -> None:
         recorded_at=NOW,
     )
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    spec = _ProjectSpec(assertions=[assertion], events=events)
     with pytest.raises(ProjectionError, match="not registered for predicate"):
-        _project(predicates, _ProjectSpec(assertions=[assertion], events=events))
+        _project(predicates, spec)
 
 
 def test_duplicate_evidence_id_fails_closed(predicates) -> None:
     """Duplicate evidence ids in projection inputs fail closed before hashing."""
     assertion = _assertion()
     events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    evidence = [_evidence("evd-1", DIGEST_A), _evidence("evd-1", "d" * 64)]
+    evidence_links = [_link("as-1")]
+    spec = _ProjectSpec(
+        assertions=[assertion],
+        events=events,
+        evidence=evidence,
+        evidence_links=evidence_links,
+    )
     with pytest.raises(ProjectionError, match="duplicate evidence id"):
-        _project(
-            predicates,
-            _ProjectSpec(
-                assertions=[assertion],
-                events=events,
-                evidence=[_evidence("evd-1", DIGEST_A), _evidence("evd-1", "d" * 64)],
-                evidence_links=[_link("as-1")],
-            ),
-        )
+        _project(predicates, spec)
 
 
 def test_future_evidence_record_fails_closed_for_historical_known_at(predicates) -> None:
@@ -611,14 +611,13 @@ def test_future_evidence_record_fails_closed_for_historical_known_at(predicates)
         custody_id="collector-1",
         recorded_at=NOW + timedelta(days=2),
     )
+    evidence_links = [_link("as-1", recorded_at=NOW + timedelta(minutes=2))]
+    spec = _ProjectSpec(
+        assertions=[assertion],
+        events=events,
+        known_at=NOW + timedelta(hours=1),
+        evidence=[future_evidence],
+        evidence_links=evidence_links,
+    )
     with pytest.raises(ProjectionError, match="recorded after known_at"):
-        _project(
-            predicates,
-            _ProjectSpec(
-                assertions=[assertion],
-                events=events,
-                known_at=NOW + timedelta(hours=1),
-                evidence=[future_evidence],
-                evidence_links=[_link("as-1", recorded_at=NOW + timedelta(minutes=2))],
-            ),
-        )
+        _project(predicates, spec)

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -1,0 +1,458 @@
+"""Unit tests for the pure GRAC v1 deterministic projector."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.governance.relationship_assertion import (
+    Assertion,
+    AssertionEvent,
+    EvidenceLink,
+    EvidenceRecord,
+    ValidationError,
+)
+from src.governance.relationship_assertion_contract import load_contract_bundle
+from src.logic.relationship_projection import (
+    PROJECTOR_VERSION,
+    ProjectionError,
+    ProjectionRevision,
+    ProjectRequest,
+    project,
+)
+
+UTC = timezone.utc
+NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
+PURPOSE = "financial_graph_current_view"
+PREDICATE_ID = "financial.bond.issuer_reference@1"
+DIGEST_A = "a" * 64
+
+
+@pytest.fixture(scope="module")
+def predicates():
+    """Pinned predicate registry from the frozen contract bundle."""
+    _contract, predicates_doc, _transitions = load_contract_bundle()
+    return predicates_doc
+
+
+def _assertion(
+    assertion_id: str = "as-1",
+    *,
+    object_id: str = "AAPL",
+    effective_from: datetime = NOW,
+    effective_to: datetime | None = None,
+    recorded_at: datetime = NOW,
+) -> Assertion:
+    return Assertion(
+        assertion_id=assertion_id,
+        predicate_id=PREDICATE_ID,
+        subject_id="AAPL_BOND_2030",
+        object_id=object_id,
+        method_id="bond.issuer_id.resolution@1",
+        proposition="Bond issuer_id references issuer",
+        confidence_status="not_assessed",
+        confidence_bp=None,
+        confidence_type=None,
+        confidence_method=None,
+        effective_from=effective_from,
+        effective_to=effective_to,
+        recorded_at=recorded_at,
+    )
+
+
+def _event(
+    assertion_id: str,
+    sequence: int,
+    to_state: str,
+    *,
+    from_state: str | None,
+    recorded_at: datetime,
+    event_id: str | None = None,
+    authority: str = "acceptor",
+    successor_assertion_id: str | None = None,
+) -> AssertionEvent:
+    return AssertionEvent(
+        event_id=event_id or f"ev-{assertion_id}-{sequence}",
+        assertion_id=assertion_id,
+        sequence=sequence,
+        from_state=from_state,  # type: ignore[arg-type]
+        to_state=to_state,  # type: ignore[arg-type]
+        authority=authority,  # type: ignore[arg-type]
+        actor_id="actor-1",
+        rationale="test",
+        policy_version="grac.v1-policy",
+        recorded_at=recorded_at,
+        successor_assertion_id=successor_assertion_id,
+    )
+
+
+def _propose_accept_events(
+    assertion_id: str,
+    *,
+    proposed_at: datetime,
+    accepted_at: datetime,
+) -> list[AssertionEvent]:
+    return [
+        _event(assertion_id, 1, "Proposed", from_state=None, recorded_at=proposed_at, authority="proposer"),
+        _event(assertion_id, 2, "Accepted", from_state="Proposed", recorded_at=accepted_at),
+    ]
+
+
+def _evidence(evidence_id: str = "evd-1", digest: str = DIGEST_A) -> EvidenceRecord:
+    return EvidenceRecord(
+        evidence_id=evidence_id,
+        source_ref=f"sample://{evidence_id}",
+        content_sha256=digest,
+        media_type="application/json",
+        visibility="internal",
+        custody_id="collector-1",
+        recorded_at=NOW,
+    )
+
+
+def _link(
+    assertion_id: str,
+    evidence_id: str = "evd-1",
+    *,
+    polarity: str = "supporting",
+    recorded_at: datetime = NOW,
+) -> EvidenceLink:
+    return EvidenceLink(
+        link_id=f"link-{assertion_id}-{evidence_id}",
+        assertion_id=assertion_id,
+        evidence_id=evidence_id,
+        polarity=polarity,  # type: ignore[arg-type]
+        recorded_at=recorded_at,
+    )
+
+
+def _project(
+    predicates,
+    assertions: list[Assertion],
+    events: list[AssertionEvent],
+    *,
+    effective_at: datetime = NOW,
+    known_at: datetime = NOW + timedelta(hours=1),
+    evidence: list[EvidenceRecord] | None = None,
+    evidence_links: list[EvidenceLink] | None = None,
+    purpose: str = PURPOSE,
+) -> ProjectionRevision:
+    return project(
+        ProjectRequest(
+            assertions=assertions,
+            events=events,
+            evidence=evidence or [],
+            evidence_links=evidence_links or [],
+            predicate_registry=predicates,
+            purpose=purpose,
+            effective_at=effective_at,
+            known_at=known_at,
+        )
+    )
+
+
+def test_empty_inputs_yield_empty_revision_and_stable_hashes(predicates) -> None:
+    """Empty assertion store projects zero edges with deterministic empty hashes."""
+    first = _project(predicates, [], [], known_at=NOW)
+    second = _project(predicates, [], [], known_at=NOW)
+    assert first.edges == ()
+    assert first.governed_scopes == ()
+    assert first.edge_set_hash == second.edge_set_hash
+    assert first.projection_hash == second.projection_hash
+    assert first.projector_version == PROJECTOR_VERSION
+    # SHA-256 of canonical JSON ``[]``.
+    assert first.edge_set_hash == "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    assert first.projection_hash == "f834ce8a5132768a2c9f871cc70abd563b383334ad43c837713356f7cc293d27"
+
+
+def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:
+    """First financial slice projects AAPL_BOND_2030 → AAPL corporate_link @ 0.8."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    result = _project(predicates, [assertion], events, known_at=NOW + timedelta(days=1))
+    assert len(result.edges) == 1
+    edge = result.edges[0]
+    assert edge.source_id == "AAPL_BOND_2030"
+    assert edge.target_id == "AAPL"
+    assert edge.edge_type == "corporate_link"
+    assert edge.strength == "0.8"
+    assert edge.direction == "subject_to_object"
+    assert edge.assertion_id == "as-1"
+    assert len(result.governed_scopes) == 1
+    assert result.governed_scopes[0].purpose == PURPOSE
+    assert result.governed_scopes[0].predicate_id == PREDICATE_ID
+    assert result.edge_set_hash == "c8c8e738ffe460a7716fcd89fa16baf494fe4015e2551a1f107e53b129a7d345"
+    assert result.projection_hash == "9bee4d5a7407b9561b96cd546cdd17f5177910f471d8e2f78aab4f0befaccb83"
+
+
+def test_input_order_invariance(predicates) -> None:
+    """Shuffled assertion/event inputs must not change hashes or edge order."""
+    a1 = _assertion("as-1", object_id="AAPL")
+    a2 = _assertion("as-2", object_id="MSFT")
+    # Distinct subjects avoid conflict: second subject for as-2.
+    a2 = Assertion(
+        assertion_id="as-2",
+        predicate_id=PREDICATE_ID,
+        subject_id="MSFT_BOND_2031",
+        object_id="MSFT",
+        method_id="bond.issuer_id.resolution@1",
+        proposition="Bond issuer_id references MSFT",
+        confidence_status="not_assessed",
+        confidence_bp=None,
+        confidence_type=None,
+        confidence_method=None,
+        effective_from=NOW,
+        effective_to=None,
+        recorded_at=NOW,
+    )
+    events = _propose_accept_events(
+        "as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2)
+    ) + _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    forward = _project(predicates, [a1, a2], events)
+    reverse = _project(predicates, [a2, a1], list(reversed(events)))
+    assert forward.edge_set_hash == reverse.edge_set_hash
+    assert forward.projection_hash == reverse.projection_hash
+    assert [edge.assertion_id for edge in forward.edges] == [edge.assertion_id for edge in reverse.edges]
+
+
+def test_replay_idempotence(predicates) -> None:
+    """Replaying the same inputs yields an identical revision payload."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    first = _project(predicates, [assertion], events)
+    second = _project(predicates, [assertion], events)
+    assert first == second
+
+
+@pytest.mark.parametrize(
+    ("effective_at", "expect_edge"),
+    [
+        (NOW - timedelta(seconds=1), False),
+        (NOW, True),
+        (NOW + timedelta(days=10), True),
+        (NOW + timedelta(days=30), True),
+        (NOW + timedelta(days=30, seconds=1), False),
+    ],
+)
+def test_exact_effective_interval_boundaries(predicates, effective_at: datetime, expect_edge: bool) -> None:
+    """Effective window is closed on both ends: from <= at <= to."""
+    assertion = _assertion(effective_from=NOW, effective_to=NOW + timedelta(days=30))
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    result = _project(predicates, [assertion], events, effective_at=effective_at)
+    assert bool(result.edges) is expect_edge
+
+
+def test_historical_known_at_reconstruction(predicates) -> None:
+    """known_at before acceptance excludes the assertion; after includes it."""
+    assertion = _assertion(recorded_at=NOW)
+    proposed_at = NOW
+    accepted_at = NOW + timedelta(hours=1)
+    events = _propose_accept_events("as-1", proposed_at=proposed_at, accepted_at=accepted_at)
+    before = _project(predicates, [assertion], events, known_at=NOW + timedelta(minutes=30))
+    after = _project(predicates, [assertion], events, known_at=accepted_at)
+    assert before.edges == ()
+    assert len(after.edges) == 1
+
+
+def test_disputed_assertions_excluded(predicates) -> None:
+    """Disputed assertions do not emit edges at that known_at."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    events.append(
+        _event(
+            "as-1",
+            3,
+            "Disputed",
+            from_state="Accepted",
+            recorded_at=NOW + timedelta(minutes=2),
+            authority="disputer",
+        )
+    )
+    result = _project(predicates, [assertion], events, known_at=NOW + timedelta(minutes=3))
+    assert result.edges == ()
+
+
+def test_fail_closed_on_cardinality_conflict(predicates) -> None:
+    """Two Accepted issuer references for one bond fail closed (no LWW)."""
+    left = _assertion("as-1", object_id="AAPL")
+    right = _assertion("as-2", object_id="MSFT")
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
+    with pytest.raises(ProjectionError, match="projection conflict"):
+        _project(predicates, [left, right], events)
+
+
+def test_supersession_selection_changes_projection(predicates) -> None:
+    """After supersession, only the Accepted successor projects."""
+    predecessor = _assertion("as-1", object_id="AAPL")
+    successor = _assertion("as-2", object_id="AAPL_NEW")
+    t0 = NOW
+    t1 = NOW + timedelta(minutes=1)
+    t2 = NOW + timedelta(minutes=2)
+    t3 = NOW + timedelta(minutes=3)
+    events = _propose_accept_events("as-1", proposed_at=t0, accepted_at=t1)
+    events += _propose_accept_events("as-2", proposed_at=t2, accepted_at=t2 + timedelta(seconds=1))
+    events.append(
+        _event(
+            "as-1",
+            3,
+            "Superseded",
+            from_state="Accepted",
+            recorded_at=t3,
+            successor_assertion_id="as-2",
+        )
+    )
+    before = _project(predicates, [predecessor, successor], events, known_at=t1 + timedelta(seconds=1))
+    after = _project(predicates, [predecessor, successor], events, known_at=t3)
+    assert [edge.assertion_id for edge in before.edges] == ["as-1"]
+    assert before.edges[0].target_id == "AAPL"
+    assert [edge.assertion_id for edge in after.edges] == ["as-2"]
+    assert after.edges[0].target_id == "AAPL_NEW"
+    assert before.edge_set_hash != after.edge_set_hash
+    assert before.projection_hash != after.projection_hash
+
+
+def test_projection_hash_is_provenance_sensitive(predicates) -> None:
+    """Same semantic edges with different evidence change projection_hash only."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    without = _project(predicates, [assertion], events)
+    with_evidence = _project(
+        predicates,
+        [assertion],
+        events,
+        evidence=[_evidence()],
+        evidence_links=[_link("as-1")],
+    )
+    assert without.edge_set_hash == with_evidence.edge_set_hash
+    assert without.projection_hash != with_evidence.projection_hash
+
+
+def test_confidence_does_not_affect_strength_or_hashes(predicates) -> None:
+    """Confidence fields must not alter registry strength or hashes."""
+    plain = _assertion()
+    assessed = Assertion(
+        assertion_id="as-1",
+        predicate_id=PREDICATE_ID,
+        subject_id="AAPL_BOND_2030",
+        object_id="AAPL",
+        method_id="bond.issuer_id.resolution@1",
+        proposition="Bond issuer_id references issuer",
+        confidence_status="assessed",
+        confidence_bp=9000,
+        confidence_type="calibration",
+        confidence_method="manual@1",
+        effective_from=NOW,
+        effective_to=None,
+        recorded_at=NOW,
+    )
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    left = _project(predicates, [plain], events)
+    right = _project(predicates, [assessed], events)
+    assert left.edges[0].strength == "0.8"
+    assert right.edges[0].strength == "0.8"
+    assert left.edge_set_hash == right.edge_set_hash
+    assert left.projection_hash == right.projection_hash
+
+
+def test_rejected_withdrawn_retracted_excluded(predicates) -> None:
+    """Terminal non-accepted states never emit edges."""
+    cases: list[tuple[str, list[AssertionEvent]]] = [
+        (
+            "Rejected",
+            [
+                _event("as-1", 1, "Proposed", from_state=None, recorded_at=NOW, authority="proposer"),
+                _event("as-1", 2, "Rejected", from_state="Proposed", recorded_at=NOW + timedelta(minutes=1)),
+            ],
+        ),
+        (
+            "Withdrawn",
+            [
+                _event("as-1", 1, "Proposed", from_state=None, recorded_at=NOW, authority="proposer"),
+                _event(
+                    "as-1",
+                    2,
+                    "Withdrawn",
+                    from_state="Proposed",
+                    recorded_at=NOW + timedelta(minutes=1),
+                    authority="proposer",
+                ),
+            ],
+        ),
+        (
+            "Retracted",
+            _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+            + [
+                _event(
+                    "as-1",
+                    3,
+                    "Retracted",
+                    from_state="Accepted",
+                    recorded_at=NOW + timedelta(minutes=2),
+                    authority="retractor",
+                )
+            ],
+        ),
+    ]
+    for _label, events in cases:
+        result = _project(predicates, [_assertion()], events, known_at=NOW + timedelta(hours=1))
+        assert result.edges == ()
+
+
+def test_naive_datetime_rejected(predicates) -> None:
+    """Projector requires timezone-aware UTC instants."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    with pytest.raises(ValidationError, match="timezone-aware UTC"):
+        project(
+            ProjectRequest(
+                assertions=[assertion],
+                events=events,
+                evidence=[],
+                evidence_links=[],
+                predicate_registry=predicates,
+                purpose=PURPOSE,
+                effective_at=datetime(2026, 7, 25, 15, 0, 0),
+                known_at=NOW,
+            )
+        )
+
+
+def test_purpose_filter_excludes_other_purposes(predicates) -> None:
+    """Assertions whose predicate purpose differs from the request are ignored."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    result = _project(predicates, [assertion], events, purpose="other_purpose")
+    assert result.edges == ()
+    assert result.governed_scopes == ()
+
+
+def test_missing_evidence_record_for_link_fails_closed(predicates) -> None:
+    """Projection fails closed when a link references missing evidence."""
+    assertion = _assertion()
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    with pytest.raises(ProjectionError, match="missing evidence record"):
+        _project(
+            predicates,
+            [assertion],
+            events,
+            evidence_links=[_link("as-1")],
+        )
+
+
+def test_hash_inputs_reject_floats_via_canonical_json(predicates) -> None:
+    """Sanity: empty projection hashes are lowercase hex and float-free."""
+    result = _project(predicates, [], [])
+    assert all(ch in "0123456789abcdef" for ch in result.edge_set_hash)
+    assert all(ch in "0123456789abcdef" for ch in result.projection_hash)
+
+
+def test_same_object_conflict_still_fails_closed(predicates) -> None:
+    """Two Accepted assertions on one conflict key fail even with identical objects."""
+    left = _assertion("as-1", object_id="AAPL")
+    right = _assertion("as-2", object_id="AAPL")
+    events = _propose_accept_events("as-1", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=1))
+    events += _propose_accept_events("as-2", proposed_at=NOW, accepted_at=NOW + timedelta(minutes=2))
+    with pytest.raises(ProjectionError, match="projection conflict"):
+        _project(predicates, [left, right], events)


### PR DESCRIPTION
## Primary Objective
Add a pure deterministic GRAC v1 projector that materializes candidate projection revisions with identical SQLite/PostgreSQL content hashes, plus INSERT-only revision persistence. Closes #1535 (parent #1530).

## Fixed Decisions
- Projector is a pure function of explicit `ProjectRequest` inputs: assertions, evidence, events, predicate registry, purpose, `effective_at`, `known_at`, contract and projector versions
- Outputs: governed scopes; sorted directed edges; semantic `edge_set_hash`; provenance-sensitive `projection_hash`; revision metadata
- SQLite and PostgreSQL produce identical pinned golden hashes for the fixed-timestamp vertical-slice fixture
- Disputed / rejected / withdrawn / retracted / superseded assertions are excluded; cardinality conflicts fail closed
- No rebuild publication, API, or frontend changes in this PR

## In Scope
- `src/logic/relationship_projection.py` pure projector
- Projection revision persistence helpers on `RelationshipAssertionRepository`
- Unit + integration coverage for determinism, bitemporal bounds, conflicts, supersession, and hash parity

## Out of Scope
- Publishing through rebuild `SUCCEEDED` (#1536)
- API / UI / `asset_relationships` mutation
- Contract rewrites or dependency changes

## Allowed Files
- `src/logic/relationship_projection.py`
- `src/data/relationship_assertion_repository.py` (projection revision persistence only)
- `tests/unit/test_relationship_projection.py`
- `tests/integration/test_relationship_projection_persistence.py`

## Forbidden Files
Rebuild control plane; API/UI; `asset_relationships` mutation; contract rewrites; dependency changes.

## Invariants
- Assertions remain truth; graph edges remain projections
- No wall clock, `uuid4`, random, env, or unordered iteration inside the pure projector
- Confidence never becomes projection strength (registry strength `0.8` for the slice)
- Conflicts fail closed (never last-write-wins)
- Empty assertion store ⇒ empty revision / zero behavioural change to existing graph/API output
- Publication remains a separate step (not this PR)

## Tests Added/Updated
- `tests/unit/test_relationship_projection.py` — input-order invariance, replay idempotence, exact effective interval boundaries, historical `known_at`, disputed exclusion, fail-closed conflicts, supersession selection, provenance-sensitive `projection_hash`, pinned golden hashes
- `tests/integration/test_relationship_projection_persistence.py` — persist/reload round-trip, identical SQLite/PostgreSQL golden hashes (PostgreSQL when `ASSET_GRAPH_DATABASE_URL` / `GRAC_SCHEMA_DATABASE_URL` is set), supersession hash change, immutability guards

## Validation Actually Run
- `pytest tests/unit/test_relationship_projection.py tests/integration/test_relationship_projection_persistence.py tests/integration/test_relationship_assertion_repository.py` → **51 passed, 4 skipped** (PostgreSQL skipped locally without URL)
- Pre-commit on commit (black/ruff/flake8/mypy) → passed
- CodeScene `code_health_review`: `relationship_projection.py` **10.0**; repository module **9.38** (pre-existing file-size signal only)
- Codacy CLI analyze unavailable in this environment (`Codacy CLI not found` / prior WSL permission failures)
- Aikido scan not run (sign-in required)

## Rollback Behaviour
Revert this PR. Candidate revision rows are additive; no publication path writes `asset_relationships`. No migration beyond existing GRAC schema from #1533/#1534.

## Merge Criteria
- Proves: input-order invariance; replay idempotence; exact interval boundaries; historical `known_at` reconstruction; disputed exclusion; fail-closed conflicts; supersession selection change; identical SQLite/PostgreSQL hashes
- Full required CI passes; no unresolved review threads
- Preceding PR #1550 (#1534) is already on `main`

## Stop Conditions
- Nondeterminism that cannot be removed without contract amendment
- Need to publish through rebuild in this PR (belongs in #1536)
- Divergent hashes across DBs without a clear pure-function bug fix

Closes #1535

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New governance projection logic and persistence affect how graph edges are derived from assertions, but changes are additive (candidate rows only) with fail-closed conflict handling and no live graph publication in this PR.
> 
> **Overview**
> Introduces a **pure GRAC v1 projector** that turns explicit assertion, event, evidence, and predicate-registry inputs into immutable **candidate projection revisions**: sorted directed edges, governed scopes, a semantic `edge_set_hash`, and a provenance-sensitive `projection_hash` (assertion IDs and evidence digests). Eligibility is derived in-projection (Accepted-only at `known_at`, purpose and effective window, lifecycle exclusions); **cardinality conflicts fail closed** with no last-write-wins.
> 
> **`RelationshipAssertionRepository`** gains INSERT-only **`persist_projection_revision`** / **`get_projection_revision`** for revision headers and edges; publication to the live graph is explicitly out of scope.
> 
> Unit tests cover determinism, bitemporal bounds, conflicts, supersession, and pinned golden hashes; integration tests cover persist/reload, SQLite/PostgreSQL hash parity, and immutability of projection tables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa29b389eb5fe09432feee2d4e74a6885ac4961. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic GRAC v1 projector and INSERT‑only persistence for projection revisions with identical hashes across SQLite and PostgreSQL; hardened provenance, conflict handling, and reload logic. No API/UI changes or publication. Closes #1535.

- **New Features**
  - Pure projector (`relationship_projection.project`) emits governed scopes, sorted edges, semantic `edge_set_hash`, and provenance‑sensitive `projection_hash`; bidirectional edges persist as one canonical row (`direction='bidirectional'`).
  - INSERT‑only persistence in `src/data/relationship_projection_persistence.py` stores immutable revisions and deterministically ordered edges; optional caller‑provided IDs/timestamps.

- **Bug Fixes**
  - Provenance and safety: ignore links after `known_at`; reject evidence recorded after `known_at` or duplicate evidence IDs; enforce registered `method_id`; conflict key includes predicate and method; translate revision `IntegrityError` to domain errors.
  - Reload/CI: governed scopes rebuilt via one batched assertion lookup; build the assertion→predicate map with an explicit typed loop to satisfy ruff and mypy; tests pin cross‑DB golden hashes, stay Python 3.10/3.11‑friendly, prepare exception inputs outside `pytest.raises`, and suppress Ruff `UP047` for a test helper.

<sup>Written for commit 785d9d8aa790628a5c885b52e950b0d5bc9ea4e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic assertion projection revisions and INSERT-only persistence.
- Projects eligible assertions into sorted candidate edges with semantic and provenance-sensitive hashes.
- Persists and reloads immutable candidate revisions without publishing them to the live graph.
- Adds deterministic, bitemporal, conflict, supersession, immutability, and cross-database hash coverage.

<h3>Confidence Score: 5/5</h3>

The change appears safe to merge with no blocking failures remaining.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The exact pytest command from /home/user/repo was executed as requested.
- Pytest completed with exit code 0 and exercised projection determinism, golden hash parity, supersession behavior, SQLite persistence/reload, and revision-row immutability.
- No publication/UI/API flow or external PostgreSQL provisioning was attempted, and no repository files were changed.

<a href="https://app.greptile.com/trex/runs/15930612/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/logic/relationship_projection.py | Adds the pure deterministic projector, eligibility and conflict handling, governed scopes, and stable revision hashes. |
| src/data/relationship_projection_persistence.py | Adds INSERT-only storage and deterministic reload mapping for projection revision headers and edges. |
| src/data/relationship_assertion_repository.py | Exposes projection revision persistence and retrieval through the assertion repository. |
| tests/unit/test_relationship_projection.py | Covers deterministic projection, temporal boundaries, conflicts, supersession, evidence provenance, and pinned hashes. |
| tests/integration/test_relationship_projection_persistence.py | Covers persistence round trips, immutability, supersession, and SQLite/PostgreSQL hash parity. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
A[Assertions, events, evidence, registry] --> B[Deterministic projector]
B --> C[Candidate projection revision]
C --> D[INSERT-only revision persistence]
D --> E[Reload revision and ordered edges]
C -. publication out of scope .-> F[Live asset graph]
```

<sub>Reviews (10): Last reviewed commit: ["fix: build predicate map with a loop to ..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/785d9d8aa790628a5c885b52e950b0d5bc9ea4e6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47369417)</sub>

<!-- /greptile_comment -->