### PR TITLE
fix: enforce GRAC lifecycle and temporal invariants

### DIFF
--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -584,7 +584,7 @@ class RelationshipAssertionRepository:
         request: SupersedeAtomicRequest,
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
         """Atomically accept a successor and supersede the predecessor."""
-        self._lock_supersession_graph(request.predecessor_id, request.successor_proposal.assertion_id)
+        self._lock_supersession_graph()
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
@@ -764,56 +764,21 @@ class RelationshipAssertionRepository:
                 select(RelationshipAssertionORM.id).where(RelationshipAssertionORM.id == assertion_id).with_for_update()
             ).scalar_one_or_none()
 
-    def _gather_supersession_graph_ids(self, predecessor_id: str, successor_id: str) -> list[str]:
-        """Gather all assertion IDs in the supersession graph reachable from predecessor and successor.
-
-        Returns a deterministic set of IDs including:
-        - The predecessor and successor themselves
-        - All forward successors reachable from either (for cycle detection)
-        - All backward predecessors reachable from either (for complete graph coverage)
-        """
-        visited: set[str] = set()
-        to_visit = [predecessor_id, successor_id]
-
-        while to_visit:
-            current_id = to_visit.pop()
-            if current_id in visited:
-                continue
-            visited.add(current_id)
-
-            # Find forward successors (assertions this one supersedes to)
-            successors = self._successor_chain_lookup(current_id)
-            for succ_id in successors:
-                if succ_id not in visited:
-                    to_visit.append(succ_id)
-
-            # Find backward predecessors (assertions that supersede to this one)
-            predecessors = self._predecessor_chain_lookup(current_id)
-            for pred_id in predecessors:
-                if pred_id not in visited:
-                    to_visit.append(pred_id)
-
-        return sorted(visited)
-
-    def _lock_supersession_graph(self, predecessor_id: str, successor_id: str) -> None:
+    def _lock_supersession_graph(self) -> None:
         """Serialize supersession graph checks for the enclosing transaction.
 
         PostgreSQL first takes a stable transaction-scoped advisory lock, then
-        locks rows in deterministic id order for the predecessor, successor, and
-        all reachable assertions in their supersession chains. SQLite skips the
-        advisory lock and retains its compatible, single-writer test behavior.
+        locks rows in deterministic id order. SQLite skips the advisory lock and
+        retains its compatible, single-writer test behavior.
         """
         bind = self._session.get_bind()
         if bind.dialect.name == "postgresql":
             self._session.connection().execute(
                 select(func.pg_advisory_xact_lock(_SUPERSESSION_LOCK_NAMESPACE, _SUPERSESSION_LOCK_RESOURCE))
             ).scalar_one()
-
-        # Gather all assertions in the supersession graph reachable from predecessor and successor
-        assertions_to_lock = self._gather_supersession_graph_ids(predecessor_id, successor_id)
-
-        # Lock the gathered assertions using existing helper
-        self._lock_assertions(*assertions_to_lock)
+        self._session.execute(
+            select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
+        ).scalars().all()
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)
@@ -882,13 +847,3 @@ class RelationshipAssertionRepository:
             )
         ).scalars()
         return [successor for successor in rows if successor is not None]
-
-    def _predecessor_chain_lookup(self, assertion_id: str) -> Sequence[str]:
-        """Find all assertions that have a Superseded event pointing to this assertion."""
-        rows = self._session.execute(
-            select(RelationshipAssertionEventORM.assertion_id).where(
-                RelationshipAssertionEventORM.successor_assertion_id == assertion_id,
-                RelationshipAssertionEventORM.to_state == "Superseded",
-            )
-        ).scalars()
-        return list(rows)

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -406,14 +406,19 @@ class RelationshipAssertionRepository:
         ).scalar_one_or_none()
         return _as_utc(value)
 
-    def _next_event_time(self, assertion_id: str) -> datetime:
-        """Allocate a server-owned timestamp strictly after the stream tail."""
+    def _next_event_time(self, assertion_id: str, *, after: datetime | None = None) -> datetime:
+        """Allocate a server-owned timestamp after the stream tail and optional floor."""
         candidate = self._server_time()
         latest = self._latest_event_recorded_at(assertion_id)
-        if latest is None or candidate > latest:
+        floor = latest
+        if after is not None:
+            normalized_after = _server_utc(after)
+            if floor is None or normalized_after > floor:
+                floor = normalized_after
+        if floor is None or candidate > floor:
             return candidate
         try:
-            return latest + timedelta(microseconds=1)
+            return floor + timedelta(microseconds=1)
         except OverflowError as exc:
             raise ValidationError("assertion event time cannot advance beyond datetime.max") from exc
 
@@ -489,8 +494,7 @@ class RelationshipAssertionRepository:
         if request.to_state == "Superseded":
             raise IllegalTransition("Superseded is available only through supersede_atomic")
         self._lock_assertions(request.assertion_id)
-        current = self._current_state(request.assertion_id)
-        proposer_actor_id = self._proposer_actor_id(request.assertion_id)
+        current, proposer_actor_id = self._state_and_proposer_actor_id(request.assertion_id)
         stamp = self._next_event_time(request.assertion_id)
         event = _plan_repository_transition(
             request,
@@ -588,7 +592,7 @@ class RelationshipAssertionRepository:
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
-            pred_state = self._current_state(request.predecessor_id)
+            pred_state, pred_proposer_actor_id = self._state_and_proposer_actor_id(request.predecessor_id)
             self._validate_supersede_preconditions(request, pred_state)
             successor, propose_event = self._propose_new(request.successor_proposal, request.proposal_ctx)
             accept_timing = TransitionTiming(
@@ -604,7 +608,10 @@ class RelationshipAssertionRepository:
                 proposer_actor_id=request.proposal_ctx.actor_id,
             )
             self._append_event(successor.assertion_id, accept_event, expected_sequence=1)
-            supersede_stamp = self._next_event_time(request.predecessor_id)
+            supersede_stamp = self._next_event_time(
+                request.predecessor_id,
+                after=accept_event.recorded_at,
+            )
             supersede_event = _plan_repository_transition(
                 RepositoryTransitionRequest(
                     assertion_id=request.predecessor_id,
@@ -616,7 +623,7 @@ class RelationshipAssertionRepository:
                 ),
                 pred_state,
                 supersede_stamp,
-                self._proposer_actor_id(request.predecessor_id),
+                pred_proposer_actor_id,
                 self._successor_chain_lookup,
             )
             self._append_event(request.predecessor_id, supersede_event, expected_sequence=request.expected_sequence)
@@ -780,19 +787,15 @@ class RelationshipAssertionRepository:
             select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
         ).scalars().all()
 
-    def _current_state(self, assertion_id: str) -> LifecycleState:
+    def _state_and_proposer_actor_id(self, assertion_id: str) -> tuple[LifecycleState, str]:
+        """Resolve one event stream and return its state and proposer of record."""
         events = self._load_events(assertion_id)
         if not events:
             raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
-        return resolve_state(events)
+        return resolve_state(events), events[0].actor_id
 
-    def _proposer_actor_id(self, assertion_id: str) -> str:
-        """Return the validated proposer-of-record identity for one stream."""
-        events = self._load_events(assertion_id)
-        if not events:
-            raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
-        resolve_state(events)
-        return events[0].actor_id
+    def _current_state(self, assertion_id: str) -> LifecycleState:
+        return self._state_and_proposer_actor_id(assertion_id)[0]
 
     def _max_sequence(self, assertion_id: str) -> int:
         value = self._session.execute(

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -584,7 +584,7 @@ class RelationshipAssertionRepository:
         request: SupersedeAtomicRequest,
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
         """Atomically accept a successor and supersede the predecessor."""
-        self._lock_supersession_graph()
+        self._lock_supersession_graph(request.predecessor_id, request.successor_proposal.assertion_id)
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
@@ -764,21 +764,56 @@ class RelationshipAssertionRepository:
                 select(RelationshipAssertionORM.id).where(RelationshipAssertionORM.id == assertion_id).with_for_update()
             ).scalar_one_or_none()
 
-    def _lock_supersession_graph(self) -> None:
+    def _gather_supersession_graph_ids(self, predecessor_id: str, successor_id: str) -> list[str]:
+        """Gather all assertion IDs in the supersession graph reachable from predecessor and successor.
+
+        Returns a deterministic set of IDs including:
+        - The predecessor and successor themselves
+        - All forward successors reachable from either (for cycle detection)
+        - All backward predecessors reachable from either (for complete graph coverage)
+        """
+        visited: set[str] = set()
+        to_visit = [predecessor_id, successor_id]
+
+        while to_visit:
+            current_id = to_visit.pop()
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+
+            # Find forward successors (assertions this one supersedes to)
+            successors = self._successor_chain_lookup(current_id)
+            for succ_id in successors:
+                if succ_id not in visited:
+                    to_visit.append(succ_id)
+
+            # Find backward predecessors (assertions that supersede to this one)
+            predecessors = self._predecessor_chain_lookup(current_id)
+            for pred_id in predecessors:
+                if pred_id not in visited:
+                    to_visit.append(pred_id)
+
+        return sorted(visited)
+
+    def _lock_supersession_graph(self, predecessor_id: str, successor_id: str) -> None:
         """Serialize supersession graph checks for the enclosing transaction.
 
         PostgreSQL first takes a stable transaction-scoped advisory lock, then
-        locks rows in deterministic id order. SQLite skips the advisory lock and
-        retains its compatible, single-writer test behavior.
+        locks rows in deterministic id order for the predecessor, successor, and
+        all reachable assertions in their supersession chains. SQLite skips the
+        advisory lock and retains its compatible, single-writer test behavior.
         """
         bind = self._session.get_bind()
         if bind.dialect.name == "postgresql":
             self._session.connection().execute(
                 select(func.pg_advisory_xact_lock(_SUPERSESSION_LOCK_NAMESPACE, _SUPERSESSION_LOCK_RESOURCE))
             ).scalar_one()
-        self._session.execute(
-            select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
-        ).scalars().all()
+
+        # Gather all assertions in the supersession graph reachable from predecessor and successor
+        assertions_to_lock = self._gather_supersession_graph_ids(predecessor_id, successor_id)
+
+        # Lock the gathered assertions using existing helper
+        self._lock_assertions(*assertions_to_lock)
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)
@@ -847,3 +882,13 @@ class RelationshipAssertionRepository:
             )
         ).scalars()
         return [successor for successor in rows if successor is not None]
+
+    def _predecessor_chain_lookup(self, assertion_id: str) -> Sequence[str]:
+        """Find all assertions that have a Superseded event pointing to this assertion."""
+        rows = self._session.execute(
+            select(RelationshipAssertionEventORM.assertion_id).where(
+                RelationshipAssertionEventORM.successor_assertion_id == assertion_id,
+                RelationshipAssertionEventORM.to_state == "Superseded",
+            )
+        ).scalars()
+        return list(rows)

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -443,10 +443,12 @@ class RelationshipAssertionRepository:
         self,
         proposal: AssertionProposal,
         ctx: AuthorityContext,
+        *,
+        after: datetime,
     ) -> tuple[Assertion, AssertionEvent]:
         """Insert a new proposal without adopting an idempotent race winner."""
         validate_authority(ctx, "proposer")
-        stamp = self._next_event_time(proposal.assertion_id)
+        stamp = self._next_event_time(proposal.assertion_id, after=after)
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp)
         return self._insert_new_proposal(
             assertion,
@@ -494,7 +496,7 @@ class RelationshipAssertionRepository:
         if request.to_state == "Superseded":
             raise IllegalTransition("Superseded is available only through supersede_atomic")
         self._lock_assertions(request.assertion_id)
-        current, proposer_actor_id = self._state_and_proposer_actor_id(request.assertion_id)
+        current, proposer_actor_id, _tail = self._stream_summary(request.assertion_id)
         stamp = self._next_event_time(request.assertion_id)
         event = _plan_repository_transition(
             request,
@@ -592,9 +594,13 @@ class RelationshipAssertionRepository:
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
-            pred_state, pred_proposer_actor_id = self._state_and_proposer_actor_id(request.predecessor_id)
+            pred_state, pred_proposer_actor_id, pred_tail = self._stream_summary(request.predecessor_id)
             self._validate_supersede_preconditions(request, pred_state)
-            successor, propose_event = self._propose_new(request.successor_proposal, request.proposal_ctx)
+            successor, propose_event = self._propose_new(
+                request.successor_proposal,
+                request.proposal_ctx,
+                after=pred_tail,
+            )
             accept_timing = TransitionTiming(
                 1,
                 request.accept_rationale,
@@ -787,15 +793,15 @@ class RelationshipAssertionRepository:
             select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
         ).scalars().all()
 
-    def _state_and_proposer_actor_id(self, assertion_id: str) -> tuple[LifecycleState, str]:
-        """Resolve one event stream and return its state and proposer of record."""
+    def _stream_summary(self, assertion_id: str) -> tuple[LifecycleState, str, datetime]:
+        """Resolve one stream into state, proposer of record, and tail time."""
         events = self._load_events(assertion_id)
         if not events:
             raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
-        return resolve_state(events), events[0].actor_id
+        return resolve_state(events), events[0].actor_id, events[-1].recorded_at
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
-        return self._state_and_proposer_actor_id(assertion_id)[0]
+        return self._stream_summary(assertion_id)[0]
 
     def _max_sequence(self, assertion_id: str) -> int:
         value = self._session.execute(

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -590,9 +590,9 @@ class RelationshipAssertionRepository:
         request: SupersedeAtomicRequest,
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
         """Atomically accept a successor and supersede the predecessor."""
-        self._lock_supersession_graph()
-        # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
+        # Savepoint so a late failure releases graph locks without losing unrelated outer work.
         with self._session.begin_nested():
+            self._lock_supersession_graph()
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
             pred_state, pred_proposer_actor_id, pred_tail = self._stream_summary(request.predecessor_id)
             self._validate_supersede_preconditions(request, pred_state)
@@ -778,11 +778,13 @@ class RelationshipAssertionRepository:
             ).scalar_one_or_none()
 
     def _lock_supersession_graph(self) -> None:
-        """Serialize supersession graph checks for the enclosing transaction.
+        """Serialize supersession graph checks for the atomic savepoint.
 
         PostgreSQL first takes a stable transaction-scoped advisory lock, then
-        locks rows in deterministic id order. SQLite skips the advisory lock and
-        retains its compatible, single-writer test behavior.
+        locks rows in deterministic id order. Successful savepoint release keeps
+        the locks through the enclosing transaction; rollback releases them.
+        SQLite skips the advisory lock and retains its compatible, single-writer
+        test behavior.
         """
         bind = self._session.get_bind()
         if bind.dialect.name == "postgresql":

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import NoReturn, cast
 from uuid import uuid4
 
@@ -34,8 +34,10 @@ from src.governance.relationship_assertion import (
     EvidenceLink,
     EvidencePolarity,
     EvidenceRecord,
+    IllegalTransition,
     LifecycleState,
     SupersessionCycle,
+    UnauthorizedTransition,
     ValidationError,
     Visibility,
 )
@@ -53,10 +55,13 @@ from src.governance.relationship_assertion_lifecycle import (
     plan_transition,
     proposals_equivalent,
     resolve_state,
+    validate_authority,
     validate_evidence_record,
 )
 
 UTC = timezone.utc
+_SUPERSESSION_LOCK_NAMESPACE = 0x46415244
+_SUPERSESSION_LOCK_RESOURCE = 0x47524143
 
 __all__ = [
     "PersistProjectionRequest",
@@ -78,7 +83,6 @@ class RepositoryTransitionRequest:
     expected_sequence: int
     rationale: str
     successor_assertion_id: str | None = None
-    recorded_at: datetime | None = None
     event_id: str | None = None
 
 
@@ -91,7 +95,6 @@ class RegisterEvidenceRequest:
     polarity: EvidencePolarity
     ctx: AuthorityContext
     link_id: str | None = None
-    recorded_at: datetime | None = None
 
 
 @dataclass(frozen=True)
@@ -100,10 +103,10 @@ class SupersedeAtomicRequest:
 
     predecessor_id: str
     successor_proposal: AssertionProposal
-    ctx: AuthorityContext
+    proposal_ctx: AuthorityContext
+    determination_ctx: AuthorityContext
     expected_sequence: int
     rationale: str
-    recorded_at: datetime | None = None
     accept_rationale: str = "accept successor"
 
 
@@ -127,6 +130,13 @@ def _as_utc(value: datetime | None) -> datetime | None:
         return None
     if value.tzinfo is None:
         return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _server_utc(value: object) -> datetime:
+    """Normalize a trusted repository clock value to timezone-aware UTC."""
+    if not isinstance(value, datetime) or value.tzinfo is None or value.utcoffset() is None:
+        raise ValidationError("repository clock must return a timezone-aware datetime")
     return value.astimezone(UTC)
 
 
@@ -282,6 +292,12 @@ def _validate_event_sequence(
         raise ConcurrencyConflict(f"expected_sequence {expected_sequence} but current max is {current_max}")
 
 
+def _validate_event_recorded_at(event: AssertionEvent, previous_recorded_at: datetime | None) -> None:
+    """Reject an event that does not advance its assertion stream clock."""
+    if previous_recorded_at is not None and event.recorded_at <= previous_recorded_at:
+        raise ValidationError("event recorded_at must be strictly increasing within an assertion stream")
+
+
 def _validate_supersede_state(predecessor_id: str, pred_state: LifecycleState) -> None:
     if pred_state not in ("Accepted", "Disputed"):
         raise ValidationError(
@@ -338,6 +354,7 @@ def _plan_repository_transition(
     request: RepositoryTransitionRequest,
     current: LifecycleState,
     stamp: datetime,
+    proposer_actor_id: str,
     successor_chain_lookup: Callable[[str], Sequence[str]],
 ) -> AssertionEvent:
     timing = TransitionTiming(
@@ -353,19 +370,13 @@ def _plan_repository_transition(
         ctx=request.ctx,
         timing=timing,
         successor_assertion_id=request.successor_assertion_id,
+        proposer_actor_id=proposer_actor_id,
     )
     if request.to_state == "Superseded":
         if request.successor_assertion_id is None:
             raise ValidationError("supersession requires successor_assertion_id")
         return plan_supersede(SupersedePlan(transition=plan, successor_chain_lookup=successor_chain_lookup))
     return plan_transition(plan)
-
-
-def _require_accepted_successor_id(successor_assertion_id: str) -> str:
-    """Normalize a required successor id for supersession persistence checks."""
-    if not successor_assertion_id.strip():
-        raise ValidationError("supersession requires successor_assertion_id")
-    return successor_assertion_id
 
 
 class RelationshipAssertionRepository:
@@ -381,22 +392,64 @@ class RelationshipAssertionRepository:
         self._session = session
         self._clock = clock or _utcnow
 
+    def _server_time(self) -> datetime:
+        """Read and normalize the trusted repository clock."""
+        return _server_utc(self._clock())
+
+    def _latest_event_recorded_at(self, assertion_id: str) -> datetime | None:
+        """Return the latest recorded time in one assertion stream."""
+        value = self._session.execute(
+            select(RelationshipAssertionEventORM.recorded_at)
+            .where(RelationshipAssertionEventORM.assertion_id == assertion_id)
+            .order_by(RelationshipAssertionEventORM.sequence.desc())
+            .limit(1)
+        ).scalar_one_or_none()
+        return _as_utc(value)
+
+    def _next_event_time(self, assertion_id: str) -> datetime:
+        """Allocate a server-owned timestamp strictly after the stream tail."""
+        candidate = self._server_time()
+        latest = self._latest_event_recorded_at(assertion_id)
+        if latest is None or candidate > latest:
+            return candidate
+        try:
+            return latest + timedelta(microseconds=1)
+        except OverflowError as exc:
+            raise ValidationError("assertion event time cannot advance beyond datetime.max") from exc
+
     def propose(
         self,
         proposal: AssertionProposal,
         ctx: AuthorityContext,
         *,
-        recorded_at: datetime | None = None,
         event_id: str | None = None,
     ) -> tuple[Assertion, AssertionEvent]:
         """Create an assertion + Proposed event, or return the existing identical proposal."""
+        validate_authority(ctx, "proposer")
         existing = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
         if existing is not None:
-            return self._existing_proposal(existing, proposal)
+            return self._existing_proposal(existing, proposal, ctx)
 
-        stamp = recorded_at or self._clock()
+        stamp = self._next_event_time(proposal.assertion_id)
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp, event_id=event_id)
-        return self._insert_new_proposal(assertion, event, proposal)
+        return self._insert_new_proposal(assertion, event, proposal, ctx)
+
+    def _propose_new(
+        self,
+        proposal: AssertionProposal,
+        ctx: AuthorityContext,
+    ) -> tuple[Assertion, AssertionEvent]:
+        """Insert a new proposal without adopting an idempotent race winner."""
+        validate_authority(ctx, "proposer")
+        stamp = self._next_event_time(proposal.assertion_id)
+        assertion, event = plan_propose(proposal, ctx, recorded_at=stamp)
+        return self._insert_new_proposal(
+            assertion,
+            event,
+            proposal,
+            ctx,
+            reuse_existing=False,
+        )
 
     def _append_event(
         self,
@@ -412,6 +465,7 @@ class RelationshipAssertionRepository:
         """
         _validate_event_identity(assertion_id, event)
         _validate_event_sequence(event, expected_sequence, self._max_sequence(assertion_id))
+        _validate_event_recorded_at(event, self._latest_event_recorded_at(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
             raise ValidationError(f"unknown assertion_id: {assertion_id}")
         try:
@@ -433,21 +487,23 @@ class RelationshipAssertionRepository:
     def transition(self, request: RepositoryTransitionRequest) -> AssertionEvent:
         """Plan and append a matrix transition under the concurrency guard."""
         if request.to_state == "Superseded":
-            successor_id = _require_accepted_successor_id(request.successor_assertion_id or "")
-            self._lock_supersession_graph()
-            self._lock_assertions(request.assertion_id, successor_id)
-            self._require_accepted_successor(successor_id)
-            assert_no_cycle(request.assertion_id, successor_id, self._successor_chain_lookup)
-        else:
-            self._lock_assertions(request.assertion_id)
+            raise IllegalTransition("Superseded is available only through supersede_atomic")
+        self._lock_assertions(request.assertion_id)
         current = self._current_state(request.assertion_id)
-        stamp = request.recorded_at or self._clock()
-        event = _plan_repository_transition(request, current, stamp, self._successor_chain_lookup)
+        proposer_actor_id = self._proposer_actor_id(request.assertion_id)
+        stamp = self._next_event_time(request.assertion_id)
+        event = _plan_repository_transition(
+            request,
+            current,
+            stamp,
+            proposer_actor_id,
+            self._successor_chain_lookup,
+        )
         return self._append_event(request.assertion_id, event, expected_sequence=request.expected_sequence)
 
     def register_evidence(self, request: RegisterEvidenceRequest) -> tuple[EvidenceRecord, EvidenceLink]:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
-        stamp = request.recorded_at or self._clock()
+        stamp = self._server_time()
         normalized = validate_evidence_record(_with_recorded_at(request.evidence, stamp))
         link = self._plan_evidence_link(request, normalized, stamp)
         stored_evidence = self._upsert_evidence(normalized)
@@ -528,29 +584,39 @@ class RelationshipAssertionRepository:
         request: SupersedeAtomicRequest,
     ) -> tuple[Assertion, AssertionEvent, AssertionEvent, AssertionEvent]:
         """Atomically accept a successor and supersede the predecessor."""
-        stamp = request.recorded_at or self._clock()
+        self._lock_supersession_graph()
         # Savepoint so a late predecessor CAS / planning failure cannot leave an orphan successor.
         with self._session.begin_nested():
-            self._lock_supersession_graph()
             self._lock_assertions(request.predecessor_id, request.successor_proposal.assertion_id)
             pred_state = self._current_state(request.predecessor_id)
             self._validate_supersede_preconditions(request, pred_state)
-            successor, propose_event = self.propose(request.successor_proposal, request.ctx, recorded_at=stamp)
-            accept_timing = TransitionTiming(1, request.accept_rationale, stamp)
-            accept_event = plan_accept(successor.assertion_id, "Proposed", request.ctx, timing=accept_timing)
+            successor, propose_event = self._propose_new(request.successor_proposal, request.proposal_ctx)
+            accept_timing = TransitionTiming(
+                1,
+                request.accept_rationale,
+                self._next_event_time(successor.assertion_id),
+            )
+            accept_event = plan_accept(
+                successor.assertion_id,
+                "Proposed",
+                request.determination_ctx,
+                timing=accept_timing,
+                proposer_actor_id=request.proposal_ctx.actor_id,
+            )
             self._append_event(successor.assertion_id, accept_event, expected_sequence=1)
+            supersede_stamp = self._next_event_time(request.predecessor_id)
             supersede_event = _plan_repository_transition(
                 RepositoryTransitionRequest(
                     assertion_id=request.predecessor_id,
                     to_state="Superseded",
-                    ctx=request.ctx,
+                    ctx=request.determination_ctx,
                     expected_sequence=request.expected_sequence,
                     rationale=request.rationale,
                     successor_assertion_id=successor.assertion_id,
-                    recorded_at=stamp,
                 ),
                 pred_state,
-                stamp,
+                supersede_stamp,
+                self._proposer_actor_id(request.predecessor_id),
                 self._successor_chain_lookup,
             )
             self._append_event(request.predecessor_id, supersede_event, expected_sequence=request.expected_sequence)
@@ -612,10 +678,12 @@ class RelationshipAssertionRepository:
         self,
         row: RelationshipAssertionORM,
         proposal: AssertionProposal,
+        ctx: AuthorityContext,
         *,
         exc: IntegrityError | None = None,
         missing_event_suffix: str = "",
     ) -> tuple[Assertion, AssertionEvent]:
+        validate_authority(ctx, "proposer")
         domain = _fix_assertion_mapping(row)
         if not proposals_equivalent(domain, proposal):
             _raise_validation(
@@ -628,6 +696,12 @@ class RelationshipAssertionRepository:
                 f"assertion {proposal.assertion_id} missing propose event{missing_event_suffix}",
                 exc,
             )
+        resolve_state(events)
+        if events[0].actor_id != ctx.actor_id:
+            error = UnauthorizedTransition("idempotent proposal reuse requires the proposer of record")
+            if exc is not None:
+                raise error from exc
+            raise error
         return domain, events[0]
 
     def _insert_new_proposal(
@@ -635,6 +709,9 @@ class RelationshipAssertionRepository:
         assertion: Assertion,
         event: AssertionEvent,
         proposal: AssertionProposal,
+        ctx: AuthorityContext,
+        *,
+        reuse_existing: bool = True,
     ) -> tuple[Assertion, AssertionEvent]:
         try:
             with self._session.begin_nested():
@@ -643,12 +720,17 @@ class RelationshipAssertionRepository:
                 self._insert_event_orm(event)
                 self._session.flush()
         except IntegrityError as exc:
+            if not reuse_existing:
+                raise ConcurrencyConflict(
+                    f"concurrent successor proposal insert conflicted for {proposal.assertion_id}"
+                ) from exc
             raced = self._session.get(RelationshipAssertionORM, proposal.assertion_id)
             if raced is None:
                 raise ValidationError(f"propose failed for {proposal.assertion_id}: {exc}") from exc
             return self._existing_proposal(
                 raced,
                 proposal,
+                ctx,
                 exc=exc,
                 missing_event_suffix=" after conflict",
             )
@@ -683,30 +765,34 @@ class RelationshipAssertionRepository:
             ).scalar_one_or_none()
 
     def _lock_supersession_graph(self) -> None:
-        """Serialize supersession graph checks against every existing assertion.
+        """Serialize supersession graph checks for the enclosing transaction.
 
-        PostgreSQL locks the rows in deterministic id order until the transaction
-        ends. Fully consuming the result acquires every lock before chain planning.
-        SQLite ignores ``FOR UPDATE`` and therefore provides no equivalent
-        graph-wide serialization.
+        PostgreSQL first takes a stable transaction-scoped advisory lock, then
+        locks rows in deterministic id order. SQLite skips the advisory lock and
+        retains its compatible, single-writer test behavior.
         """
+        bind = self._session.get_bind()
+        if bind.dialect.name == "postgresql":
+            self._session.connection().execute(
+                select(func.pg_advisory_xact_lock(_SUPERSESSION_LOCK_NAMESPACE, _SUPERSESSION_LOCK_RESOURCE))
+            ).scalar_one()
         self._session.execute(
             select(RelationshipAssertionORM.id).order_by(RelationshipAssertionORM.id).with_for_update()
         ).scalars().all()
-
-    def _require_accepted_successor(self, successor_assertion_id: str) -> None:
-        """Reject missing or non-Accepted successors for direct supersession."""
-        if self._session.get(RelationshipAssertionORM, successor_assertion_id) is None:
-            raise ValidationError(f"unknown successor_assertion_id: {successor_assertion_id}")
-        state = self._current_state(successor_assertion_id)
-        if state != "Accepted":
-            raise ValidationError(f"successor {successor_assertion_id} must be Accepted to supersede (current={state})")
 
     def _current_state(self, assertion_id: str) -> LifecycleState:
         events = self._load_events(assertion_id)
         if not events:
             raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
         return resolve_state(events)
+
+    def _proposer_actor_id(self, assertion_id: str) -> str:
+        """Return the validated proposer-of-record identity for one stream."""
+        events = self._load_events(assertion_id)
+        if not events:
+            raise ValidationError(f"unknown or eventless assertion_id: {assertion_id}")
+        resolve_state(events)
+        return events[0].actor_id
 
     def _max_sequence(self, assertion_id: str) -> int:
         value = self._session.execute(

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, timezone
 from typing import NoReturn, cast
 from uuid import uuid4
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -396,20 +396,25 @@ class RelationshipAssertionRepository:
         """Read and normalize the trusted repository clock."""
         return _server_utc(self._clock())
 
-    def _latest_event_recorded_at(self, assertion_id: str) -> datetime | None:
-        """Return the latest recorded time in one assertion stream."""
+    def _latest_assertion_recorded_at(self, assertion_id: str) -> datetime | None:
+        """Return the latest event or evidence-link time for one assertion."""
+        timeline = union_all(
+            select(RelationshipAssertionEventORM.recorded_at.label("recorded_at")).where(
+                RelationshipAssertionEventORM.assertion_id == assertion_id
+            ),
+            select(RelationshipAssertionEvidenceORM.recorded_at.label("recorded_at")).where(
+                RelationshipAssertionEvidenceORM.assertion_id == assertion_id
+            ),
+        ).subquery()
         value = self._session.execute(
-            select(RelationshipAssertionEventORM.recorded_at)
-            .where(RelationshipAssertionEventORM.assertion_id == assertion_id)
-            .order_by(RelationshipAssertionEventORM.sequence.desc())
-            .limit(1)
+            select(timeline.c.recorded_at).order_by(timeline.c.recorded_at.desc()).limit(1)
         ).scalar_one_or_none()
         return _as_utc(value)
 
-    def _next_event_time(self, assertion_id: str, *, after: datetime | None = None) -> datetime:
-        """Allocate a server-owned timestamp after the stream tail and optional floor."""
+    def _next_assertion_time(self, assertion_id: str, *, after: datetime | None = None) -> datetime:
+        """Allocate a timestamp after the assertion's event/evidence timeline."""
         candidate = self._server_time()
-        latest = self._latest_event_recorded_at(assertion_id)
+        latest = self._latest_assertion_recorded_at(assertion_id)
         floor = latest
         if after is not None:
             normalized_after = _server_utc(after)
@@ -435,7 +440,7 @@ class RelationshipAssertionRepository:
         if existing is not None:
             return self._existing_proposal(existing, proposal, ctx)
 
-        stamp = self._next_event_time(proposal.assertion_id)
+        stamp = self._next_assertion_time(proposal.assertion_id)
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp, event_id=event_id)
         return self._insert_new_proposal(assertion, event, proposal, ctx)
 
@@ -448,7 +453,7 @@ class RelationshipAssertionRepository:
     ) -> tuple[Assertion, AssertionEvent]:
         """Insert a new proposal without adopting an idempotent race winner."""
         validate_authority(ctx, "proposer")
-        stamp = self._next_event_time(proposal.assertion_id, after=after)
+        stamp = self._next_assertion_time(proposal.assertion_id, after=after)
         assertion, event = plan_propose(proposal, ctx, recorded_at=stamp)
         return self._insert_new_proposal(
             assertion,
@@ -472,7 +477,7 @@ class RelationshipAssertionRepository:
         """
         _validate_event_identity(assertion_id, event)
         _validate_event_sequence(event, expected_sequence, self._max_sequence(assertion_id))
-        _validate_event_recorded_at(event, self._latest_event_recorded_at(assertion_id))
+        _validate_event_recorded_at(event, self._latest_assertion_recorded_at(assertion_id))
         if self._session.get(RelationshipAssertionORM, assertion_id) is None:
             raise ValidationError(f"unknown assertion_id: {assertion_id}")
         try:
@@ -497,7 +502,7 @@ class RelationshipAssertionRepository:
             raise IllegalTransition("Superseded is available only through supersede_atomic")
         self._lock_assertions(request.assertion_id)
         current, proposer_actor_id, _tail = self._stream_summary(request.assertion_id)
-        stamp = self._next_event_time(request.assertion_id)
+        stamp = self._next_assertion_time(request.assertion_id)
         event = _plan_repository_transition(
             request,
             current,
@@ -509,7 +514,8 @@ class RelationshipAssertionRepository:
 
     def register_evidence(self, request: RegisterEvidenceRequest) -> tuple[EvidenceRecord, EvidenceLink]:
         """Register immutable evidence (digest-validated) and an append-only polarity link."""
-        stamp = self._server_time()
+        self._lock_assertions(request.assertion_id)
+        stamp = self._next_assertion_time(request.assertion_id)
         normalized = validate_evidence_record(_with_recorded_at(request.evidence, stamp))
         link = self._plan_evidence_link(request, normalized, stamp)
         stored_evidence = self._upsert_evidence(normalized)
@@ -604,7 +610,7 @@ class RelationshipAssertionRepository:
             accept_timing = TransitionTiming(
                 1,
                 request.accept_rationale,
-                self._next_event_time(successor.assertion_id),
+                self._next_assertion_time(successor.assertion_id),
             )
             accept_event = plan_accept(
                 successor.assertion_id,
@@ -614,7 +620,7 @@ class RelationshipAssertionRepository:
                 proposer_actor_id=request.proposal_ctx.actor_id,
             )
             self._append_event(successor.assertion_id, accept_event, expected_sequence=1)
-            supersede_stamp = self._next_event_time(
+            supersede_stamp = self._next_assertion_time(
                 request.predecessor_id,
                 after=accept_event.recorded_at,
             )

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -587,6 +587,8 @@ def plan_retract(
 
 def plan_supersede(plan: SupersedePlan) -> AssertionEvent:
     """Plan Accepted|Disputed → Superseded with cycle prevention."""
+    if plan.transition.to_state != "Superseded":
+        raise IllegalTransition("plan_supersede requires a Superseded transition")
     assert_no_cycle(
         plan.transition.assertion_id,
         plan.transition.successor_assertion_id or "",

--- a/src/governance/relationship_assertion_lifecycle.py
+++ b/src/governance/relationship_assertion_lifecycle.py
@@ -60,6 +60,7 @@ from src.governance.relationship_assertion_contract import (
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
 _GROUPED_SHA256_RE = re.compile(r"^[0-9a-f]{4}(?:-[0-9a-f]{4}){15}$")
 _UTC_OFFSET = timedelta(0)
+_DETERMINATION_STATES: frozenset[LifecycleState] = frozenset({"Accepted", "Rejected", "Superseded"})
 
 
 @dataclass(frozen=True)
@@ -83,6 +84,7 @@ class TransitionPlan:
     ctx: AuthorityContext
     timing: TransitionTiming
     successor_assertion_id: str | None = None
+    proposer_actor_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -94,6 +96,7 @@ class NamedTransitionPlan:
     current: LifecycleState
     ctx: AuthorityContext
     timing: TransitionTiming
+    proposer_actor_id: str | None = None
 
 
 @dataclass(frozen=True)
@@ -283,6 +286,9 @@ def _validate_initial_event(event: AssertionEvent) -> None:
     """Ensure the first event in a stream is a proper propose transition."""
     if event.from_state is not None or event.to_state != "Proposed":
         raise ValidationError("initial event must transition from None to Proposed")
+    if event.authority != "proposer":
+        raise ValidationError("initial event must use proposer authority")
+    _require_non_empty(event.actor_id, "actor_id", MAX_ACTOR_ID_LEN)
 
 
 def _validate_event_continuity(event: AssertionEvent, previous_state: LifecycleState) -> None:
@@ -305,6 +311,7 @@ def _validate_follow_on_event(
     event: AssertionEvent,
     previous_state: LifecycleState,
     transitions: TransitionsDocument,
+    proposer_actor_id: str,
 ) -> None:
     """Ensure a follow-on event aligns with matrix rules and continuity."""
     _validate_event_continuity(event, previous_state)
@@ -312,7 +319,28 @@ def _validate_follow_on_event(
     allowed = find_transition(transitions, from_state_value, event.to_state)
     if allowed is None:
         raise ValidationError(f"event transition outside matrix: {from_state_value}->{event.to_state}")
+    if event.authority != allowed.authority:
+        raise ValidationError(
+            f"event authority {event.authority!r} does not match required authority {allowed.authority!r}"
+        )
     _validate_successor_pointer(allowed, event)
+    _validate_actor_relationship(event.to_state, event.actor_id, proposer_actor_id)
+
+
+def _validate_actor_relationship(
+    to_state: LifecycleState,
+    actor_id: str,
+    proposer_actor_id: str | None,
+) -> None:
+    """Enforce proposer ownership and reviewer separation for sensitive transitions."""
+    actor = _require_non_empty(actor_id, "actor_id", MAX_ACTOR_ID_LEN)
+    if to_state not in _DETERMINATION_STATES and to_state != "Withdrawn":
+        return
+    proposer = _require_non_empty(proposer_actor_id or "", "proposer_actor_id", MAX_ACTOR_ID_LEN)
+    if to_state == "Withdrawn" and actor != proposer:
+        raise UnauthorizedTransition("withdrawal actor must match the assertion proposer of record")
+    if to_state in _DETERMINATION_STATES and actor == proposer:
+        raise UnauthorizedTransition("determining actor must differ from the assertion proposer of record")
 
 
 def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
@@ -322,17 +350,28 @@ def resolve_state(events: Sequence[AssertionEvent]) -> LifecycleState:
     ordered = sorted(events, key=lambda event: event.sequence)
     expected = 1
     previous_state: LifecycleState | None = None
+    previous_recorded_at: datetime | None = None
+    proposer_actor_id: str | None = None
     transitions = load_transitions()
     for event in ordered:
         sequence = _require_non_bool_int(event.sequence, "event sequence")
         if sequence != expected:
             raise ValidationError(f"event sequence gap: expected {expected}, got {event.sequence}")
         _require_utc_datetime(event.recorded_at, "recorded_at")
+        if previous_recorded_at is not None and event.recorded_at <= previous_recorded_at:
+            raise ValidationError("event recorded_at must be strictly increasing within an assertion stream")
         if expected == 1:
             _validate_initial_event(event)
+            proposer_actor_id = event.actor_id
         else:
-            _validate_follow_on_event(event, cast(LifecycleState, previous_state), transitions)
+            _validate_follow_on_event(
+                event,
+                cast(LifecycleState, previous_state),
+                transitions,
+                cast(str, proposer_actor_id),
+            )
         previous_state = event.to_state
+        previous_recorded_at = event.recorded_at
         expected += 1
     return ordered[-1].to_state
 
@@ -421,6 +460,7 @@ def _build_transition_event(
     """Materialize a planned transition as an append-only event DTO."""
     required_role = cast(AuthorityRole, allowed.authority)
     validate_authority(plan.ctx, required_role)
+    _validate_actor_relationship(plan.to_state, plan.ctx.actor_id, plan.proposer_actor_id)
     expected_sequence_value = _require_non_bool_int(plan.timing.expected_sequence, "expected_sequence")
     rationale_value = _require_non_empty(plan.timing.rationale, "rationale", MAX_RATIONALE_LEN)
     return AssertionEvent(
@@ -439,11 +479,18 @@ def _build_transition_event(
     )
 
 
-def plan_transition(plan: TransitionPlan) -> AssertionEvent:
-    """Plan a single matrix transition with authority and concurrency guards."""
+def _plan_transition(plan: TransitionPlan) -> AssertionEvent:
+    """Plan a matrix transition after its public entry point has been selected."""
     _matrix, allowed = _validate_transition_plan(plan)
     successor = _resolve_successor(plan, allowed)
     return _build_transition_event(plan, allowed, successor)
+
+
+def plan_transition(plan: TransitionPlan) -> AssertionEvent:
+    """Plan a non-supersession matrix transition with authority guards."""
+    if plan.to_state == "Superseded":
+        raise IllegalTransition("Superseded is available only through plan_supersede")
+    return _plan_transition(plan)
 
 
 def _plan_named_transition(plan: NamedTransitionPlan) -> AssertionEvent:
@@ -455,6 +502,7 @@ def _plan_named_transition(plan: NamedTransitionPlan) -> AssertionEvent:
             to_state=plan.to_state,
             ctx=plan.ctx,
             timing=plan.timing,
+            proposer_actor_id=plan.proposer_actor_id,
         )
     )
 
@@ -465,9 +513,12 @@ def plan_accept(
     ctx: AuthorityContext,
     *,
     timing: TransitionTiming,
+    proposer_actor_id: str,
 ) -> AssertionEvent:
     """Plan Proposed|Disputed → Accepted."""
-    return _plan_named_transition(NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing))
+    return _plan_named_transition(
+        NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing, proposer_actor_id)
+    )
 
 
 def plan_reject(
@@ -476,9 +527,12 @@ def plan_reject(
     ctx: AuthorityContext,
     *,
     timing: TransitionTiming,
+    proposer_actor_id: str,
 ) -> AssertionEvent:
     """Plan Proposed → Rejected."""
-    return _plan_named_transition(NamedTransitionPlan("Rejected", assertion_id, current, ctx, timing))
+    return _plan_named_transition(
+        NamedTransitionPlan("Rejected", assertion_id, current, ctx, timing, proposer_actor_id)
+    )
 
 
 def plan_withdraw(
@@ -487,9 +541,12 @@ def plan_withdraw(
     ctx: AuthorityContext,
     *,
     timing: TransitionTiming,
+    proposer_actor_id: str,
 ) -> AssertionEvent:
     """Plan Proposed → Withdrawn."""
-    return _plan_named_transition(NamedTransitionPlan("Withdrawn", assertion_id, current, ctx, timing))
+    return _plan_named_transition(
+        NamedTransitionPlan("Withdrawn", assertion_id, current, ctx, timing, proposer_actor_id)
+    )
 
 
 def plan_dispute(
@@ -509,9 +566,12 @@ def plan_reaffirm(
     ctx: AuthorityContext,
     *,
     timing: TransitionTiming,
+    proposer_actor_id: str,
 ) -> AssertionEvent:
     """Plan Disputed → Accepted (reaffirm)."""
-    return _plan_named_transition(NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing))
+    return _plan_named_transition(
+        NamedTransitionPlan("Accepted", assertion_id, current, ctx, timing, proposer_actor_id)
+    )
 
 
 def plan_retract(
@@ -532,7 +592,7 @@ def plan_supersede(plan: SupersedePlan) -> AssertionEvent:
         plan.transition.successor_assertion_id or "",
         plan.successor_chain_lookup,
     )
-    return plan_transition(plan.transition)
+    return _plan_transition(plan.transition)
 
 
 def _validate_evidence_link_scope(plan: EvidenceRegistrationPlan) -> None:

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -897,6 +897,76 @@ class TestSupersessionAtomics:
 class TestPostgresSupersessionSerialization:
     """Transaction-scoped serialization on two independent PostgreSQL sessions."""
 
+    def test_failed_supersession_releases_advisory_lock(self, postgres_engine) -> None:
+        """A failed atomic operation releases its lock while preserving outer work."""
+        factory = create_session_factory(postgres_engine)
+        token = uuid4().hex[:8]
+        predecessor_a = f"{token}-pred-a"
+        predecessor_b = f"{token}-pred-b"
+        successor_a = f"{token}-succ-a"
+        successor_b = f"{token}-succ-b"
+        pending_id = f"{token}-outer"
+
+        setup_session = factory()
+        try:
+            setup_repo = RelationshipAssertionRepository(setup_session)
+            _propose_accepted(setup_repo, predecessor_a)
+            _propose_accepted(setup_repo, predecessor_b)
+            setup_session.commit()
+        finally:
+            setup_session.close()
+
+        first_session = factory()
+        second_session = factory()
+        try:
+            first_repo = RelationshipAssertionRepository(first_session)
+            first_session.add(_pending_evidence_row(pending_id))
+            failed_request = SupersedeAtomicRequest(
+                predecessor_id=predecessor_a,
+                successor_proposal=_proposal(successor_a),
+                proposal_ctx=_ctx("proposer", actor_id="successor-proposer-a"),
+                determination_ctx=_ctx("disputer", actor_id="unauthorized-determiner"),
+                expected_sequence=2,
+                rationale="failed serialized supersession",
+            )
+
+            with pytest.raises(UnauthorizedTransition):
+                first_repo.supersede_atomic(failed_request)
+
+            assert first_repo.current_state(predecessor_a) == "Accepted"
+            assert first_session.get(RelationshipAssertionORM, successor_a) is None
+            assert first_session.get(RelationshipEvidenceORM, pending_id) is not None
+            assert first_session.in_transaction()
+
+            lock_available = second_session.execute(
+                text("SELECT pg_try_advisory_xact_lock(:namespace, :resource)"),
+                {
+                    "namespace": SUPERSESSION_LOCK_NAMESPACE,
+                    "resource": SUPERSESSION_LOCK_RESOURCE,
+                },
+            ).scalar_one()
+            assert lock_available is True
+
+            second_repo = RelationshipAssertionRepository(second_session)
+            successor, _propose, _accept, _supersede = second_repo.supersede_atomic(
+                SupersedeAtomicRequest(
+                    predecessor_id=predecessor_b,
+                    successor_proposal=_proposal(successor_b),
+                    proposal_ctx=_ctx("proposer", actor_id="successor-proposer-b"),
+                    determination_ctx=_ctx("acceptor", actor_id="supersession-determiner-b"),
+                    expected_sequence=2,
+                    rationale="successful serialized supersession",
+                )
+            )
+            assert successor.assertion_id == successor_b
+            second_session.commit()
+            first_session.commit()
+        finally:
+            second_session.rollback()
+            second_session.close()
+            first_session.rollback()
+            first_session.close()
+
     def test_atomic_supersessions_share_advisory_transaction_lock(self, postgres_engine) -> None:
         """A second atomic supersession waits until the first transaction releases its lock."""
         factory = create_session_factory(postgres_engine)

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -187,9 +187,9 @@ def _track_supersession_lock_order(repo, monkeypatch) -> list[str]:
     original_lock = repo._lock_supersession_graph
     original_lookup = repo._successor_chain_lookup
 
-    def track_lock(predecessor_id: str, successor_id: str) -> None:
+    def track_lock() -> None:
         calls.append("lock")
-        original_lock(predecessor_id, successor_id)
+        original_lock()
 
     def track_chain_lookup(assertion_id: str):
         calls.append("cycle")

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -1217,6 +1217,66 @@ class TestServerRecordedAt:
         assert accepted.recorded_at > proposed.recorded_at
         assert rows[1].recorded_at > rows[0].recorded_at
 
+    def test_evidence_and_events_share_a_monotonic_assertion_clock(self, repo_session) -> None:
+        """Clock regression cannot make a lifecycle event predate known evidence."""
+        clock_values = (
+            NOW,
+            NOW + timedelta(hours=2),
+            NOW + timedelta(hours=1),
+            NOW,
+        )
+        values = iter(clock_values)
+
+        def clock() -> datetime:
+            return next(values, clock_values[-1])
+
+        repository = RelationshipAssertionRepository(repo_session, clock=clock)
+        _assertion, proposed = repository.propose(
+            _proposal(),
+            _ctx("proposer", actor_id="owner"),
+        )
+        _evidence_record, first_link = repository.register_evidence(
+            RegisterEvidenceRequest(
+                assertion_id="as-1",
+                evidence=_evidence("ev-1"),
+                polarity="supporting",
+                ctx=_ctx("proposer", actor_id="owner"),
+            )
+        )
+        accepted = repository.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor", actor_id="reviewer"),
+                    "expected_sequence": 1,
+                    "rationale": "accept",
+                }
+            )
+        )
+        _evidence_record, second_link = repository.register_evidence(
+            RegisterEvidenceRequest(
+                assertion_id="as-1",
+                evidence=_evidence("ev-2"),
+                polarity="supporting",
+                ctx=_ctx("acceptor", actor_id="reviewer"),
+            )
+        )
+
+        assert proposed.recorded_at < first_link.recorded_at < accepted.recorded_at < second_link.recorded_at
+        at_first_link = repository.get_as_of("as-1", known_at=first_link.recorded_at)
+        at_acceptance = repository.get_as_of("as-1", known_at=accepted.recorded_at)
+        at_second_link = repository.get_as_of("as-1", known_at=second_link.recorded_at)
+        assert at_first_link is not None
+        assert at_first_link.state == "Proposed"
+        assert len(at_first_link.evidence_links) == 1
+        assert at_acceptance is not None
+        assert at_acceptance.state == "Accepted"
+        assert len(at_acceptance.evidence_links) == 1
+        assert at_second_link is not None
+        assert at_second_link.state == "Accepted"
+        assert len(at_second_link.evidence_links) == 2
+
 
 class TestGetAsOf:
     """Bitemporal reconstruction."""

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -187,9 +187,9 @@ def _track_supersession_lock_order(repo, monkeypatch) -> list[str]:
     original_lock = repo._lock_supersession_graph
     original_lookup = repo._successor_chain_lookup
 
-    def track_lock() -> None:
+    def track_lock(predecessor_id: str, successor_id: str) -> None:
         calls.append("lock")
-        original_lock()
+        original_lock(predecessor_id, successor_id)
 
     def track_chain_lookup(assertion_id: str):
         calls.append("cycle")

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -2,12 +2,20 @@
 
 from __future__ import annotations
 
+import os
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from inspect import signature
+from queue import Queue
+from threading import Event
+from time import monotonic, sleep
 from unittest.mock import Mock
+from uuid import uuid4
 
 import pytest
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, text
 from sqlalchemy.exc import DBAPIError
+from sqlalchemy.schema import CreateSchema, DropSchema
 
 from src.data.database import create_session_factory, init_db
 from src.data.relationship_assertion_db_models import (
@@ -22,6 +30,8 @@ from src.data.relationship_assertion_repository import (
     SupersedeAtomicRequest,
 )
 from src.governance.relationship_assertion import (
+    Assertion,
+    AssertionEvent,
     AssertionProposal,
     AuthorityContext,
     ConcurrencyConflict,
@@ -36,7 +46,44 @@ from tests.conftest import enable_sqlite_foreign_keys
 UTC = timezone.utc
 NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
 DIGEST = "b" * 64
+SUPERSESSION_LOCK_NAMESPACE = 0x46415244
+SUPERSESSION_LOCK_RESOURCE = 0x47524143
 pytestmark = pytest.mark.integration
+
+
+def _postgres_url() -> str | None:
+    """Return the explicitly configured PostgreSQL integration-test URL."""
+    for variable in ("ASSET_GRAPH_DATABASE_URL", "GRAC_SCHEMA_DATABASE_URL"):
+        url = os.getenv(variable)
+        if url and url.startswith("postgresql"):
+            return url
+    return None
+
+
+@pytest.fixture
+def postgres_engine():
+    """Yield a disposable schema-isolated PostgreSQL engine."""
+    postgres_url = _postgres_url()
+    if postgres_url is None:
+        pytest.skip("PostgreSQL URL not set (ASSET_GRAPH_DATABASE_URL / GRAC_SCHEMA_DATABASE_URL)")
+
+    schema_name = f"grac_test_{uuid4().hex}"
+    admin_engine = create_engine(postgres_url, future=True)
+    with admin_engine.begin() as connection:
+        connection.execute(CreateSchema(schema_name))
+    isolated_engine = create_engine(
+        postgres_url,
+        future=True,
+        connect_args={"options": f"-csearch_path={schema_name}"},
+    )
+    try:
+        init_db(isolated_engine)
+        yield isolated_engine
+    finally:
+        isolated_engine.dispose()
+        with admin_engine.begin() as connection:
+            connection.execute(DropSchema(schema_name, cascade=True, if_exists=True))
+        admin_engine.dispose()
 
 
 @pytest.fixture
@@ -65,9 +112,9 @@ def repo(repo_session) -> RelationshipAssertionRepository:
     return RelationshipAssertionRepository(repo_session, clock=clock)
 
 
-def _ctx(*roles: str) -> AuthorityContext:
+def _ctx(*roles: str, actor_id: str = "actor-1") -> AuthorityContext:
     return AuthorityContext(
-        actor_id="actor-1",
+        actor_id=actor_id,
         roles=frozenset(roles),  # type: ignore[arg-type]
         policy_version="grac.v1-policy",
         correlation_id="corr-repo",
@@ -120,13 +167,13 @@ def _transition(fields: dict[str, object]) -> RepositoryTransitionRequest:
 
 def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
     """Helper: propose then accept an assertion."""
-    repo.propose(_proposal(assertion_id), _ctx("proposer"))
+    repo.propose(_proposal(assertion_id), _ctx("proposer", actor_id="proposer-1"))
     repo.transition(
         _transition(
             {
                 "assertion_id": assertion_id,
                 "to_state": "Accepted",
-                "ctx": _ctx("acceptor"),
+                "ctx": _ctx("acceptor", actor_id="determiner-1"),
                 "expected_sequence": 1,
                 "rationale": "accept",
             }
@@ -182,6 +229,24 @@ class TestProposeIdempotency:
         )
         assert len(events) == 1
 
+    def test_propose_idempotent_reuse_revalidates_proposer_role(self, repo) -> None:
+        """An idempotency hit does not bypass current proposer authority."""
+        repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+
+        with pytest.raises(UnauthorizedTransition):
+            repo.propose(_proposal(), _ctx("acceptor", actor_id="owner"))
+
+        assert repo.max_sequence("as-1") == 1
+
+    def test_propose_idempotent_reuse_requires_proposer_of_record(self, repo) -> None:
+        """A foreign proposer cannot reuse another actor's assertion id."""
+        repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+
+        with pytest.raises(UnauthorizedTransition, match="proposer of record"):
+            repo.propose(_proposal(), _ctx("proposer", actor_id="foreign-proposer"))
+
+        assert repo.max_sequence("as-1") == 1
+
     def test_propose_conflict_on_different_payload(self, repo) -> None:
         """Same id with a different proposition fails closed."""
         repo.propose(_proposal(), _ctx("proposer"))
@@ -217,13 +282,13 @@ class TestTransitionsAndIllegal:
 
     def test_full_happy_path_accept_dispute_reaffirm(self, repo, repo_session) -> None:
         """Accepted → Disputed → Accepted persists ordered events."""
-        repo.propose(_proposal(), _ctx("proposer"))
+        repo.propose(_proposal(), _ctx("proposer", actor_id="proposer"))
         repo.transition(
             _transition(
                 {
                     "assertion_id": "as-1",
                     "to_state": "Accepted",
-                    "ctx": _ctx("acceptor"),
+                    "ctx": _ctx("acceptor", actor_id="determiner"),
                     "expected_sequence": 1,
                     "rationale": "a",
                 }
@@ -234,7 +299,7 @@ class TestTransitionsAndIllegal:
                 {
                     "assertion_id": "as-1",
                     "to_state": "Disputed",
-                    "ctx": _ctx("disputer"),
+                    "ctx": _ctx("disputer", actor_id="disputer"),
                     "expected_sequence": 2,
                     "rationale": "d",
                 }
@@ -245,7 +310,7 @@ class TestTransitionsAndIllegal:
                 {
                     "assertion_id": "as-1",
                     "to_state": "Accepted",
-                    "ctx": _ctx("acceptor"),
+                    "ctx": _ctx("acceptor", actor_id="determiner"),
                     "expected_sequence": 3,
                     "rationale": "r",
                 }
@@ -287,6 +352,96 @@ class TestTransitionsAndIllegal:
             repo.transition(request)
         assert repo.current_state("as-1") == "Proposed"
 
+    @pytest.mark.parametrize("to_state", ["Accepted", "Rejected"])
+    def test_proposer_cannot_make_own_determination(self, repo, to_state: str) -> None:
+        """Accept and reject require a principal distinct from the proposer."""
+        repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": to_state,
+                "ctx": _ctx("acceptor", actor_id="owner"),
+                "expected_sequence": 1,
+                "rationale": "self determination",
+            }
+        )
+
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            repo.transition(request)
+
+        assert repo.current_state("as-1") == "Proposed"
+
+    def test_proposer_cannot_reaffirm_own_assertion(self, repo) -> None:
+        """Reaffirmation preserves proposer/determiner separation."""
+        repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor", actor_id="reviewer"),
+                    "expected_sequence": 1,
+                    "rationale": "accept",
+                }
+            )
+        )
+        repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Disputed",
+                    "ctx": _ctx("disputer", actor_id="challenger"),
+                    "expected_sequence": 2,
+                    "rationale": "dispute",
+                }
+            )
+        )
+
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            repo.transition(
+                _transition(
+                    {
+                        "assertion_id": "as-1",
+                        "to_state": "Accepted",
+                        "ctx": _ctx("acceptor", actor_id="owner"),
+                        "expected_sequence": 3,
+                        "rationale": "self reaffirm",
+                    }
+                )
+            )
+
+        assert repo.current_state("as-1") == "Disputed"
+
+    def test_withdrawal_requires_proposer_of_record(self, repo) -> None:
+        """A proposer role cannot withdraw another actor's proposal."""
+        repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+        foreign_request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Withdrawn",
+                "ctx": _ctx("proposer", actor_id="foreign-proposer"),
+                "expected_sequence": 1,
+                "rationale": "foreign withdrawal",
+            }
+        )
+
+        with pytest.raises(UnauthorizedTransition, match="proposer of record"):
+            repo.transition(foreign_request)
+
+        event = repo.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Withdrawn",
+                    "ctx": _ctx("proposer", actor_id="owner"),
+                    "expected_sequence": 1,
+                    "rationale": "owner withdrawal",
+                }
+            )
+        )
+        assert event.actor_id == "owner"
+        assert repo.current_state("as-1") == "Withdrawn"
+
     def test_assertion_rows_remain_immutable(self, repo, repo_session) -> None:
         """Schema immutability guards still reject UPDATE on assertion rows."""
         repo.propose(_proposal(), _ctx("proposer"))
@@ -310,7 +465,7 @@ class TestConcurrency:
                 {
                     "assertion_id": "as-1",
                     "to_state": "Accepted",
-                    "ctx": _ctx("acceptor"),
+                    "ctx": _ctx("acceptor", actor_id="determiner"),
                     "expected_sequence": 1,
                     "rationale": "a",
                 }
@@ -387,6 +542,8 @@ class TestEvidenceRegistration:
         )
         repo_session.commit()
         assert evidence.content_sha256 == DIGEST
+        assert evidence.recorded_at == NOW + timedelta(milliseconds=1)
+        assert link.recorded_at == evidence.recorded_at
         assert link.polarity == "supporting"
         as_of = repo.get_as_of("as-1", known_at=NOW + timedelta(hours=1))
         assert as_of is not None
@@ -519,7 +676,8 @@ class TestSupersessionAtomics:
             SupersedeAtomicRequest(
                 predecessor_id="as-pred",
                 successor_proposal=_proposal("as-succ"),
-                ctx=_ctx("proposer", "acceptor"),
+                proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+                determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
                 expected_sequence=2,
                 rationale="refresh evidence",
             )
@@ -530,6 +688,10 @@ class TestSupersessionAtomics:
         assert accept_event.to_state == "Accepted"
         assert supersede_event.to_state == "Superseded"
         assert supersede_event.successor_assertion_id == "as-succ"
+        assert propose_event.actor_id == "successor-proposer"
+        assert accept_event.actor_id == "supersession-determiner"
+        assert supersede_event.actor_id == "supersession-determiner"
+        assert propose_event.recorded_at < accept_event.recorded_at
         assert repo.current_state("as-pred") == "Superseded"
         assert repo.current_state("as-succ") == "Accepted"
 
@@ -541,7 +703,8 @@ class TestSupersessionAtomics:
             SupersedeAtomicRequest(
                 predecessor_id="as-pred",
                 successor_proposal=_proposal("as-succ"),
-                ctx=_ctx("proposer", "acceptor"),
+                proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+                determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
                 expected_sequence=2,
                 rationale="refresh evidence",
             )
@@ -556,12 +719,57 @@ class TestSupersessionAtomics:
         request = SupersedeAtomicRequest(
             predecessor_id="as-pred",
             successor_proposal=_proposal("as-succ"),
-            ctx=_ctx("proposer", "acceptor"),
+            proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+            determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
             expected_sequence=1,
             rationale="stale supersede",
         )
         with pytest.raises(ConcurrencyConflict):
             repo.supersede_atomic(request)
+        assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
+        assert repo.current_state("as-pred") == "Accepted"
+        repo_session.rollback()
+
+    def test_supersede_atomic_rolls_back_after_late_authority_failure(self, repo, repo_session) -> None:
+        """A failed successor determination leaves no orphan and preserves outer work."""
+        _propose_accepted(repo, "as-pred")
+        repo_session.commit()
+        pending = _pending_evidence_row("ev-outer-supersede")
+        repo_session.add(pending)
+        request = SupersedeAtomicRequest(
+            predecessor_id="as-pred",
+            successor_proposal=_proposal("as-succ"),
+            proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+            determination_ctx=_ctx("disputer", actor_id="unauthorized-determiner"),
+            expected_sequence=2,
+            rationale="unauthorized supersede",
+        )
+
+        with pytest.raises(UnauthorizedTransition):
+            repo.supersede_atomic(request)
+
+        assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
+        assert repo.current_state("as-pred") == "Accepted"
+        assert repo_session.get(RelationshipEvidenceORM, pending.id) is not None
+        repo_session.commit()
+
+    @pytest.mark.parametrize("determination_actor", ["proposer-1", "successor-proposer"])
+    def test_supersede_atomic_requires_distinct_determiner(self, repo, repo_session, determination_actor: str) -> None:
+        """The determiner must differ from both predecessor and successor proposers."""
+        _propose_accepted(repo, "as-pred")
+        repo_session.commit()
+        request = SupersedeAtomicRequest(
+            predecessor_id="as-pred",
+            successor_proposal=_proposal("as-succ"),
+            proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+            determination_ctx=_ctx("acceptor", actor_id=determination_actor),
+            expected_sequence=2,
+            rationale="same-actor supersede",
+        )
+
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            repo.supersede_atomic(request)
+
         assert repo_session.get(RelationshipAssertionORM, "as-succ") is None
         assert repo.current_state("as-pred") == "Accepted"
         repo_session.rollback()
@@ -572,7 +780,8 @@ class TestSupersessionAtomics:
         request = SupersedeAtomicRequest(
             predecessor_id="as-1",
             successor_proposal=_proposal("as-1"),
-            ctx=_ctx("proposer", "acceptor"),
+            proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+            determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
             expected_sequence=2,
             rationale="self",
         )
@@ -586,7 +795,8 @@ class TestSupersessionAtomics:
             SupersedeAtomicRequest(
                 predecessor_id="as-a",
                 successor_proposal=_proposal("as-b"),
-                ctx=_ctx("proposer", "acceptor"),
+                proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+                determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
                 expected_sequence=2,
                 rationale="replace A with B",
             )
@@ -594,7 +804,8 @@ class TestSupersessionAtomics:
         cycle_request = SupersedeAtomicRequest(
             predecessor_id="as-b",
             successor_proposal=_proposal("as-a"),
-            ctx=_ctx("proposer", "acceptor"),
+            proposal_ctx=_ctx("proposer", actor_id="next-proposer"),
+            determination_ctx=_ctx("acceptor", actor_id="next-determiner"),
             expected_sequence=2,
             rationale="replace B with A",
         )
@@ -602,59 +813,276 @@ class TestSupersessionAtomics:
         with pytest.raises(SupersessionCycle):
             repo.supersede_atomic(cycle_request)
 
-    @pytest.mark.parametrize(
-        ("successor_id", "seed_proposed", "match"),
-        [
-            ("as-missing", False, "unknown successor"),
-            ("as-succ", True, "must be Accepted"),
-        ],
-        ids=["unknown_successor", "inactive_successor"],
-    )
-    def test_transition_supersede_requires_accepted_successor(
-        self,
-        repo,
-        successor_id: str,
-        seed_proposed: bool,
-        match: str,
-    ) -> None:
-        """Direct supersession requires an existing Accepted successor."""
+    def test_transition_rejects_direct_supersession(self, repo) -> None:
+        """Supersession is available only through the atomic repository path."""
         _propose_accepted(repo, "as-pred")
-        if seed_proposed:
-            repo.propose(_proposal(successor_id), _ctx("proposer"))
         request = _transition(
             {
                 "assertion_id": "as-pred",
                 "to_state": "Superseded",
-                "ctx": _ctx("acceptor"),
+                "ctx": _ctx("acceptor", actor_id="supersession-determiner"),
                 "expected_sequence": 2,
-                "rationale": "invalid successor",
-                "successor_assertion_id": successor_id,
-            }
-        )
-        with pytest.raises(ValidationError, match=match):
-            repo.transition(request)
-        assert repo.current_state("as-pred") == "Accepted"
-        if seed_proposed:
-            assert repo.current_state(successor_id) == "Proposed"
-
-    def test_transition_supersede_locks_graph_before_chain_validation(self, repo, monkeypatch) -> None:
-        """Direct supersession takes the graph lock before validating its chain."""
-        _propose_accepted(repo, "as-pred")
-        _propose_accepted(repo, "as-succ")
-        calls = _track_supersession_lock_order(repo, monkeypatch)
-        request = _transition(
-            {
-                "assertion_id": "as-pred",
-                "to_state": "Superseded",
-                "ctx": _ctx("acceptor"),
-                "expected_sequence": 2,
-                "rationale": "replace",
+                "rationale": "direct bypass",
                 "successor_assertion_id": "as-succ",
             }
         )
-        repo.transition(request)
 
-        assert calls[:2] == ["lock", "cycle"]
+        with pytest.raises(IllegalTransition, match="only through supersede_atomic"):
+            repo.transition(request)
+
+        assert repo.current_state("as-pred") == "Accepted"
+
+
+class TestPostgresSupersessionSerialization:
+    """Transaction-scoped serialization on two independent PostgreSQL sessions."""
+
+    def test_atomic_supersessions_share_advisory_transaction_lock(self, postgres_engine) -> None:
+        """A second atomic supersession waits until the first transaction releases its lock."""
+        factory = create_session_factory(postgres_engine)
+        token = uuid4().hex[:8]
+        predecessor_a = f"{token}-pred-a"
+        predecessor_b = f"{token}-pred-b"
+        successor_a = f"{token}-succ-a"
+        successor_b = f"{token}-succ-b"
+
+        setup_session = factory()
+        try:
+            setup_repo = RelationshipAssertionRepository(setup_session)
+            _propose_accepted(setup_repo, predecessor_a)
+            _propose_accepted(setup_repo, predecessor_b)
+            setup_session.commit()
+        finally:
+            setup_session.close()
+
+        second_pid_queue: Queue[int] = Queue(maxsize=1)
+        second_request = SupersedeAtomicRequest(
+            predecessor_id=predecessor_b,
+            successor_proposal=_proposal(successor_b),
+            proposal_ctx=_ctx("proposer", actor_id="successor-proposer-b"),
+            determination_ctx=_ctx("acceptor", actor_id="supersession-determiner-b"),
+            expected_sequence=2,
+            rationale="second serialized supersession",
+        )
+
+        def run_second() -> str:
+            second_session = factory()
+            try:
+                second_pid = int(second_session.execute(text("SELECT pg_backend_pid()")).scalar_one())
+                second_session.execute(text("SET LOCAL statement_timeout = '10s'"))
+                second_pid_queue.put(second_pid)
+                second_repo = RelationshipAssertionRepository(second_session)
+                successor, _propose, _accept, _supersede = second_repo.supersede_atomic(second_request)
+                second_session.commit()
+                return successor.assertion_id
+            finally:
+                second_session.rollback()
+                second_session.close()
+
+        first_session = factory()
+        try:
+            first_pid = int(first_session.execute(text("SELECT pg_backend_pid()")).scalar_one())
+            first_repo = RelationshipAssertionRepository(first_session)
+            first_repo.supersede_atomic(
+                SupersedeAtomicRequest(
+                    predecessor_id=predecessor_a,
+                    successor_proposal=_proposal(successor_a),
+                    proposal_ctx=_ctx("proposer", actor_id="successor-proposer-a"),
+                    determination_ctx=_ctx("acceptor", actor_id="supersession-determiner-a"),
+                    expected_sequence=2,
+                    rationale="first serialized supersession",
+                )
+            )
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(run_second)
+                try:
+                    second_pid = second_pid_queue.get(timeout=5)
+                    assert second_pid != first_pid
+                    observed = (False, False, False)
+                    deadline = monotonic() + 5
+                    with postgres_engine.connect() as monitor:
+                        while monotonic() < deadline:
+                            row = monitor.execute(
+                                text("""
+                                    SELECT
+                                      EXISTS (
+                                        SELECT 1 FROM pg_locks
+                                        WHERE pid = :first_pid
+                                          AND locktype = 'advisory'
+                                          AND granted
+                                          AND classid::bigint = :namespace
+                                          AND objid::bigint = :resource
+                                      ),
+                                      EXISTS (
+                                        SELECT 1 FROM pg_locks
+                                        WHERE pid = :second_pid
+                                          AND locktype = 'advisory'
+                                          AND NOT granted
+                                          AND classid::bigint = :namespace
+                                          AND objid::bigint = :resource
+                                      ),
+                                      :first_pid = ANY(pg_blocking_pids(:second_pid))
+                                    """),
+                                {
+                                    "first_pid": first_pid,
+                                    "second_pid": second_pid,
+                                    "namespace": SUPERSESSION_LOCK_NAMESPACE,
+                                    "resource": SUPERSESSION_LOCK_RESOURCE,
+                                },
+                            ).one()
+                            observed = (bool(row[0]), bool(row[1]), bool(row[2]))
+                            if all(observed) or future.done():
+                                break
+                            sleep(0.02)
+                    assert observed == (True, True, True)
+                    assert not future.done()
+                    first_session.commit()
+                    assert future.result(timeout=5) == successor_b
+                finally:
+                    if first_session.in_transaction():
+                        first_session.rollback()
+        finally:
+            first_session.rollback()
+            first_session.close()
+
+        verification_session = factory()
+        try:
+            verification_repo = RelationshipAssertionRepository(verification_session)
+            assert verification_repo.current_state(predecessor_a) == "Superseded"
+            assert verification_repo.current_state(predecessor_b) == "Superseded"
+            assert verification_repo.current_state(successor_a) == "Accepted"
+            assert verification_repo.current_state(successor_b) == "Accepted"
+        finally:
+            verification_session.close()
+
+    def test_atomic_supersession_rejects_concurrent_successor_proposal(self, postgres_engine) -> None:
+        """Atomic supersession never adopts a proposal committed by another transaction."""
+        factory = create_session_factory(postgres_engine)
+        token = uuid4().hex[:8]
+        predecessor_id = f"{token}-pred"
+        successor_id = f"{token}-succ"
+        proposal = _proposal(successor_id)
+        proposal_ctx = _ctx("proposer", actor_id="racing-proposer")
+        reached_strict_insert = Event()
+        release_strict_insert = Event()
+
+        setup_session = factory()
+        try:
+            _propose_accepted(RelationshipAssertionRepository(setup_session), predecessor_id)
+            setup_session.commit()
+        finally:
+            setup_session.close()
+
+        class _PausingRepository(RelationshipAssertionRepository):
+            def _propose_new(
+                self,
+                pending_proposal: AssertionProposal,
+                ctx: AuthorityContext,
+            ) -> tuple[Assertion, AssertionEvent]:
+                reached_strict_insert.set()
+                if not release_strict_insert.wait(timeout=5):
+                    raise AssertionError("timed out waiting for the concurrent proposal")
+                return super()._propose_new(pending_proposal, ctx)
+
+        atomic_request = SupersedeAtomicRequest(
+            predecessor_id=predecessor_id,
+            successor_proposal=proposal,
+            proposal_ctx=proposal_ctx,
+            determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
+            expected_sequence=2,
+            rationale="reject concurrent successor",
+        )
+
+        def run_atomic() -> None:
+            atomic_session = factory()
+            try:
+                atomic_session.execute(text("SET LOCAL statement_timeout = '10s'"))
+                atomic_repo = _PausingRepository(atomic_session)
+                with pytest.raises(ConcurrencyConflict, match="concurrent successor proposal"):
+                    atomic_repo.supersede_atomic(atomic_request)
+            finally:
+                atomic_session.rollback()
+                atomic_session.close()
+
+        ordinary_session = factory()
+        try:
+            with ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(run_atomic)
+                try:
+                    assert reached_strict_insert.wait(timeout=5)
+                    ordinary_repo = RelationshipAssertionRepository(ordinary_session)
+                    ordinary_repo.propose(proposal, proposal_ctx)
+                    ordinary_session.commit()
+                finally:
+                    release_strict_insert.set()
+                future.result(timeout=5)
+        finally:
+            ordinary_session.rollback()
+            ordinary_session.close()
+
+        verification_session = factory()
+        try:
+            verification_repo = RelationshipAssertionRepository(verification_session)
+            assert verification_repo.current_state(predecessor_id) == "Accepted"
+            assert verification_repo.current_state(successor_id) == "Proposed"
+        finally:
+            verification_session.close()
+
+
+class TestServerRecordedAt:
+    """Repository-owned timestamp assignment and stream monotonicity."""
+
+    def test_lifecycle_write_apis_expose_no_recorded_at(self) -> None:
+        """Callers have no timestamp injection point on lifecycle writes."""
+        assert "recorded_at" not in signature(RelationshipAssertionRepository.propose).parameters
+        assert "recorded_at" not in RepositoryTransitionRequest.__dataclass_fields__
+        assert "recorded_at" not in RegisterEvidenceRequest.__dataclass_fields__
+        assert "recorded_at" not in SupersedeAtomicRequest.__dataclass_fields__
+
+    @pytest.mark.parametrize(
+        "clock_values",
+        [
+            (NOW, NOW),
+            (NOW, NOW - timedelta(hours=1)),
+        ],
+        ids=["constant_clock", "backward_clock"],
+    )
+    def test_event_times_remain_strictly_monotonic(self, repo_session, clock_values) -> None:
+        """A constant or backward server clock cannot backdate a later event."""
+        values = iter(clock_values)
+
+        def clock() -> datetime:
+            return next(values, clock_values[-1])
+
+        repository = RelationshipAssertionRepository(repo_session, clock=clock)
+        assertion, proposed = repository.propose(
+            _proposal(),
+            _ctx("proposer", actor_id="owner"),
+        )
+        accepted = repository.transition(
+            _transition(
+                {
+                    "assertion_id": "as-1",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor", actor_id="reviewer"),
+                    "expected_sequence": 1,
+                    "rationale": "accept",
+                }
+            )
+        )
+
+        rows = (
+            repo_session.execute(
+                select(RelationshipAssertionEventORM)
+                .where(RelationshipAssertionEventORM.assertion_id == "as-1")
+                .order_by(RelationshipAssertionEventORM.sequence)
+            )
+            .scalars()
+            .all()
+        )
+        assert assertion.recorded_at == NOW
+        assert proposed.recorded_at == NOW
+        assert accepted.recorded_at > proposed.recorded_at
+        assert rows[1].recorded_at > rows[0].recorded_at
 
 
 class TestGetAsOf:
@@ -662,22 +1090,23 @@ class TestGetAsOf:
 
     def test_get_as_of_hides_future_events(self, repo) -> None:
         """Events recorded after known_at do not affect reconstructed state."""
-        t0 = NOW
-        repo.propose(_proposal(), _ctx("proposer"), recorded_at=t0)
-        repo.transition(
+        _assertion, proposed = repo.propose(
+            _proposal(),
+            _ctx("proposer", actor_id="owner"),
+        )
+        accepted = repo.transition(
             _transition(
                 {
                     "assertion_id": "as-1",
                     "to_state": "Accepted",
-                    "ctx": _ctx("acceptor"),
+                    "ctx": _ctx("acceptor", actor_id="reviewer"),
                     "expected_sequence": 1,
                     "rationale": "accept",
-                    "recorded_at": t0 + timedelta(hours=2),
                 }
             )
         )
-        early = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=1))
-        late = repo.get_as_of("as-1", known_at=t0 + timedelta(hours=3))
+        early = repo.get_as_of("as-1", known_at=proposed.recorded_at)
+        late = repo.get_as_of("as-1", known_at=accepted.recorded_at)
         assert early is not None and early.state == "Proposed"
         assert late is not None and late.state == "Accepted"
 

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -232,18 +232,22 @@ class TestProposeIdempotency:
     def test_propose_idempotent_reuse_revalidates_proposer_role(self, repo) -> None:
         """An idempotency hit does not bypass current proposer authority."""
         repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+        proposal = _proposal()
+        ctx = _ctx("acceptor", actor_id="owner")
 
         with pytest.raises(UnauthorizedTransition):
-            repo.propose(_proposal(), _ctx("acceptor", actor_id="owner"))
+            repo.propose(proposal, ctx)
 
         assert repo.max_sequence("as-1") == 1
 
     def test_propose_idempotent_reuse_requires_proposer_of_record(self, repo) -> None:
         """A foreign proposer cannot reuse another actor's assertion id."""
         repo.propose(_proposal(), _ctx("proposer", actor_id="owner"))
+        proposal = _proposal()
+        ctx = _ctx("proposer", actor_id="foreign-proposer")
 
         with pytest.raises(UnauthorizedTransition, match="proposer of record"):
-            repo.propose(_proposal(), _ctx("proposer", actor_id="foreign-proposer"))
+            repo.propose(proposal, ctx)
 
         assert repo.max_sequence("as-1") == 1
 
@@ -397,18 +401,17 @@ class TestTransitionsAndIllegal:
             )
         )
 
+        request = _transition(
+            {
+                "assertion_id": "as-1",
+                "to_state": "Accepted",
+                "ctx": _ctx("acceptor", actor_id="owner"),
+                "expected_sequence": 3,
+                "rationale": "self reaffirm",
+            }
+        )
         with pytest.raises(UnauthorizedTransition, match="must differ"):
-            repo.transition(
-                _transition(
-                    {
-                        "assertion_id": "as-1",
-                        "to_state": "Accepted",
-                        "ctx": _ctx("acceptor", actor_id="owner"),
-                        "expected_sequence": 3,
-                        "rationale": "self reaffirm",
-                    }
-                )
-            )
+            repo.transition(request)
 
         assert repo.current_state("as-1") == "Disputed"
 
@@ -697,13 +700,13 @@ class TestSupersessionAtomics:
         assert repo.current_state("as-succ") == "Accepted"
 
     def test_supersede_atomic_preserves_cross_stream_temporal_order(self, repo_session) -> None:
-        """A backward clock cannot supersede a predecessor before accepting its successor."""
+        """A backward clock cannot backdate any successor or supersession event."""
         clock_values = iter(
             (
-                NOW,
-                NOW + timedelta(milliseconds=1),
                 NOW + timedelta(hours=1),
                 NOW + timedelta(hours=1, milliseconds=1),
+                NOW,
+                NOW,
                 NOW,
             )
         )
@@ -712,8 +715,22 @@ class TestSupersessionAtomics:
             return next(clock_values, NOW)
 
         repository = RelationshipAssertionRepository(repo_session, clock=clock)
-        _propose_accepted(repository, "as-pred")
-        _successor, _proposed, accepted, superseded = repository.supersede_atomic(
+        repository.propose(
+            _proposal("as-pred"),
+            _ctx("proposer", actor_id="proposer-1"),
+        )
+        predecessor_accepted = repository.transition(
+            _transition(
+                {
+                    "assertion_id": "as-pred",
+                    "to_state": "Accepted",
+                    "ctx": _ctx("acceptor", actor_id="reviewer-1"),
+                    "expected_sequence": 1,
+                    "rationale": "accept",
+                }
+            )
+        )
+        _successor, proposed, accepted, superseded = repository.supersede_atomic(
             SupersedeAtomicRequest(
                 predecessor_id="as-pred",
                 successor_proposal=_proposal("as-succ"),
@@ -724,9 +741,18 @@ class TestSupersessionAtomics:
             )
         )
 
+        successor_at_predecessor_acceptance = repository.get_as_of(
+            "as-succ",
+            known_at=predecessor_accepted.recorded_at,
+        )
+        predecessor_as_of_proposal = repository.get_as_of("as-pred", known_at=proposed.recorded_at)
+        successor_as_of_proposal = repository.get_as_of("as-succ", known_at=proposed.recorded_at)
         predecessor_as_of_acceptance = repository.get_as_of("as-pred", known_at=accepted.recorded_at)
         successor_as_of_acceptance = repository.get_as_of("as-succ", known_at=accepted.recorded_at)
-        assert accepted.recorded_at < superseded.recorded_at
+        assert predecessor_accepted.recorded_at < proposed.recorded_at < accepted.recorded_at < superseded.recorded_at
+        assert successor_at_predecessor_acceptance is None
+        assert predecessor_as_of_proposal is not None and predecessor_as_of_proposal.state == "Accepted"
+        assert successor_as_of_proposal is not None and successor_as_of_proposal.state == "Proposed"
         assert predecessor_as_of_acceptance is not None and predecessor_as_of_acceptance.state == "Accepted"
         assert successor_as_of_acceptance is not None and successor_as_of_acceptance.state == "Accepted"
 
@@ -1012,11 +1038,13 @@ class TestPostgresSupersessionSerialization:
                 self,
                 pending_proposal: AssertionProposal,
                 ctx: AuthorityContext,
+                *,
+                after: datetime,
             ) -> tuple[Assertion, AssertionEvent]:
                 reached_strict_insert.set()
                 if not release_strict_insert.wait(timeout=5):
                     raise AssertionError("timed out waiting for the concurrent proposal")
-                return super()._propose_new(pending_proposal, ctx)
+                return super()._propose_new(pending_proposal, ctx, after=after)
 
         atomic_request = SupersedeAtomicRequest(
             predecessor_id=predecessor_id,

--- a/tests/integration/test_relationship_assertion_repository.py
+++ b/tests/integration/test_relationship_assertion_repository.py
@@ -692,8 +692,43 @@ class TestSupersessionAtomics:
         assert accept_event.actor_id == "supersession-determiner"
         assert supersede_event.actor_id == "supersession-determiner"
         assert propose_event.recorded_at < accept_event.recorded_at
+        assert accept_event.recorded_at < supersede_event.recorded_at
         assert repo.current_state("as-pred") == "Superseded"
         assert repo.current_state("as-succ") == "Accepted"
+
+    def test_supersede_atomic_preserves_cross_stream_temporal_order(self, repo_session) -> None:
+        """A backward clock cannot supersede a predecessor before accepting its successor."""
+        clock_values = iter(
+            (
+                NOW,
+                NOW + timedelta(milliseconds=1),
+                NOW + timedelta(hours=1),
+                NOW + timedelta(hours=1, milliseconds=1),
+                NOW,
+            )
+        )
+
+        def clock() -> datetime:
+            return next(clock_values, NOW)
+
+        repository = RelationshipAssertionRepository(repo_session, clock=clock)
+        _propose_accepted(repository, "as-pred")
+        _successor, _proposed, accepted, superseded = repository.supersede_atomic(
+            SupersedeAtomicRequest(
+                predecessor_id="as-pred",
+                successor_proposal=_proposal("as-succ"),
+                proposal_ctx=_ctx("proposer", actor_id="successor-proposer"),
+                determination_ctx=_ctx("acceptor", actor_id="supersession-determiner"),
+                expected_sequence=2,
+                rationale="refresh evidence",
+            )
+        )
+
+        predecessor_as_of_acceptance = repository.get_as_of("as-pred", known_at=accepted.recorded_at)
+        successor_as_of_acceptance = repository.get_as_of("as-succ", known_at=accepted.recorded_at)
+        assert accepted.recorded_at < superseded.recorded_at
+        assert predecessor_as_of_acceptance is not None and predecessor_as_of_acceptance.state == "Accepted"
+        assert successor_as_of_acceptance is not None and successor_as_of_acceptance.state == "Accepted"
 
     def test_supersede_atomic_locks_graph_before_chain_validation(self, repo, monkeypatch) -> None:
         """Atomic supersession takes the graph lock before validating its chain."""
@@ -904,23 +939,23 @@ class TestPostgresSupersessionSerialization:
                             row = monitor.execute(
                                 text("""
                                     SELECT
-                                      EXISTS (
-                                        SELECT 1 FROM pg_locks
-                                        WHERE pid = :first_pid
-                                          AND locktype = 'advisory'
-                                          AND granted
-                                          AND classid::bigint = :namespace
-                                          AND objid::bigint = :resource
-                                      ),
-                                      EXISTS (
-                                        SELECT 1 FROM pg_locks
-                                        WHERE pid = :second_pid
-                                          AND locktype = 'advisory'
-                                          AND NOT granted
-                                          AND classid::bigint = :namespace
-                                          AND objid::bigint = :resource
-                                      ),
-                                      :first_pid = ANY(pg_blocking_pids(:second_pid))
+                                        EXISTS (
+                                            SELECT 1 FROM pg_locks
+                                            WHERE pid = :first_pid
+                                                AND locktype = 'advisory'
+                                                AND granted
+                                                AND classid::bigint = :namespace
+                                                AND objid::bigint = :resource
+                                        ),
+                                        EXISTS (
+                                            SELECT 1 FROM pg_locks
+                                            WHERE pid = :second_pid
+                                                AND locktype = 'advisory'
+                                                AND NOT granted
+                                                AND classid::bigint = :namespace
+                                                AND objid::bigint = :resource
+                                        ),
+                                        :first_pid = ANY(pg_blocking_pids(:second_pid))
                                     """),
                                 {
                                     "first_pid": first_pid,

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -35,7 +35,6 @@ from tests.conftest import enable_sqlite_foreign_keys
 
 UTC = timezone.utc
 NOW = datetime(2026, 7, 25, 15, 0, 0, tzinfo=UTC)
-ACCEPTED_AT = NOW + timedelta(minutes=1)
 KNOWN_AT = NOW + timedelta(days=1)
 PURPOSE = "financial_graph_current_view"
 PREDICATE_ID = "financial.bond.issuer_reference@1"
@@ -121,9 +120,9 @@ def repo(projection_engine) -> Iterator[RelationshipAssertionRepository]:
     session.close()
 
 
-def _ctx(*roles: str) -> AuthorityContext:
+def _ctx(actor_id: str, *roles: str) -> AuthorityContext:
     return AuthorityContext(
-        actor_id="actor-1",
+        actor_id=actor_id,
         roles=frozenset(roles),  # type: ignore[arg-type]
         policy_version="grac.v1-policy",
         correlation_id="corr-projection",
@@ -150,16 +149,19 @@ def _transition(fields: dict[str, object]) -> RepositoryTransitionRequest:
 
 def _propose_accepted(repo: RelationshipAssertionRepository, assertion_id: str = "as-1") -> None:
     """Propose and accept with fixed timestamps so hashes are dialect-stable."""
-    repo.propose(_proposal(assertion_id), _ctx("proposer"), recorded_at=NOW, event_id=f"ev-{assertion_id}-1")
+    repo.propose(
+        _proposal(assertion_id),
+        _ctx(f"proposer-{assertion_id}", "proposer"),
+        event_id=f"ev-{assertion_id}-1",
+    )
     repo.transition(
         _transition(
             {
                 "assertion_id": assertion_id,
                 "to_state": "Accepted",
-                "ctx": _ctx("acceptor"),
+                "ctx": _ctx(f"determiner-{assertion_id}", "acceptor"),
                 "expected_sequence": 1,
                 "rationale": "accept",
-                "recorded_at": ACCEPTED_AT,
                 "event_id": f"ev-{assertion_id}-2",
             }
         )
@@ -214,8 +216,7 @@ def test_persist_and_reload_projection_revision(repo: RelationshipAssertionRepos
                 recorded_at=NOW,
             ),
             polarity="supporting",
-            ctx=_ctx("proposer"),
-            recorded_at=ACCEPTED_AT + timedelta(minutes=1),
+            ctx=_ctx("proposer-as-1", "proposer"),
             link_id="link-1",
         )
     )
@@ -286,10 +287,10 @@ def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionReposi
         SupersedeAtomicRequest(
             predecessor_id="as-1",
             successor_proposal=_proposal("as-2", object_id="AAPL_NEW"),
-            ctx=_ctx("acceptor", "proposer"),
+            proposal_ctx=_ctx("proposer-as-2", "proposer"),
+            determination_ctx=_ctx("supersession-determiner", "acceptor"),
             expected_sequence=2,
             rationale="refresh issuer",
-            recorded_at=supersede_at,
         )
     )
     after = _project_from_repo(repo, ["as-1", "as-2"])

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -574,6 +574,22 @@ class TestSupersessionCycles:
         with pytest.raises(SupersessionCycle):
             plan_supersede(plan)
 
+    def test_dedicated_supersession_rejects_other_target_state(self) -> None:
+        """The dedicated planner cannot be reused for an ordinary matrix edge."""
+        plan = SupersedePlan(
+            transition=TransitionPlan(
+                assertion_id="as-1",
+                current="Proposed",
+                to_state="Accepted",
+                ctx=_ctx("acceptor"),
+                timing=_timing(rationale="accept"),
+                successor_assertion_id="as-2",
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
+        )
+        with pytest.raises(IllegalTransition, match="requires a Superseded transition"):
+            plan_supersede(plan)
+
     def test_cycle_via_lookup_forbidden(self) -> None:
         """Successor chains that reach the predecessor are rejected."""
         chain = {"as-2": ("as-3",), "as-3": ("as-1",)}

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -44,11 +45,13 @@ from src.governance.relationship_assertion_lifecycle import (
 UTC = timezone.utc
 NOW = datetime(2026, 7, 25, 12, 0, 0, tzinfo=UTC)
 DIGEST = "a" * 64
+DEFAULT_ACTOR_ID = "actor-1"
+PROPOSER_ACTOR_ID = "proposer-1"
 
 
-def _ctx(*roles: str) -> AuthorityContext:
+def _ctx(*roles: str, actor_id: str = DEFAULT_ACTOR_ID) -> AuthorityContext:
     return AuthorityContext(
-        actor_id="actor-1",
+        actor_id=actor_id,
         roles=frozenset(roles),  # type: ignore[arg-type]
         policy_version="grac.v1-policy",
         correlation_id="corr-1",
@@ -94,6 +97,7 @@ class TestAuthorityAndBounds:
             to_state="Accepted",
             ctx=_ctx("acceptor"),
             timing=_timing(rationale="x" * (MAX_RATIONALE_LEN + 1)),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
         )
         with pytest.raises(ValidationError, match="rationale"):
             plan_transition(plan)
@@ -207,7 +211,11 @@ class TestProposeAndResolve:
 
     def test_resolve_state_folds_sequence(self) -> None:
         """State resolution follows the highest sequence event."""
-        _, e1 = plan_propose(_proposal(), _ctx("proposer"), recorded_at=NOW)
+        _, e1 = plan_propose(
+            _proposal(),
+            _ctx("proposer", actor_id=PROPOSER_ACTOR_ID),
+            recorded_at=NOW,
+        )
         e2 = plan_accept(
             "as-1",
             "Proposed",
@@ -216,8 +224,68 @@ class TestProposeAndResolve:
                 rationale="ok",
                 recorded_at=NOW + timedelta(seconds=1),
             ),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
         )
         assert resolve_state([e1, e2]) == "Accepted"
+
+    @pytest.mark.parametrize(
+        "recorded_at",
+        [NOW, NOW - timedelta(microseconds=1)],
+        ids=["equal", "backdated"],
+    )
+    def test_resolve_state_rejects_non_monotonic_recorded_at(self, recorded_at: datetime) -> None:
+        """Replay rejects equal or backdated event timestamps."""
+        _, e1 = plan_propose(
+            _proposal(),
+            _ctx("proposer", actor_id=PROPOSER_ACTOR_ID),
+            recorded_at=NOW,
+        )
+        e2 = plan_accept(
+            "as-1",
+            "Proposed",
+            _ctx("acceptor"),
+            timing=_timing(rationale="accept", recorded_at=recorded_at),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
+        )
+
+        with pytest.raises(ValidationError, match="strictly increasing"):
+            resolve_state([e1, e2])
+
+    def test_resolve_state_rejects_wrong_event_authority(self) -> None:
+        """Replay verifies persisted event authority against the matrix."""
+        _, e1 = plan_propose(
+            _proposal(),
+            _ctx("proposer", actor_id=PROPOSER_ACTOR_ID),
+            recorded_at=NOW,
+        )
+        e2 = plan_accept(
+            "as-1",
+            "Proposed",
+            _ctx("acceptor"),
+            timing=_timing(recorded_at=NOW + timedelta(seconds=1)),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
+        )
+
+        with pytest.raises(ValidationError, match="event authority"):
+            resolve_state([e1, replace(e2, authority="proposer")])
+
+    def test_resolve_state_rejects_same_actor_determination(self) -> None:
+        """Replay preserves proposer and determiner separation."""
+        _, e1 = plan_propose(
+            _proposal(),
+            _ctx("proposer", actor_id=PROPOSER_ACTOR_ID),
+            recorded_at=NOW,
+        )
+        e2 = plan_accept(
+            "as-1",
+            "Proposed",
+            _ctx("acceptor"),
+            timing=_timing(recorded_at=NOW + timedelta(seconds=1)),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
+        )
+
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            resolve_state([e1, replace(e2, actor_id=PROPOSER_ACTOR_ID)])
 
     def test_resolve_state_rejects_invalid_initial_event(self) -> None:
         """Persisted streams must begin with a proper propose event."""
@@ -267,23 +335,27 @@ class TestTransitionMatrix:
         assert len(transitions.transitions) >= 9
 
     @pytest.mark.parametrize(
-        ("from_state", "to_state", "role"),
+        ("from_state", "to_state", "role", "proposer_actor_id"),
         [
-            ("Proposed", "Accepted", "acceptor"),
-            ("Proposed", "Rejected", "acceptor"),
-            ("Proposed", "Withdrawn", "proposer"),
-            ("Accepted", "Disputed", "disputer"),
-            ("Accepted", "Retracted", "retractor"),
-            ("Accepted", "Superseded", "acceptor"),
-            ("Disputed", "Accepted", "acceptor"),
-            ("Disputed", "Retracted", "retractor"),
-            ("Disputed", "Superseded", "acceptor"),
+            ("Proposed", "Accepted", "acceptor", PROPOSER_ACTOR_ID),
+            ("Proposed", "Rejected", "acceptor", PROPOSER_ACTOR_ID),
+            ("Proposed", "Withdrawn", "proposer", DEFAULT_ACTOR_ID),
+            ("Accepted", "Disputed", "disputer", None),
+            ("Accepted", "Retracted", "retractor", None),
+            ("Disputed", "Accepted", "acceptor", PROPOSER_ACTOR_ID),
+            ("Disputed", "Retracted", "retractor", None),
         ],
     )
-    def test_allowed_matrix_edges(self, from_state, to_state, role, transitions) -> None:
-        """Every registry edge plans successfully with the required authority."""
+    def test_allowed_non_supersession_edges(
+        self,
+        from_state,
+        to_state,
+        role,
+        proposer_actor_id,
+        transitions,
+    ) -> None:
+        """Every non-supersession registry edge plans with its required authority."""
         timing = _timing(transitions=transitions)
-        successor_assertion_id = "as-successor" if to_state == "Superseded" else None
         event = plan_transition(
             TransitionPlan(
                 assertion_id="as-1",
@@ -291,12 +363,28 @@ class TestTransitionMatrix:
                 to_state=to_state,
                 ctx=_ctx(role),
                 timing=timing,
-                successor_assertion_id=successor_assertion_id,
+                proposer_actor_id=proposer_actor_id,
             )
         )
         assert event.to_state == to_state
         assert event.authority == role
         assert event.sequence == 2
+
+    @pytest.mark.parametrize("current", ["Accepted", "Disputed"])
+    def test_generic_supersession_rejected(self, current, transitions) -> None:
+        """Supersession is unavailable through the generic planner."""
+        plan = TransitionPlan(
+            assertion_id="as-1",
+            current=current,
+            to_state="Superseded",
+            ctx=_ctx("acceptor"),
+            timing=_timing(rationale="replace", transitions=transitions),
+            successor_assertion_id="as-2",
+            proposer_actor_id=PROPOSER_ACTOR_ID,
+        )
+
+        with pytest.raises(IllegalTransition, match="only through plan_supersede"):
+            plan_transition(plan)
 
     @pytest.mark.parametrize(
         ("from_state", "to_state"),
@@ -327,49 +415,83 @@ class TestTransitionMatrix:
         ctx = _ctx("proposer")
         timing = _timing(rationale="nope", transitions=transitions)
         with pytest.raises(UnauthorizedTransition):
-            plan_accept("as-1", "Proposed", ctx, timing=timing)
+            plan_accept(
+                "as-1",
+                "Proposed",
+                ctx,
+                timing=timing,
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
 
-    @pytest.mark.parametrize(
-        ("plan", "exc_type", "match"),
-        [
-            (
-                TransitionPlan(
-                    assertion_id="as-1",
-                    current="Accepted",
-                    to_state="Superseded",
-                    ctx=_ctx("acceptor"),
-                    timing=_timing(rationale="missing successor"),
-                ),
-                ValidationError,
-                "successor_assertion_id",
-            ),
-            (
-                TransitionPlan(
-                    assertion_id="as-1",
-                    current="Proposed",
-                    to_state="Accepted",
-                    ctx=_ctx("acceptor"),
-                    timing=_timing(rationale="bad successor"),
-                    successor_assertion_id="as-2",
-                ),
-                IllegalTransition,
-                "must not set successor",
-            ),
-        ],
-        ids=["supersession_requires_successor", "non_supersession_forbids_successor"],
-    )
-    def test_successor_pointer_rules(self, transitions, plan, exc_type, match) -> None:
-        """Successor pointer is required only on supersession edges."""
+    def test_supersession_requires_successor(self, transitions) -> None:
+        """The dedicated supersession planner requires a successor pointer."""
         plan = TransitionPlan(
-            assertion_id=plan.assertion_id,
-            current=plan.current,
-            to_state=plan.to_state,
-            ctx=plan.ctx,
-            timing=_timing(rationale=plan.timing.rationale, transitions=transitions),
-            successor_assertion_id=plan.successor_assertion_id,
+            assertion_id="as-1",
+            current="Accepted",
+            to_state="Superseded",
+            ctx=_ctx("acceptor"),
+            timing=_timing(rationale="missing successor", transitions=transitions),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
         )
-        with pytest.raises(exc_type, match=match):
+        with pytest.raises(ValidationError, match="successor"):
+            plan_supersede(SupersedePlan(transition=plan))
+
+    def test_non_supersession_forbids_successor(self, transitions) -> None:
+        """A non-supersession transition cannot carry a successor pointer."""
+        plan = TransitionPlan(
+            assertion_id="as-1",
+            current="Proposed",
+            to_state="Accepted",
+            ctx=_ctx("acceptor"),
+            timing=_timing(rationale="bad successor", transitions=transitions),
+            successor_assertion_id="as-2",
+            proposer_actor_id=PROPOSER_ACTOR_ID,
+        )
+        with pytest.raises(IllegalTransition, match="must not set successor"):
             plan_transition(plan)
+
+
+class TestActorOwnership:
+    """Actor ownership and proposer/determiner separation."""
+
+    def test_accept_rejects_proposer_as_determiner(self) -> None:
+        """An assertion proposer cannot accept the same assertion."""
+        ctx = _ctx("acceptor", actor_id=PROPOSER_ACTOR_ID)
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            plan_accept(
+                "as-1",
+                "Proposed",
+                ctx,
+                timing=_timing(rationale="self-accept"),
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
+
+    def test_supersede_rejects_predecessor_proposer_as_determiner(self) -> None:
+        """A predecessor proposer cannot determine its supersession."""
+        plan = SupersedePlan(
+            transition=TransitionPlan(
+                assertion_id="as-1",
+                current="Accepted",
+                to_state="Superseded",
+                ctx=_ctx("acceptor", actor_id=PROPOSER_ACTOR_ID),
+                timing=_timing(rationale="self-supersede"),
+                successor_assertion_id="as-2",
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
+        )
+        with pytest.raises(UnauthorizedTransition, match="must differ"):
+            plan_supersede(plan)
+
+    def test_withdraw_rejects_foreign_proposer(self) -> None:
+        """A proposer role does not confer ownership of another proposal."""
+        with pytest.raises(UnauthorizedTransition, match="must match"):
+            plan_withdraw(
+                "as-1",
+                "Proposed",
+                _ctx("proposer"),
+                timing=_timing(rationale="foreign withdrawal"),
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
 
 
 class TestConcurrencyGuard:
@@ -380,14 +502,26 @@ class TestConcurrencyGuard:
         ctx = _ctx("acceptor")
         timing = _timing(expected_sequence=0, rationale="bad")
         with pytest.raises(ConcurrencyConflict):
-            plan_accept("as-1", "Proposed", ctx, timing=timing)
+            plan_accept(
+                "as-1",
+                "Proposed",
+                ctx,
+                timing=timing,
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
 
     def test_expected_sequence_rejects_bool(self) -> None:
         """expected_sequence must be an integer sequence, not bool."""
         ctx = _ctx("acceptor")
         timing = _timing(expected_sequence=True, rationale="bad")  # type: ignore[arg-type]
         with pytest.raises(ValidationError, match="expected_sequence"):
-            plan_accept("as-1", "Proposed", ctx, timing=timing)
+            plan_accept(
+                "as-1",
+                "Proposed",
+                ctx,
+                timing=timing,
+                proposer_actor_id=PROPOSER_ACTOR_ID,
+            )
 
     def test_next_sequence_is_expected_plus_one(self) -> None:
         """Planned event sequence is always expected_sequence + 1."""
@@ -396,12 +530,33 @@ class TestConcurrencyGuard:
             "Proposed",
             _ctx("acceptor"),
             timing=_timing(expected_sequence=3, rationale="reject"),
+            proposer_actor_id=PROPOSER_ACTOR_ID,
         )
         assert event.sequence == 4
 
 
 class TestSupersessionCycles:
     """Cycle and self-supersession prevention."""
+
+    @pytest.mark.parametrize("current", ["Accepted", "Disputed"])
+    def test_dedicated_supersession_allowed(self, current) -> None:
+        """The dedicated planner handles both valid supersession source states."""
+        event = plan_supersede(
+            SupersedePlan(
+                transition=TransitionPlan(
+                    assertion_id="as-1",
+                    current=current,
+                    to_state="Superseded",
+                    ctx=_ctx("acceptor"),
+                    timing=_timing(rationale="replace"),
+                    successor_assertion_id="as-2",
+                    proposer_actor_id=PROPOSER_ACTOR_ID,
+                )
+            )
+        )
+
+        assert event.to_state == "Superseded"
+        assert event.successor_assertion_id == "as-2"
 
     def test_self_supersession_forbidden(self) -> None:
         """An assertion cannot supersede itself."""
@@ -413,6 +568,7 @@ class TestSupersessionCycles:
                 ctx=_ctx("acceptor"),
                 timing=_timing(rationale="self"),
                 successor_assertion_id="as-1",
+                proposer_actor_id=PROPOSER_ACTOR_ID,
             )
         )
         with pytest.raises(SupersessionCycle):
@@ -500,6 +656,7 @@ class TestNamedPlanners:
             "Proposed",
             _ctx("proposer"),
             timing=_timing(rationale="withdraw"),
+            proposer_actor_id=DEFAULT_ACTOR_ID,
         )
         disputed = plan_dispute(
             "as-1",

--- a/tests/unit/test_relationship_assertion_lifecycle.py
+++ b/tests/unit/test_relationship_assertion_lifecycle.py
@@ -265,9 +265,10 @@ class TestProposeAndResolve:
             timing=_timing(recorded_at=NOW + timedelta(seconds=1)),
             proposer_actor_id=PROPOSER_ACTOR_ID,
         )
+        invalid_authority = replace(e2, authority="proposer")
 
         with pytest.raises(ValidationError, match="event authority"):
-            resolve_state([e1, replace(e2, authority="proposer")])
+            resolve_state([e1, invalid_authority])
 
     def test_resolve_state_rejects_same_actor_determination(self) -> None:
         """Replay preserves proposer and determiner separation."""
@@ -283,9 +284,10 @@ class TestProposeAndResolve:
             timing=_timing(recorded_at=NOW + timedelta(seconds=1)),
             proposer_actor_id=PROPOSER_ACTOR_ID,
         )
+        self_determined = replace(e2, actor_id=PROPOSER_ACTOR_ID)
 
         with pytest.raises(UnauthorizedTransition, match="must differ"):
-            resolve_state([e1, replace(e2, actor_id=PROPOSER_ACTOR_ID)])
+            resolve_state([e1, self_determined])
 
     def test_resolve_state_rejects_invalid_initial_event(self) -> None:
         """Persisted streams must begin with a proper propose event."""
@@ -433,8 +435,9 @@ class TestTransitionMatrix:
             timing=_timing(rationale="missing successor", transitions=transitions),
             proposer_actor_id=PROPOSER_ACTOR_ID,
         )
+        supersede_plan = SupersedePlan(transition=plan)
         with pytest.raises(ValidationError, match="successor"):
-            plan_supersede(SupersedePlan(transition=plan))
+            plan_supersede(supersede_plan)
 
     def test_non_supersession_forbids_successor(self, transitions) -> None:
         """A non-supersession transition cannot carry a successor pointer."""
@@ -457,12 +460,13 @@ class TestActorOwnership:
     def test_accept_rejects_proposer_as_determiner(self) -> None:
         """An assertion proposer cannot accept the same assertion."""
         ctx = _ctx("acceptor", actor_id=PROPOSER_ACTOR_ID)
+        timing = _timing(rationale="self-accept")
         with pytest.raises(UnauthorizedTransition, match="must differ"):
             plan_accept(
                 "as-1",
                 "Proposed",
                 ctx,
-                timing=_timing(rationale="self-accept"),
+                timing=timing,
                 proposer_actor_id=PROPOSER_ACTOR_ID,
             )
 
@@ -484,12 +488,14 @@ class TestActorOwnership:
 
     def test_withdraw_rejects_foreign_proposer(self) -> None:
         """A proposer role does not confer ownership of another proposal."""
+        ctx = _ctx("proposer")
+        timing = _timing(rationale="foreign withdrawal")
         with pytest.raises(UnauthorizedTransition, match="must match"):
             plan_withdraw(
                 "as-1",
                 "Proposed",
-                _ctx("proposer"),
-                timing=_timing(rationale="foreign withdrawal"),
+                ctx,
+                timing=timing,
                 proposer_actor_id=PROPOSER_ACTOR_ID,
             )
 

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -89,6 +89,7 @@ class _EventSpec:
     recorded_at: datetime
     event_id: str | None = None
     authority: str = "acceptor"
+    actor_id: str = "determiner-1"
     successor_assertion_id: str | None = None
 
 
@@ -132,7 +133,7 @@ def _event(spec: _EventSpec) -> AssertionEvent:
         from_state=spec.from_state,  # type: ignore[arg-type]
         to_state=spec.to_state,  # type: ignore[arg-type]
         authority=spec.authority,  # type: ignore[arg-type]
-        actor_id="actor-1",
+        actor_id=spec.actor_id,
         rationale="test",
         policy_version="grac.v1-policy",
         recorded_at=spec.recorded_at,
@@ -155,6 +156,7 @@ def _propose_accept_events(
                 from_state=None,
                 recorded_at=proposed_at,
                 authority="proposer",
+                actor_id="proposer-1",
             )
         ),
         _event(
@@ -462,7 +464,8 @@ def _terminal_state_events(to_state: str) -> list[AssertionEvent]:
                 )
             )
         ]
-    authority = "proposer"
+    authority = "acceptor" if to_state == "Rejected" else "proposer"
+    actor_id = "determiner-1" if to_state == "Rejected" else "proposer-1"
     return [
         _event(
             _EventSpec(
@@ -471,7 +474,8 @@ def _terminal_state_events(to_state: str) -> list[AssertionEvent]:
                 "Proposed",
                 from_state=None,
                 recorded_at=NOW,
-                authority=authority,
+                authority="proposer",
+                actor_id="proposer-1",
             )
         ),
         _event(
@@ -482,6 +486,7 @@ def _terminal_state_events(to_state: str) -> list[AssertionEvent]:
                 from_state="Proposed",
                 recorded_at=NOW + timedelta(minutes=1),
                 authority=authority,
+                actor_id=actor_id,
             )
         ),
     ]


### PR DESCRIPTION
Closes #1555

Parent programme: #1530. Downstream corrective issue #1556 and publication issue #1536 remain blocked until this PR merges and their later gates pass.

## Primary Objective

Enforce the amended GRAC v1 lifecycle, actor, temporal, atomicity, and PostgreSQL supersession invariants before any publication or command API work begins.

## Architectural Alignment

Assertions remain immutable truth and graph edges remain projections. This change preserves append-only history, the existing repository boundary, SQLite compatibility, and the rule that supersession is a single atomic successor-creation path. It does not publish projections or change the database schema.

## Root Cause

The foundation implementation left several contract gaps: generic supersession remained reachable; one authority context represented both proposal and determination; proposer role was not bound to the actor of record; idempotent reuse skipped actor validation; callers could inject lifecycle `recorded_at`; replay accepted non-monotonic event time; and existing-row locks did not prove transaction-wide PostgreSQL supersession serialization. Adversarial review found further gaps: atomic supersession could adopt a concurrently inserted successor; independently allocated stream timestamps could violate cross-stream causal order; failed nested supersessions could retain transaction-scoped locks; and evidence links were timestamped outside the assertion event clock floor, allowing an Accepted historical snapshot to omit evidence known before acceptance.

## Fixed Decisions

- Generic lifecycle and repository transition entry points reject `Superseded`; only the dedicated atomic path can create that edge.
- Atomic supersession takes separate proposal and determination contexts; the determiner must differ from both successor and predecessor proposers of record.
- Withdrawal is restricted to the proposer of record.
- Idempotent proposal reuse revalidates proposer authority and actor identity, including insert-race recovery.
- Atomic successor creation uses a strict-new insert path; a concurrent ordinary proposal produces `ConcurrencyConflict` and is never adopted.
- Repository lifecycle timestamps are server-owned, timezone-aware UTC values with no public caller injection point.
- Events and evidence links share one strictly monotonic per-assertion timestamp floor. Evidence registration locks the assertion row before allocating its timestamp, matching lifecycle transition serialization.
- Atomic history is causally ordered as predecessor tail < successor proposal < successor acceptance < predecessor supersession.
- Replay rejects equal/backdated timestamps and invalid persisted authority/actor relationships.
- PostgreSQL supersession acquires its transaction-scoped advisory lock and deterministic row locks inside the atomic savepoint: successful operations retain serialization through the outer transaction, while failed operations release both lock classes without discarding unrelated outer work. SQLite intentionally makes no equivalent row-lock claim.
- Transition and supersession planning derive current state and proposer identity from one validated event-stream fold.

## In Scope

- Lifecycle planner/replay enforcement.
- Repository identity, timestamp, evidence-link ordering, atomic insertion, savepoint, and PostgreSQL serialization behavior.
- Focused lifecycle/repository tests and two explicitly recorded fixture-only compatibility updates.

## Out of Scope

- Schema definitions, migrations, RLS, triggers, indexes, or hosted-provider changes.
- Projection implementation, hashing, governed-scope persistence, publication, rebuild wiring, APIs, frontend, workflows, dependencies, scanners, or capability promotion.
- Performance/module-splitting refactors and any work from #1556 or #1536.

## Files Expected to Change

Original #1555 allowlist:

- `src/governance/relationship_assertion_lifecycle.py`
- `src/data/relationship_assertion_repository.py`
- `tests/unit/test_relationship_assertion_lifecycle.py`
- `tests/integration/test_relationship_assertion_repository.py`

Fixture-only compatibility paths added before modification through explicit issue scope notes:

- `tests/integration/test_relationship_projection_persistence.py` ? request/actor fixture compatibility only ([scope note](https://github.com/DashFin-FarDb/financial-asset-relationship-db/issues/1555#issuecomment-5116258828)).
- `tests/unit/test_relationship_projection.py` ? valid proposer/determiner event fixture identities only ([scope note](https://github.com/DashFin-FarDb/financial-asset-relationship-db/issues/1555#issuecomment-5116889546)).

No other file differs from base. `src/governance/relationship_assertion.py` was allowed but did not require modification.

## Allowed / Forbidden

Allowed: the six paths above and their focused validation.

Forbidden and unchanged: schema, migrations, projection implementation, publication/rebuild, routers, frontend, workflows, dependencies, scanner configuration, and hosted-provider state.

## Invariants

- Append-only history and immutable prior assertions.
- Atomic-only, strict-new supersession.
- Proposer-of-record ownership and proposer/determiner separation.
- Server-owned UTC and one strictly monotonic event/evidence timeline per assertion.
- Successor acceptance before predecessor supersession.
- Fail-closed conflicts and idempotent actor validation.
- Transaction-scoped PostgreSQL serialization, with SQLite compatibility explicitly scoped.
- GRAC remains `NEXT`; this PR creates no visible graph or API behavior.

## Tests Added / Updated

- Generic/direct supersession rejection, dedicated planner target-state rejection, and dedicated supersession success.
- Same-actor determination, foreign withdrawal, and foreign/wrong-role idempotent reuse failures.
- Persisted authority/actor replay checks and equal/backdated timestamp rejection.
- Constant/backward server-clock monotonic allocation and no public `recorded_at` parameters.
- Backward-clock evidence/event regression proving proposal < evidence < acceptance < later evidence and that Accepted as-of snapshots include all evidence known before acceptance.
- Cross-stream backward-clock regression proving predecessor acceptance < successor proposal < successor acceptance < predecessor supersession, with correct as-of visibility at each boundary.
- Late authority failure rollback with no orphan successor and unrelated outer work preserved.
- Exact PostgreSQL advisory-lock proof using distinct backend PIDs, `pg_locks`, and `pg_blocking_pids`.
- Failed PostgreSQL supersession releases advisory and row locks before the outer transaction ends while unrelated outer work remains committable.
- Coordinated ordinary-proposal versus atomic-supersession race proving strict non-adoption.

## Validation Commands / Evidence

- Base: `origin/main@be37f00b1f44904746205719b7ce92d4b8b7b600`.
- Exact current head: `5da5459d09cea01a44d2cf132022224627f7dbc3`.
- `pre-commit run --files <six touched files>` ? passed: whitespace, EOF, conflict/debug, mixed-line-ending, Black, Ruff, flake8, and mypy.
- Real PostgreSQL-enabled GRAC slice ? **270 passed, 0 skipped, 0 failed** across contract, ORM, projector, lifecycle, schema, repository, projection persistence, and documentation tests.
- Same full slice without PostgreSQL ? **248 passed, 22 expected PostgreSQL-only skips**.
- Focused lifecycle/repository run without PostgreSQL ? **97 passed, 3 expected PostgreSQL-only skips**.
- Disposable PostgreSQL database and role removed and verified absent after validation.
- `git diff --check` ? passed.
- All review threads are resolved on this exact head.

## Automation Control Incident

After the initial push, CodeRabbit pushed out-of-scope commit `b30de3581f0043cb067779fdf3976196cec125d1` and marked the PR ready. Commit `39bbb707735bcb530236589f7da4cd2d4f3ca2bc` reverts that automation commit exactly; the trees before the bot commit and after its revert are identical. The bot commit remains in transparent history, no force-push was used, and the PR has been restored to draft. This incident is evidence for the programme?s bot write/draft-state governance hardening; it does not broaden this PR?s code scope.

## Rollback Behaviour

There is no migration or hosted-state change. The bot commit and revert cancel in content. Reverting `5da5459d09cea01a44d2cf132022224627f7dbc3`, then `239e1de3ba0864e9808fc0f4be0d479139ea6a14`, then `4bb3b668a4287c26e29870bacf3597e438545ffb`, then `a17a8a1403a03b46e5beb34a684d518fae6936e6`, then `ce630a3bf6203b23349f31eef90a66123328ec09` restores the pre-PR implementation. At runtime, stale sequence, invalid authority, actor conflict, or concurrent successor insertion unwinds the nested savepoint; no orphan atomic successor is retained and unrelated outer transaction work is preserved.

## Merge Criteria

- [x] Focused unit and SQLite integration behavior passes.
- [x] Real two-connection PostgreSQL serialization, proposal-race, and shared evidence/event clock tests pass without skip.
- [x] Cross-stream temporal causality is regression-tested.
- [x] Pre-commit checks pass on every touched file.
- [x] Exact file scope and required PR claims are documented.
- [ ] Full required GitHub CI passes on this exact SHA.
- [x] No unresolved substantive review threads remain.
- [ ] Human reviewer confirms the high-risk correction; no auto-merge.

## Stop Conditions

No stop condition was triggered: the correction required no schema/publication change, actor separation fits the amended contract, PostgreSQL serialization was demonstrated with independent connections, and no stage-5C ownership/cancellation safeguard was weakened. Stop and return to #1530 if review requests schema, publication, contract-semantic weakening, or hidden scope expansion.

## Programme State

- Preceding merged correction/base: `main@be37f00b` (PR #1554).
- Corrective head: `5da5459d09cea01a44d2cf132022224627f7dbc3`.
- Capability remains **NEXT**.
- This PR is intentionally **draft**, requires human review, and must not auto-merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enforces GRAC lifecycle, actor-separation, temporal-ordering, and atomic-supersession invariants.
- Restricts supersession to the dedicated atomic repository path with strict-new successor creation.
- Validates proposer ownership, determiner separation, persisted authority, and actor relationships.
- Assigns server-owned, strictly increasing timestamps across assertion events and evidence links.
- Adds PostgreSQL advisory and deterministic row locking around atomic supersession.
- Expands lifecycle, repository, concurrency, rollback, temporal, and fixture-compatibility coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Compared the complete verbose baseline run grac-focused-lifecycle-01-before.log with the current-HEAD run grac-focused-lifecycle-02-after.log to verify consistency between the baseline and HEAD contract-validation results.
- Noted the baseline run reported 126 passed and 7 skipped at revision 239e1de3ba0864e9808fc0f4be0d479139ea6a14, while the HEAD run reported 127 passed and 7 skipped at revision 5da5459d09cea01a44d2cf132022224627f7dbc3.
- Verified that both logs record the exact command, working directory, revision, exit code, and credential-safe PostgreSQL environment check.
- Confirmed via artifact verification that both captures are complete.

<a href="https://app.greptile.com/trex/runs/16528604/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| src/data/relationship_assertion_repository.py | Introduces server-owned monotonic timestamps, actor-aware stream folding, strict atomic successor creation, and PostgreSQL supersession serialization. |
| src/governance/relationship_assertion_lifecycle.py | Enforces persisted authority, proposer ownership, determiner separation, monotonic replay, and dedicated supersession planning. |
| tests/integration/test_relationship_assertion_repository.py | Adds extensive repository coverage for timestamp ordering, rollback isolation, actor validation, PostgreSQL locking, and proposal races. |
| tests/integration/test_relationship_projection_persistence.py | Updates repository-backed projection fixtures for server-owned timestamps and distinct proposer and determiner identities. |
| tests/unit/test_relationship_assertion_lifecycle.py | Expands planner and replay coverage for authority, actor relationships, temporal monotonicity, and supersession entry-point restrictions. |
| tests/unit/test_relationship_projection.py | Updates projection event fixtures to satisfy the amended proposer and determiner identity invariants. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Caller
participant Repo as Assertion Repository
participant Planner as Lifecycle Planner
participant DB as PostgreSQL / SQLite

Caller->>Repo: supersede_atomic(request)
Repo->>DB: Begin nested transaction
Repo->>DB: Acquire graph and assertion locks
Repo->>Repo: Fold predecessor stream
Repo->>Planner: Validate supersession preconditions
Repo->>DB: Insert strict-new successor proposal
Repo->>Planner: Plan successor acceptance
Repo->>DB: Append acceptance event
Repo->>Planner: Plan predecessor supersession
Repo->>DB: Append supersession event
Repo->>DB: Release savepoint
Repo-->>Caller: Successor and ordered events
```

<sub>Reviews (6): Last reviewed commit: ["fix: share assertion evidence clock floo..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/5da5459d09cea01a44d2cf132022224627f7dbc3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48294130)</sub>

<!-- /greptile_comment -->