### PR TITLE
fix: harden GRAC hosted schema and PostgreSQL proof

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,9 +156,7 @@ jobs:
           ADMIN_USERNAME: admin
           ADMIN_PASSWORD: changeme
         run: |
-          pytest tests/unit/test_relationship_assertion_db_models.py \
-            tests/unit/test_relationship_assertion_lifecycle.py \
-            tests/integration/test_relationship_assertion_schema.py \
+          pytest tests/integration/test_relationship_assertion_schema.py \
             tests/integration/test_relationship_assertion_repository.py \
             tests/integration/test_relationship_projection_persistence.py -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,10 @@ jobs:
           ADMIN_PASSWORD: changeme
         run: |
           pytest tests/unit/test_relationship_assertion_db_models.py \
-            tests/integration/test_relationship_assertion_schema.py -v
+            tests/unit/test_relationship_assertion_lifecycle.py \
+            tests/integration/test_relationship_assertion_schema.py \
+            tests/integration/test_relationship_assertion_repository.py \
+            tests/integration/test_relationship_projection_persistence.py -v
 
   security:
     name: Security checks

--- a/src/data/relationship_assertion_db_models.py
+++ b/src/data/relationship_assertion_db_models.py
@@ -54,8 +54,12 @@ STRENGTH_DECIMAL_CHECK = (
     "length(strength) BETWEEN 1 AND 32 "
     "AND translate(strength, '0123456789.', '') = '' "
     "AND strength NOT LIKE '.%' AND strength NOT LIKE '%.' "
-    "AND strength NOT LIKE '%..%' AND strength NOT LIKE '%.%.%'"
+    "AND strength NOT LIKE '%..%' AND strength NOT LIKE '%.%.%' "
+    "AND (strength = '0' OR strength = '1' OR strength LIKE '0.%' "
+    "OR (strength LIKE '1.%' AND replace(substr(strength, 3), '0', '') = ''))"
 )
+
+EFFECTIVE_WINDOW_CHECK = "effective_to IS NULL OR effective_to >= effective_from"
 
 
 class RelationshipEvidenceORM(Base):
@@ -94,6 +98,7 @@ class RelationshipAssertionORM(Base):
         CheckConstraint(CONFIDENCE_BP_RANGE_CHECK, name="ck_relationship_assertions_confidence_bp"),
         CheckConstraint(CONFIDENCE_ASSESSED_CHECK, name="ck_relationship_assertions_confidence_assessed"),
         Index("ix_relationship_assertions_predicate_subject", "predicate_id", "subject_id"),
+        CheckConstraint(EFFECTIVE_WINDOW_CHECK, name="ck_relationship_assertions_effective_window"),
         Index("ix_relationship_assertions_recorded_at", "recorded_at"),
         Index("ix_relationship_assertions_effective_from", "effective_from"),
     )
@@ -157,6 +162,7 @@ class RelationshipAssertionEventORM(Base):
         ),
         Index("ix_relationship_assertion_events_assertion_id", "assertion_id"),
         Index("ix_relationship_assertion_events_recorded_at", "recorded_at"),
+        Index("ix_relationship_assertion_events_successor_assertion_id", "successor_assertion_id"),
     )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
@@ -209,6 +215,7 @@ class RelationshipProjectionRevisionORM(Base):
     projector_version: Mapped[str] = mapped_column(String(64), nullable=False)
     edge_set_hash: Mapped[str] = mapped_column(String(64), nullable=False)
     projection_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    governed_scopes: Mapped[str] = mapped_column(Text, nullable=False, server_default="[]")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
 
 

--- a/src/data/relationship_assertion_schema.py
+++ b/src/data/relationship_assertion_schema.py
@@ -141,7 +141,7 @@ def _backfill_projection_revision_scopes(connection: Connection, backend: str) -
 
 
 def _allow_projection_revision_backfill(connection: Connection, backend: str) -> None:
-    """Temporarily disable only the revision UPDATE guard inside an owner migration transaction."""
+    """Temporarily disable revision guards inside an owner migration transaction."""
     if backend == "postgresql":
         connection.execute(text("ALTER TABLE relationship_projection_revisions DISABLE TRIGGER USER"))
         return

--- a/src/data/relationship_assertion_schema.py
+++ b/src/data/relationship_assertion_schema.py
@@ -39,6 +39,7 @@ def ensure_relationship_assertion_schema(engine: Engine) -> None:
     """
     backend = make_url(str(engine.url)).get_backend_name()
     with engine.begin() as connection:
+        _ensure_projection_revision_scope_metadata(connection, backend)
         if backend == "sqlite":
             if not _sqlite_guards_present(connection):
                 _install_sqlite_immutability_guards(connection)
@@ -48,6 +49,78 @@ def ensure_relationship_assertion_schema(engine: Engine) -> None:
             else:
                 # Upgrade path: earlier installs may have left untrusted EXECUTE.
                 _revoke_immutability_function_execute(connection)
+            _harden_postgresql_grac_access(connection)
+
+
+def _ensure_projection_revision_scope_metadata(connection: Connection, backend: str) -> None:
+    """Add durable scope metadata and the successor FK index on upgrade."""
+    if backend == "sqlite":
+        rows = connection.execute(text("PRAGMA table_info(relationship_projection_revisions)")).fetchall()
+        column_names = {row[1] for row in rows}
+    elif backend == "postgresql":
+        column_names = {
+            row[0]
+            for row in connection.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_schema = current_schema() "
+                    "AND table_name = 'relationship_projection_revisions'"
+                )
+            )
+        }
+    else:
+        return
+    if "governed_scopes" not in column_names:
+        connection.execute(
+            text(
+                "ALTER TABLE relationship_projection_revisions " "ADD COLUMN governed_scopes TEXT NOT NULL DEFAULT '[]'"
+            )
+        )
+    connection.execute(
+        text(
+            "CREATE INDEX IF NOT EXISTS ix_relationship_assertion_events_successor_assertion_id "
+            "ON relationship_assertion_events (successor_assertion_id)"
+        )
+    )
+
+
+def _harden_postgresql_grac_access(connection: Connection) -> None:
+    """Enable RLS and revoke public/untrusted table grants without adding policies."""
+    roles = _untrusted_database_roles()
+    for table_name in GRAC_TABLE_NAMES:
+        _require_grac_table(table_name)
+        connection.execute(text(f"ALTER TABLE {table_name} ENABLE ROW LEVEL SECURITY"))
+        connection.execute(text(f"REVOKE ALL PRIVILEGES ON TABLE {table_name} FROM PUBLIC"))
+        for role in roles:
+            connection.execute(
+                text(
+                    f"DO $revoke$ BEGIN EXECUTE format("
+                    f"'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I', "
+                    f"pg_catalog.current_schema(), '{table_name}', '{role}'); "
+                    f"EXCEPTION WHEN undefined_object THEN NULL; "
+                    f"WHEN insufficient_privilege THEN NULL; END $revoke$"
+                )
+            )
+    insecure = (
+        connection.execute(
+            text(
+                "SELECT c.relname FROM pg_class AS c "
+                "JOIN pg_namespace AS n ON n.oid = c.relnamespace "
+                "WHERE n.nspname = pg_catalog.current_schema() "
+                "AND c.relname IN :tables "
+                "AND (NOT c.relrowsecurity OR EXISTS ("
+                "SELECT 1 FROM pg_policy AS p WHERE p.polrelid = c.oid) OR EXISTS ("
+                "SELECT 1 FROM aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) "
+                "AS acl(grantor, grantee, privilege_type, is_grantable) "
+                "WHERE acl.grantee = 0))"
+            ).bindparams(bindparam("tables", expanding=True)),
+            {"tables": list(GRAC_TABLE_NAMES)},
+        )
+        .scalars()
+        .all()
+    )
+    if insecure:
+        raise PermissionError(f"GRAC RLS/grant hardening failed for tables: {sorted(insecure)}")
 
 
 def list_immutability_trigger_names(table_name: str) -> tuple[str, str, str]:
@@ -136,6 +209,7 @@ def _postgresql_guards_present(connection: Connection) -> bool:
             WHERE p.proname = :name
                 AND p.pronargs = 0
                 AND n.nspname = pg_catalog.current_schema()
+                AND COALESCE(p.proconfig, ARRAY[]::text[]) @> ARRAY['search_path=pg_catalog']
             """),
         {"name": _IMMUTABILITY_FUNCTION},
     ).first()
@@ -338,6 +412,7 @@ def _install_postgresql_immutability_guards(connection: Connection) -> None:
             CREATE OR REPLACE FUNCTION {_IMMUTABILITY_FUNCTION}()
             RETURNS trigger
             LANGUAGE plpgsql
+            SET search_path TO pg_catalog
             AS $$
             BEGIN
                 RAISE EXCEPTION 'GRAC v1 immutability: % forbidden on %',

--- a/src/data/relationship_assertion_schema.py
+++ b/src/data/relationship_assertion_schema.py
@@ -97,8 +97,7 @@ def _harden_postgresql_grac_access(connection: Connection) -> None:
                     f"DO $revoke$ BEGIN EXECUTE format("
                     f"'REVOKE ALL PRIVILEGES ON TABLE %I.%I FROM %I', "
                     f"pg_catalog.current_schema(), '{table_name}', '{role}'); "
-                    f"EXCEPTION WHEN undefined_object THEN NULL; "
-                    f"WHEN insufficient_privilege THEN NULL; END $revoke$"
+                    f"EXCEPTION WHEN undefined_object THEN NULL; END $revoke$"
                 )
             )
     insecure = (

--- a/src/data/relationship_assertion_schema.py
+++ b/src/data/relationship_assertion_schema.py
@@ -114,6 +114,25 @@ def _backfill_projection_revision_scopes(connection: Connection, backend: str) -
             raise RuntimeError(f"inconsistent purpose while backfilling revision {revision_id}")
         if predicate_id is not None:
             predicates.add(predicate_id)
+    published_rows = connection.execute(
+        text(
+            "SELECT revision.id, revision.purpose "
+            "FROM relationship_projection_revisions AS revision "
+            "JOIN relationship_projection_publications AS publication "
+            "ON publication.revision_id = revision.id "
+            "JOIN rebuild_jobs AS job ON job.job_id = publication.rebuild_job_id "
+            "WHERE job.status = 'succeeded' "
+            "ORDER BY revision.purpose, publication.published_at, "
+            "publication.rebuild_job_id, publication.id"
+        )
+    ).all()
+    published_scopes: dict[str, set[str]] = {}
+    for revision_id, purpose in published_rows:
+        _revision_purpose, predicates = scope_pairs[revision_id]
+        if predicates:
+            published_scopes[purpose] = predicates
+        elif prior := published_scopes.get(purpose):
+            scope_pairs[revision_id] = (purpose, set(prior))
     payloads = [
         {
             "revision_id": revision_id,

--- a/src/data/relationship_assertion_schema.py
+++ b/src/data/relationship_assertion_schema.py
@@ -7,6 +7,7 @@ reject UPDATE/DELETE (and PostgreSQL TRUNCATE) on all seven append-only tables.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from collections.abc import Mapping
@@ -14,7 +15,11 @@ from collections.abc import Mapping
 from sqlalchemy import bindparam, text
 from sqlalchemy.engine import Connection, Engine, make_url
 
-from src.data.relationship_assertion_db_models import GRAC_TABLE_NAMES
+from src.data.relationship_assertion_db_models import (
+    EFFECTIVE_WINDOW_CHECK,
+    GRAC_TABLE_NAMES,
+    STRENGTH_DECIMAL_CHECK,
+)
 
 # Keep names well under PostgreSQL's 63-byte identifier limit for every table.
 _IMMUTABILITY_FUNCTION = "grac_v1_reject_mutation"
@@ -41,19 +46,23 @@ def ensure_relationship_assertion_schema(engine: Engine) -> None:
     with engine.begin() as connection:
         _ensure_projection_revision_scope_metadata(connection, backend)
         if backend == "sqlite":
+            _require_sqlite_grac_constraints(connection)
             if not _sqlite_guards_present(connection):
                 _install_sqlite_immutability_guards(connection)
         elif backend == "postgresql":
+            _ensure_postgresql_grac_constraints(connection)
             if not _postgresql_guards_present(connection):
                 _install_postgresql_immutability_guards(connection)
             else:
                 # Upgrade path: earlier installs may have left untrusted EXECUTE.
                 _revoke_immutability_function_execute(connection)
-            _harden_postgresql_grac_access(connection)
+            if not _postgresql_grac_access_hardened(connection):
+                _harden_postgresql_grac_access(connection)
 
 
 def _ensure_projection_revision_scope_metadata(connection: Connection, backend: str) -> None:
     """Add durable scope metadata and the successor FK index on upgrade."""
+    requires_backfill = False
     if backend == "sqlite":
         rows = connection.execute(text("PRAGMA table_info(relationship_projection_revisions)")).fetchall()
         column_names = {row[1] for row in rows}
@@ -71,6 +80,7 @@ def _ensure_projection_revision_scope_metadata(connection: Connection, backend: 
     else:
         return
     if "governed_scopes" not in column_names:
+        requires_backfill = True
         connection.execute(
             text(
                 "ALTER TABLE relationship_projection_revisions " "ADD COLUMN governed_scopes TEXT NOT NULL DEFAULT '[]'"
@@ -82,6 +92,118 @@ def _ensure_projection_revision_scope_metadata(connection: Connection, backend: 
             "ON relationship_assertion_events (successor_assertion_id)"
         )
     )
+    if requires_backfill:
+        _backfill_projection_revision_scopes(connection, backend)
+
+
+def _backfill_projection_revision_scopes(connection: Connection, backend: str) -> None:
+    """Derive canonical metadata for revisions created before governed_scopes existed."""
+    rows = connection.execute(
+        text(
+            "SELECT revision.id, revision.purpose, assertion.predicate_id "
+            "FROM relationship_projection_revisions AS revision "
+            "LEFT JOIN relationship_projection_edges AS edge ON edge.revision_id = revision.id "
+            "LEFT JOIN relationship_assertions AS assertion ON assertion.id = edge.assertion_id "
+            "ORDER BY revision.id, assertion.predicate_id"
+        )
+    ).all()
+    scope_pairs: dict[str, tuple[str, set[str]]] = {}
+    for revision_id, purpose, predicate_id in rows:
+        existing_purpose, predicates = scope_pairs.setdefault(revision_id, (purpose, set()))
+        if existing_purpose != purpose:
+            raise RuntimeError(f"inconsistent purpose while backfilling revision {revision_id}")
+        if predicate_id is not None:
+            predicates.add(predicate_id)
+    payloads = [
+        {
+            "revision_id": revision_id,
+            "governed_scopes": json.dumps(
+                [{"predicate_id": predicate_id, "purpose": purpose} for predicate_id in sorted(predicates)],
+                separators=(",", ":"),
+                sort_keys=True,
+            ),
+        }
+        for revision_id, (purpose, predicates) in scope_pairs.items()
+    ]
+    if not payloads:
+        return
+    _allow_projection_revision_backfill(connection, backend)
+    try:
+        connection.execute(
+            text(
+                "UPDATE relationship_projection_revisions "
+                "SET governed_scopes = :governed_scopes WHERE id = :revision_id"
+            ),
+            payloads,
+        )
+    finally:
+        _restore_projection_revision_immutability(connection, backend)
+
+
+def _allow_projection_revision_backfill(connection: Connection, backend: str) -> None:
+    """Temporarily disable only the revision UPDATE guard inside an owner migration transaction."""
+    if backend == "postgresql":
+        connection.execute(text("ALTER TABLE relationship_projection_revisions DISABLE TRIGGER USER"))
+        return
+    update_name, _delete_name, _truncate_name = list_immutability_trigger_names("relationship_projection_revisions")
+    connection.execute(text(f"DROP TRIGGER IF EXISTS {update_name}"))
+
+
+def _restore_projection_revision_immutability(connection: Connection, backend: str) -> None:
+    """Restore the revision immutability guard after controlled metadata backfill."""
+    if backend == "postgresql":
+        connection.execute(text("ALTER TABLE relationship_projection_revisions ENABLE TRIGGER USER"))
+        return
+    _install_sqlite_immutability_guards(connection)
+
+
+def _require_sqlite_grac_constraints(connection: Connection) -> None:
+    """Fail closed when a legacy SQLite database lacks non-additive GRAC CHECKs."""
+    expected = {
+        "relationship_assertions": "ck_relationship_assertions_effective_window",
+        "relationship_projection_edges": "ck_relationship_projection_edges_strength",
+    }
+    rows = connection.execute(
+        text("SELECT name, sql FROM sqlite_master WHERE type = 'table' AND name IN :tables").bindparams(
+            bindparam("tables", expanding=True)
+        ),
+        {"tables": list(expected)},
+    ).all()
+    actual = {name: sql or "" for name, sql in rows}
+    missing = [table for table, constraint in expected.items() if constraint not in actual.get(table, "")]
+    if missing:
+        raise RuntimeError(
+            "legacy SQLite GRAC CHECK migration required for "
+            + ", ".join(sorted(missing))
+            + "; automatic table rebuild is intentionally not performed at application startup"
+        )
+
+
+def _ensure_postgresql_grac_constraints(connection: Connection) -> None:
+    """Install and validate new GRAC CHECKs; validation fails closed on invalid history."""
+    constraints = (
+        ("relationship_assertions", "ck_relationship_assertions_effective_window", EFFECTIVE_WINDOW_CHECK),
+        ("relationship_projection_edges", "ck_relationship_projection_edges_strength", STRENGTH_DECIMAL_CHECK),
+    )
+    rows = connection.execute(
+        text(
+            "SELECT rel.relname, con.conname, pg_get_constraintdef(con.oid), con.convalidated "
+            "FROM pg_constraint AS con "
+            "JOIN pg_class AS rel ON rel.oid = con.conrelid "
+            "JOIN pg_namespace AS namespace ON namespace.oid = rel.relnamespace "
+            "WHERE namespace.nspname = current_schema() AND con.conname IN :names"
+        ).bindparams(bindparam("names", expanding=True)),
+        {"names": [name for _table, name, _check in constraints]},
+    ).all()
+    existing = {(table, name): (definition, validated) for table, name, definition, validated in rows}
+    for table, name, check in constraints:
+        current = existing.get((table, name))
+        if current is not None and (name.endswith("strength") and "replace" not in current[0]):
+            connection.execute(text(f"ALTER TABLE {table} DROP CONSTRAINT {name}"))
+            current = None
+        if current is None:
+            connection.execute(text(f"ALTER TABLE {table} ADD CONSTRAINT {name} CHECK ({check}) NOT VALID"))
+        connection.execute(text(f"ALTER TABLE {table} VALIDATE CONSTRAINT {name}"))
 
 
 def _harden_postgresql_grac_access(connection: Connection) -> None:
@@ -100,7 +222,19 @@ def _harden_postgresql_grac_access(connection: Connection) -> None:
                     f"EXCEPTION WHEN undefined_object THEN NULL; END $revoke$"
                 )
             )
-    insecure = (
+    insecure = _postgresql_grac_access_gaps(connection, roles)
+    if insecure:
+        raise PermissionError(f"GRAC RLS/grant hardening failed for tables: {sorted(insecure)}")
+
+
+def _postgresql_grac_access_hardened(connection: Connection) -> bool:
+    """Return whether GRAC RLS and untrusted-role grants already meet the contract."""
+    return not _postgresql_grac_access_gaps(connection, _untrusted_database_roles())
+
+
+def _postgresql_grac_access_gaps(connection: Connection, roles: tuple[str, ...]) -> list[str]:
+    """Return GRAC tables without RLS hardening or reachable by an untrusted role."""
+    return list(
         connection.execute(
             text(
                 "SELECT c.relname FROM pg_class AS c "
@@ -111,15 +245,20 @@ def _harden_postgresql_grac_access(connection: Connection) -> None:
                 "SELECT 1 FROM pg_policy AS p WHERE p.polrelid = c.oid) OR EXISTS ("
                 "SELECT 1 FROM aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) "
                 "AS acl(grantor, grantee, privilege_type, is_grantable) "
-                "WHERE acl.grantee = 0))"
-            ).bindparams(bindparam("tables", expanding=True)),
-            {"tables": list(GRAC_TABLE_NAMES)},
+                "WHERE acl.grantee = 0) OR EXISTS (SELECT 1 FROM pg_roles AS rol "
+                "WHERE rol.rolname IN :roles AND (has_table_privilege(rol.oid, c.oid, "
+                "'SELECT, INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER') "
+                "OR has_any_column_privilege(rol.oid, c.oid, "
+                "'SELECT, INSERT, UPDATE, REFERENCES'))))"
+            ).bindparams(
+                bindparam("tables", expanding=True),
+                bindparam("roles", expanding=True),
+            ),
+            {"tables": list(GRAC_TABLE_NAMES), "roles": list(roles)},
         )
         .scalars()
         .all()
     )
-    if insecure:
-        raise PermissionError(f"GRAC RLS/grant hardening failed for tables: {sorted(insecure)}")
 
 
 def list_immutability_trigger_names(table_name: str) -> tuple[str, str, str]:

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -12,15 +13,54 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from src.data.db_models import RebuildJobORM
 from src.data.relationship_assertion_db_models import (
-    RelationshipAssertionORM,
     RelationshipProjectionEdgeORM,
+    RelationshipProjectionPublicationORM,
     RelationshipProjectionRevisionORM,
 )
 from src.governance.relationship_assertion import ConcurrencyConflict, ValidationError
 from src.logic.relationship_projection import GovernedScope, ProjectionEdge, ProjectionRevision
 
 UTC = timezone.utc
+
+
+def _canonical_governed_scopes(scopes: Sequence[GovernedScope], purpose: str) -> tuple[GovernedScope, ...]:
+    """Validate and canonically order one revision's durable scope set."""
+    pairs = {(scope.purpose, scope.predicate_id) for scope in scopes}
+    if any(scope_purpose != purpose or not predicate_id for scope_purpose, predicate_id in pairs):
+        raise ValidationError("governed scopes must be non-empty predicates for the revision purpose")
+    return tuple(
+        GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(pairs)
+    )
+
+
+def _serialize_governed_scopes(scopes: Sequence[GovernedScope], purpose: str) -> str:
+    """Encode the canonical scope metadata stored independently of edge rows."""
+    canonical = _canonical_governed_scopes(scopes, purpose)
+    return json.dumps(
+        [{"predicate_id": scope.predicate_id, "purpose": scope.purpose} for scope in canonical],
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+
+
+def _deserialize_governed_scopes(raw: str, purpose: str) -> tuple[GovernedScope, ...]:
+    """Decode stored scope metadata and reject malformed or non-canonical values."""
+    try:
+        values = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValidationError("projection revision governed_scopes is not valid JSON") from exc
+    if not isinstance(values, list):
+        raise ValidationError("projection revision governed_scopes must be a JSON array")
+    try:
+        scopes = tuple(GovernedScope(purpose=value["purpose"], predicate_id=value["predicate_id"]) for value in values)
+    except (KeyError, TypeError) as exc:
+        raise ValidationError("projection revision governed_scopes has invalid entries") from exc
+    canonical = _canonical_governed_scopes(scopes, purpose)
+    if raw != _serialize_governed_scopes(canonical, purpose):
+        raise ValidationError("projection revision governed_scopes is not canonical")
+    return canonical
 
 
 @dataclass(frozen=True)
@@ -117,6 +157,7 @@ def _projection_revision_orm(
         contract_version=revision.contract_version,
         projector_version=revision.projector_version,
         edge_set_hash=revision.edge_set_hash,
+        governed_scopes=_serialize_governed_scopes(revision.governed_scopes, revision.purpose),
         projection_hash=revision.projection_hash,
         created_at=created_at,
     )
@@ -194,7 +235,7 @@ class ProjectionRevisionStore:
             return None
         edge_rows = self._load_edge_rows(revision_id)
         edges = tuple(_projection_edge_from_orm(edge_row) for edge_row in edge_rows)
-        governed_scopes = self._derive_governed_scopes(row.purpose, edges)
+        governed_scopes = _deserialize_governed_scopes(row.governed_scopes, row.purpose)
         revision, created_at = _domain_revision_from_orm(row, edges, governed_scopes)
         return PersistedProjectionRevision(
             revision_id=row.id,
@@ -203,34 +244,29 @@ class ProjectionRevisionStore:
             edge_ids=tuple(edge_row.id for edge_row in edge_rows),
         )
 
-    def _derive_governed_scopes(
-        self,
-        purpose: str,
-        edges: Sequence[ProjectionEdge],
-    ) -> tuple[GovernedScope, ...]:
-        """Rebuild governed scopes via one batched assertion lookup."""
-        assertion_ids = sorted({edge.assertion_id for edge in edges})
-        if not assertion_ids:
-            return ()
-        predicate_ids = self._predicate_ids_for_assertions(assertion_ids)
-        return tuple(
-            GovernedScope(purpose=purpose, predicate_id=predicate_id) for predicate_id in sorted(predicate_ids)
-        )
-
-    def _predicate_ids_for_assertions(self, assertion_ids: Sequence[str]) -> set[str]:
-        """Map assertion ids to predicate ids, failing closed on missing rows."""
-        rows = self._session.execute(
-            select(RelationshipAssertionORM.id, RelationshipAssertionORM.predicate_id).where(
-                RelationshipAssertionORM.id.in_(assertion_ids)
+    def latest_published_scopes(self, purpose: str) -> tuple[GovernedScope, ...]:
+        """Load metadata from the latest successful publication for the purpose."""
+        row = self._session.execute(
+            select(RelationshipProjectionRevisionORM)
+            .join(
+                RelationshipProjectionPublicationORM,
+                RelationshipProjectionPublicationORM.revision_id == RelationshipProjectionRevisionORM.id,
             )
-        ).all()
-        predicate_by_assertion: dict[str, str] = {}
-        for assertion_id, predicate_id in rows:
-            predicate_by_assertion[assertion_id] = predicate_id
-        for assertion_id in assertion_ids:
-            if assertion_id not in predicate_by_assertion:
-                raise ValidationError(f"projection edge references unknown assertion_id: {assertion_id}")
-        return {predicate_by_assertion[assertion_id] for assertion_id in assertion_ids}
+            .where(RelationshipProjectionRevisionORM.purpose == purpose)
+            .join(
+                RebuildJobORM,
+                RebuildJobORM.job_id == RelationshipProjectionPublicationORM.rebuild_job_id,
+            )
+            .where(RebuildJobORM.status == "succeeded")
+            .order_by(
+                RelationshipProjectionPublicationORM.published_at.desc(),
+                RelationshipProjectionPublicationORM.rebuild_job_id.desc(),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        if row is None:
+            return ()
+        return _deserialize_governed_scopes(row.governed_scopes, purpose)
 
     def _insert_rows(
         self,

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -20,24 +20,19 @@ from src.data.relationship_assertion_db_models import (
     RelationshipProjectionRevisionORM,
 )
 from src.governance.relationship_assertion import ConcurrencyConflict, ValidationError
-from src.logic.relationship_projection import GovernedScope, ProjectionEdge, ProjectionRevision
+from src.logic.relationship_projection import (
+    GovernedScope,
+    ProjectionEdge,
+    ProjectionRevision,
+    canonicalize_governed_scopes,
+)
 
 UTC = timezone.utc
 
 
-def _canonical_governed_scopes(scopes: Sequence[GovernedScope], purpose: str) -> tuple[GovernedScope, ...]:
-    """Validate and canonically order one revision's durable scope set."""
-    pairs = {(scope.purpose, scope.predicate_id) for scope in scopes}
-    if any(scope_purpose != purpose or not predicate_id for scope_purpose, predicate_id in pairs):
-        raise ValidationError("governed scopes must be non-empty predicates for the revision purpose")
-    return tuple(
-        GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(pairs)
-    )
-
-
 def _serialize_governed_scopes(scopes: Sequence[GovernedScope], purpose: str) -> str:
     """Encode the canonical scope metadata stored independently of edge rows."""
-    canonical = _canonical_governed_scopes(scopes, purpose)
+    canonical = canonicalize_governed_scopes(scopes, purpose)
     return json.dumps(
         [{"predicate_id": scope.predicate_id, "purpose": scope.purpose} for scope in canonical],
         separators=(",", ":"),
@@ -57,7 +52,7 @@ def _deserialize_governed_scopes(raw: str, purpose: str) -> tuple[GovernedScope,
         scopes = tuple(GovernedScope(purpose=value["purpose"], predicate_id=value["predicate_id"]) for value in values)
     except (KeyError, TypeError) as exc:
         raise ValidationError("projection revision governed_scopes has invalid entries") from exc
-    canonical = _canonical_governed_scopes(scopes, purpose)
+    canonical = canonicalize_governed_scopes(scopes, purpose)
     if raw != _serialize_governed_scopes(canonical, purpose):
         raise ValidationError("projection revision governed_scopes is not canonical")
     return canonical

--- a/src/data/relationship_projection_persistence.py
+++ b/src/data/relationship_projection_persistence.py
@@ -256,6 +256,7 @@ class ProjectionRevisionStore:
             .order_by(
                 RelationshipProjectionPublicationORM.published_at.desc(),
                 RelationshipProjectionPublicationORM.rebuild_job_id.desc(),
+                RelationshipProjectionPublicationORM.id.desc(),
             )
             .limit(1)
         ).scalar_one_or_none()

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -90,6 +90,7 @@ class ProjectRequest:
     effective_at: datetime
     known_at: datetime
     contract_version: str = CONTRACT_VERSION
+    previously_published_scopes: Sequence[GovernedScope] = ()
     projector_version: str = PROJECTOR_VERSION
 
 
@@ -121,6 +122,8 @@ class _HashInputs:
     contract_version: str
     projector_version: str
     evidence_rows: tuple[Mapping[str, str], ...]
+
+    governed_scopes: tuple[GovernedScope, ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -363,6 +366,9 @@ def _compute_hashes(edges: Sequence[ProjectionEdge], inputs: _HashInputs) -> tup
         "contract_version": inputs.contract_version,
         "edges": [_provenance_edge_payload(edge) for edge in ordered],
         "effective_at": _canonical_instant(inputs.effective_at),
+        "governed_scopes": [
+            {"predicate_id": scope.predicate_id, "purpose": scope.purpose} for scope in inputs.governed_scopes
+        ],
         "evidence": list(inputs.evidence_rows),
         "known_at": _canonical_instant(inputs.known_at),
         "projector_version": inputs.projector_version,
@@ -372,9 +378,20 @@ def _compute_hashes(edges: Sequence[ProjectionEdge], inputs: _HashInputs) -> tup
     return edge_set_hash, projection_hash
 
 
-def _governed_scopes(candidates: Sequence[_Candidate], purpose: str) -> tuple[GovernedScope, ...]:
-    """Return sorted unique governed scopes from successful candidates."""
-    scopes = {(purpose, candidate.predicate.id) for candidate in candidates}
+def _governed_scopes(
+    candidates: Sequence[_Candidate],
+    purpose: str,
+    previously_published_scopes: Sequence[GovernedScope],
+) -> tuple[GovernedScope, ...]:
+    """Carry published scopes forward and add scopes from successful candidates."""
+    scopes = set()
+    for scope in previously_published_scopes:
+        if scope.purpose != purpose:
+            raise ProjectionError("previously published scope purpose does not match projection purpose")
+        scopes.add((scope.purpose, scope.predicate_id))
+    if any(not predicate_id for _scope_purpose, predicate_id in scopes):
+        raise ProjectionError("previously published scope predicate must be non-empty")
+    scopes.update((purpose, candidate.predicate.id) for candidate in candidates)
     return tuple(
         GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(scopes)
     )
@@ -397,6 +414,7 @@ def project(request: ProjectRequest) -> ProjectionRevision:
     candidates = _select_accepted_candidates(request.assertions, events_by_id, predicates, window)
     _fail_closed_on_conflicts(candidates)
     edges = tuple(sorted((candidate.edge for candidate in candidates), key=_edge_sort_key))
+    governed_scopes = _governed_scopes(candidates, request.purpose, request.previously_published_scopes)
     evidence_rows = _evidence_payload_for_edges(
         edges,
         _EvidenceBundle(evidence=request.evidence, links=request.evidence_links, known_at=known),
@@ -410,6 +428,7 @@ def project(request: ProjectRequest) -> ProjectionRevision:
             contract_version=request.contract_version,
             projector_version=request.projector_version,
             evidence_rows=tuple(evidence_rows),
+            governed_scopes=governed_scopes,
         ),
     )
     return ProjectionRevision(
@@ -421,5 +440,5 @@ def project(request: ProjectRequest) -> ProjectionRevision:
         edge_set_hash=edge_set_hash,
         projection_hash=projection_hash,
         edges=edges,
-        governed_scopes=_governed_scopes(candidates, request.purpose),
+        governed_scopes=governed_scopes,
     )

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -378,23 +378,31 @@ def _compute_hashes(edges: Sequence[ProjectionEdge], inputs: _HashInputs) -> tup
     return edge_set_hash, projection_hash
 
 
+def canonicalize_governed_scopes(
+    scopes: Sequence[GovernedScope],
+    purpose: str,
+) -> tuple[GovernedScope, ...]:
+    """Validate, deduplicate, and sort governed scopes for one purpose."""
+    pairs = {(scope.purpose, scope.predicate_id) for scope in scopes}
+    if any(scope_purpose != purpose or not predicate_id for scope_purpose, predicate_id in pairs):
+        raise ValidationError("governed scopes must be non-empty predicates for the projection purpose")
+    return tuple(
+        GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(pairs)
+    )
+
+
 def _governed_scopes(
     candidates: Sequence[_Candidate],
     purpose: str,
     previously_published_scopes: Sequence[GovernedScope],
 ) -> tuple[GovernedScope, ...]:
     """Carry published scopes forward and add scopes from successful candidates."""
-    scopes = set()
-    for scope in previously_published_scopes:
-        if scope.purpose != purpose:
-            raise ProjectionError("previously published scope purpose does not match projection purpose")
-        scopes.add((scope.purpose, scope.predicate_id))
-    if any(not predicate_id for _scope_purpose, predicate_id in scopes):
-        raise ProjectionError("previously published scope predicate must be non-empty")
-    scopes.update((purpose, candidate.predicate.id) for candidate in candidates)
-    return tuple(
-        GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(scopes)
-    )
+    scopes = [*previously_published_scopes]
+    scopes.extend(GovernedScope(purpose, candidate.predicate.id) for candidate in candidates)
+    try:
+        return canonicalize_governed_scopes(scopes, purpose)
+    except ValidationError as exc:
+        raise ProjectionError(str(exc)) from exc
 
 
 def project(request: ProjectRequest) -> ProjectionRevision:

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -33,7 +33,7 @@ from src.governance.relationship_assertion_lifecycle import resolve_state
 
 UTC = timezone.utc
 _UTC_OFFSET = timedelta(0)
-PROJECTOR_VERSION = "projector.v1"
+PROJECTOR_VERSION = "projector.v2"
 _ACCEPTED: LifecycleState = "Accepted"
 _CONFLICT_ATTRS = frozenset({"predicate_id", "subject_id", "object_id", "method_id"})
 
@@ -384,7 +384,13 @@ def canonicalize_governed_scopes(
 ) -> tuple[GovernedScope, ...]:
     """Validate, deduplicate, and sort governed scopes for one purpose."""
     pairs = {(scope.purpose, scope.predicate_id) for scope in scopes}
-    if any(scope_purpose != purpose or not predicate_id for scope_purpose, predicate_id in pairs):
+    if any(
+        not isinstance(scope_purpose, str)
+        or not isinstance(predicate_id, str)
+        or scope_purpose != purpose
+        or not predicate_id
+        for scope_purpose, predicate_id in pairs
+    ):
         raise ValidationError("governed scopes must be non-empty predicates for the projection purpose")
     return tuple(
         GovernedScope(purpose=item_purpose, predicate_id=predicate_id) for item_purpose, predicate_id in sorted(pairs)

--- a/tests/integration/test_relationship_assertion_schema.py
+++ b/tests/integration/test_relationship_assertion_schema.py
@@ -47,6 +47,7 @@ EXPECTED_CHECK_NAMES = {
         "ck_relationship_assertions_confidence_status",
         "ck_relationship_assertions_confidence_bp",
         "ck_relationship_assertions_confidence_assessed",
+        "ck_relationship_assertions_effective_window",
     },
     "relationship_assertion_evidence": {"ck_relationship_assertion_evidence_polarity"},
     "relationship_assertion_events": {
@@ -84,6 +85,7 @@ EXPECTED_INDEX_NAMES = {
         "ix_relationship_assertion_events_assertion_id",
         "ix_relationship_assertion_events_recorded_at",
         "uq_relationship_assertion_events_sequence",
+        "ix_relationship_assertion_events_successor_assertion_id",
     },
     "relationship_projection_revisions": {
         "ix_relationship_projection_revisions_purpose",
@@ -300,6 +302,34 @@ class TestRelationshipAssertionSchemaParity:
             actual |= _fk_pairs(schema_engine, table)
         missing = expected - actual
         assert not missing, f"missing FKs: {missing}"
+
+    @staticmethod
+    def test_postgresql_access_hardening(schema_engine: Engine):
+        """PostgreSQL GRAC tables are RLS-protected with no public policies or grants."""
+        if schema_engine.dialect.name != "postgresql":
+            pytest.skip("PostgreSQL-only RLS catalog assertion")
+        init_db(schema_engine)
+        with schema_engine.connect() as conn:
+            rows = conn.execute(
+                text(
+                    "SELECT c.relname, c.relrowsecurity, count(p.oid), bool_or(acl.grantee = 0) "
+                    "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+                    "LEFT JOIN pg_policy p ON p.polrelid = c.oid "
+                    "LEFT JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl ON true "
+                    "WHERE n.nspname = current_schema() AND c.relname = ANY(:tables) "
+                    "GROUP BY c.relname, c.relrowsecurity"
+                ),
+                {"tables": list(GRAC_TABLE_NAMES)},
+            ).all()
+            function_config = conn.execute(
+                text(
+                    "SELECT proconfig FROM pg_proc WHERE proname = 'grac_v1_reject_mutation' "
+                    "AND pronamespace = current_schema()::regnamespace"
+                )
+            ).scalar_one()
+        assert {row[0] for row in rows} == set(GRAC_TABLE_NAMES)
+        assert all(row[1] and row[2] == 0 and not row[3] for row in rows)
+        assert "search_path=pg_catalog" in (function_config or [])
 
 
 @pytest.mark.integration

--- a/tests/integration/test_relationship_assertion_schema.py
+++ b/tests/integration/test_relationship_assertion_schema.py
@@ -20,6 +20,7 @@ from src.data.relationship_assertion_db_models import (
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
     RelationshipProjectionEdgeORM,
+    RelationshipProjectionPublicationORM,
     RelationshipProjectionRevisionORM,
 )
 from src.data.relationship_assertion_schema import (
@@ -329,6 +330,42 @@ class TestRelationshipAssertionSchemaBootstrap:
                     assertion_id="as-legacy",
                 )
             )
+            conn.execute(
+                RebuildJobORM.__table__.insert(),
+                [
+                    {
+                        "job_id": "job-a",
+                        "requested_by": "tester",
+                        "status": "succeeded",
+                        "created_at": now,
+                        "updated_at": now,
+                    },
+                    {
+                        "job_id": "job-z",
+                        "requested_by": "tester",
+                        "status": "succeeded",
+                        "created_at": now,
+                        "updated_at": now,
+                    },
+                ],
+            )
+            conn.execute(
+                RelationshipProjectionPublicationORM.__table__.insert(),
+                [
+                    {
+                        "id": "pub-source",
+                        "revision_id": "rev-with-edge",
+                        "rebuild_job_id": "job-a",
+                        "published_at": now,
+                    },
+                    {
+                        "id": "pub-empty",
+                        "revision_id": "rev-empty",
+                        "rebuild_job_id": "job-z",
+                        "published_at": now,
+                    },
+                ],
+            )
             conn.execute(text("ALTER TABLE relationship_projection_revisions DROP COLUMN governed_scopes"))
 
         ensure_relationship_assertion_schema(schema_engine)
@@ -338,7 +375,7 @@ class TestRelationshipAssertionSchemaBootstrap:
                 text("SELECT id, governed_scopes FROM relationship_projection_revisions ORDER BY id")
             ).all()
         assert scopes == [
-            ("rev-empty", "[]"),
+            ("rev-empty", '[{"predicate_id":"financial.bond.issuer_reference@1","purpose":"current_view"}]'),
             (
                 "rev-with-edge",
                 '[{"predicate_id":"financial.bond.issuer_reference@1","purpose":"current_view"}]',

--- a/tests/integration/test_relationship_assertion_schema.py
+++ b/tests/integration/test_relationship_assertion_schema.py
@@ -19,6 +19,8 @@ from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEvidenceORM,
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
+    RelationshipProjectionEdgeORM,
+    RelationshipProjectionRevisionORM,
 )
 from src.data.relationship_assertion_schema import (
     ensure_relationship_assertion_schema,
@@ -264,6 +266,87 @@ class TestRelationshipAssertionSchemaBootstrap:
         init_db(schema_engine)
         ensure_relationship_assertion_schema(schema_engine)
         assert set(GRAC_TABLE_NAMES).issubset(_table_names(schema_engine))
+
+    @staticmethod
+    def test_upgrade_backfills_legacy_projection_scopes(schema_engine: Engine):
+        """Adding governed_scopes preserves canonical metadata and restores guards."""
+        now = datetime.now(tz=UTC)
+        Base.metadata.create_all(schema_engine)
+        with schema_engine.begin() as conn:
+            conn.execute(
+                RelationshipAssertionORM.__table__.insert().values(
+                    id="as-legacy",
+                    predicate_id="financial.bond.issuer_reference@1",
+                    subject_id="bond-1",
+                    object_id="issuer-1",
+                    method_id="method-1",
+                    proposition="legacy assertion",
+                    confidence_bp=None,
+                    confidence_type=None,
+                    confidence_method=None,
+                    confidence_status="not_assessed",
+                    effective_from=now,
+                    effective_to=None,
+                    recorded_at=now,
+                )
+            )
+            conn.execute(
+                RelationshipProjectionRevisionORM.__table__.insert(),
+                [
+                    {
+                        "id": "rev-with-edge",
+                        "purpose": "current_view",
+                        "effective_at": now,
+                        "known_at": now,
+                        "contract_version": "grac.v1",
+                        "projector_version": "projector.v2",
+                        "edge_set_hash": DIGEST,
+                        "projection_hash": DIGEST,
+                        "created_at": now,
+                    },
+                    {
+                        "id": "rev-empty",
+                        "purpose": "current_view",
+                        "effective_at": now,
+                        "known_at": now,
+                        "contract_version": "grac.v1",
+                        "projector_version": "projector.v2",
+                        "edge_set_hash": DIGEST,
+                        "projection_hash": DIGEST,
+                        "created_at": now,
+                    },
+                ],
+            )
+            conn.execute(
+                RelationshipProjectionEdgeORM.__table__.insert().values(
+                    id="edge-legacy",
+                    revision_id="rev-with-edge",
+                    source_id="bond-1",
+                    target_id="issuer-1",
+                    edge_type="issuer_reference",
+                    strength="0.8",
+                    direction="subject_to_object",
+                    assertion_id="as-legacy",
+                )
+            )
+            conn.execute(text("ALTER TABLE relationship_projection_revisions DROP COLUMN governed_scopes"))
+
+        ensure_relationship_assertion_schema(schema_engine)
+
+        with schema_engine.connect() as conn:
+            scopes = conn.execute(
+                text("SELECT id, governed_scopes FROM relationship_projection_revisions ORDER BY id")
+            ).all()
+        assert scopes == [
+            ("rev-empty", "[]"),
+            (
+                "rev-with-edge",
+                '[{"predicate_id":"financial.bond.issuer_reference@1","purpose":"current_view"}]',
+            ),
+        ]
+        with pytest.raises((DBAPIError, IntegrityError)):
+            with schema_engine.begin() as conn:
+                conn.execute(text("UPDATE relationship_projection_revisions SET purpose = 'changed'"))
 
 
 @pytest.mark.integration

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -64,10 +64,10 @@ GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "107e53b129a7d345",
 )
 GOLDEN_PROJECTION_HASH = _sha256_hex(
-    "9f061549b5713b51",
-    "78153dfd886c7a6e",
-    "f7bcd81027d53dac",
-    "d9222c480bea3ff6",
+    "d8a4b70b62f827bc",
+    "292ff922874c99de",
+    "63a30ea0292253f1",
+    "32808f1e9720dbd4",
 )
 ASSERT = TestCase()
 pytestmark = pytest.mark.integration
@@ -280,7 +280,29 @@ def test_latest_published_scopes_are_durable_and_deterministic(repo: Relationshi
     repo.persist_projection_revision(
         PersistProjectionRequest(source, revision_id="rev-source", created_at=NOW, edge_ids=["edge-source"])
     )
-    retained_scope = GovernedScope(PURPOSE, "financial.bond.issuer_reference@retained")
+    repo._session.add(
+        RebuildJobORM(
+            job_id="job-a",
+            requested_by="tester",
+            status="succeeded",
+            created_at=NOW,
+            updated_at=NOW,
+        )
+    )
+    repo._session.flush()
+    repo._session.add(
+        RelationshipProjectionPublicationORM(
+            id="pub-a",
+            revision_id="rev-source",
+            rebuild_job_id="job-a",
+            published_at=KNOWN_AT,
+            execution_id="exec-a",
+        )
+    )
+    repo._session.flush()
+    store = ProjectionRevisionStore(repo._session, clock=lambda: NOW)
+    retained_scopes = store.latest_published_scopes(PURPOSE)
+    assert retained_scopes == (GovernedScope(PURPOSE, PREDICATE_ID),)
     empty = project(
         ProjectRequest(
             assertions=[],
@@ -291,11 +313,11 @@ def test_latest_published_scopes_are_durable_and_deterministic(repo: Relationshi
             purpose=PURPOSE,
             effective_at=NOW,
             known_at=KNOWN_AT,
-            previously_published_scopes=(retained_scope,),
+            previously_published_scopes=retained_scopes,
         )
     )
     repo.persist_projection_revision(PersistProjectionRequest(empty, revision_id="rev-empty", created_at=KNOWN_AT))
-    for job_id in ("job-a", "job-z"):
+    for job_id in ("job-z",):
         repo._session.add(
             RebuildJobORM(
                 job_id=job_id,
@@ -309,13 +331,6 @@ def test_latest_published_scopes_are_durable_and_deterministic(repo: Relationshi
     repo._session.add_all(
         [
             RelationshipProjectionPublicationORM(
-                id="pub-a",
-                revision_id="rev-source",
-                rebuild_job_id="job-a",
-                published_at=KNOWN_AT,
-                execution_id="exec-a",
-            ),
-            RelationshipProjectionPublicationORM(
                 id="pub-z",
                 revision_id="rev-empty",
                 rebuild_job_id="job-z",
@@ -326,11 +341,11 @@ def test_latest_published_scopes_are_durable_and_deterministic(repo: Relationshi
     )
     repo._session.commit()
     store = ProjectionRevisionStore(repo._session, clock=lambda: NOW)
-    assert store.latest_published_scopes(PURPOSE) == (retained_scope,)
+    assert store.latest_published_scopes(PURPOSE) == retained_scopes
     loaded = store.get("rev-empty")
     assert loaded is not None
     assert loaded.revision.edges == ()
-    assert loaded.revision.governed_scopes == (retained_scope,)
+    assert loaded.revision.governed_scopes == retained_scopes
 
 
 def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionRepository) -> None:

--- a/tests/integration/test_relationship_projection_persistence.py
+++ b/tests/integration/test_relationship_projection_persistence.py
@@ -14,6 +14,8 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import DBAPIError, IntegrityError, OperationalError, ProgrammingError
 
 from src.data.database import Base, create_session_factory, init_db
+from src.data.db_models import RebuildJobORM
+from src.data.relationship_assertion_db_models import RelationshipProjectionPublicationORM
 from src.data.relationship_assertion_repository import (
     PersistProjectionRequest,
     RegisterEvidenceRequest,
@@ -21,6 +23,7 @@ from src.data.relationship_assertion_repository import (
     RepositoryTransitionRequest,
     SupersedeAtomicRequest,
 )
+from src.data.relationship_projection_persistence import ProjectionRevisionStore
 from src.governance.relationship_assertion import (
     Assertion,
     AssertionEvent,
@@ -30,7 +33,7 @@ from src.governance.relationship_assertion import (
     EvidenceRecord,
 )
 from src.governance.relationship_assertion_contract import load_contract_bundle
-from src.logic.relationship_projection import ProjectRequest, project
+from src.logic.relationship_projection import GovernedScope, ProjectRequest, project
 from tests.conftest import enable_sqlite_foreign_keys
 
 UTC = timezone.utc
@@ -61,10 +64,10 @@ GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "107e53b129a7d345",
 )
 GOLDEN_PROJECTION_HASH = _sha256_hex(
-    "9bee4d5a7407b956",
-    "1b96cd546cdd17f5",
-    "177910f471d8e2f7",
-    "8aab4f0befaccb83",
+    "9f061549b5713b51",
+    "78153dfd886c7a6e",
+    "f7bcd81027d53dac",
+    "d9222c480bea3ff6",
 )
 ASSERT = TestCase()
 pytestmark = pytest.mark.integration
@@ -268,6 +271,66 @@ def test_identical_hashes_across_dialects(projection_engine, repo: RelationshipA
     ASSERT.assertEqual(loaded.revision.edge_set_hash, GOLDEN_EDGE_SET_HASH)
     ASSERT.assertEqual(loaded.revision.projection_hash, GOLDEN_PROJECTION_HASH)
     ASSERT.assertEqual(loaded.revision.edges[0].strength, "0.8")
+
+
+def test_latest_published_scopes_are_durable_and_deterministic(repo: RelationshipAssertionRepository) -> None:
+    """Latest successful publication carries canonical scopes through an empty-edge revision."""
+    _propose_accepted(repo, "as-1")
+    source = _project_from_repo(repo, ["as-1"])
+    repo.persist_projection_revision(
+        PersistProjectionRequest(source, revision_id="rev-source", created_at=NOW, edge_ids=["edge-source"])
+    )
+    retained_scope = GovernedScope(PURPOSE, "financial.bond.issuer_reference@retained")
+    empty = project(
+        ProjectRequest(
+            assertions=[],
+            events=[],
+            evidence=[],
+            evidence_links=[],
+            predicate_registry=load_contract_bundle()[1],
+            purpose=PURPOSE,
+            effective_at=NOW,
+            known_at=KNOWN_AT,
+            previously_published_scopes=(retained_scope,),
+        )
+    )
+    repo.persist_projection_revision(PersistProjectionRequest(empty, revision_id="rev-empty", created_at=KNOWN_AT))
+    for job_id in ("job-a", "job-z"):
+        repo._session.add(
+            RebuildJobORM(
+                job_id=job_id,
+                requested_by="tester",
+                status="succeeded",
+                created_at=NOW,
+                updated_at=NOW,
+            )
+        )
+    repo._session.flush()
+    repo._session.add_all(
+        [
+            RelationshipProjectionPublicationORM(
+                id="pub-a",
+                revision_id="rev-source",
+                rebuild_job_id="job-a",
+                published_at=KNOWN_AT,
+                execution_id="exec-a",
+            ),
+            RelationshipProjectionPublicationORM(
+                id="pub-z",
+                revision_id="rev-empty",
+                rebuild_job_id="job-z",
+                published_at=KNOWN_AT,
+                execution_id="exec-z",
+            ),
+        ]
+    )
+    repo._session.commit()
+    store = ProjectionRevisionStore(repo._session, clock=lambda: NOW)
+    assert store.latest_published_scopes(PURPOSE) == (retained_scope,)
+    loaded = store.get("rev-empty")
+    assert loaded is not None
+    assert loaded.revision.edges == ()
+    assert loaded.revision.governed_scopes == (retained_scope,)
 
 
 def test_supersession_changes_persisted_hashes(repo: RelationshipAssertionRepository) -> None:

--- a/tests/unit/test_relationship_assertion_db_models.py
+++ b/tests/unit/test_relationship_assertion_db_models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -139,6 +139,29 @@ def test_confidence_shape_check_rejects_assessed_without_bp() -> None:
     with engine.begin() as connection:
         with pytest.raises(IntegrityError):
             connection.execute(insert_stmt)
+    engine.dispose()
+
+
+def test_effective_window_rejects_end_before_start() -> None:
+    """Assertions cannot end before their effective start."""
+    engine = create_engine_from_url("sqlite:///:memory:")
+    init_db(engine)
+    now = datetime.now(timezone.utc)
+    values = {
+        "id": "12121212-1212-1212-1212-121212121212",
+        "predicate_id": "financial.bond.issuer_reference@1",
+        "subject_id": "AAPL_BOND_2030",
+        "object_id": "AAPL",
+        "method_id": "bond.issuer_id.resolution@1",
+        "proposition": "issuer reference",
+        "confidence_status": "not_assessed",
+        "effective_from": now,
+        "effective_to": now - timedelta(seconds=1),
+        "recorded_at": now,
+    }
+    with engine.begin() as connection:
+        with pytest.raises(IntegrityError):
+            connection.execute(RelationshipAssertionORM.__table__.insert().values(**values))
     engine.dispose()
 
 
@@ -431,7 +454,7 @@ class TestRelationshipAssertionLinksAndEvents:
 
     @staticmethod
     def test_invalid_strength_rejected(db_session):
-        """Edge strength must be a decimal-like numeric string."""
+        """Edge strength must be within the closed zero-to-one interval."""
         _add_assertion(db_session)
         now = _utcnow()
         db_session.add(
@@ -455,7 +478,7 @@ class TestRelationshipAssertionLinksAndEvents:
                 source_id="AAPL_BOND_2030",
                 target_id="AAPL",
                 edge_type="corporate_link",
-                strength="strong",
+                strength="1.1",
                 direction="subject_to_object",
                 assertion_id="as-1",
             )

--- a/tests/unit/test_relationship_assertion_db_models.py
+++ b/tests/unit/test_relationship_assertion_db_models.py
@@ -28,6 +28,7 @@ from src.data.relationship_assertion_schema import (
     _expected_postgresql_trigger_names,
     _expected_sqlite_trigger_bindings,
     _expected_sqlite_trigger_names,
+    _harden_postgresql_grac_access,
     _postgresql_guards_present,
     _revoke_immutability_function_execute,
     _sqlite_guards_present,
@@ -554,6 +555,18 @@ def test_revoke_immutability_execute_scopes_acl_check_to_current_schema() -> Non
     assert "rolname IN" in acl_sql
     assert "roles" in acl_sql
     assert acl_params["roles"] == ["anon", "authenticated"]
+
+
+def test_table_grant_hardening_does_not_suppress_insufficient_privilege() -> None:
+    """Table grant revocation fails closed when the schema role lacks privilege."""
+    connection = MagicMock()
+    connection.execute.return_value.scalars.return_value.all.return_value = []
+
+    _harden_postgresql_grac_access(connection)
+
+    statements = "\n".join(str(call.args[0]) for call in connection.execute.call_args_list)
+    assert "undefined_object" in statements
+    assert "insufficient_privilege" not in statements
 
 
 def test_postgresql_guards_present_scopes_triggers_to_current_schema() -> None:

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -17,6 +17,7 @@ from src.governance.relationship_assertion import (
 from src.governance.relationship_assertion_contract import load_contract_bundle
 from src.logic.relationship_projection import (
     PROJECTOR_VERSION,
+    GovernedScope,
     ProjectionError,
     ProjectionRevision,
     ProjectRequest,
@@ -41,10 +42,10 @@ EMPTY_EDGE_SET_HASH = _sha256_hex(
     "73c2f11161202b945",
 )
 EMPTY_PROJECTION_HASH = _sha256_hex(
-    "f834ce8a5132768a",
-    "2c9f871cc70abd56",
-    "3b383334ad43c837",
-    "713356f7cc293d27",
+    "924520d579a2fb60",
+    "47d770f7997bae36",
+    "efad3e48b62e1867",
+    "12ce9990236b2cc5",
 )
 GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "c8c8e738ffe460a7",
@@ -53,10 +54,10 @@ GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "107e53b129a7d345",
 )
 GOLDEN_PROJECTION_HASH = _sha256_hex(
-    "9bee4d5a7407b956",
-    "1b96cd546cdd17f5",
-    "177910f471d8e2f7",
-    "8aab4f0befaccb83",
+    "9f061549b5713b51",
+    "78153dfd886c7a6e",
+    "f7bcd81027d53dac",
+    "d9222c480bea3ff6",
 )
 
 
@@ -104,6 +105,7 @@ class _ProjectSpec:
     evidence: list[EvidenceRecord] | None = None
     evidence_links: list[EvidenceLink] | None = None
     purpose: str = PURPOSE
+    previously_published_scopes: tuple[GovernedScope, ...] = ()
 
 
 def _assertion(spec: _AssertionSpec | None = None) -> Assertion:
@@ -210,6 +212,7 @@ def _project(predicates, spec: _ProjectSpec) -> ProjectionRevision:
             purpose=spec.purpose,
             effective_at=spec.effective_at,
             known_at=spec.known_at,
+            previously_published_scopes=spec.previously_published_scopes,
         )
     )
 
@@ -226,6 +229,23 @@ def test_empty_inputs_yield_empty_revision_and_stable_hashes(predicates) -> None
     # SHA-256 of canonical JSON ``[]``.
     assert first.edge_set_hash == EMPTY_EDGE_SET_HASH
     assert first.projection_hash == EMPTY_PROJECTION_HASH
+
+
+def test_empty_edge_revision_preserves_previously_published_scope(predicates) -> None:
+    """A later empty revision retains its durable governed scope."""
+    result = _project(
+        predicates,
+        _ProjectSpec(
+            assertions=[],
+            events=[],
+            known_at=NOW,
+            previously_published_scopes=(GovernedScope(PURPOSE, PREDICATE_ID),),
+        ),
+    )
+    assert result.edges == ()
+    assert result.governed_scopes == (GovernedScope(PURPOSE, PREDICATE_ID),)
+    assert result.edge_set_hash == EMPTY_EDGE_SET_HASH
+    assert result.projection_hash != EMPTY_PROJECTION_HASH
 
 
 def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -21,6 +21,7 @@ from src.logic.relationship_projection import (
     ProjectionError,
     ProjectionRevision,
     ProjectRequest,
+    canonicalize_governed_scopes,
     project,
 )
 
@@ -246,6 +247,15 @@ def test_empty_edge_revision_preserves_previously_published_scope(predicates) ->
     assert result.governed_scopes == (GovernedScope(PURPOSE, PREDICATE_ID),)
     assert result.edge_set_hash == EMPTY_EDGE_SET_HASH
     assert result.projection_hash != EMPTY_PROJECTION_HASH
+
+
+def test_governed_scope_canonicalization_deduplicates_and_sorts() -> None:
+    """The shared canonicalizer yields one stable scope set for projection and persistence."""
+    scopes = canonicalize_governed_scopes(
+        (GovernedScope(PURPOSE, "z"), GovernedScope(PURPOSE, "a"), GovernedScope(PURPOSE, "z")),
+        PURPOSE,
+    )
+    assert scopes == (GovernedScope(PURPOSE, "a"), GovernedScope(PURPOSE, "z"))
 
 
 def test_accepted_issuer_reference_projects_corporate_link(predicates) -> None:

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -43,10 +43,10 @@ EMPTY_EDGE_SET_HASH = _sha256_hex(
     "73c2f11161202b945",
 )
 EMPTY_PROJECTION_HASH = _sha256_hex(
-    "924520d579a2fb60",
-    "47d770f7997bae36",
-    "efad3e48b62e1867",
-    "12ce9990236b2cc5",
+    "f5492976c265fce3",
+    "fefeec8fb143fb97",
+    "d008d22402a4abdd",
+    "74b0a056b4575e56",
 )
 GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "c8c8e738ffe460a7",
@@ -55,10 +55,16 @@ GOLDEN_EDGE_SET_HASH = _sha256_hex(
     "107e53b129a7d345",
 )
 GOLDEN_PROJECTION_HASH = _sha256_hex(
-    "9f061549b5713b51",
-    "78153dfd886c7a6e",
-    "f7bcd81027d53dac",
-    "d9222c480bea3ff6",
+    "d8a4b70b62f827bc",
+    "292ff922874c99de",
+    "63a30ea0292253f1",
+    "32808f1e9720dbd4",
+)
+RETAINED_SCOPE_PROJECTION_HASH = _sha256_hex(
+    "38ff587db19700cb",
+    "58202e67577b47e7",
+    "185b610ca99c0a90",
+    "2c1e97c943008d5c",
 )
 
 
@@ -246,7 +252,12 @@ def test_empty_edge_revision_preserves_previously_published_scope(predicates) ->
     assert result.edges == ()
     assert result.governed_scopes == (GovernedScope(PURPOSE, PREDICATE_ID),)
     assert result.edge_set_hash == EMPTY_EDGE_SET_HASH
-    assert result.projection_hash != EMPTY_PROJECTION_HASH
+    assert result.projection_hash == RETAINED_SCOPE_PROJECTION_HASH
+    repeated = _project(
+        predicates,
+        _ProjectSpec(assertions=[], events=[], known_at=NOW, previously_published_scopes=result.governed_scopes),
+    )
+    assert repeated.projection_hash == RETAINED_SCOPE_PROJECTION_HASH
 
 
 def test_governed_scope_canonicalization_deduplicates_and_sorts() -> None:


### PR DESCRIPTION
## **User description**
Closes #1556

## Primary Objective

Harden the GRAC v1 hosted schema and make PostgreSQL proof non-optional in CI.

## What changed

- Enforce effective windows and strength in the closed `[0, 1]` interval; add the successor FK index.
- Store canonical governed-scope metadata on every projection revision, including empty-edge revisions; load the latest successful publication deterministically by `published_at DESC, rebuild_job_id DESC`.
- Enable RLS on all seven GRAC tables, revoke PUBLIC/anon/authenticated table grants, require no policies, and pin the immutability function's `search_path` to `pg_catalog`.
- Expand the dedicated PostgreSQL CI job to schema, lifecycle, repository concurrency, and projection-persistence coverage.

## Scope

Only GRAC ORM/schema/projector/persistence code, their focused tests, and the PostgreSQL CI job changed. No hosted provider state was modified.

## Hosted gate

The required exact-SHA hosted authorization rerun remains pending explicit operator authorization after deployment. This PR deliberately does not perform any Supabase/hosted mutation.

## Validation

- `pre-commit run --files …`
- Dedicated PostgreSQL scope: **175 passed, 25 skipped** (the skips are non-PostgreSQL parameter cases).

## Merge criteria

CI passes; review confirms the hosted authorization gate is scheduled before production enablement.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the GRAC v1 hosted schema and makes the PostgreSQL proof mandatory in CI. Adds durable governed-scope metadata, `projector.v2` hashing, and fixes legacy backfill to preserve scopes for empty publications.

- **New Features**
  - Data checks: enforce assertion effective windows; constrain edge strength to [0,1]; add index on `successor_assertion_id`.
  - Durable scopes: persist canonical `governed_scopes` JSON on every revision (including empty-edge); validate and reject non-canonical JSON on read; include scopes in `projector.v2` hash inputs; projector carries `previously_published_scopes`; shared canonicalizer between projection and persistence; backfill now processes publications in order and carries scopes into empty-edge revisions; deterministic latest-publication reads by `published_at DESC, rebuild_job_id DESC, id DESC`.
  - PostgreSQL hardening: enable RLS on all GRAC tables; revoke `PUBLIC`/untrusted grants; pin immutability function `search_path` to `pg_catalog`; fail closed if any table is not hardened.
  - SQLite safety: require non-additive GRAC CHECKs and fail closed if missing (no auto-rebuild at startup).
  - CI: expand the PostgreSQL job to cover schema, lifecycle, repository concurrency, and projection persistence; proof is non-optional.

- **Migration**
  - Schema upgrade adds `governed_scopes` to `relationship_projection_revisions` (default `[]`) and creates the successor FK index; controlled backfill derives canonical scopes from historical edges/publications and carries scopes forward for legacy empty publications; immutability guards are restored after update.
  - Hosted deployments require the post-deploy authorization gate before enabling access; no hosted state is mutated. With RLS enforced and public grants revoked, define required policies before granting role access.

<sup>Written for commit 48de6eaa8621de96cf89b5d770ce2bbdf33ae94e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Harden GRAC data validation, access controls, and projection scope persistence

### What Changed
- Reject relationship assertions with invalid effective date ranges and projection edges with strengths outside the closed 0–1 interval
- Preserve governed scopes on every projection revision, including revisions with no edges, and select the latest successful publication deterministically
- Protect all GRAC PostgreSQL tables with row-level security, remove public and untrusted table access, and constrain mutation guards to the system catalog
- Expand PostgreSQL CI coverage to include schema, repository, lifecycle, concurrency, and projection persistence behavior

### Impact
`✅ Fewer invalid relationship records`
`✅ Governed scopes retained across empty projections`
`✅ Restricted unauthorized GRAC table access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change strengthens governed relationship assertion storage and projection lifecycle handling. It adds GRAC schema constraints and PostgreSQL access hardening, stores canonical governed scopes with projection revisions, and carries those scopes into empty successful publications.

No defects were confirmed.

## T-Rex validation blocked

- **Tool:** The focused governed-scope lifecycle harness could not create its SQLite schema because the required `translate()` SQLite user-defined function was not registered. The legacy-upgrade, empty-publication, follow-on projection, and persistence path did not execute. [Configure VMs](https://app.greptile.com/-/settings/trex#environments)

<h3>Confidence Score: 3/5</h3>

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- We attempted to run the governed-scopes lifecycle harness against both the parent commit and the PR, exercising the legacy-upgrade to latest-published-scopes to empty projection to persistence/reload flow and malformed-scope rejection.
- We prepared and wired a focused Python harness that implements the exact lifecycle path used for validation of legacy upgrades, latest-published-scopes, empty projection, persistence, and malformed-scope rejection.
- We collected and reviewed lifecycle run logs for both the parent and PR commits to validate the blocker observed during setup, specifically the SQLite DDL failure from translate() not being registered.

<a href="https://app.greptile.com/trex/runs/16548898/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (4): Last reviewed commit: ["fix: preserve scopes in legacy empty pub..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/48de6eaa8621de96cf89b5d770ce2bbdf33ae94e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48603016)</sub>

<!-- /greptile_comment -->