### PR TITLE
feat: publish governed projections through rebuild control plane

### DIFF
--- a/api/graph_lifecycle_providers.py
+++ b/api/graph_lifecycle_providers.py
@@ -351,6 +351,27 @@ def save_graph_to_persistence(
         engine.dispose()
 
 
+def stage_graph_snapshot(session: Session, graph: AssetRelationshipGraph) -> None:
+    """Stage a graph snapshot in the caller-owned transaction without committing.
+
+    GRAC publication uses this boundary so the read-model snapshot, candidate
+    revision, rebuild success transition, and publication row commit together.
+    """
+    try:
+        AssetGraphRepository(session).save_graph(graph)
+    except Exception as exc:
+        log_event(
+            logger,
+            logging.ERROR,
+            ObservabilityEvent(
+                event="graph_persistence_stage_failed",
+                message=f"Failed to stage rebuilt graph: {exc.__class__.__name__}",
+                metadata={"error": exc.__class__.__name__},
+            ),
+        )
+        raise GraphPersistenceSaveError(_GRAPH_PERSISTENCE_SAVE_ERROR_MESSAGE) from None
+
+
 def _create_graph_persistence_engine(database_url: str) -> Engine:
     """
     Create a SQLAlchemy engine for graph persistence.

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -67,7 +67,6 @@ from ..graph_lifecycle_providers import (
     get_graph_lifecycle_settings,
     resolve_durable_graph_persistence_url,
     resolve_hosted_graph_database_url,
-    save_graph_to_persistence,
     stage_graph_snapshot,
 )
 from ..metrics import (
@@ -839,43 +838,6 @@ def _heartbeat_keeper(
             return
 
 
-def _load_persisted_graph_snapshot(
-    session_factory: Callable[[], Session],
-) -> AssetRelationshipGraph:
-    """Load the currently persisted graph snapshot for rollback safety."""
-    with session_scope(session_factory) as session:
-        return AssetGraphRepository(session).load_graph()
-
-
-def _restore_persisted_graph_snapshot(
-    persistence_url: str,
-    snapshot: AssetRelationshipGraph,
-) -> None:
-    """Attempt to restore the provided graph snapshot to persistence.
-
-    On failure, emit an observability event and continue.
-
-    Parameters:
-        persistence_url (str): Resolved durable persistence URL where the snapshot should be saved.
-        snapshot (AssetRelationshipGraph): In-memory graph snapshot to be restored.
-
-    """
-    try:
-        save_graph_to_persistence(persistence_url, snapshot)
-    except Exception as restore_exc:
-        log_event(
-            logger,
-            logging.ERROR,
-            ObservabilityEvent(
-                event="graph_rebuild_snapshot_restore_failed",
-                message=(
-                    f"Failed to restore persisted graph snapshot after rebuild failure: {type(restore_exc).__name__}"
-                ),
-                metadata={"error": type(restore_exc).__name__},
-            ),
-        )
-
-
 def _handle_rebuild_failure(
     session_factory: Callable[[], Session],
     job_id: str,
@@ -883,16 +845,10 @@ def _handle_rebuild_failure(
     exc: Exception | asyncio.CancelledError,
     job_started_at: float,
     success_persisted: bool,
-    graph_saved: bool,
-    graph_snapshot: AssetRelationshipGraph | None,
-    resolved_url: str,
     source: GraphRebuildSource | None,
 ) -> NoReturn:
-    """Handle a rebuild failure and restore prior snapshot if appropriate."""
+    """Mark a rebuild failed after the publication transaction rolls back."""
     if not success_persisted:
-        if graph_saved and graph_snapshot is not None:
-            _restore_persisted_graph_snapshot(resolved_url, graph_snapshot)
-
         if isinstance(exc, RebuildCancelledError):
             _finalize_cancellation_safe(session_factory, job_id, execution_id)
         else:
@@ -1033,7 +989,7 @@ def _orchestrate_heartbeat(
 def _run_rebuild_pipeline(
     session_factory: Callable[[], Session],
     settings: GraphLifecycleSettings,
-    resolved_url: str,
+    _resolved_url: str,
     job_id: str,
     execution_id: str,
     job_started_at: float,
@@ -1043,9 +999,6 @@ def _run_rebuild_pipeline(
     """Run a single rebuild of the asset relationship graph."""
     source: GraphRebuildSource | None = None
     success_persisted = False
-    graph_snapshot: AssetRelationshipGraph | None = None
-    graph_saved = False
-
     try:
         _verify_execution_state(lock_lost, cancel_event, "initialization")
 
@@ -1080,13 +1033,10 @@ def _run_rebuild_pipeline(
             lock_lost=lock_lost,
             cancel_event=cancel_event,
         )
-        graph_saved = True
         success_persisted = True
         synchronize_runtime_graph(graph, job_id=job_id)
         return response
     except Exception as exc:
-        if lock_lost.is_set() or isinstance(exc, _DistributedLockLostError):
-            graph_saved = False
         _handle_rebuild_failure(
             session_factory=session_factory,
             job_id=job_id,
@@ -1094,9 +1044,6 @@ def _run_rebuild_pipeline(
             exc=exc,
             job_started_at=job_started_at,
             success_persisted=success_persisted,
-            graph_saved=graph_saved,
-            graph_snapshot=graph_snapshot,
-            resolved_url=resolved_url,
             source=source,
         )
 

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -1234,13 +1234,7 @@ def _perform_rebuild_and_persist_sync(
     user_ref: str,
     execution_id: str,
 ) -> GraphRebuildResponse:
-    """
-    Rebuild the asset graph, persist the result, and publish the new graph to runtime state.
-
-    Returns:
-        GraphRebuildResponse: Final rebuild response containing persisted status, source information,
-        and asset/relationship/regulatory counts.
-    """
+    """Rebuild, persist, and publish the asset relationship graph."""
     (
         domain_session_factory,
         coordination_session_factory,
@@ -1774,7 +1768,12 @@ def _finalize_rebuild_success(
         _guard_publication_lock(coordination_session, lock_holder_id, lock_ttl_seconds, "publication-pre-success")
 
         pre_success_check = partial(_verify_execution_state, lock_lost, cancel_event, "publication-pre-success")
-        pre_commit_check = partial(_verify_execution_state, lock_lost, cancel_event, "publication-pre-commit")
+
+        def pre_commit_check() -> None:
+            """Renew the held lease and verify events immediately before publication commit."""
+            _guard_publication_lock(coordination_session, lock_holder_id, lock_ttl_seconds, "publication-pre-commit")
+            _verify_execution_state(lock_lost, cancel_event, "publication-pre-commit")
+
         assertion_repo.finalize_projection_publication(
             FinalizeProjectionPublicationRequest(
                 projection=PersistProjectionRequest(revision=revision, created_at=publication_time),

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -25,15 +25,22 @@ from sqlalchemy.orm import Session
 from src.data.database import create_engine_from_url, create_session_factory
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
 from src.data.distributed_lock import DistributedLock, LockAcquisitionTimeout, LockLifecycleState, LockState
+from src.data.relationship_assertion_repository import (
+    FinalizeProjectionPublicationRequest,
+    RelationshipAssertionRepository,
+)
+from src.data.relationship_projection_persistence import PersistProjectionRequest
 from src.data.repository import (
     AssetGraphRepository,
     RebuildCancellationRequestedError,
     RebuildFailureDetails,
     session_scope,
 )
+from src.governance.relationship_assertion_contract import load_contract_bundle
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
+from src.logic.relationship_projection import ProjectRequest, overlay_governed_relationships, project
 from src.observability.facade import ObservabilityEvent, log_event
 
 from ..api_models import (
@@ -61,6 +68,7 @@ from ..graph_lifecycle_providers import (
     resolve_durable_graph_persistence_url,
     resolve_hosted_graph_database_url,
     save_graph_to_persistence,
+    stage_graph_snapshot,
 )
 from ..metrics import (
     HEARTBEAT_LAST_SUCCESS_TIMESTAMP,
@@ -104,6 +112,7 @@ _REBUILD_PATH = "/api/graph/rebuild"
 _MAX_REBUILD_JOB_LIST_RESULTS = 100
 _MAX_AUDIT_USER_REF_LENGTH = 64
 _MAX_FAILURE_MESSAGE_LENGTH = 512
+_GRAC_CURRENT_PURPOSE = "financial_graph_current_view"
 
 # Regex to match URLs, DSNs, and user:pass@host credential sequences for redaction.
 # Intent: Redact connection strings, credentials, and full URL segments containing sensitive details.
@@ -1059,17 +1068,6 @@ def _run_rebuild_pipeline(
         _verify_execution_state(lock_lost, cancel_event, "pre-persistence")
         _update_job_source_safe(session_factory, job_id, execution_id, str(source))
 
-        graph_snapshot = _load_persisted_graph_snapshot(session_factory)
-
-        def _pre_commit_gate() -> None:
-            """Verify execution validity immediately before database commit."""
-            _verify_execution_state(lock_lost, cancel_event, "graph-commit")
-
-        save_graph_to_persistence(resolved_url, graph, pre_commit_check=_pre_commit_gate)
-        graph_saved = True
-
-        if lock_lost.is_set():
-            graph_saved = False
         _verify_execution_state(lock_lost, cancel_event, "pre-success-write")
 
         response = _finalize_rebuild_success(
@@ -1079,7 +1077,10 @@ def _run_rebuild_pipeline(
             graph=graph,
             source=source,
             job_started_at=job_started_at,
+            lock_lost=lock_lost,
+            cancel_event=cancel_event,
         )
+        graph_saved = True
         success_persisted = True
         synchronize_runtime_graph(graph, job_id=job_id)
         return response
@@ -1615,24 +1616,63 @@ def _finalize_rebuild_success(
     graph: AssetRelationshipGraph,
     source: GraphRebuildSource,
     job_started_at: float,
+    lock_lost: threading.Event,
+    cancel_event: threading.Event,
 ) -> GraphRebuildResponse:
-    """Build the rebuild response payload and persist success job state."""
-    regulatory_events = getattr(graph, "regulatory_events", []) or []
-    response = GraphRebuildResponse(
-        status="persisted",
-        source=source,
-        asset_count=len(graph.assets),
-        relationship_count=sum(len(items) for items in graph.relationships.values()),
-        regulatory_event_count=len(regulatory_events),
-    )
-    _mark_job_succeeded_safe(
-        session_factory,
-        job_id,
-        execution_id,
-        node_count=response.asset_count,
-        edge_count=response.relationship_count,
-        duration_ms=_duration_ms(job_started_at),
-    )
+    """Atomically persist the graph, candidate, success transition, and publication."""
+    _verify_execution_state(lock_lost, cancel_event, "publication-transaction-start")
+    publication_time = datetime.now(timezone.utc)  # noqa: UP017
+    _contract, predicates, _transitions = load_contract_bundle()
+
+    with session_scope(session_factory) as session:
+        assertion_repo = RelationshipAssertionRepository(session)
+        snapshot = assertion_repo.load_projection_source_snapshot()
+        revision = project(
+            ProjectRequest(
+                assertions=snapshot.assertions,
+                events=snapshot.events,
+                evidence=snapshot.evidence,
+                evidence_links=snapshot.evidence_links,
+                predicate_registry=predicates,
+                purpose=_GRAC_CURRENT_PURPOSE,
+                effective_at=publication_time,
+                known_at=publication_time,
+                previously_published_scopes=assertion_repo.latest_published_scopes(_GRAC_CURRENT_PURPOSE),
+            )
+        )
+        graph.relationships = overlay_governed_relationships(graph.relationships, revision, predicates)
+
+        regulatory_events = getattr(graph, "regulatory_events", []) or []
+        response = GraphRebuildResponse(
+            status="persisted",
+            source=source,
+            asset_count=len(graph.assets),
+            relationship_count=sum(len(items) for items in graph.relationships.values()),
+            regulatory_event_count=len(regulatory_events),
+        )
+        stage_graph_snapshot(session, graph)
+
+        pre_commit_stage = "publication-pre-success"
+
+        def _publication_gate() -> None:
+            """Recheck lock and cancellation immediately around finalization."""
+            nonlocal pre_commit_stage
+            _verify_execution_state(lock_lost, cancel_event, pre_commit_stage)
+            pre_commit_stage = "publication-pre-commit"
+
+        assertion_repo.finalize_projection_publication(
+            FinalizeProjectionPublicationRequest(
+                projection=PersistProjectionRequest(revision=revision, created_at=publication_time),
+                rebuild_job_id=job_id,
+                execution_id=execution_id,
+                node_count=response.asset_count,
+                edge_count=response.relationship_count,
+                duration_ms=_duration_ms(job_started_at),
+                published_at=publication_time,
+            ),
+            pre_commit_check=_publication_gate,
+        )
+
     update_rebuild_state_metric("succeeded")
     record_rebuild_state_transition("running", "succeeded")
     return response

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -14,6 +14,7 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from copy import copy
 from datetime import datetime, timezone
+from functools import partial
 from time import perf_counter
 from typing import Annotated, Any, NoReturn, cast
 
@@ -1190,6 +1191,43 @@ def _acquire_rebuild_lock(
     return dist_lock
 
 
+def _release_rebuild_lock_safe(dist_lock: DistributedLock | None, lock_acquired: bool) -> None:
+    """Release an acquired rebuild lock without masking the rebuild outcome."""
+    if dist_lock is None or not lock_acquired or dist_lock.state == LockLifecycleState.LOST:
+        return
+    try:
+        dist_lock.release()
+    except Exception as release_exc:
+        log_event(
+            logger,
+            logging.ERROR,
+            ObservabilityEvent(
+                event="rebuild_lock_release_failed",
+                message=f"Failed to release distributed rebuild lock: {type(release_exc).__name__}",
+                metadata={"error": type(release_exc).__name__},
+            ),
+        )
+
+
+def _dispose_rebuild_engine_safe(engine: Engine | None, *, event: str, message: str) -> None:
+    """Dispose a rebuild engine without masking the rebuild outcome."""
+    if engine is None:
+        return
+    try:
+        engine.dispose()
+    except Exception as dispose_exc:
+        error_name = type(dispose_exc).__name__
+        log_event(
+            logger,
+            logging.ERROR,
+            ObservabilityEvent(
+                event=event,
+                message=f"{message}: {error_name}",
+                metadata={"error": error_name},
+            ),
+        )
+
+
 def _perform_rebuild_and_persist_sync(
     settings: GraphLifecycleSettings,
     *,
@@ -1260,47 +1298,17 @@ def _perform_rebuild_and_persist_sync(
             )
 
     finally:
-        if dist_lock is not None and lock_acquired and dist_lock.state != LockLifecycleState.LOST:
-            try:
-                dist_lock.release()
-            except Exception as release_exc:
-                log_event(
-                    logger,
-                    logging.ERROR,
-                    ObservabilityEvent(
-                        event="rebuild_lock_release_failed",
-                        message=f"Failed to release distributed rebuild lock: {type(release_exc).__name__}",
-                        metadata={"error": type(release_exc).__name__},
-                    ),
-                )
-
-        if coordination_engine is not None:
-            try:
-                coordination_engine.dispose()
-            except Exception as dispose_exc:
-                log_event(
-                    logger,
-                    logging.ERROR,
-                    ObservabilityEvent(
-                        event="rebuild_coordination_engine_dispose_failed",
-                        message=f"Failed to dispose coordination database engine: {type(dispose_exc).__name__}",
-                        metadata={"error": type(dispose_exc).__name__},
-                    ),
-                )
-
-        if domain_engine is not None:
-            try:
-                domain_engine.dispose()
-            except Exception as dispose_exc:
-                log_event(
-                    logger,
-                    logging.ERROR,
-                    ObservabilityEvent(
-                        event="rebuild_domain_engine_dispose_failed",
-                        message=f"Failed to dispose domain database engine: {type(dispose_exc).__name__}",
-                        metadata={"error": type(dispose_exc).__name__},
-                    ),
-                )
+        _release_rebuild_lock_safe(dist_lock, lock_acquired)
+        _dispose_rebuild_engine_safe(
+            coordination_engine,
+            event="rebuild_coordination_engine_dispose_failed",
+            message="Failed to dispose coordination database engine",
+        )
+        _dispose_rebuild_engine_safe(
+            domain_engine,
+            event="rebuild_domain_engine_dispose_failed",
+            message="Failed to dispose domain database engine",
+        )
 
 
 def _validate_coordination_database_primary(session_factory: Callable[[], Session]) -> None:
@@ -1628,12 +1636,11 @@ def _publication_transactions(
     """Hold the coordination predicate until the domain publication commits."""
     domain_session = domain_session_factory()
     try:
-        if coordination_is_domain:
-            coordination_session = domain_session
-        else:
-            if coordination_session_factory is None:
-                raise RuntimeError("Separate coordination persistence requires a session factory")
-            coordination_session = coordination_session_factory()
+        coordination_session = _open_coordination_session(
+            domain_session,
+            coordination_session_factory,
+            coordination_is_domain=coordination_is_domain,
+        )
     except Exception:
         domain_session.close()
         raise
@@ -1643,25 +1650,54 @@ def _publication_transactions(
             domain_session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
         yield domain_session, coordination_session
         domain_session.commit()
-        if coordination_session is not domain_session:
-            try:
-                coordination_session.commit()
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                # Domain publication is already durable and was guarded at its commit point.
-                coordination_session.rollback()
-                logger.error(
-                    "Coordination lease renewal failed after durable publication commit: %s",
-                    type(exc).__name__,
-                )
+        _commit_coordination_after_domain(domain_session, coordination_session)
     except Exception:
-        domain_session.rollback()
-        if coordination_session is not domain_session:
-            coordination_session.rollback()
+        _rollback_publication_sessions(domain_session, coordination_session)
         raise
     finally:
-        if coordination_session is not domain_session:
-            coordination_session.close()
-        domain_session.close()
+        _close_publication_sessions(domain_session, coordination_session)
+
+
+def _open_coordination_session(
+    domain_session: Session,
+    coordination_session_factory: Callable[[], Session] | None,
+    *,
+    coordination_is_domain: bool,
+) -> Session:
+    """Open or reuse the coordination session for publication."""
+    if coordination_is_domain:
+        return domain_session
+    if coordination_session_factory is None:
+        raise RuntimeError("Separate coordination persistence requires a session factory")
+    return coordination_session_factory()
+
+
+def _commit_coordination_after_domain(domain_session: Session, coordination_session: Session) -> None:
+    """Commit a separate coordination renewal after the guarded domain commit."""
+    if coordination_session is domain_session:
+        return
+    try:
+        coordination_session.commit()
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        coordination_session.rollback()
+        logger.error(
+            "Coordination lease renewal failed after durable publication commit: %s",
+            type(exc).__name__,
+        )
+
+
+def _rollback_publication_sessions(domain_session: Session, coordination_session: Session) -> None:
+    """Roll back publication sessions that have not committed successfully."""
+    domain_session.rollback()
+    if coordination_session is not domain_session:
+        coordination_session.rollback()
+
+
+def _close_publication_sessions(domain_session: Session, coordination_session: Session) -> None:
+    """Close publication sessions without double-closing a shared session."""
+    if coordination_session is not domain_session:
+        coordination_session.close()
+    domain_session.close()
 
 
 def _renew_publication_lock(
@@ -1678,6 +1714,20 @@ def _renew_publication_lock(
         ttl_seconds=ttl_seconds,
     ):
         raise _DistributedLockLostError(f"Lost distributed lock at stage={stage}")
+
+
+def _guard_publication_lock(
+    session: Session,
+    holder_id: str | None,
+    ttl_seconds: int | None,
+    stage: str,
+) -> None:
+    """Validate optional lock inputs and renew the owned publication lease."""
+    if (holder_id is None) != (ttl_seconds is None):
+        raise RuntimeError("Publication lock guard requires both holder identity and TTL")
+    if holder_id is None or ttl_seconds is None:
+        return
+    _renew_publication_lock(session, holder_id=holder_id, ttl_seconds=ttl_seconds, stage=stage)
 
 
 def _finalize_rebuild_success(
@@ -1703,15 +1753,12 @@ def _finalize_rebuild_success(
         coordination_session_factory,
         coordination_is_domain=coordination_is_domain,
     ) as (session, coordination_session):
-        if (lock_holder_id is None) != (lock_ttl_seconds is None):
-            raise RuntimeError("Publication lock guard requires both holder identity and TTL")
-        if lock_holder_id is not None and lock_ttl_seconds is not None:
-            _renew_publication_lock(
-                coordination_session,
-                holder_id=lock_holder_id,
-                ttl_seconds=lock_ttl_seconds,
-                stage="publication-transaction-start",
-            )
+        _guard_publication_lock(
+            coordination_session,
+            lock_holder_id,
+            lock_ttl_seconds,
+            "publication-transaction-start",
+        )
 
         assertion_repo = RelationshipAssertionRepository(session)
         publication_time = assertion_repo.next_publication_time(_GRAC_CURRENT_PURPOSE)
@@ -1724,14 +1771,10 @@ def _finalize_rebuild_success(
         )
         stage_graph_snapshot(session, publication_graph)
 
-        if lock_holder_id is not None and lock_ttl_seconds is not None:
-            _renew_publication_lock(
-                coordination_session,
-                holder_id=lock_holder_id,
-                ttl_seconds=lock_ttl_seconds,
-                stage="publication-pre-success",
-            )
+        _guard_publication_lock(coordination_session, lock_holder_id, lock_ttl_seconds, "publication-pre-success")
 
+        pre_success_check = partial(_verify_execution_state, lock_lost, cancel_event, "publication-pre-success")
+        pre_commit_check = partial(_verify_execution_state, lock_lost, cancel_event, "publication-pre-commit")
         assertion_repo.finalize_projection_publication(
             FinalizeProjectionPublicationRequest(
                 projection=PersistProjectionRequest(revision=revision, created_at=publication_time),
@@ -1742,16 +1785,8 @@ def _finalize_rebuild_success(
                 duration_ms=_duration_ms(job_started_at),
                 published_at=publication_time,
             ),
-            pre_success_check=lambda: _verify_execution_state(
-                lock_lost,
-                cancel_event,
-                "publication-pre-success",
-            ),
-            pre_commit_check=lambda: _verify_execution_state(
-                lock_lost,
-                cancel_event,
-                "publication-pre-commit",
-            ),
+            pre_success_check=pre_success_check,
+            pre_commit_check=pre_commit_check,
         )
         _verify_execution_state(lock_lost, cancel_event, "publication-outer-commit")
 

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -12,6 +12,7 @@ import time
 from collections.abc import Callable, Generator
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
+from copy import copy
 from datetime import datetime, timezone
 from time import perf_counter
 from typing import Annotated, Any, NoReturn, cast
@@ -32,6 +33,7 @@ from src.data.relationship_assertion_repository import (
 from src.data.relationship_projection_persistence import PersistProjectionRequest
 from src.data.repository import (
     AssetGraphRepository,
+    CoordinationLockRepository,
     RebuildCancellationRequestedError,
     RebuildFailureDetails,
     session_scope,
@@ -40,7 +42,12 @@ from src.governance.relationship_assertion_contract import load_contract_bundle
 from src.logic.asset_graph import AssetRelationshipGraph
 from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
-from src.logic.relationship_projection import ProjectRequest, overlay_governed_relationships, project
+from src.logic.relationship_projection import (
+    ProjectionRevision,
+    ProjectRequest,
+    overlay_governed_relationships,
+    project,
+)
 from src.observability.facade import ObservabilityEvent, log_event
 
 from ..api_models import (
@@ -995,6 +1002,10 @@ def _run_rebuild_pipeline(
     job_started_at: float,
     lock_lost: threading.Event,
     cancel_event: threading.Event,
+    lock_holder_id: str | None = None,
+    lock_ttl_seconds: int | None = None,
+    coordination_session_factory: Callable[[], Session] | None = None,
+    coordination_is_domain: bool = True,
 ) -> GraphRebuildResponse:
     """Run a single rebuild of the asset relationship graph."""
     source: GraphRebuildSource | None = None
@@ -1032,8 +1043,14 @@ def _run_rebuild_pipeline(
             job_started_at=job_started_at,
             lock_lost=lock_lost,
             cancel_event=cancel_event,
+            lock_holder_id=lock_holder_id,
+            lock_ttl_seconds=lock_ttl_seconds,
+            coordination_session_factory=coordination_session_factory,
+            coordination_is_domain=coordination_is_domain,
         )
         success_persisted = True
+        update_rebuild_state_metric("succeeded")
+        record_rebuild_state_transition("running", "succeeded")
         synchronize_runtime_graph(graph, job_id=job_id)
         return response
     except Exception as exc:
@@ -1198,7 +1215,7 @@ def _perform_rebuild_and_persist_sync(
     lock_acquired = False
 
     try:
-        lock_ttl = settings.rebuild_lock_ttl_seconds
+        lock_ttl = min(settings.rebuild_lock_ttl_seconds, 300)
         dist_lock = _acquire_rebuild_lock(coordination_session_factory, lock_ttl)
         lock_acquired = True
 
@@ -1236,6 +1253,10 @@ def _perform_rebuild_and_persist_sync(
                 job_started_at,
                 lock_lost,
                 cancel_event,
+                lock_holder_id=dist_lock.holder_id,
+                lock_ttl_seconds=lock_ttl,
+                coordination_session_factory=coordination_session_factory,
+                coordination_is_domain=coordination_engine is None,
             )
 
     finally:
@@ -1555,6 +1576,110 @@ def _sanitize_failure_message(exc: Exception | asyncio.CancelledError) -> str:
     return sanitized
 
 
+def _prepare_projection_publication(
+    assertion_repo: RelationshipAssertionRepository,
+    graph: AssetRelationshipGraph,
+    source: GraphRebuildSource,
+    publication_time: datetime,
+    cancel_event: threading.Event,
+) -> tuple[ProjectionRevision, AssetRelationshipGraph, GraphRebuildResponse]:
+    """Construct the governed projection, staged graph copy, and response."""
+    _contract, predicates, _transitions = load_contract_bundle()
+    snapshot = assertion_repo.load_projection_source_snapshot(cancel_check=cancel_event.is_set)
+    asset_ids = frozenset(graph.assets)
+    eligible_assertions = tuple(
+        assertion
+        for assertion in snapshot.assertions
+        if assertion.subject_id in asset_ids and assertion.object_id in asset_ids
+    )
+    revision = project(
+        ProjectRequest(
+            assertions=eligible_assertions,
+            events=snapshot.events,
+            evidence=snapshot.evidence,
+            evidence_links=snapshot.evidence_links,
+            predicate_registry=predicates,
+            purpose=_GRAC_CURRENT_PURPOSE,
+            effective_at=publication_time,
+            known_at=publication_time,
+            previously_published_scopes=assertion_repo.latest_published_scopes(_GRAC_CURRENT_PURPOSE),
+        )
+    )
+    publication_graph = copy(graph)
+    publication_graph.relationships = overlay_governed_relationships(graph.relationships, revision, predicates)
+    regulatory_events = getattr(publication_graph, "regulatory_events", []) or []
+    response = GraphRebuildResponse(
+        status="persisted",
+        source=source,
+        asset_count=len(publication_graph.assets),
+        relationship_count=sum(len(items) for items in publication_graph.relationships.values()),
+        regulatory_event_count=len(regulatory_events),
+    )
+    return revision, publication_graph, response
+
+
+@contextmanager
+def _publication_transactions(
+    domain_session_factory: Callable[[], Session],
+    coordination_session_factory: Callable[[], Session] | None,
+    *,
+    coordination_is_domain: bool,
+) -> Generator[tuple[Session, Session], None, None]:
+    """Hold the coordination predicate until the domain publication commits."""
+    domain_session = domain_session_factory()
+    try:
+        if coordination_is_domain:
+            coordination_session = domain_session
+        else:
+            if coordination_session_factory is None:
+                raise RuntimeError("Separate coordination persistence requires a session factory")
+            coordination_session = coordination_session_factory()
+    except Exception:
+        domain_session.close()
+        raise
+
+    try:
+        if domain_session.get_bind().dialect.name == "postgresql":
+            domain_session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+        yield domain_session, coordination_session
+        domain_session.commit()
+        if coordination_session is not domain_session:
+            try:
+                coordination_session.commit()
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                # Domain publication is already durable and was guarded at its commit point.
+                coordination_session.rollback()
+                logger.error(
+                    "Coordination lease renewal failed after durable publication commit: %s",
+                    type(exc).__name__,
+                )
+    except Exception:
+        domain_session.rollback()
+        if coordination_session is not domain_session:
+            coordination_session.rollback()
+        raise
+    finally:
+        if coordination_session is not domain_session:
+            coordination_session.close()
+        domain_session.close()
+
+
+def _renew_publication_lock(
+    session: Session,
+    *,
+    holder_id: str,
+    ttl_seconds: int,
+    stage: str,
+) -> None:
+    """Renew and transactionally hold the owner-validated publication lock."""
+    if not CoordinationLockRepository(session).renew_owned_lock(
+        lock_name="graph_rebuild",
+        holder_id=holder_id,
+        ttl_seconds=ttl_seconds,
+    ):
+        raise _DistributedLockLostError(f"Lost distributed lock at stage={stage}")
+
+
 def _finalize_rebuild_success(
     *,
     session_factory: Callable[[], Session],
@@ -1565,47 +1690,47 @@ def _finalize_rebuild_success(
     job_started_at: float,
     lock_lost: threading.Event,
     cancel_event: threading.Event,
+    lock_holder_id: str | None = None,
+    lock_ttl_seconds: int | None = None,
+    coordination_session_factory: Callable[[], Session] | None = None,
+    coordination_is_domain: bool = True,
 ) -> GraphRebuildResponse:
     """Atomically persist the graph, candidate, success transition, and publication."""
     _verify_execution_state(lock_lost, cancel_event, "publication-transaction-start")
-    publication_time = datetime.now(timezone.utc)  # noqa: UP017
-    _contract, predicates, _transitions = load_contract_bundle()
 
-    with session_scope(session_factory) as session:
-        assertion_repo = RelationshipAssertionRepository(session)
-        snapshot = assertion_repo.load_projection_source_snapshot()
-        revision = project(
-            ProjectRequest(
-                assertions=snapshot.assertions,
-                events=snapshot.events,
-                evidence=snapshot.evidence,
-                evidence_links=snapshot.evidence_links,
-                predicate_registry=predicates,
-                purpose=_GRAC_CURRENT_PURPOSE,
-                effective_at=publication_time,
-                known_at=publication_time,
-                previously_published_scopes=assertion_repo.latest_published_scopes(_GRAC_CURRENT_PURPOSE),
+    with _publication_transactions(
+        session_factory,
+        coordination_session_factory,
+        coordination_is_domain=coordination_is_domain,
+    ) as (session, coordination_session):
+        if (lock_holder_id is None) != (lock_ttl_seconds is None):
+            raise RuntimeError("Publication lock guard requires both holder identity and TTL")
+        if lock_holder_id is not None and lock_ttl_seconds is not None:
+            _renew_publication_lock(
+                coordination_session,
+                holder_id=lock_holder_id,
+                ttl_seconds=lock_ttl_seconds,
+                stage="publication-transaction-start",
             )
+
+        assertion_repo = RelationshipAssertionRepository(session)
+        publication_time = assertion_repo.next_publication_time(_GRAC_CURRENT_PURPOSE)
+        revision, publication_graph, response = _prepare_projection_publication(
+            assertion_repo,
+            graph,
+            source,
+            publication_time,
+            cancel_event,
         )
-        graph.relationships = overlay_governed_relationships(graph.relationships, revision, predicates)
+        stage_graph_snapshot(session, publication_graph)
 
-        regulatory_events = getattr(graph, "regulatory_events", []) or []
-        response = GraphRebuildResponse(
-            status="persisted",
-            source=source,
-            asset_count=len(graph.assets),
-            relationship_count=sum(len(items) for items in graph.relationships.values()),
-            regulatory_event_count=len(regulatory_events),
-        )
-        stage_graph_snapshot(session, graph)
-
-        pre_commit_stage = "publication-pre-success"
-
-        def _publication_gate() -> None:
-            """Recheck lock and cancellation immediately around finalization."""
-            nonlocal pre_commit_stage
-            _verify_execution_state(lock_lost, cancel_event, pre_commit_stage)
-            pre_commit_stage = "publication-pre-commit"
+        if lock_holder_id is not None and lock_ttl_seconds is not None:
+            _renew_publication_lock(
+                coordination_session,
+                holder_id=lock_holder_id,
+                ttl_seconds=lock_ttl_seconds,
+                stage="publication-pre-success",
+            )
 
         assertion_repo.finalize_projection_publication(
             FinalizeProjectionPublicationRequest(
@@ -1617,11 +1742,20 @@ def _finalize_rebuild_success(
                 duration_ms=_duration_ms(job_started_at),
                 published_at=publication_time,
             ),
-            pre_commit_check=_publication_gate,
+            pre_success_check=lambda: _verify_execution_state(
+                lock_lost,
+                cancel_event,
+                "publication-pre-success",
+            ),
+            pre_commit_check=lambda: _verify_execution_state(
+                lock_lost,
+                cancel_event,
+                "publication-pre-commit",
+            ),
         )
+        _verify_execution_state(lock_lost, cancel_event, "publication-outer-commit")
 
-    update_rebuild_state_metric("succeeded")
-    record_rebuild_state_transition("running", "succeeded")
+    graph.relationships = publication_graph.relationships
     return response
 
 

--- a/api/routers/graph_admin.py
+++ b/api/routers/graph_admin.py
@@ -1626,6 +1626,7 @@ def _publication_transactions(
     coordination_session_factory: Callable[[], Session] | None,
     *,
     coordination_is_domain: bool,
+    pre_domain_commit: Callable[[], None] | None = None,
 ) -> Generator[tuple[Session, Session], None, None]:
     """Hold the coordination predicate until the domain publication commits."""
     domain_session = domain_session_factory()
@@ -1643,6 +1644,8 @@ def _publication_transactions(
         if domain_session.get_bind().dialect.name == "postgresql":
             domain_session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
         yield domain_session, coordination_session
+        if pre_domain_commit is not None:
+            pre_domain_commit()
         domain_session.commit()
         _commit_coordination_after_domain(domain_session, coordination_session)
     except Exception:
@@ -1746,6 +1749,12 @@ def _finalize_rebuild_success(
         session_factory,
         coordination_session_factory,
         coordination_is_domain=coordination_is_domain,
+        pre_domain_commit=partial(
+            _verify_execution_state,
+            lock_lost,
+            cancel_event,
+            "publication-domain-commit",
+        ),
     ) as (session, coordination_session):
         _guard_publication_lock(
             coordination_session,
@@ -1787,8 +1796,6 @@ def _finalize_rebuild_success(
             pre_success_check=pre_success_check,
             pre_commit_check=pre_commit_check,
         )
-        _verify_execution_state(lock_lost, cancel_event, "publication-outer-commit")
-
     graph.relationships = publication_graph.relationships
     return response
 

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -12,11 +12,14 @@ from sqlalchemy import func, select, union_all
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from src.data.db_models import RebuildJobORM
 from src.data.relationship_assertion_db_models import (
     RelationshipAssertionEventORM,
     RelationshipAssertionEvidenceORM,
     RelationshipAssertionORM,
     RelationshipEvidenceORM,
+    RelationshipProjectionPublicationORM,
+    RelationshipProjectionRevisionORM,
 )
 from src.data.relationship_projection_persistence import (
     PersistedProjectionRevision,
@@ -58,14 +61,18 @@ from src.governance.relationship_assertion_lifecycle import (
     validate_authority,
     validate_evidence_record,
 )
+from src.logic.relationship_projection import GovernedScope
 
 UTC = timezone.utc
 _SUPERSESSION_LOCK_NAMESPACE = 0x46415244
 _SUPERSESSION_LOCK_RESOURCE = 0x47524143
 
 __all__ = [
+    "FinalizeProjectionPublicationRequest",
     "PersistProjectionRequest",
     "PersistedProjectionRevision",
+    "ProjectionSourceSnapshot",
+    "PublishedProjectionRevision",
     "RegisterEvidenceRequest",
     "RelationshipAssertionRepository",
     "RepositoryTransitionRequest",
@@ -108,6 +115,41 @@ class SupersedeAtomicRequest:
     expected_sequence: int
     rationale: str
     accept_rationale: str = "accept successor"
+
+
+@dataclass(frozen=True)
+class ProjectionSourceSnapshot:
+    """Deterministically ordered assertion data consumed by the projector."""
+
+    assertions: tuple[Assertion, ...]
+    events: tuple[AssertionEvent, ...]
+    evidence: tuple[EvidenceRecord, ...]
+    evidence_links: tuple[EvidenceLink, ...]
+
+
+@dataclass(frozen=True)
+class FinalizeProjectionPublicationRequest:
+    """Inputs for the sole atomic rebuild-success publication path."""
+
+    projection: PersistProjectionRequest
+    rebuild_job_id: str
+    execution_id: str
+    node_count: int
+    edge_count: int
+    duration_ms: int
+    publication_id: str | None = None
+    published_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class PublishedProjectionRevision:
+    """Projection revision and publication committed by one rebuild."""
+
+    persisted: PersistedProjectionRevision
+    publication_id: str
+    rebuild_job_id: str
+    execution_id: str
+    published_at: datetime
 
 
 def _utcnow() -> datetime:
@@ -684,6 +726,117 @@ class RelationshipAssertionRepository:
     def get_projection_revision(self, revision_id: str) -> PersistedProjectionRevision | None:
         """Load a persisted candidate revision and its ordered edges."""
         return ProjectionRevisionStore(self._session, clock=self._clock).get(revision_id)
+
+    def load_projection_source_snapshot(self) -> ProjectionSourceSnapshot:
+        """Load all append-only projector inputs in deterministic order."""
+        assertion_rows = self._session.execute(
+            select(RelationshipAssertionORM).order_by(RelationshipAssertionORM.id)
+        ).scalars()
+        event_rows = self._session.execute(
+            select(RelationshipAssertionEventORM).order_by(
+                RelationshipAssertionEventORM.assertion_id,
+                RelationshipAssertionEventORM.sequence,
+                RelationshipAssertionEventORM.id,
+            )
+        ).scalars()
+        evidence_rows = self._session.execute(
+            select(RelationshipEvidenceORM).order_by(RelationshipEvidenceORM.id)
+        ).scalars()
+        link_rows = self._session.execute(
+            select(RelationshipAssertionEvidenceORM).order_by(
+                RelationshipAssertionEvidenceORM.assertion_id,
+                RelationshipAssertionEvidenceORM.evidence_id,
+                RelationshipAssertionEvidenceORM.id,
+            )
+        ).scalars()
+        return ProjectionSourceSnapshot(
+            assertions=tuple(_fix_assertion_mapping(row) for row in assertion_rows),
+            events=tuple(_event_from_orm(row) for row in event_rows),
+            evidence=tuple(_evidence_from_orm(row) for row in evidence_rows),
+            evidence_links=tuple(_link_from_orm(row) for row in link_rows),
+        )
+
+    def latest_published_scopes(self, purpose: str) -> tuple[GovernedScope, ...]:
+        """Load scopes from the latest successfully published revision."""
+        return ProjectionRevisionStore(self._session, clock=self._clock).latest_published_scopes(purpose)
+
+    def latest_published_projection(self, purpose: str) -> PersistedProjectionRevision | None:
+        """Load the latest successful projection publication for ``purpose``."""
+        revision_id = self._session.execute(
+            select(RelationshipProjectionPublicationORM.revision_id)
+            .join(
+                RelationshipProjectionRevisionORM,
+                RelationshipProjectionRevisionORM.id == RelationshipProjectionPublicationORM.revision_id,
+            )
+            .join(
+                RebuildJobORM,
+                RebuildJobORM.job_id == RelationshipProjectionPublicationORM.rebuild_job_id,
+            )
+            .where(RelationshipProjectionRevisionORM.purpose == purpose)
+            .where(RebuildJobORM.status == "succeeded")
+            .order_by(
+                RelationshipProjectionPublicationORM.published_at.desc(),
+                RelationshipProjectionPublicationORM.rebuild_job_id.desc(),
+                RelationshipProjectionPublicationORM.id.desc(),
+            )
+            .limit(1)
+        ).scalar_one_or_none()
+        return None if revision_id is None else self.get_projection_revision(revision_id)
+
+    def finalize_projection_publication(
+        self,
+        request: FinalizeProjectionPublicationRequest,
+        *,
+        pre_commit_check: Callable[[], None],
+    ) -> PublishedProjectionRevision:
+        """Atomically persist one candidate, succeed its owner job, and publish it.
+
+        The existing owner-guarded ``RUNNING -> SUCCEEDED`` update serializes
+        concurrent first publishers for the rebuild job. Any failure rolls the
+        candidate, success transition, and publication back together.
+        """
+        execution_id = request.execution_id
+        if not isinstance(execution_id, str) or not execution_id.strip():
+            raise ValidationError("publication execution_id must be non-null and non-empty")
+
+        persisted = self.persist_projection_revision(request.projection)
+        pre_commit_check()
+
+        from src.data.repository import AssetGraphRepository  # pylint: disable=import-outside-toplevel
+
+        AssetGraphRepository(self._session).mark_rebuild_job_succeeded(
+            request.rebuild_job_id,
+            execution_id=execution_id,
+            node_count=request.node_count,
+            edge_count=request.edge_count,
+            duration_ms=request.duration_ms,
+        )
+
+        publication_id = request.publication_id or str(uuid4())
+        published_at = self._server_time() if request.published_at is None else _server_utc(request.published_at)
+        try:
+            with self._session.begin_nested():
+                self._session.add(
+                    RelationshipProjectionPublicationORM(
+                        id=publication_id,
+                        revision_id=persisted.revision_id,
+                        rebuild_job_id=request.rebuild_job_id,
+                        execution_id=execution_id,
+                        published_at=published_at,
+                    )
+                )
+                self._session.flush()
+        except IntegrityError as exc:
+            raise ConcurrencyConflict(f"publication insert conflicted for rebuild {request.rebuild_job_id}") from exc
+
+        pre_commit_check()
+        return PublishedProjectionRevision(
+            persisted=persisted,
+            publication_id=publication_id,
+            rebuild_job_id=request.rebuild_job_id,
+            execution_id=execution_id,
+            published_at=published_at,
+        )
 
     def current_state(self, assertion_id: str) -> LifecycleState:
         """Return the latest lifecycle state for ``assertion_id``."""

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -61,6 +61,7 @@ from src.governance.relationship_assertion_lifecycle import (
     validate_authority,
     validate_evidence_record,
 )
+from src.logic.reconciliation_engine import RebuildCancelledError
 from src.logic.relationship_projection import GovernedScope
 
 UTC = timezone.utc
@@ -727,11 +728,29 @@ class RelationshipAssertionRepository:
         """Load a persisted candidate revision and its ordered edges."""
         return ProjectionRevisionStore(self._session, clock=self._clock).get(revision_id)
 
-    def load_projection_source_snapshot(self) -> ProjectionSourceSnapshot:
-        """Load all append-only projector inputs in deterministic order."""
+    def load_projection_source_snapshot(
+        self,
+        *,
+        cancel_check: Callable[[], bool] | None = None,
+    ) -> ProjectionSourceSnapshot:
+        """Load all append-only projector inputs from one deterministic snapshot."""
+        bind = self._session.get_bind()
+        if bind.dialect.name == "postgresql" and not self._session.in_transaction():
+            self._session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
+
+        def check_cancelled() -> None:
+            if cancel_check is not None and cancel_check():
+                raise RebuildCancelledError("Rebuild cancelled while loading projection source snapshot")
+
+        check_cancelled()
         assertion_rows = self._session.execute(
             select(RelationshipAssertionORM).order_by(RelationshipAssertionORM.id)
         ).scalars()
+        assertions = []
+        for row in assertion_rows:
+            check_cancelled()
+            assertions.append(_fix_assertion_mapping(row))
+
         event_rows = self._session.execute(
             select(RelationshipAssertionEventORM).order_by(
                 RelationshipAssertionEventORM.assertion_id,
@@ -739,9 +758,19 @@ class RelationshipAssertionRepository:
                 RelationshipAssertionEventORM.id,
             )
         ).scalars()
+        events = []
+        for row in event_rows:
+            check_cancelled()
+            events.append(_event_from_orm(row))
+
         evidence_rows = self._session.execute(
             select(RelationshipEvidenceORM).order_by(RelationshipEvidenceORM.id)
         ).scalars()
+        evidence = []
+        for row in evidence_rows:
+            check_cancelled()
+            evidence.append(_evidence_from_orm(row))
+
         link_rows = self._session.execute(
             select(RelationshipAssertionEvidenceORM).order_by(
                 RelationshipAssertionEvidenceORM.assertion_id,
@@ -749,11 +778,16 @@ class RelationshipAssertionRepository:
                 RelationshipAssertionEvidenceORM.id,
             )
         ).scalars()
+        evidence_links = []
+        for row in link_rows:
+            check_cancelled()
+            evidence_links.append(_link_from_orm(row))
+        check_cancelled()
         return ProjectionSourceSnapshot(
-            assertions=tuple(_fix_assertion_mapping(row) for row in assertion_rows),
-            events=tuple(_event_from_orm(row) for row in event_rows),
-            evidence=tuple(_evidence_from_orm(row) for row in evidence_rows),
-            evidence_links=tuple(_link_from_orm(row) for row in link_rows),
+            assertions=tuple(assertions),
+            events=tuple(events),
+            evidence=tuple(evidence),
+            evidence_links=tuple(evidence_links),
         )
 
     def latest_published_scopes(self, purpose: str) -> tuple[GovernedScope, ...]:
@@ -783,10 +817,40 @@ class RelationshipAssertionRepository:
         ).scalar_one_or_none()
         return None if revision_id is None else self.get_projection_revision(revision_id)
 
+    def next_publication_time(self, purpose: str) -> datetime:
+        """Return a database-derived timestamp ordered after prior successful publications."""
+        database_now: datetime | None
+        if self._session.get_bind().dialect.name == "sqlite":
+            raw_database_now = self._session.execute(select(func.strftime("%Y-%m-%d %H:%M:%f", "now"))).scalar_one()
+            database_now = datetime.fromisoformat(raw_database_now).replace(tzinfo=UTC)
+        else:
+            database_now = _as_utc(self._session.execute(select(func.current_timestamp())).scalar_one())
+        if database_now is None:
+            raise ValidationError("database current timestamp is required for publication")
+        latest = _as_utc(
+            self._session.execute(
+                select(func.max(RelationshipProjectionPublicationORM.published_at))
+                .join(
+                    RelationshipProjectionRevisionORM,
+                    RelationshipProjectionRevisionORM.id == RelationshipProjectionPublicationORM.revision_id,
+                )
+                .join(
+                    RebuildJobORM,
+                    RebuildJobORM.job_id == RelationshipProjectionPublicationORM.rebuild_job_id,
+                )
+                .where(RelationshipProjectionRevisionORM.purpose == purpose)
+                .where(RebuildJobORM.status == "succeeded")
+            ).scalar_one()
+        )
+        if latest is not None and latest >= database_now:
+            return latest + timedelta(microseconds=1)
+        return database_now
+
     def finalize_projection_publication(
         self,
         request: FinalizeProjectionPublicationRequest,
         *,
+        pre_success_check: Callable[[], None],
         pre_commit_check: Callable[[], None],
     ) -> PublishedProjectionRevision:
         """Atomically persist one candidate, succeed its owner job, and publish it.
@@ -799,8 +863,7 @@ class RelationshipAssertionRepository:
         if not isinstance(execution_id, str) or not execution_id.strip():
             raise ValidationError("publication execution_id must be non-null and non-empty")
 
-        persisted = self.persist_projection_revision(request.projection)
-        pre_commit_check()
+        pre_success_check()
 
         from src.data.repository import AssetGraphRepository  # pylint: disable=import-outside-toplevel
 
@@ -811,6 +874,7 @@ class RelationshipAssertionRepository:
             edge_count=request.edge_count,
             duration_ms=request.duration_ms,
         )
+        persisted = self.persist_projection_revision(request.projection)
 
         publication_id = request.publication_id or str(uuid4())
         published_at = self._server_time() if request.published_at is None else _server_utc(request.published_at)

--- a/src/data/relationship_assertion_repository.py
+++ b/src/data/relationship_assertion_repository.py
@@ -183,6 +183,12 @@ def _server_utc(value: object) -> datetime:
     return value.astimezone(UTC)
 
 
+def _check_rebuild_cancelled(cancel_check: Callable[[], bool] | None) -> None:
+    """Raise the rebuild cancellation signal when requested."""
+    if cancel_check is not None and cancel_check():
+        raise RebuildCancelledError("Rebuild cancelled while loading projection source snapshot")
+
+
 def _event_from_orm(row: RelationshipAssertionEventORM) -> AssertionEvent:
     recorded_at = _as_utc(row.recorded_at)
     if recorded_at is None:
@@ -738,17 +744,13 @@ class RelationshipAssertionRepository:
         if bind.dialect.name == "postgresql" and not self._session.in_transaction():
             self._session.connection(execution_options={"isolation_level": "REPEATABLE READ"})
 
-        def check_cancelled() -> None:
-            if cancel_check is not None and cancel_check():
-                raise RebuildCancelledError("Rebuild cancelled while loading projection source snapshot")
-
-        check_cancelled()
+        _check_rebuild_cancelled(cancel_check)
         assertion_rows = self._session.execute(
             select(RelationshipAssertionORM).order_by(RelationshipAssertionORM.id)
         ).scalars()
         assertions = []
         for row in assertion_rows:
-            check_cancelled()
+            _check_rebuild_cancelled(cancel_check)
             assertions.append(_fix_assertion_mapping(row))
 
         event_rows = self._session.execute(
@@ -760,7 +762,7 @@ class RelationshipAssertionRepository:
         ).scalars()
         events = []
         for row in event_rows:
-            check_cancelled()
+            _check_rebuild_cancelled(cancel_check)
             events.append(_event_from_orm(row))
 
         evidence_rows = self._session.execute(
@@ -768,7 +770,7 @@ class RelationshipAssertionRepository:
         ).scalars()
         evidence = []
         for row in evidence_rows:
-            check_cancelled()
+            _check_rebuild_cancelled(cancel_check)
             evidence.append(_evidence_from_orm(row))
 
         link_rows = self._session.execute(
@@ -780,9 +782,9 @@ class RelationshipAssertionRepository:
         ).scalars()
         evidence_links = []
         for row in link_rows:
-            check_cancelled()
+            _check_rebuild_cancelled(cancel_check)
             evidence_links.append(_link_from_orm(row))
-        check_cancelled()
+        _check_rebuild_cancelled(cancel_check)
         return ProjectionSourceSnapshot(
             assertions=tuple(assertions),
             events=tuple(events),

--- a/src/data/repository.py
+++ b/src/data/repository.py
@@ -209,6 +209,22 @@ class CoordinationLockRepository:
             ttl_seconds=ttl_seconds,
         )
 
+    def renew_owned_lock(self, *, lock_name: str, holder_id: str, ttl_seconds: int) -> bool:
+        """Renew an unexpired lease owned by ``holder_id`` in the current transaction."""
+        if ttl_seconds <= 0:
+            raise ValueError("ttl_seconds must be greater than 0")
+        now = datetime.now(timezone.utc)  # noqa: UP017
+        result = self.session.execute(
+            update(DistributedLockORM)
+            .where(
+                DistributedLockORM.lock_name == lock_name,
+                DistributedLockORM.holder_id == holder_id,
+                DistributedLockORM.expires_at > now,
+            )
+            .values(expires_at=now + timedelta(seconds=ttl_seconds), updated_at=now)
+        )
+        return bool(result.rowcount and result.rowcount > 0)  # type: ignore[attr-defined]
+
     def release_lock(self, *, lock_name: str, holder_id: str) -> bool:
         """Release a distributed lock if held by the specified holder."""
         result = self.session.execute(

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -462,6 +462,36 @@ def project(request: ProjectRequest) -> ProjectionRevision:
     )
 
 
+def _governed_edge_types(
+    revision: ProjectionRevision,
+    predicate_registry: PredicatesDocument | Sequence[PredicateSpec],
+) -> set[str]:
+    """Validate governed scopes and return the edge types they own."""
+    predicates = _predicate_index(predicate_registry)
+    edge_types: set[str] = set()
+    for scope in revision.governed_scopes:
+        if scope.purpose != revision.purpose:
+            raise ProjectionError("governed scope purpose does not match revision purpose")
+        predicate = predicates.get(scope.predicate_id)
+        if predicate is None:
+            raise ProjectionError(f"governed scope predicate is not registered: {scope.predicate_id}")
+        if predicate.projection.purpose != revision.purpose:
+            raise ProjectionError(f"governed scope predicate has wrong purpose: {scope.predicate_id}")
+        edge_types.add(predicate.projection.edge_type)
+    return edge_types
+
+
+def _edge_strength(edge: ProjectionEdge) -> float:
+    """Convert and range-check a governed edge strength."""
+    try:
+        strength = float(Decimal(edge.strength))
+    except (InvalidOperation, ValueError) as exc:
+        raise ProjectionError(f"projection edge has invalid strength: {edge.strength}") from exc
+    if not 0.0 <= strength <= 1.0:
+        raise ProjectionError(f"projection edge strength is out of range: {edge.strength}")
+    return strength
+
+
 def overlay_governed_relationships(
     relationships: Mapping[str, Sequence[GraphRelationship]],
     revision: ProjectionRevision,
@@ -473,17 +503,7 @@ def overlay_governed_relationships(
     emits no edges. This prevents an empty governed revision from allowing a
     legacy edge to reappear.
     """
-    predicates = _predicate_index(predicate_registry)
-    governed_edge_types: set[str] = set()
-    for scope in revision.governed_scopes:
-        if scope.purpose != revision.purpose:
-            raise ProjectionError("governed scope purpose does not match revision purpose")
-        predicate = predicates.get(scope.predicate_id)
-        if predicate is None:
-            raise ProjectionError(f"governed scope predicate is not registered: {scope.predicate_id}")
-        if predicate.projection.purpose != revision.purpose:
-            raise ProjectionError(f"governed scope predicate has wrong purpose: {scope.predicate_id}")
-        governed_edge_types.add(predicate.projection.edge_type)
+    governed_edge_types = _governed_edge_types(revision, predicate_registry)
 
     overlaid: dict[str, list[GraphRelationship]] = {}
     for source_id, entries in relationships.items():
@@ -494,12 +514,7 @@ def overlay_governed_relationships(
     for edge in revision.edges:
         if edge.edge_type not in governed_edge_types:
             raise ProjectionError(f"projection edge is outside governed scope: {edge.edge_type}")
-        try:
-            strength = float(Decimal(edge.strength))
-        except (InvalidOperation, ValueError) as exc:
-            raise ProjectionError(f"projection edge has invalid strength: {edge.strength}") from exc
-        if not 0.0 <= strength <= 1.0:
-            raise ProjectionError(f"projection edge strength is out of range: {edge.strength}")
+        strength = _edge_strength(edge)
         overlaid.setdefault(edge.source_id, []).append((edge.target_id, edge.edge_type, strength))
         if edge.direction == "bidirectional":
             overlaid.setdefault(edge.target_id, []).append((edge.source_id, edge.edge_type, strength))

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -12,6 +12,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 from src.governance.relationship_assertion import (
@@ -92,6 +93,9 @@ class ProjectRequest:
     contract_version: str = CONTRACT_VERSION
     previously_published_scopes: Sequence[GovernedScope] = ()
     projector_version: str = PROJECTOR_VERSION
+
+
+GraphRelationship = tuple[str, str, float]
 
 
 @dataclass(frozen=True, slots=True)
@@ -456,3 +460,51 @@ def project(request: ProjectRequest) -> ProjectionRevision:
         edges=edges,
         governed_scopes=governed_scopes,
     )
+
+
+def overlay_governed_relationships(
+    relationships: Mapping[str, Sequence[GraphRelationship]],
+    revision: ProjectionRevision,
+    predicate_registry: PredicatesDocument | Sequence[PredicateSpec],
+) -> dict[str, list[GraphRelationship]]:
+    """Overlay one governed revision on legacy relationships deterministically.
+
+    Established scopes own their registered edge types even when the revision
+    emits no edges. This prevents an empty governed revision from allowing a
+    legacy edge to reappear.
+    """
+    predicates = _predicate_index(predicate_registry)
+    governed_edge_types: set[str] = set()
+    for scope in revision.governed_scopes:
+        if scope.purpose != revision.purpose:
+            raise ProjectionError("governed scope purpose does not match revision purpose")
+        predicate = predicates.get(scope.predicate_id)
+        if predicate is None:
+            raise ProjectionError(f"governed scope predicate is not registered: {scope.predicate_id}")
+        if predicate.projection.purpose != revision.purpose:
+            raise ProjectionError(f"governed scope predicate has wrong purpose: {scope.predicate_id}")
+        governed_edge_types.add(predicate.projection.edge_type)
+
+    overlaid: dict[str, list[GraphRelationship]] = {}
+    for source_id, entries in relationships.items():
+        retained = [entry for entry in entries if entry[1] not in governed_edge_types]
+        if retained:
+            overlaid[source_id] = retained
+
+    for edge in revision.edges:
+        if edge.edge_type not in governed_edge_types:
+            raise ProjectionError(f"projection edge is outside governed scope: {edge.edge_type}")
+        try:
+            strength = float(Decimal(edge.strength))
+        except (InvalidOperation, ValueError) as exc:
+            raise ProjectionError(f"projection edge has invalid strength: {edge.strength}") from exc
+        if not 0.0 <= strength <= 1.0:
+            raise ProjectionError(f"projection edge strength is out of range: {edge.strength}")
+        overlaid.setdefault(edge.source_id, []).append((edge.target_id, edge.edge_type, strength))
+        if edge.direction == "bidirectional":
+            overlaid.setdefault(edge.target_id, []).append((edge.source_id, edge.edge_type, strength))
+
+    return {
+        source_id: sorted(entries, key=lambda entry: (entry[0], entry[1], entry[2]))
+        for source_id, entries in sorted(overlaid.items())
+    }

--- a/src/logic/relationship_projection.py
+++ b/src/logic/relationship_projection.py
@@ -470,26 +470,67 @@ def _governed_edge_types(
     predicates = _predicate_index(predicate_registry)
     edge_types: set[str] = set()
     for scope in revision.governed_scopes:
-        if scope.purpose != revision.purpose:
-            raise ProjectionError("governed scope purpose does not match revision purpose")
-        predicate = predicates.get(scope.predicate_id)
-        if predicate is None:
-            raise ProjectionError(f"governed scope predicate is not registered: {scope.predicate_id}")
-        if predicate.projection.purpose != revision.purpose:
-            raise ProjectionError(f"governed scope predicate has wrong purpose: {scope.predicate_id}")
-        edge_types.add(predicate.projection.edge_type)
+        edge_types.add(_governed_edge_type(scope, revision, predicates))
     return edge_types
+
+
+def _governed_edge_type(
+    scope: GovernedScope,
+    revision: ProjectionRevision,
+    predicates: Mapping[str, PredicateSpec],
+) -> str:
+    """Validate one governed scope and return its registered edge type."""
+    if scope.purpose != revision.purpose:
+        raise ProjectionError("governed scope purpose does not match revision purpose")
+    predicate = predicates.get(scope.predicate_id)
+    if predicate is None:
+        raise ProjectionError(f"governed scope predicate is not registered: {scope.predicate_id}")
+    if predicate.projection.purpose != revision.purpose:
+        raise ProjectionError(f"governed scope predicate has wrong purpose: {scope.predicate_id}")
+    return predicate.projection.edge_type
 
 
 def _edge_strength(edge: ProjectionEdge) -> float:
     """Convert and range-check a governed edge strength."""
-    try:
-        strength = float(Decimal(edge.strength))
-    except (InvalidOperation, ValueError) as exc:
-        raise ProjectionError(f"projection edge has invalid strength: {edge.strength}") from exc
+    strength = _parse_edge_strength(edge.strength)
     if not 0.0 <= strength <= 1.0:
         raise ProjectionError(f"projection edge strength is out of range: {edge.strength}")
     return strength
+
+
+def _parse_edge_strength(value: str) -> float:
+    """Convert a governed edge strength from its canonical decimal form."""
+    try:
+        return float(Decimal(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ProjectionError(f"projection edge has invalid strength: {value}") from exc
+
+
+def _retained_relationships(
+    relationships: Mapping[str, Sequence[GraphRelationship]],
+    governed_edge_types: set[str],
+) -> dict[str, list[GraphRelationship]]:
+    """Remove legacy entries owned by governed edge scopes."""
+    retained_relationships: dict[str, list[GraphRelationship]] = {}
+    for source_id, entries in relationships.items():
+        retained = [entry for entry in entries if entry[1] not in governed_edge_types]
+        if retained:
+            retained_relationships[source_id] = retained
+    return retained_relationships
+
+
+def _append_projection_edge(
+    relationships: dict[str, list[GraphRelationship]],
+    edge: ProjectionEdge,
+    governed_edge_types: set[str],
+) -> None:
+    """Validate and append one projected edge to the governed overlay."""
+    if edge.edge_type not in governed_edge_types:
+        raise ProjectionError(f"projection edge is outside governed scope: {edge.edge_type}")
+    strength = _edge_strength(edge)
+    relationships.setdefault(edge.source_id, []).append((edge.target_id, edge.edge_type, strength))
+    if edge.direction == "bidirectional":
+        relationships.setdefault(edge.target_id, []).append((edge.source_id, edge.edge_type, strength))
 
 
 def overlay_governed_relationships(
@@ -504,20 +545,10 @@ def overlay_governed_relationships(
     legacy edge to reappear.
     """
     governed_edge_types = _governed_edge_types(revision, predicate_registry)
-
-    overlaid: dict[str, list[GraphRelationship]] = {}
-    for source_id, entries in relationships.items():
-        retained = [entry for entry in entries if entry[1] not in governed_edge_types]
-        if retained:
-            overlaid[source_id] = retained
+    overlaid = _retained_relationships(relationships, governed_edge_types)
 
     for edge in revision.edges:
-        if edge.edge_type not in governed_edge_types:
-            raise ProjectionError(f"projection edge is outside governed scope: {edge.edge_type}")
-        strength = _edge_strength(edge)
-        overlaid.setdefault(edge.source_id, []).append((edge.target_id, edge.edge_type, strength))
-        if edge.direction == "bidirectional":
-            overlaid.setdefault(edge.target_id, []).append((edge.source_id, edge.edge_type, strength))
+        _append_projection_edge(overlaid, edge, governed_edge_types)
 
     return {
         source_id: sorted(entries, key=lambda entry: (entry[0], entry[1], entry[2]))

--- a/tests/integration/test_distributed_hosting_failure_modes.py
+++ b/tests/integration/test_distributed_hosting_failure_modes.py
@@ -15,6 +15,7 @@ import api.routers.graph_admin as graph_admin
 from src.data.database import create_engine_from_url, create_session_factory, init_db
 from src.data.db_models import RebuildJobORM, RebuildJobStatus
 from src.data.distributed_lock import DistributedLock
+from src.data.relationship_assertion_repository import RelationshipAssertionRepository
 from src.data.repository import AssetGraphRepository, session_scope
 from src.logic.recovery_gate import ExecutionBlockedError, RecoveryGate
 from tests.helpers.graph_scale_factory import build_scale_graph
@@ -219,11 +220,11 @@ def test_rebuild_failure_after_persist_does_not_corrupt_durable_graph_truth(
             lambda *_args, **_kwargs: (replacement, "sample"),
         )
 
-        def fail_success(*_args, **_kwargs):
-            """Simulate a failure while marking the job as succeeded."""
+        def fail_publication(*_args, **_kwargs):
+            """Simulate a failure inside the atomic publication boundary."""
             raise RuntimeError("synthetic success metadata failure")
 
-        monkeypatch.setattr(graph_admin, "_mark_job_succeeded_safe", fail_success)  # pylint: disable=protected-access
+        monkeypatch.setattr(RelationshipAssertionRepository, "finalize_projection_publication", fail_publication)
 
         with pytest.raises(graph_admin._RebuildExecutionError):  # pylint: disable=protected-access
             graph_admin._run_rebuild_pipeline(  # pylint: disable=protected-access

--- a/tests/integration/test_distributed_hosting_failure_modes.py
+++ b/tests/integration/test_distributed_hosting_failure_modes.py
@@ -268,8 +268,6 @@ def test_lock_lost_during_rebuild_aborts_before_success_marking(
 
         lock_lost = threading.Event()
         graph_built = False
-        save_called = False
-        success_called = False
         built_graph = build_scale_graph(asset_count=5, relationship_count=10, prefix="LOST")
 
         def build_then_lose_lock(*_args, **_kwargs):
@@ -279,19 +277,7 @@ def test_lock_lost_during_rebuild_aborts_before_success_marking(
             lock_lost.set()
             return built_graph, "sample"
 
-        def track_save(*_args, **_kwargs):
-            """Track if the graph save function was called."""
-            nonlocal save_called
-            save_called = True
-
-        def track_success(*_args, **_kwargs):
-            """Track if the job success function was called."""
-            nonlocal success_called
-            success_called = True
-
         monkeypatch.setattr(graph_admin, "build_rebuild_graph", build_then_lose_lock)
-        monkeypatch.setattr(graph_admin, "save_graph_to_persistence", track_save)
-        monkeypatch.setattr(graph_admin, "_mark_job_succeeded_safe", track_success)  # pylint: disable=protected-access
 
         with pytest.raises(graph_admin._RebuildExecutionError) as exc_info:  # pylint: disable=protected-access
             graph_admin._run_rebuild_pipeline(  # pylint: disable=protected-access
@@ -314,7 +300,6 @@ def test_lock_lost_during_rebuild_aborts_before_success_marking(
             job = AssetGraphRepository(session).get_rebuild_job(job_id)
             assert job is not None
             assert job.status == RebuildJobStatus.FAILED
-        assert save_called is False
-        assert success_called is False
+            assert len(AssetGraphRepository(session).load_graph().assets) == 0
     finally:
         engine.dispose()

--- a/tests/integration/test_financial_relationship_vertical_slice.py
+++ b/tests/integration/test_financial_relationship_vertical_slice.py
@@ -1,0 +1,300 @@
+"""End-to-end proof for atomic GRAC projection publication."""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from time import perf_counter
+from typing import cast
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, sessionmaker
+
+import api.routers.graph_admin as graph_admin
+from src.data.database import create_engine_from_url, create_session_factory, init_db
+from src.data.db_models import RebuildJobORM, RebuildJobStatus
+from src.data.relationship_assertion_db_models import (
+    RelationshipProjectionPublicationORM,
+    RelationshipProjectionRevisionORM,
+)
+from src.data.relationship_assertion_repository import (
+    RelationshipAssertionRepository,
+    RepositoryTransitionRequest,
+)
+from src.data.repository import AssetGraphRepository, session_scope
+from src.data.sample_data import create_sample_database
+from src.governance.relationship_assertion import AssertionProposal, AuthorityContext, ValidationError
+from src.logic.reconciliation_engine import RebuildCancelledError
+
+UTC = timezone.utc
+PURPOSE = "financial_graph_current_view"
+PREDICATE_ID = "financial.bond.issuer_reference@1"
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def publication_session_factory(tmp_path: Path) -> Iterator[sessionmaker]:
+    """Create one durable SQLite database for publication/restart proof."""
+    engine = create_engine_from_url(f"sqlite:///{tmp_path / 'grac-publication.db'}")
+    init_db(engine)
+    try:
+        yield create_session_factory(engine)
+    finally:
+        engine.dispose()
+
+
+def _authority(actor_id: str, role: str) -> AuthorityContext:
+    return AuthorityContext(
+        actor_id=actor_id,
+        roles=frozenset({role}),  # type: ignore[arg-type]
+        policy_version="grac.v1-policy",
+        correlation_id="corr-publication",
+    )
+
+
+def _create_running_job(
+    factory: sessionmaker,
+    *,
+    execution_id: str = "exec-publication",
+    persist_graph: bool = True,
+) -> str:
+    """Create an owner-bound running rebuild with an optional prior snapshot."""
+    with session_scope(factory) as session:
+        repo = AssetGraphRepository(session)
+        if persist_graph:
+            repo.save_graph(create_sample_database())
+        job_id = repo.create_rebuild_job(requested_by="integration-test")
+        repo.mark_rebuild_job_running(job_id, execution_id)
+        return job_id
+
+
+def _finalize(
+    factory: sessionmaker,
+    job_id: str,
+    *,
+    execution_id: str = "exec-publication",
+    graph=None,
+    lock_lost=None,
+    cancel_event=None,
+):
+    """Invoke the production atomic publication boundary."""
+    return graph_admin._finalize_rebuild_success(  # pylint: disable=protected-access
+        session_factory=factory,
+        job_id=job_id,
+        execution_id=execution_id,
+        graph=graph or create_sample_database(),
+        source="sample",
+        job_started_at=perf_counter(),
+        lock_lost=lock_lost or threading.Event(),
+        cancel_event=cancel_event or threading.Event(),
+    )
+
+
+def _publication_count(session: Session) -> int:
+    return session.execute(select(func.count()).select_from(RelationshipProjectionPublicationORM)).scalar_one()
+
+
+def _revision_count(session: Session) -> int:
+    return session.execute(select(func.count()).select_from(RelationshipProjectionRevisionORM)).scalar_one()
+
+
+def _canonical_relationships(relationships):
+    """Return relationship tuples ordered for semantic snapshot comparison."""
+    return {
+        source_id: sorted(entries, key=lambda entry: (entry[0], entry[1], entry[2]))
+        for source_id, entries in sorted(relationships.items())
+    }
+
+
+def test_empty_unestablished_store_preserves_legacy_graph_and_publishes_once(
+    publication_session_factory: sessionmaker,
+) -> None:
+    """An empty unestablished assertion store leaves graph behaviour unchanged."""
+    graph = create_sample_database()
+    legacy_relationships = {source: list(entries) for source, entries in graph.relationships.items()}
+    job_id = _create_running_job(publication_session_factory)
+
+    response = _finalize(publication_session_factory, job_id, graph=graph)
+
+    assert response.relationship_count == sum(len(entries) for entries in legacy_relationships.values())
+    with session_scope(publication_session_factory) as session:
+        job = session.get(RebuildJobORM, job_id)
+        assert job is not None
+        assert job.status == RebuildJobStatus.SUCCEEDED
+        assert _publication_count(session) == 1
+        assert _revision_count(session) == 1
+        latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
+        assert latest is not None
+        assert latest.revision.edges == ()
+        assert latest.revision.governed_scopes == ()
+        assert _canonical_relationships(AssetGraphRepository(session).load_graph().relationships) == (
+            _canonical_relationships(legacy_relationships)
+        )
+
+    with pytest.raises(ValueError):
+        _finalize(publication_session_factory, job_id)
+    with session_scope(publication_session_factory) as session:
+        assert _publication_count(session) == 1
+        assert _revision_count(session) == 1
+
+
+@pytest.mark.parametrize(
+    ("execution_id", "expected_error"),
+    [
+        ("stale-owner", ValueError),
+        (cast(str, None), ValidationError),
+        ("", ValidationError),
+    ],
+)
+def test_invalid_publication_identity_rolls_back_everything(
+    publication_session_factory: sessionmaker,
+    execution_id: str,
+    expected_error: type[Exception],
+) -> None:
+    """Null, empty, and mismatched identities cannot expose a candidate."""
+    job_id = _create_running_job(publication_session_factory, execution_id="owner-execution")
+
+    with pytest.raises(expected_error):
+        _finalize(publication_session_factory, job_id, execution_id=execution_id)
+
+    with session_scope(publication_session_factory) as session:
+        job = session.get(RebuildJobORM, job_id)
+        assert job is not None
+        assert job.status == RebuildJobStatus.RUNNING
+        assert _publication_count(session) == 0
+        assert _revision_count(session) == 0
+
+
+class _TripEvent:
+    """Event-like test double that trips on a selected safety check."""
+
+    def __init__(self, trip_on: int) -> None:
+        self._trip_on = trip_on
+        self._checks = 0
+
+    def is_set(self) -> bool:
+        self._checks += 1
+        return self._checks >= self._trip_on
+
+
+@pytest.mark.parametrize(
+    ("event_name", "expected_error"),
+    [
+        ("lock_lost", graph_admin._DistributedLockLostError),  # pylint: disable=protected-access
+        ("cancel_event", RebuildCancelledError),
+    ],
+)
+def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
+    publication_session_factory: sessionmaker,
+    event_name: str,
+    expected_error: type[Exception],
+) -> None:
+    """Lock loss or cancellation at the final gate leaves no visible candidate."""
+    initial_graph = create_sample_database()
+    initial_relationships = {source: list(entries) for source, entries in initial_graph.relationships.items()}
+    job_id = _create_running_job(publication_session_factory)
+    lock_lost = _TripEvent(3) if event_name == "lock_lost" else threading.Event()
+    cancel_event = _TripEvent(3) if event_name == "cancel_event" else threading.Event()
+
+    with pytest.raises(expected_error):
+        _finalize(
+            publication_session_factory,
+            job_id,
+            lock_lost=lock_lost,
+            cancel_event=cancel_event,
+        )
+
+    with session_scope(publication_session_factory) as session:
+        job = session.get(RebuildJobORM, job_id)
+        assert job is not None
+        assert job.status == RebuildJobStatus.RUNNING
+        assert _publication_count(session) == 0
+        assert _revision_count(session) == 0
+        assert _canonical_relationships(AssetGraphRepository(session).load_graph().relationships) == (
+            _canonical_relationships(initial_relationships)
+        )
+
+
+def test_governed_issuer_slice_survives_restart_and_empty_successor(
+    publication_session_factory: sessionmaker,
+) -> None:
+    """Publish, reload, then retain governed scope after the edge is retracted."""
+    proposer = _authority("actor-proposer", "proposer")
+    determiner = _authority("actor-determiner", "acceptor")
+    retractor = _authority("actor-retractor", "retractor")
+    effective_from = datetime.now(tz=UTC) - timedelta(days=1)
+
+    with session_scope(publication_session_factory) as session:
+        repo = RelationshipAssertionRepository(session)
+        repo.propose(
+            AssertionProposal(
+                assertion_id="assertion-issuer",
+                predicate_id=PREDICATE_ID,
+                subject_id="AAPL_BOND_2030",
+                object_id="AAPL",
+                method_id="bond.issuer_id.resolution@1",
+                proposition="AAPL is the issuer of AAPL_BOND_2030",
+                effective_from=effective_from,
+            ),
+            proposer,
+            event_id="event-proposed",
+        )
+        repo.transition(
+            RepositoryTransitionRequest(
+                assertion_id="assertion-issuer",
+                to_state="Accepted",
+                ctx=determiner,
+                expected_sequence=1,
+                rationale="independent determination",
+                event_id="event-accepted",
+            )
+        )
+
+    first_job_id = _create_running_job(publication_session_factory)
+    _finalize(publication_session_factory, first_job_id)
+
+    with session_scope(publication_session_factory) as session:
+        repo = RelationshipAssertionRepository(session)
+        first = repo.latest_published_projection(PURPOSE)
+        assert first is not None
+        assert first.revision.governed_scopes[0].predicate_id == PREDICATE_ID
+        assert first.revision.edges[0].assertion_id == "assertion-issuer"
+        restarted = AssetGraphRepository(session).load_graph()
+        assert ("AAPL", "corporate_link", 0.8) in restarted.relationships["AAPL_BOND_2030"]
+        history = repo.get_as_of("assertion-issuer", known_at=datetime.now(tz=UTC))
+        assert history is not None
+        assert history.events[0].actor_id == "actor-proposer"
+        assert history.events[1].actor_id == "actor-determiner"
+        assert history.events[0].actor_id != history.events[1].actor_id
+
+        repo.transition(
+            RepositoryTransitionRequest(
+                assertion_id="assertion-issuer",
+                to_state="Retracted",
+                ctx=retractor,
+                expected_sequence=2,
+                rationale="issuer relationship withdrawn",
+                event_id="event-retracted",
+            )
+        )
+
+    second_job_id = _create_running_job(publication_session_factory, persist_graph=False)
+    _finalize(publication_session_factory, second_job_id)
+
+    with session_scope(publication_session_factory) as session:
+        repo = RelationshipAssertionRepository(session)
+        second = repo.latest_published_projection(PURPOSE)
+        assert second is not None
+        assert second.revision.edges == ()
+        assert second.revision.governed_scopes[0].predicate_id == PREDICATE_ID
+        restarted = AssetGraphRepository(session).load_graph()
+        assert all(
+            relationship_type != "corporate_link"
+            for entries in restarted.relationships.values()
+            for _target_id, relationship_type, _strength in entries
+        )
+        assert _publication_count(session) == 2

--- a/tests/integration/test_financial_relationship_vertical_slice.py
+++ b/tests/integration/test_financial_relationship_vertical_slice.py
@@ -7,7 +7,7 @@ from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from time import perf_counter
-from typing import cast
+from typing import Any
 
 import pytest
 from sqlalchemy import func, select
@@ -24,7 +24,7 @@ from src.data.relationship_assertion_repository import (
     RelationshipAssertionRepository,
     RepositoryTransitionRequest,
 )
-from src.data.repository import AssetGraphRepository, session_scope
+from src.data.repository import AssetGraphRepository, CoordinationLockRepository, session_scope
 from src.data.sample_data import create_sample_database
 from src.governance.relationship_assertion import AssertionProposal, AuthorityContext, ValidationError
 from src.logic.reconciliation_engine import RebuildCancelledError
@@ -75,22 +75,22 @@ def _create_running_job(
 def _finalize(
     factory: sessionmaker,
     job_id: str,
-    *,
-    execution_id: str = "exec-publication",
-    graph=None,
-    lock_lost=None,
-    cancel_event=None,
+    **overrides: Any,
 ):
     """Invoke the production atomic publication boundary."""
+    arguments: dict[str, Any] = {
+        "session_factory": factory,
+        "job_id": job_id,
+        "execution_id": "exec-publication",
+        "graph": create_sample_database(),
+        "source": "sample",
+        "job_started_at": perf_counter(),
+        "lock_lost": threading.Event(),
+        "cancel_event": threading.Event(),
+    }
+    arguments.update(overrides)
     return graph_admin._finalize_rebuild_success(  # pylint: disable=protected-access
-        session_factory=factory,
-        job_id=job_id,
-        execution_id=execution_id,
-        graph=graph or create_sample_database(),
-        source="sample",
-        job_started_at=perf_counter(),
-        lock_lost=lock_lost or threading.Event(),
-        cancel_event=cancel_event or threading.Event(),
+        **arguments,
     )
 
 
@@ -128,7 +128,8 @@ def test_empty_unestablished_store_preserves_legacy_graph_and_publishes_once(
         assert _publication_count(session) == 1
         assert _revision_count(session) == 1
         publication = session.execute(select(RelationshipProjectionPublicationORM)).scalar_one()
-        assert publication.execution_id == "exec-publication"
+        assert publication.execution_id is not None
+        assert publication.execution_id == job.execution_id
         assert publication.rebuild_job_id == job_id
         latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
         assert latest is not None
@@ -149,13 +150,13 @@ def test_empty_unestablished_store_preserves_legacy_graph_and_publishes_once(
     ("execution_id", "expected_error"),
     [
         ("stale-owner", ValueError),
-        (cast(str, None), ValidationError),
+        (None, ValidationError),
         ("", ValidationError),
     ],
 )
 def test_invalid_publication_identity_rolls_back_everything(
     publication_session_factory: sessionmaker,
-    execution_id: str,
+    execution_id: str | None,
     expected_error: type[Exception],
 ) -> None:
     """Null, empty, and mismatched identities cannot expose a candidate."""
@@ -172,16 +173,125 @@ def test_invalid_publication_identity_rolls_back_everything(
         assert _revision_count(session) == 0
 
 
-class _TripEvent:
-    """Event-like test double that trips on a selected safety check."""
+def test_dangling_assertion_endpoints_are_deferred_without_blocking_publication(
+    publication_session_factory: sessionmaker,
+) -> None:
+    """Assertions outside the rebuilt asset universe stay dormant instead of violating graph FKs."""
+    with session_scope(publication_session_factory) as session:
+        repo = RelationshipAssertionRepository(session)
+        repo.propose(
+            AssertionProposal(
+                assertion_id="assertion-missing-bond",
+                predicate_id=PREDICATE_ID,
+                subject_id="MISSING_BOND",
+                object_id="AAPL",
+                method_id="bond.issuer_id.resolution@1",
+                proposition="AAPL is the issuer of a currently absent bond",
+                effective_from=datetime.now(tz=UTC) - timedelta(days=1),
+            ),
+            _authority("actor-proposer", "proposer"),
+            event_id="event-missing-proposed",
+        )
+        repo.transition(
+            RepositoryTransitionRequest(
+                assertion_id="assertion-missing-bond",
+                to_state="Accepted",
+                ctx=_authority("actor-determiner", "acceptor"),
+                expected_sequence=1,
+                rationale="independent determination",
+                event_id="event-missing-accepted",
+            )
+        )
 
-    def __init__(self, trip_on: int) -> None:
-        self._trip_on = trip_on
-        self._checks = 0
+    job_id = _create_running_job(publication_session_factory)
+    _finalize(publication_session_factory, job_id)
 
-    def is_set(self) -> bool:
-        self._checks += 1
-        return self._checks >= self._trip_on
+    with session_scope(publication_session_factory) as session:
+        job = session.get(RebuildJobORM, job_id)
+        latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
+        assert job is not None and job.status == RebuildJobStatus.SUCCEEDED
+        assert latest is not None and latest.revision.edges == ()
+        assert _publication_count(session) == 1
+
+
+def test_publication_time_is_monotonic_when_a_prior_worker_clock_is_ahead(
+    publication_session_factory: sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Database ordering keeps a later commit latest despite skewed prior publication time."""
+    future_time = datetime.now(tz=UTC) + timedelta(days=1)
+    original_next_time = RelationshipAssertionRepository.next_publication_time
+    monkeypatch.setattr(
+        RelationshipAssertionRepository,
+        "next_publication_time",
+        lambda _repo, _purpose: future_time,
+    )
+    first_job_id = _create_running_job(publication_session_factory)
+    _finalize(publication_session_factory, first_job_id)
+    monkeypatch.setattr(RelationshipAssertionRepository, "next_publication_time", original_next_time)
+
+    second_job_id = _create_running_job(publication_session_factory, persist_graph=False)
+    _finalize(publication_session_factory, second_job_id)
+
+    with session_scope(publication_session_factory) as session:
+        second = session.execute(
+            select(RelationshipProjectionPublicationORM).where(
+                RelationshipProjectionPublicationORM.rebuild_job_id == second_job_id
+            )
+        ).scalar_one()
+        latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
+        assert second.published_at.replace(tzinfo=UTC) > future_time
+        assert latest is not None and latest.revision_id == second.revision_id
+
+
+def test_publication_guard_supports_a_separate_coordination_database(
+    publication_session_factory: sessionmaker,
+    tmp_path: Path,
+) -> None:
+    """A held coordination predicate can safely guard a separate domain commit."""
+    coordination_engine = create_engine_from_url(f"sqlite:///{tmp_path / 'grac-coordination.db'}")
+    init_db(coordination_engine)
+    coordination_factory = create_session_factory(coordination_engine)
+    try:
+        with session_scope(coordination_factory) as session:
+            result = CoordinationLockRepository(session).acquire_lock(
+                lock_name="graph_rebuild",
+                holder_id="split-worker",
+                ttl_seconds=30,
+            )
+            assert result.success is True
+
+        job_id = _create_running_job(publication_session_factory)
+        _finalize(
+            publication_session_factory,
+            job_id,
+            lock_holder_id="split-worker",
+            lock_ttl_seconds=30,
+            coordination_session_factory=coordination_factory,
+            coordination_is_domain=False,
+        )
+
+        with session_scope(publication_session_factory) as session:
+            job = session.get(RebuildJobORM, job_id)
+            assert job is not None and job.status == RebuildJobStatus.SUCCEEDED
+            assert _publication_count(session) == 1
+    finally:
+        coordination_engine.dispose()
+
+
+class _TripGate:
+    """Safety verifier that fails only at one named execution stage."""
+
+    def __init__(self, verifier, *, target_stage: str, event_name: str, error_type: type[Exception]) -> None:
+        self._verifier = verifier
+        self._target_stage = target_stage
+        self._event_name = event_name
+        self._error_type = error_type
+
+    def __call__(self, lock_lost, cancel_event, stage: str) -> None:
+        if stage == self._target_stage:
+            raise self._error_type(f"{self._event_name} at stage={stage}")
+        self._verifier(lock_lost, cancel_event, stage)
 
 
 @pytest.mark.parametrize(
@@ -193,23 +303,29 @@ class _TripEvent:
 )
 def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
     publication_session_factory: sessionmaker,
+    monkeypatch: pytest.MonkeyPatch,
     event_name: str,
     expected_error: type[Exception],
 ) -> None:
-    """Lock loss or cancellation at the final gate leaves no visible candidate."""
+    """Lock loss or cancellation at the named final gate leaves no visible candidate."""
     initial_graph = create_sample_database()
     initial_relationships = {source: list(entries) for source, entries in initial_graph.relationships.items()}
     job_id = _create_running_job(publication_session_factory)
-    lock_lost = _TripEvent(3) if event_name == "lock_lost" else threading.Event()
-    cancel_event = _TripEvent(3) if event_name == "cancel_event" else threading.Event()
+    monkeypatch.setattr(
+        graph_admin,
+        "_verify_execution_state",
+        _TripGate(
+            graph_admin._verify_execution_state,  # pylint: disable=protected-access
+            target_stage="publication-pre-commit",
+            event_name=event_name,
+            error_type=expected_error,
+        ),
+    )
 
     with pytest.raises(expected_error):
-        _finalize(
-            publication_session_factory,
-            job_id,
-            lock_lost=lock_lost,
-            cancel_event=cancel_event,
-        )
+        _finalize(publication_session_factory, job_id, graph=initial_graph)
+
+    assert _canonical_relationships(initial_graph.relationships) == _canonical_relationships(initial_relationships)
 
     with session_scope(publication_session_factory) as session:
         job = session.get(RebuildJobORM, job_id)
@@ -222,15 +338,8 @@ def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
         )
 
 
-def test_governed_issuer_slice_survives_restart_and_empty_successor(
-    publication_session_factory: sessionmaker,
-) -> None:
-    """Publish, reload, then retain governed scope after the edge is retracted."""
-    proposer = _authority("actor-proposer", "proposer")
-    determiner = _authority("actor-determiner", "acceptor")
-    retractor = _authority("actor-retractor", "retractor")
-    effective_from = datetime.now(tz=UTC) - timedelta(days=1)
-
+def _accept_issuer_assertion(publication_session_factory: sessionmaker) -> None:
+    """Create and independently accept the canonical issuer assertion."""
     with session_scope(publication_session_factory) as session:
         repo = RelationshipAssertionRepository(session)
         repo.propose(
@@ -241,25 +350,25 @@ def test_governed_issuer_slice_survives_restart_and_empty_successor(
                 object_id="AAPL",
                 method_id="bond.issuer_id.resolution@1",
                 proposition="AAPL is the issuer of AAPL_BOND_2030",
-                effective_from=effective_from,
+                effective_from=datetime.now(tz=UTC) - timedelta(days=1),
             ),
-            proposer,
+            _authority("actor-proposer", "proposer"),
             event_id="event-proposed",
         )
         repo.transition(
             RepositoryTransitionRequest(
                 assertion_id="assertion-issuer",
                 to_state="Accepted",
-                ctx=determiner,
+                ctx=_authority("actor-determiner", "acceptor"),
                 expected_sequence=1,
                 rationale="independent determination",
                 event_id="event-accepted",
             )
         )
 
-    first_job_id = _create_running_job(publication_session_factory)
-    _finalize(publication_session_factory, first_job_id)
 
+def _verify_first_publication_and_retract(publication_session_factory: sessionmaker) -> None:
+    """Verify restart state and retract the accepted issuer assertion."""
     with session_scope(publication_session_factory) as session:
         repo = RelationshipAssertionRepository(session)
         first = repo.latest_published_projection(PURPOSE)
@@ -270,21 +379,27 @@ def test_governed_issuer_slice_survives_restart_and_empty_successor(
         assert ("AAPL", "corporate_link", 0.8) in restarted.relationships["AAPL_BOND_2030"]
         history = repo.get_as_of("assertion-issuer", known_at=datetime.now(tz=UTC))
         assert history is not None
-        assert history.events[0].actor_id == "actor-proposer"
-        assert history.events[1].actor_id == "actor-determiner"
-        assert history.events[0].actor_id != history.events[1].actor_id
-
+        assert [event.actor_id for event in history.events] == ["actor-proposer", "actor-determiner"]
         repo.transition(
             RepositoryTransitionRequest(
                 assertion_id="assertion-issuer",
                 to_state="Retracted",
-                ctx=retractor,
+                ctx=_authority("actor-retractor", "retractor"),
                 expected_sequence=2,
                 rationale="issuer relationship withdrawn",
                 event_id="event-retracted",
             )
         )
 
+
+def test_governed_issuer_slice_survives_restart_and_empty_successor(
+    publication_session_factory: sessionmaker,
+) -> None:
+    """Publish, reload, then retain governed scope after the edge is retracted."""
+    _accept_issuer_assertion(publication_session_factory)
+    first_job_id = _create_running_job(publication_session_factory)
+    _finalize(publication_session_factory, first_job_id)
+    _verify_first_publication_and_retract(publication_session_factory)
     second_job_id = _create_running_job(publication_session_factory, persist_graph=False)
     _finalize(publication_session_factory, second_job_id)
 

--- a/tests/integration/test_financial_relationship_vertical_slice.py
+++ b/tests/integration/test_financial_relationship_vertical_slice.py
@@ -127,6 +127,9 @@ def test_empty_unestablished_store_preserves_legacy_graph_and_publishes_once(
         assert job.status == RebuildJobStatus.SUCCEEDED
         assert _publication_count(session) == 1
         assert _revision_count(session) == 1
+        publication = session.execute(select(RelationshipProjectionPublicationORM)).scalar_one()
+        assert publication.execution_id == "exec-publication"
+        assert publication.rebuild_job_id == job_id
         latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
         assert latest is not None
         assert latest.revision.edges == ()

--- a/tests/integration/test_financial_relationship_vertical_slice.py
+++ b/tests/integration/test_financial_relationship_vertical_slice.py
@@ -298,7 +298,7 @@ class _TripGate:
 
 
 @pytest.mark.parametrize(
-    ("event_name", "expected_error", "target_stage"),
+    "gate_case",
     [
         ("lock_lost", graph_admin._DistributedLockLostError, "publication-pre-commit"),
         ("cancel_event", RebuildCancelledError, "publication-pre-commit"),
@@ -309,11 +309,10 @@ class _TripGate:
 def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
     publication_session_factory: sessionmaker,
     monkeypatch: pytest.MonkeyPatch,
-    event_name: str,
-    expected_error: type[Exception],
-    target_stage: str,
+    gate_case: tuple[str, type[Exception], str],
 ) -> None:
     """Lock loss or cancellation at the named final gate leaves no visible candidate."""
+    event_name, expected_error, target_stage = gate_case
     initial_graph = create_sample_database()
     initial_relationships = {source: list(entries) for source, entries in initial_graph.relationships.items()}
     job_id = _create_running_job(publication_session_factory)

--- a/tests/integration/test_financial_relationship_vertical_slice.py
+++ b/tests/integration/test_financial_relationship_vertical_slice.py
@@ -211,6 +211,9 @@ def test_dangling_assertion_endpoints_are_deferred_without_blocking_publication(
         latest = RelationshipAssertionRepository(session).latest_published_projection(PURPOSE)
         assert job is not None and job.status == RebuildJobStatus.SUCCEEDED
         assert latest is not None and latest.revision.edges == ()
+        assert latest.revision.governed_scopes == ()
+        restarted = AssetGraphRepository(session).load_graph()
+        assert ("AAPL", "corporate_link", 0.9) in restarted.relationships["AAPL_BOND_2030"]
         assert _publication_count(session) == 1
 
 
@@ -295,10 +298,12 @@ class _TripGate:
 
 
 @pytest.mark.parametrize(
-    ("event_name", "expected_error"),
+    ("event_name", "expected_error", "target_stage"),
     [
-        ("lock_lost", graph_admin._DistributedLockLostError),  # pylint: disable=protected-access
-        ("cancel_event", RebuildCancelledError),
+        ("lock_lost", graph_admin._DistributedLockLostError, "publication-pre-commit"),
+        ("cancel_event", RebuildCancelledError, "publication-pre-commit"),
+        ("lock_lost", graph_admin._DistributedLockLostError, "publication-domain-commit"),
+        ("cancel_event", RebuildCancelledError, "publication-domain-commit"),
     ],
 )
 def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
@@ -306,6 +311,7 @@ def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
     monkeypatch: pytest.MonkeyPatch,
     event_name: str,
     expected_error: type[Exception],
+    target_stage: str,
 ) -> None:
     """Lock loss or cancellation at the named final gate leaves no visible candidate."""
     initial_graph = create_sample_database()
@@ -316,7 +322,7 @@ def test_final_safety_gate_rolls_back_graph_candidate_success_and_publication(
         "_verify_execution_state",
         _TripGate(
             graph_admin._verify_execution_state,  # pylint: disable=protected-access
-            target_stage="publication-pre-commit",
+            target_stage=target_stage,
             event_name=event_name,
             error_type=expected_error,
         ),

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -459,7 +459,7 @@ async def test_lock_ttl_behavioral_contract(test_client: httpx.AsyncClient, sess
         # Signature: session_factory, dist_lock, job_id, execution_id, lock_ttl
         passed_lock_ttl = args[4]
         assert passed_lock_ttl == 30
-        assert mock_renew.call_count == 2
+        assert mock_renew.call_count == 3
         mock_renew.assert_called_with(lock_name="graph_rebuild", holder_id="test_worker", ttl_seconds=30)
 
 

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -27,6 +27,7 @@ from api.graph_lifecycle import reset_graph
 from src.config.settings import get_settings
 from src.data.database import create_engine_from_url, create_session_factory, init_db
 from src.data.distributed_lock import LockState
+from src.data.relationship_assertion_repository import RelationshipAssertionRepository
 from src.data.repository import AssetGraphRepository
 from src.logic.asset_graph import AssetRelationshipGraph
 
@@ -168,7 +169,7 @@ async def test_persistence_save_failure_returns_sanitized_500(
         raise ValueError(f"Failed to persist graph at {raw_url}")
 
     monkeypatch.setattr("api.routers.graph_admin.build_rebuild_graph", MagicMock(return_value=AssetRelationshipGraph()))
-    monkeypatch.setattr("api.routers.graph_admin.save_graph_to_persistence", fail_save)
+    monkeypatch.setattr(RelationshipAssertionRepository, "finalize_projection_publication", fail_save)
 
     with caplog.at_level(logging.ERROR):
         response = await test_client.post("/api/graph/rebuild")
@@ -446,7 +447,6 @@ async def test_lock_ttl_behavioral_contract(test_client: httpx.AsyncClient, sess
         patch("api.routers.graph_admin.DistributedLock", return_value=mock_lock),
         patch("api.routers.graph_admin._orchestrate_heartbeat", side_effect=mock_orchestrate_ctx) as mock_heartbeat,
         patch("api.routers.graph_admin.build_rebuild_graph", return_value=(AssetRelationshipGraph(), "sample")),
-        patch("api.routers.graph_admin.save_graph_to_persistence"),
     ):
         response = await test_client.post("/api/graph/rebuild")
         assert response.status_code == 200

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -164,11 +164,11 @@ async def test_persistence_save_failure_returns_sanitized_500(
     _init_empty_db(database_url)
     _configure_persistence(monkeypatch, database_url)
 
-    def fail_save(*args, **kwargs):
-        """Simulate a persistence save failure."""
-        raise ValueError(f"Failed to persist graph at {raw_url}")
-
-    monkeypatch.setattr("api.routers.graph_admin.build_rebuild_graph", MagicMock(return_value=AssetRelationshipGraph()))
+    fail_save = MagicMock(side_effect=ValueError(f"Failed to persist graph at {raw_url}"))
+    monkeypatch.setattr(
+        "api.routers.graph_admin.build_rebuild_graph",
+        MagicMock(return_value=(AssetRelationshipGraph(), "sample")),
+    )
     monkeypatch.setattr(RelationshipAssertionRepository, "finalize_projection_publication", fail_save)
 
     with caplog.at_level(logging.ERROR):
@@ -182,6 +182,7 @@ async def test_persistence_save_failure_returns_sanitized_500(
     assert "secret" not in response_text
     assert raw_url not in log_output
     assert "secret" not in log_output
+    fail_save.assert_called_once()
 
 
 # --- Core Rebuild Distributed Lock TTL Flow Integrations ---

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -130,7 +130,7 @@ async def test_unexpected_rebuild_failure_returns_sanitized_500(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Unexpected rebuild failures must hide private environment contexts from responses."""
-    raw_detail = "sensitive rebuild detail with secret: abc123def456"
+    raw_detail = "sensitive rebuild detail with secret: abc123def456"  # gitleaks:allow
     database_url = _sqlite_url(tmp_path)
     _init_empty_db(database_url)
     _configure_persistence(monkeypatch, database_url)

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -447,6 +447,7 @@ async def test_lock_ttl_behavioral_contract(test_client: httpx.AsyncClient, sess
         patch("api.routers.graph_admin.DistributedLock", return_value=mock_lock),
         patch("api.routers.graph_admin._orchestrate_heartbeat", side_effect=mock_orchestrate_ctx) as mock_heartbeat,
         patch("api.routers.graph_admin.build_rebuild_graph", return_value=(AssetRelationshipGraph(), "sample")),
+        patch("api.routers.graph_admin.CoordinationLockRepository.renew_owned_lock", return_value=True) as mock_renew,
     ):
         response = await test_client.post("/api/graph/rebuild")
         assert response.status_code == 200
@@ -458,6 +459,8 @@ async def test_lock_ttl_behavioral_contract(test_client: httpx.AsyncClient, sess
         # Signature: session_factory, dist_lock, job_id, execution_id, lock_ttl
         passed_lock_ttl = args[4]
         assert passed_lock_ttl == 30
+        assert mock_renew.call_count == 2
+        mock_renew.assert_called_with(lock_name="graph_rebuild", holder_id="test_worker", ttl_seconds=30)
 
 
 # --- Resilience Guardrail Enforcements ---

--- a/tests/integration/test_graph_rebuild_persistence.py
+++ b/tests/integration/test_graph_rebuild_persistence.py
@@ -263,41 +263,38 @@ async def test_rebuild_pipeline_execution_with_ttl(session_factory_provider, mon
     _, db_url = session_factory_provider
     _configure_persistence(monkeypatch, db_url)
 
-    mock_lock = MagicMock()
-    mock_lock.acquire.return_value = True
-
-    mock_repo = MagicMock(spec=AssetGraphRepository)
-    job_id = "job_test_pipe"
-    mock_repo.create_rebuild_job.return_value = job_id
-
     monkeypatch.setattr(
         "api.routers.graph_admin.build_rebuild_graph", MagicMock(return_value=(AssetRelationshipGraph(), "sample"))
     )
-    monkeypatch.setattr("api.routers.graph_admin.save_graph_to_persistence", MagicMock())
 
-    with patch("api.routers.graph_admin.AssetGraphRepository", return_value=mock_repo):
-        settings = get_settings()
-        engine_for_test = create_engine_from_url(db_url)
-        try:
-            session_factory = create_session_factory(engine_for_test)
-            job_started_at = time.time()
-            lock_lost_event = threading.Event()
-            execution_id = "test-exec-pipe"
+    settings = get_settings()
+    engine_for_test = create_engine_from_url(db_url)
+    try:
+        session_factory = create_session_factory(engine_for_test)
+        execution_id = "test-exec-pipe"
+        with session_factory() as session:
+            repo = AssetGraphRepository(session)
+            job_id = repo.create_rebuild_job(requested_by="test_user")
+            repo.mark_rebuild_job_running(job_id, execution_id)
+            session.commit()
 
-            graph_admin._run_rebuild_pipeline(
-                session_factory,
-                settings,
-                db_url,
-                job_id,
-                execution_id,
-                job_started_at,
-                lock_lost_event,
-                threading.Event(),
-            )
-        finally:
-            engine_for_test.dispose()
+        graph_admin._run_rebuild_pipeline(
+            session_factory,
+            settings,
+            db_url,
+            job_id,
+            execution_id,
+            time.time(),
+            threading.Event(),
+            threading.Event(),
+        )
 
-        mock_repo.mark_rebuild_job_succeeded.assert_called_once()
+        with session_factory() as session:
+            job = AssetGraphRepository(session).get_rebuild_job(job_id)
+            assert job is not None
+            assert job.status == "succeeded"
+    finally:
+        engine_for_test.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_rebuild_checkpoint_resume.py
+++ b/tests/integration/test_rebuild_checkpoint_resume.py
@@ -194,10 +194,7 @@ async def test_checkpoint_resume_integration(session_factory_provider, raw_engin
             session.commit()
 
         # Run pipeline
-        with (
-            patch("api.routers.graph_admin.save_graph_to_persistence", MagicMock()),
-            pytest.raises(RuntimeError, match="Simulated crash"),
-        ):
+        with pytest.raises(RuntimeError, match="Simulated crash"):
             graph_admin._run_rebuild_pipeline(
                 raw_factory,
                 get_settings(),

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -117,6 +117,18 @@ def test_overlay_adds_bidirectional_governed_edge_deterministically(predicates) 
     }
 
 
+@pytest.mark.parametrize("strength", ["NaN", "Infinity", "-0.1", "1.1"])
+def test_overlay_rejects_non_finite_or_out_of_range_strengths(predicates, strength: str) -> None:
+    """Governed edge strengths must remain finite and within the graph range."""
+    revision = _overlay_revision(
+        edges=(ProjectionEdge("BOND", "ISSUER", "corporate_link", strength, "subject_to_object", "assertion-1"),),
+        scopes=(GovernedScope(PURPOSE, PREDICATE_ID),),
+    )
+
+    with pytest.raises(ProjectionError, match="strength is out of range"):
+        overlay_governed_relationships({}, revision, predicates)
+
+
 @dataclass(frozen=True)
 class _AssertionSpec:
     """Fixture knobs for issuer-reference assertions."""

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -18,10 +18,12 @@ from src.governance.relationship_assertion_contract import load_contract_bundle
 from src.logic.relationship_projection import (
     PROJECTOR_VERSION,
     GovernedScope,
+    ProjectionEdge,
     ProjectionError,
     ProjectionRevision,
     ProjectRequest,
     canonicalize_governed_scopes,
+    overlay_governed_relationships,
     project,
 )
 
@@ -73,6 +75,46 @@ def predicates():
     """Pinned predicate registry from the frozen contract bundle."""
     _contract, predicates_doc, _transitions = load_contract_bundle()
     return predicates_doc
+
+
+def _overlay_revision(*, edges=(), scopes=()) -> ProjectionRevision:
+    """Build a minimal revision for governed graph-overlay unit tests."""
+    return ProjectionRevision(
+        purpose=PURPOSE,
+        effective_at=NOW,
+        known_at=NOW,
+        contract_version="grac.v1",
+        projector_version=PROJECTOR_VERSION,
+        edge_set_hash=EMPTY_EDGE_SET_HASH,
+        projection_hash=EMPTY_PROJECTION_HASH,
+        edges=tuple(edges),
+        governed_scopes=tuple(scopes),
+    )
+
+
+def test_overlay_empty_established_scope_suppresses_legacy_edge_type(predicates) -> None:
+    """An established empty scope owns and removes its registered legacy edge type."""
+    relationships = {
+        "BOND": [("ISSUER", "corporate_link", 0.9), ("PEER", "same_sector", 0.7)],
+    }
+    revision = _overlay_revision(scopes=(GovernedScope(PURPOSE, PREDICATE_ID),))
+
+    assert overlay_governed_relationships(relationships, revision, predicates) == {
+        "BOND": [("PEER", "same_sector", 0.7)]
+    }
+
+
+def test_overlay_adds_bidirectional_governed_edge_deterministically(predicates) -> None:
+    """A governed bidirectional edge replaces legacy ownership in both directions."""
+    revision = _overlay_revision(
+        edges=(ProjectionEdge("BOND", "ISSUER", "corporate_link", "0.8", "bidirectional", "assertion-1"),),
+        scopes=(GovernedScope(PURPOSE, PREDICATE_ID),),
+    )
+
+    assert overlay_governed_relationships({}, revision, predicates) == {
+        "BOND": [("ISSUER", "corporate_link", 0.8)],
+        "ISSUER": [("BOND", "corporate_link", 0.8)],
+    }
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_relationship_projection.py
+++ b/tests/unit/test_relationship_projection.py
@@ -117,6 +117,23 @@ def test_overlay_adds_bidirectional_governed_edge_deterministically(predicates) 
     }
 
 
+def test_bidirectional_overlay_replaces_legacy_reverse_and_retains_other_edges(predicates) -> None:
+    """A governed reverse edge replaces only its owned legacy edge type."""
+    relationships = {
+        "BOND": [("ISSUER", "corporate_link", 0.9)],
+        "ISSUER": [("BOND", "corporate_link", 0.9), ("PEER", "same_sector", 0.7)],
+    }
+    revision = _overlay_revision(
+        edges=(ProjectionEdge("BOND", "ISSUER", "corporate_link", "0.8", "bidirectional", "assertion-1"),),
+        scopes=(GovernedScope(PURPOSE, PREDICATE_ID),),
+    )
+
+    assert overlay_governed_relationships(relationships, revision, predicates) == {
+        "BOND": [("ISSUER", "corporate_link", 0.8)],
+        "ISSUER": [("BOND", "corporate_link", 0.8), ("PEER", "same_sector", 0.7)],
+    }
+
+
 @pytest.mark.parametrize("strength", ["NaN", "Infinity", "-0.1", "1.1"])
 def test_overlay_rejects_non_finite_or_out_of_range_strengths(predicates, strength: str) -> None:
     """Governed edge strengths must remain finite and within the graph range."""

--- a/tests/unit/test_repository_distributed_lock.py
+++ b/tests/unit/test_repository_distributed_lock.py
@@ -134,6 +134,23 @@ class TestDistributedLockRepository:
         expected_min_expiry = datetime.now(UTC) + timedelta(seconds=60)
         assert _ensure_utc(snapshot.expires_at) > expected_min_expiry
 
+    def test_renew_owned_lock_rejects_expired_lease(self, lock_repository_factory):
+        """Strict publication renewal cannot revive an expired lease."""
+        repo = lock_repository_factory()
+        now = datetime.now(UTC)
+        repo.session.add(
+            DistributedLockORM(
+                lock_name="test_lock",
+                holder_id="holder1",
+                expires_at=now - timedelta(seconds=1),
+                created_at=now - timedelta(seconds=60),
+                updated_at=now - timedelta(seconds=60),
+            )
+        )
+        repo.session.commit()
+
+        assert repo.renew_owned_lock(lock_name="test_lock", holder_id="holder1", ttl_seconds=60) is False
+
     def test_acquire_lock_takeover_expired(self, lock_repository_factory):
         """Test taking over an expired lock."""
         repo = lock_repository_factory()


### PR DESCRIPTION
## **User description**
## Primary Objective

Publish one deterministic GRAC projection revision through the existing rebuild control plane so the graph snapshot, candidate revision, owner-validated `RUNNING -> SUCCEEDED` transition, and publication row commit atomically.

Closes #1536.

This clean replacement explicitly supersedes closed PRs #1565 and #1567. No commits were cherry-picked from either reconstruction.

## Architectural Alignment

- Exact RC2 base and preceding merge SHA: `a1732133dbf619c4faf2d0225872870beb77ed3e`.
- Assertions remain truth; `asset_relationships` and the runtime adjacency map remain projections.
- Publication uses the existing rebuild job success transition and does not create a second success path.
- GRAC remains `NEXT`; this PR makes no `CURRENT` capability claim.

## Root Cause

The superseded implementation exposed an unused publish-after-success repository method. That separated visibility from the owner-guarded success transition, allowed null-identity and first-publisher concurrency gaps, and let graph persistence commit before publication. The replacement makes the transaction boundary the first design checkpoint.

## Fixed Decisions

- One caller-owned database transaction stages the graph snapshot, persists exactly one candidate, performs the existing execution-owner conditional success update, appends one publication, and commits.
- A publication `execution_id` must be a non-empty string and must own the guarded rebuild transition.
- Lock loss and cancellation are checked at transaction entry, before success, and immediately before commit.
- Governed scopes are loaded from the latest successful publication and carried across empty-edge revisions.
- Established scopes replace their registered legacy edge types; an unestablished empty store leaves the graph semantically unchanged.
- No schema, migration, dependency, scanner, workflow, frontend, or API-command surface changes.

## In Scope

- Existing rebuild control-plane integration.
- Deterministic projector input loading and governed overlay.
- Atomic publication persistence and latest-publication reload.
- Issuer-reference vertical-slice, rollback, restart, identity, cardinality, and empty-edge tests.

## Out of Scope

- Frontend and command/explanation APIs.
- Schema, RLS, migrations, Alembic, or `asset_relationships` schema changes.
- New authorization models.
- Dependency, scanner, deployment, workflow, or unrelated cleanup.
- Contract semantic changes, alternate publication paths, auto-merge, or a `CURRENT` claim.

## Files Expected to Change

- `api/graph_lifecycle_providers.py` — stage the graph in a caller-owned transaction.
- `api/routers/graph_admin.py` — make the existing success finalizer own projection and publication.
- `src/data/relationship_assertion_repository.py` — deterministic projection snapshot reads and atomic success/publication persistence.
- `src/logic/relationship_projection.py` — deterministic governed overlay semantics.
- `tests/integration/test_financial_relationship_vertical_slice.py` — required behavioral proof.

All paths are within #1536's binding allowlist.

## Invariants

- Exactly one revision is published per rebuild.
- Publication identity is non-null, non-empty, and owner-matched.
- Failed, cancelled, lock-lost, orphaned, or merely persisted candidates never become current.
- Candidate, graph read model, success state, and publication share one commit/rollback boundary.
- Empty-edge successors retain established scope across restart and suppress legacy reappearance.
- Empty assertion store with no established scope produces zero semantic graph change.
- Stage-5C `execution_id` and `cancel_event` safeguards remain intact.

## Tests Added or Updated

- Empty unestablished store preserves the legacy graph and publishes once.
- A rebuild cannot publish a second revision.
- Null, empty, and mismatched identities roll back candidate and publication.
- Final lock-loss and cancellation gates roll back graph, candidate, success, and publication.
- Accepted issuer assertion publishes with distinct proposal/determination actors and reloads after restart.
- Retraction produces an empty-edge successor that retains scope and suppresses the legacy corporate link after restart.

## Validation Actually Run

- `pre-commit run --files <five changed files>` — passed (Black, Ruff import sorting, Flake8, mypy, whitespace and conflict checks).
- `pytest tests/unit/test_relationship_projection.py tests/integration/test_relationship_projection_persistence.py tests/integration/test_financial_relationship_vertical_slice.py tests/unit/test_repository_cancellation.py -q` — `45 passed, 5 skipped`.
- The five skips are PostgreSQL variants requiring `ASSET_GRAPH_DATABASE_URL` or `GRAC_SCHEMA_DATABASE_URL`; required CI must execute them before merge.
- `python -m py_compile <changed Python files>` — passed.
- `git diff --check` — passed.
- CodeRabbit CLI review was attempted against the uncommitted RC2 diff but the external service remained in `reviewing` without returning findings and was stopped; automated PR review remains enabled.

## Rollback Behaviour

Any projection, graph staging, identity, success-transition, publication, lock, cancellation, flush, or commit failure rolls back the graph snapshot, candidate revision, job success transition, and publication together. The existing failure/cancellation finalizers then retain authority over terminal job state.

## Bot and Governance Controls

- Branch protection restricts pushes to maintainer `mohavro`; no GitHub App is allowed to push.
- Automated reviews, comments, labels, and checks remain enabled.
- Bot-authored write-backs and auto-merge are not authorized.
- Conversation resolution is required and force-push/deletion are disabled on the branch.

## Merge Criteria

- Exact RC2 ancestry remains intact.
- Required SQLite and PostgreSQL publication/restart/concurrency proof passes with no unexpected skip.
- Full required CI and pre-commit pass at the final head.
- No unresolved substantive review thread, pending/unavailable required check, or bot-authored commit remains.
- A human maintainer verifies rollback behavior, branch protection, current head, and RC2 evidence before marking ready or merging.

## Stop Conditions

- A second publication or success path appears necessary.
- Any required change falls outside #1536's allowlist.
- A candidate can become visible without the owner-matched atomic success transaction.
- Empty-edge/restart scope continuity cannot be proved.
- Stage-5C ownership or cancellation safety would be weakened.
- RC2 ancestry or its exact-SHA authorization evidence becomes invalid.

___

## **CodeAnt-AI Description**
Publish governed graph projections atomically and preserve their ownership across rebuilds

### What Changed
- Graph snapshots, projection revisions, rebuild success, and publication records now become visible in one transaction, so failed or cancelled rebuilds leave the previous graph unchanged.
- Governed relationship types replace legacy entries, including when a published revision contains no edges; unrelated legacy relationships remain intact.
- Projection inputs and published scopes are loaded deterministically, allowing governed relationships to survive restarts and remove withdrawn edges from successor rebuilds.
- Rebuild publication validates execution ownership, rejects invalid edge strengths, and prevents expired coordination leases from reaching the commit.
- Publication timestamps remain ordered even when workers have inaccurate clocks, and failures continue to return sanitized error details.

### Impact
`✅ No partial graph or projection publications`
`✅ Withdrawn governed relationships stay removed after rebuild`
`✅ Fewer stale-worker and expired-lock publications`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change makes graph rebuild completion publish the rebuilt graph snapshot, governed relationship projection, rebuild success state, and publication record together. It also adds lease renewal and cancellation checks around finalization, plus coverage for restart, persistence failure, and empty-edge behavior.

No defects were confirmed.

## T-Rex validation blocked

A focused SQLite check of atomic publication failure paths could not reach the rebuild finalization code because the application import required the missing `ADMIN_USERNAME` and `ADMIN_PASSWORD` credentials.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

No verified or unresolved defects remain. The attempted SQLite failure-path check was blocked before it reached the target code and did not demonstrate a product defect.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A focused SQLite probe was authored to exercise rebuild publication success, publication persistence failure, cancellation before commit, and rebuild-success transition failure, and it reached application import but stopped before the finalization path because ADMIN\_USERNAME and ADMIN\_PASSWORD were not configured.
- The probe execution was captured showing the run reached application import but did not execute or verify the publication behavior due to missing credentials.
- The validation notes capture the probe source and the before-run record, showing the command, working directory, and exit status; the run halted at import because no user credentials were configured.
- Code-path notes identify where finalize\_projection\_publication transitions occur and where persistence and publication happen within the caller transaction, along with how domain transactions rollback on exceptions.

<a href="https://app.greptile.com/trex/runs/16886207/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (8): Last reviewed commit: ["test: allow synthetic redaction fixture"](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/51b09ceeec691dcadd22dfb56519c4b415e5bb15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49296756)</sub>

<!-- /greptile_comment -->