### PR TITLE
feat: add relationship evidence and history panel

### DIFF
--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -4,10 +4,15 @@
 
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import NetworkVisualization from "../../app/components/NetworkVisualization";
 import type { VisualizationData } from "../../app/types/api";
 import { mockVisualizationData } from "../test-utils";
+import { api } from "../../app/lib/api";
+
+jest.mock("../../app/lib/api");
+const mockedApi = api as jest.Mocked<typeof api>;
 
 jest.mock("react-plotly.js", () => {
   return function MockPlot({ data }: { data: unknown }) {
@@ -117,5 +122,112 @@ describe("NetworkVisualization Component", () => {
         /Visualization is unavailable because the dataset is too large/,
       ),
     ).toBeInTheDocument();
+  });
+
+  describe("keyboard-accessible relationship selection", () => {
+    const governedData: VisualizationData = {
+      nodes: mockVisualizationData.nodes,
+      edges: [
+        {
+          source: "ASSET_1",
+          target: "ASSET_2",
+          relationship_type: "SAME_SECTOR",
+          strength: 0.7,
+        },
+        {
+          source: "ASSET_2",
+          target: "ASSET_1",
+          relationship_type: "CORPORATE_LINK",
+          strength: 0.9,
+          assertion_id: "assertion-1",
+          governance_status: "governed",
+          revision_id: "rev-1",
+          scope_refs: ["predicate-issuer"],
+        },
+      ],
+      network_density: 0.5,
+    };
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it("lists every relationship with a governed/legacy badge", () => {
+      render(<NetworkVisualization data={governedData} />);
+
+      expect(
+        screen.getByRole("group", { name: "Relationships (keyboard-accessible list)" }),
+      ).toBeInTheDocument();
+      expect(screen.getByText("Legacy")).toBeInTheDocument();
+      expect(screen.getByText("Governed")).toBeInTheDocument();
+    });
+
+    it("selects a relationship via keyboard/click on the list, not only line-clicking", async () => {
+      mockedApi.getAssertion.mockResolvedValue({
+        assertion_id: "assertion-1",
+        predicate_id: "predicate-issuer",
+        subject_id: "ASSET_2",
+        object_id: "ASSET_1",
+        method_id: "method-1",
+        proposition: "ASSET_2 is the issuer of ASSET_1",
+        confidence_status: "not_assessed",
+        confidence_bp: null,
+        confidence_type: null,
+        confidence_method: null,
+        effective_from: "2024-01-01T00:00:00Z",
+        effective_to: null,
+        recorded_at: "2024-01-01T00:00:00Z",
+        state: "Accepted",
+        known_at: "2024-01-01T00:00:00Z",
+        effective_at: "2024-01-01T00:00:00Z",
+        sequence: 1,
+        evidence: [],
+      });
+      mockedApi.getAssertionHistory.mockResolvedValue({
+        assertion_id: "assertion-1",
+        effective_from: "2024-01-01T00:00:00Z",
+        effective_to: null,
+        recorded_at: "2024-01-01T00:00:00Z",
+        state: "Accepted",
+        known_at: "2024-01-01T00:00:00Z",
+        effective_at: "2024-01-01T00:00:00Z",
+        events: [
+          {
+            event_id: "event-1",
+            assertion_id: "assertion-1",
+            sequence: 1,
+            from_state: null,
+            to_state: "Proposed",
+            authority: "proposer",
+            recorded_at: "2024-01-01T00:00:00Z",
+          },
+        ],
+      });
+
+      const user = userEvent.setup();
+      render(<NetworkVisualization data={governedData} />);
+
+      const governedButton = screen.getByRole("button", {
+        name: /ASSET_2.*ASSET_1.*CORPORATE_LINK.*Governed/,
+      });
+      await user.tab();
+      // Tab until the target button is focused, then activate with the keyboard.
+      governedButton.focus();
+      await user.keyboard("{Enter}");
+
+      expect(governedButton).toHaveAttribute("aria-pressed", "true");
+      await waitFor(() => {
+        expect(mockedApi.getAssertion).toHaveBeenCalledWith(
+          "assertion-1",
+          undefined,
+          expect.anything(),
+        );
+      });
+      await waitFor(() => {
+        expect(
+          screen.getByText("ASSET_2 is the issuer of ASSET_1"),
+        ).toBeInTheDocument();
+      });
+    });
   });
 });

--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -212,16 +212,28 @@ describe("NetworkVisualization Component", () => {
       const governedButton = screen.getByRole("button", {
         name: /ASSET_2.*ASSET_1.*CORPORATE_LINK.*Governed/,
       });
-      await user.tab();
-      // Tab until the target button is focused, then activate with the keyboard.
-      governedButton.focus();
+
+      // Exercise a genuine tab sequence (rather than calling `.focus()`
+      // directly) so this test actually proves the button is reachable via
+      // keyboard navigation, not merely programmatically focusable.
+      const MAX_TAB_STOPS = 25;
+      let reachedButton = false;
+      for (let tabStop = 0; tabStop < MAX_TAB_STOPS; tabStop += 1) {
+        await user.tab();
+        if (document.activeElement === governedButton) {
+          reachedButton = true;
+          break;
+        }
+      }
+      expect(reachedButton).toBe(true);
+
       await user.keyboard("{Enter}");
 
       expect(governedButton).toHaveAttribute("aria-pressed", "true");
       await waitFor(() => {
         expect(mockedApi.getAssertion).toHaveBeenCalledWith(
           "assertion-1",
-          undefined,
+          expect.objectContaining({ known_at: expect.any(String) }),
           expect.anything(),
         );
       });

--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -156,7 +156,9 @@ describe("NetworkVisualization Component", () => {
       render(<NetworkVisualization data={governedData} />);
 
       expect(
-        screen.getByRole("group", { name: "Relationships (keyboard-accessible list)" }),
+        screen.getByRole("group", {
+          name: "Relationships (keyboard-accessible list)",
+        }),
       ).toBeInTheDocument();
       expect(screen.getByText("Legacy")).toBeInTheDocument();
       expect(screen.getByText("Governed")).toBeInTheDocument();

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -9,7 +9,10 @@ import RelationshipExplanationPanel, {
   type ExplainableRelationship,
 } from "../../app/components/RelationshipExplanationPanel";
 import { api } from "../../app/lib/api";
-import type { AssertionExplanation, AssertionHistory } from "../../app/types/api";
+import type {
+  AssertionExplanation,
+  AssertionHistory,
+} from "../../app/types/api";
 
 jest.mock("../../app/lib/api");
 const mockedApi = api as jest.Mocked<typeof api>;
@@ -119,16 +122,20 @@ describe("RelationshipExplanationPanel", () => {
   it("labels an ungoverned relationship as legacy without fetching", () => {
     render(<RelationshipExplanationPanel relationship={legacyRelationship} />);
     expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(
-      screen.getByText(/outside any governed scope/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/outside any governed scope/)).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
   it("shows a bounded unavailable state for a governed edge with no assertion id", () => {
-    render(<RelationshipExplanationPanel relationship={governedWithoutAssertionId} />);
+    render(
+      <RelationshipExplanationPanel
+        relationship={governedWithoutAssertionId}
+      />,
+    );
     expect(
-      screen.getByText(/governed, but its assertion metadata is not yet available/),
+      screen.getByText(
+        /governed, but its assertion metadata is not yet available/,
+      ),
     ).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
@@ -137,9 +144,13 @@ describe("RelationshipExplanationPanel", () => {
     mockedApi.getAssertion.mockResolvedValue(baseExplanation);
     mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
-    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading governed explanation..."),
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -166,32 +177,39 @@ describe("RelationshipExplanationPanel", () => {
 
   it("shows a not-found state without fabricating governance facts on a 404", async () => {
     mockedApi.getAssertion.mockRejectedValue({ response: { status: 404 } });
-    mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: 404 } });
+    mockedApi.getAssertionHistory.mockRejectedValue({
+      response: { status: 404 },
+    });
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/could not be found/),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/could not be found/)).toBeInTheDocument();
     });
   });
 
   it("shows a bounded unavailable state on a non-404 failure", async () => {
     mockedApi.getAssertion.mockRejectedValue({ response: { status: 503 } });
-    mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: 503 } });
+    mockedApi.getAssertionHistory.mockRejectedValue({
+      response: { status: 503 },
+    });
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(/temporarily unavailable/),
-      ).toBeInTheDocument();
+      expect(screen.getByText(/temporarily unavailable/)).toBeInTheDocument();
     });
   });
 
   it("shows superseded chain information when a successor is recorded", async () => {
-    mockedApi.getAssertion.mockResolvedValue({ ...baseExplanation, state: "Superseded" });
+    mockedApi.getAssertion.mockResolvedValue({
+      ...baseExplanation,
+      state: "Superseded",
+    });
     mockedApi.getAssertionHistory.mockResolvedValue({
       ...baseHistory,
       state: "Superseded",
@@ -210,7 +228,9 @@ describe("RelationshipExplanationPanel", () => {
       ],
     });
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
     await waitFor(() => {
       expect(
@@ -242,7 +262,9 @@ describe("RelationshipExplanationPanel", () => {
       );
     });
 
-    rerender(<RelationshipExplanationPanel relationship={legacyRelationship} />);
+    rerender(
+      <RelationshipExplanationPanel relationship={legacyRelationship} />,
+    );
 
     expect(screen.getByText("Legacy")).toBeInTheDocument();
   });

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -9,10 +9,7 @@ import RelationshipExplanationPanel, {
   type ExplainableRelationship,
 } from "../../app/components/RelationshipExplanationPanel";
 import { api } from "../../app/lib/api";
-import type {
-  AssertionExplanation,
-  AssertionHistory,
-} from "../../app/types/api";
+import type { AssertionExplanation, AssertionHistory } from "../../app/types/api";
 
 jest.mock("../../app/lib/api");
 const mockedApi = api as jest.Mocked<typeof api>;
@@ -122,20 +119,16 @@ describe("RelationshipExplanationPanel", () => {
   it("labels an ungoverned relationship as legacy without fetching", () => {
     render(<RelationshipExplanationPanel relationship={legacyRelationship} />);
     expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(screen.getByText(/outside any governed scope/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/outside any governed scope/),
+    ).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
   it("shows a bounded unavailable state for a governed edge with no assertion id", () => {
-    render(
-      <RelationshipExplanationPanel
-        relationship={governedWithoutAssertionId}
-      />,
-    );
+    render(<RelationshipExplanationPanel relationship={governedWithoutAssertionId} />);
     expect(
-      screen.getByText(
-        /governed, but its assertion metadata is not yet available/,
-      ),
+      screen.getByText(/governed, but its assertion metadata is not yet available/),
     ).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
@@ -144,13 +137,9 @@ describe("RelationshipExplanationPanel", () => {
     mockedApi.getAssertion.mockResolvedValue(baseExplanation);
     mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
 
-    render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
-    );
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
 
-    expect(
-      screen.getByText("Loading governed explanation..."),
-    ).toBeInTheDocument();
+    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -175,41 +164,25 @@ describe("RelationshipExplanationPanel", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("shows a not-found state without fabricating governance facts on a 404", async () => {
-    mockedApi.getAssertion.mockRejectedValue({ response: { status: 404 } });
-    mockedApi.getAssertionHistory.mockRejectedValue({
-      response: { status: 404 },
-    });
+  it.each([
+    { httpStatus: 404, expectedText: /could not be found/ },
+    { httpStatus: 503, expectedText: /temporarily unavailable/ },
+  ])(
+    "shows a bounded state without fabricating governance facts on a $httpStatus failure",
+    async ({ httpStatus, expectedText }) => {
+      mockedApi.getAssertion.mockRejectedValue({ response: { status: httpStatus } });
+      mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: httpStatus } });
 
-    render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
-    );
+      render(<RelationshipExplanationPanel relationship={governedRelationship} />);
 
-    await waitFor(() => {
-      expect(screen.getByText(/could not be found/)).toBeInTheDocument();
-    });
-  });
-
-  it("shows a bounded unavailable state on a non-404 failure", async () => {
-    mockedApi.getAssertion.mockRejectedValue({ response: { status: 503 } });
-    mockedApi.getAssertionHistory.mockRejectedValue({
-      response: { status: 503 },
-    });
-
-    render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
-    );
-
-    await waitFor(() => {
-      expect(screen.getByText(/temporarily unavailable/)).toBeInTheDocument();
-    });
-  });
+      await waitFor(() => {
+        expect(screen.getByText(expectedText)).toBeInTheDocument();
+      });
+    },
+  );
 
   it("shows superseded chain information when a successor is recorded", async () => {
-    mockedApi.getAssertion.mockResolvedValue({
-      ...baseExplanation,
-      state: "Superseded",
-    });
+    mockedApi.getAssertion.mockResolvedValue({ ...baseExplanation, state: "Superseded" });
     mockedApi.getAssertionHistory.mockResolvedValue({
       ...baseHistory,
       state: "Superseded",
@@ -228,14 +201,18 @@ describe("RelationshipExplanationPanel", () => {
       ],
     });
 
-    render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
-    );
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
 
     await waitFor(() => {
       expect(
-        screen.getByText(/Predecessor information is only available/),
-      ).toBeInTheDocument();
+        screen.getAllByText((_, element) =>
+          Boolean(
+            element?.textContent?.includes(
+              "does not expose a backward predecessor reference",
+            ),
+          ),
+        ).length,
+      ).toBeGreaterThan(0);
     });
     expect(
       screen.getAllByText((_, element) =>
@@ -244,6 +221,23 @@ describe("RelationshipExplanationPanel", () => {
         ),
       ).length,
     ).toBeGreaterThan(0);
+  });
+
+  it("passes identical as-of bounds to both the explanation and history requests", async () => {
+    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
+    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
+
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+
+    await waitFor(() => {
+      expect(mockedApi.getAssertion).toHaveBeenCalledTimes(1);
+      expect(mockedApi.getAssertionHistory).toHaveBeenCalledTimes(1);
+    });
+
+    const explanationParams = mockedApi.getAssertion.mock.calls[0][1];
+    const historyParams = mockedApi.getAssertionHistory.mock.calls[0][1];
+    expect(explanationParams).toBeDefined();
+    expect(explanationParams).toEqual(historyParams);
   });
 
   it("re-fetches when the selected relationship changes and no stale state leaks through", async () => {
@@ -257,14 +251,12 @@ describe("RelationshipExplanationPanel", () => {
     await waitFor(() => {
       expect(mockedApi.getAssertion).toHaveBeenCalledWith(
         "assertion-1",
-        undefined,
+        expect.objectContaining({ known_at: expect.any(String) }),
         expect.anything(),
       );
     });
 
-    rerender(
-      <RelationshipExplanationPanel relationship={legacyRelationship} />,
-    );
+    rerender(<RelationshipExplanationPanel relationship={legacyRelationship} />);
 
     expect(screen.getByText("Legacy")).toBeInTheDocument();
   });

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -9,7 +9,10 @@ import RelationshipExplanationPanel, {
   type ExplainableRelationship,
 } from "../../app/components/RelationshipExplanationPanel";
 import { api } from "../../app/lib/api";
-import type { AssertionExplanation, AssertionHistory } from "../../app/types/api";
+import type {
+  AssertionExplanation,
+  AssertionHistory,
+} from "../../app/types/api";
 
 jest.mock("../../app/lib/api");
 const mockedApi = api as jest.Mocked<typeof api>;
@@ -119,16 +122,20 @@ describe("RelationshipExplanationPanel", () => {
   it("labels an ungoverned relationship as legacy without fetching", () => {
     render(<RelationshipExplanationPanel relationship={legacyRelationship} />);
     expect(screen.getByText("Legacy")).toBeInTheDocument();
-    expect(
-      screen.getByText(/outside any governed scope/),
-    ).toBeInTheDocument();
+    expect(screen.getByText(/outside any governed scope/)).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
   it("shows a bounded unavailable state for a governed edge with no assertion id", () => {
-    render(<RelationshipExplanationPanel relationship={governedWithoutAssertionId} />);
+    render(
+      <RelationshipExplanationPanel
+        relationship={governedWithoutAssertionId}
+      />,
+    );
     expect(
-      screen.getByText(/governed, but its assertion metadata is not yet available/),
+      screen.getByText(
+        /governed, but its assertion metadata is not yet available/,
+      ),
     ).toBeInTheDocument();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
@@ -137,9 +144,13 @@ describe("RelationshipExplanationPanel", () => {
     mockedApi.getAssertion.mockResolvedValue(baseExplanation);
     mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
-    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading governed explanation..."),
+    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -170,10 +181,16 @@ describe("RelationshipExplanationPanel", () => {
   ])(
     "shows a bounded state without fabricating governance facts on a $httpStatus failure",
     async ({ httpStatus, expectedText }) => {
-      mockedApi.getAssertion.mockRejectedValue({ response: { status: httpStatus } });
-      mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: httpStatus } });
+      mockedApi.getAssertion.mockRejectedValue({
+        response: { status: httpStatus },
+      });
+      mockedApi.getAssertionHistory.mockRejectedValue({
+        response: { status: httpStatus },
+      });
 
-      render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+      render(
+        <RelationshipExplanationPanel relationship={governedRelationship} />,
+      );
 
       await waitFor(() => {
         expect(screen.getByText(expectedText)).toBeInTheDocument();
@@ -182,7 +199,10 @@ describe("RelationshipExplanationPanel", () => {
   );
 
   it("shows superseded chain information when a successor is recorded", async () => {
-    mockedApi.getAssertion.mockResolvedValue({ ...baseExplanation, state: "Superseded" });
+    mockedApi.getAssertion.mockResolvedValue({
+      ...baseExplanation,
+      state: "Superseded",
+    });
     mockedApi.getAssertionHistory.mockResolvedValue({
       ...baseHistory,
       state: "Superseded",
@@ -201,7 +221,9 @@ describe("RelationshipExplanationPanel", () => {
       ],
     });
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
     await waitFor(() => {
       expect(
@@ -227,7 +249,9 @@ describe("RelationshipExplanationPanel", () => {
     mockedApi.getAssertion.mockResolvedValue(baseExplanation);
     mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
 
-    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+    render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
 
     await waitFor(() => {
       expect(mockedApi.getAssertion).toHaveBeenCalledTimes(1);
@@ -256,7 +280,9 @@ describe("RelationshipExplanationPanel", () => {
       );
     });
 
-    rerender(<RelationshipExplanationPanel relationship={legacyRelationship} />);
+    rerender(
+      <RelationshipExplanationPanel relationship={legacyRelationship} />,
+    );
 
     expect(screen.getByText("Legacy")).toBeInTheDocument();
   });

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -1,0 +1,249 @@
+/**
+ * Focused unit + accessibility tests for RelationshipExplanationPanel.
+ */
+
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import RelationshipExplanationPanel, {
+  type ExplainableRelationship,
+} from "../../app/components/RelationshipExplanationPanel";
+import { api } from "../../app/lib/api";
+import type { AssertionExplanation, AssertionHistory } from "../../app/types/api";
+
+jest.mock("../../app/lib/api");
+const mockedApi = api as jest.Mocked<typeof api>;
+
+const legacyRelationship: ExplainableRelationship = {
+  source: "ASSET_1",
+  target: "ASSET_2",
+  relationship_type: "SAME_SECTOR",
+  strength: 0.8,
+};
+
+const governedRelationship: ExplainableRelationship = {
+  source: "ASSET_1",
+  target: "ASSET_3",
+  relationship_type: "CORPORATE_LINK",
+  strength: 0.5,
+  assertion_id: "assertion-1",
+  governance_status: "governed",
+  revision_id: "rev-1",
+  scope_refs: ["predicate-issuer"],
+};
+
+const governedWithoutAssertionId: ExplainableRelationship = {
+  ...governedRelationship,
+  assertion_id: null,
+};
+
+const baseExplanation: AssertionExplanation = {
+  assertion_id: "assertion-1",
+  predicate_id: "predicate-issuer",
+  subject_id: "ASSET_1",
+  object_id: "ASSET_3",
+  method_id: "method-1",
+  proposition: "ASSET_1 is the issuer of ASSET_3",
+  confidence_status: "assessed",
+  confidence_bp: 9500,
+  confidence_type: "statistical",
+  confidence_method: "manual-review",
+  effective_from: "2024-01-01T00:00:00Z",
+  effective_to: null,
+  recorded_at: "2024-01-01T00:00:00Z",
+  state: "Accepted",
+  known_at: "2024-01-01T00:00:00Z",
+  effective_at: "2024-01-01T00:00:00Z",
+  sequence: 2,
+  evidence: [
+    {
+      evidence_id: "evidence-public",
+      polarity: "supporting",
+      visibility: "public",
+      redacted: false,
+      source_ref: "https://example.com/filing",
+      content_sha256: "abc123",
+    },
+    {
+      evidence_id: "evidence-restricted",
+      polarity: "supporting",
+      visibility: "restricted",
+      redacted: true,
+    },
+  ],
+};
+
+const baseHistory: AssertionHistory = {
+  assertion_id: "assertion-1",
+  effective_from: "2024-01-01T00:00:00Z",
+  effective_to: null,
+  recorded_at: "2024-01-01T00:00:00Z",
+  state: "Accepted",
+  known_at: "2024-01-01T00:00:00Z",
+  effective_at: "2024-01-01T00:00:00Z",
+  events: [
+    {
+      event_id: "event-1",
+      assertion_id: "assertion-1",
+      sequence: 1,
+      from_state: null,
+      to_state: "Proposed",
+      authority: "proposer",
+      recorded_at: "2024-01-01T00:00:00Z",
+    },
+    {
+      event_id: "event-2",
+      assertion_id: "assertion-1",
+      sequence: 2,
+      from_state: "Proposed",
+      to_state: "Accepted",
+      authority: "acceptor",
+      recorded_at: "2024-01-02T00:00:00Z",
+    },
+  ],
+};
+
+describe("RelationshipExplanationPanel", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("shows a placeholder when no relationship is selected", () => {
+    render(<RelationshipExplanationPanel relationship={null} />);
+    expect(
+      screen.getByText("Select a relationship to see how it was determined."),
+    ).toBeInTheDocument();
+    expect(mockedApi.getAssertion).not.toHaveBeenCalled();
+  });
+
+  it("labels an ungoverned relationship as legacy without fetching", () => {
+    render(<RelationshipExplanationPanel relationship={legacyRelationship} />);
+    expect(screen.getByText("Legacy")).toBeInTheDocument();
+    expect(
+      screen.getByText(/outside any governed scope/),
+    ).toBeInTheDocument();
+    expect(mockedApi.getAssertion).not.toHaveBeenCalled();
+  });
+
+  it("shows a bounded unavailable state for a governed edge with no assertion id", () => {
+    render(<RelationshipExplanationPanel relationship={governedWithoutAssertionId} />);
+    expect(
+      screen.getByText(/governed, but its assertion metadata is not yet available/),
+    ).toBeInTheDocument();
+    expect(mockedApi.getAssertion).not.toHaveBeenCalled();
+  });
+
+  it("renders the full governed explanation once fetched", async () => {
+    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
+    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
+
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+
+    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("ASSET_1 is the issuer of ASSET_3"),
+      ).toBeInTheDocument();
+    });
+
+    // Confidence vs. projection strength are shown as distinct facts.
+    expect(screen.getByText(/statistical/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.50/)).toBeInTheDocument();
+
+    // Public evidence shows its digest; restricted evidence never leaks a body/reference.
+    expect(screen.getByText(/SHA-256: abc123/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Evidence body and restricted references are not shown/),
+    ).toBeInTheDocument();
+
+    // Proposer and determining authority are distinct, identity-redacted roles.
+    expect(screen.getAllByText(/Proposer of record/).length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText(/Determining authority \(acceptor\)/).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows a not-found state without fabricating governance facts on a 404", async () => {
+    mockedApi.getAssertion.mockRejectedValue({ response: { status: 404 } });
+    mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: 404 } });
+
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/could not be found/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows a bounded unavailable state on a non-404 failure", async () => {
+    mockedApi.getAssertion.mockRejectedValue({ response: { status: 503 } });
+    mockedApi.getAssertionHistory.mockRejectedValue({ response: { status: 503 } });
+
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/temporarily unavailable/),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows superseded chain information when a successor is recorded", async () => {
+    mockedApi.getAssertion.mockResolvedValue({ ...baseExplanation, state: "Superseded" });
+    mockedApi.getAssertionHistory.mockResolvedValue({
+      ...baseHistory,
+      state: "Superseded",
+      events: [
+        ...baseHistory.events,
+        {
+          event_id: "event-3",
+          assertion_id: "assertion-1",
+          sequence: 3,
+          from_state: "Accepted",
+          to_state: "Superseded",
+          authority: "acceptor",
+          recorded_at: "2024-02-01T00:00:00Z",
+          successor_assertion_id: "assertion-2",
+        },
+      ],
+    });
+
+    render(<RelationshipExplanationPanel relationship={governedRelationship} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Predecessor information is only available/),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getAllByText((_, element) =>
+        Boolean(
+          element?.textContent?.includes("superseded by assertion assertion-2"),
+        ),
+      ).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("re-fetches when the selected relationship changes and no stale state leaks through", async () => {
+    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
+    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
+
+    const { rerender } = render(
+      <RelationshipExplanationPanel relationship={governedRelationship} />,
+    );
+
+    await waitFor(() => {
+      expect(mockedApi.getAssertion).toHaveBeenCalledWith(
+        "assertion-1",
+        undefined,
+        expect.anything(),
+      );
+    });
+
+    rerender(<RelationshipExplanationPanel relationship={legacyRelationship} />);
+
+    expect(screen.getByText("Legacy")).toBeInTheDocument();
+  });
+});

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -320,61 +320,109 @@ function RelationshipListItem({
  *   Edges are objects with at least: `source`, `target`, `relationship_type`, `strength`.
  * @returns A JSX element rendering the 3D network plot when data is valid, or a centred status message when data is missing, invalid or too large.
  */
+/**
+ * Resolve the edges valid for a (possibly absent) visualization payload.
+ * Extracted so `NetworkVisualization` itself does not branch on the shape of
+ * `data` directly.
+ */
+function resolveValidEdges(data: VisualizationData | null | undefined) {
+  if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges)) {
+    return [];
+  }
+  return buildValidEdges(data.nodes, data.edges);
+}
+
+/**
+ * Resolve the plot-ready `VisualizationPreparation` for a (possibly absent)
+ * visualization payload.
+ */
+function resolvePreparation(
+  data: VisualizationData | null | undefined,
+  validEdges: readonly PreparedEdge[],
+): VisualizationPreparation {
+  if (!data) {
+    return {
+      status: "empty",
+      message: "No visualization data available.",
+      plotData: [],
+    };
+  }
+  return prepareVisualizationData(data, validEdges);
+}
+
+/** Extract the clicked edge's stable key from a Plotly click event, if any. */
+function resolveClickedKey(event: {
+  points?: ReadonlyArray<{ customdata?: unknown }>;
+}): string | null {
+  const customdata = event?.points?.[0]?.customdata;
+  return typeof customdata === "string" ? customdata : null;
+}
+
+/**
+ * Resolve the currently selected edge from `validEdges`. Always re-resolved
+ * from the current `validEdges`, so a stale key can never point at a
+ * relationship other than the one the user selected: if the dataset changes
+ * such that the key no longer exists, this naturally becomes `null` instead
+ * of silently resolving to an unrelated edge.
+ */
+function resolveSelectedEdge(
+  validEdges: readonly PreparedEdge[],
+  selectedKey: string | null,
+): PreparedEdge["edge"] | null {
+  return validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null;
+}
+
+type StatusMessageProps = Readonly<{
+  status: Exclude<VisualizationPreparation["status"], "ready">;
+  message: string;
+}>;
+
+/** Centred status message shown in place of the plot when data isn't ready. */
+function StatusMessage({ status, message }: StatusMessageProps) {
+  const isUrgent = status === "tooLarge";
+  return (
+    <div
+      className="text-center p-8 text-gray-600"
+      role={isUrgent ? "alert" : "status"}
+      aria-live={isUrgent ? "assertive" : "polite"}
+    >
+      {message}
+    </div>
+  );
+}
+
 export default function NetworkVisualization({
   data,
 }: NetworkVisualizationProps) {
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
-  const validEdges = useMemo<PreparedEdge[]>(() => {
-    if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges))
-      return [];
-    return buildValidEdges(data.nodes, data.edges);
-  }, [data]);
+  const validEdges = useMemo<PreparedEdge[]>(
+    () => resolveValidEdges(data),
+    [data],
+  );
 
-  const preparation = useMemo<VisualizationPreparation>(() => {
-    if (!data) {
-      return {
-        status: "empty",
-        message: "No visualization data available.",
-        plotData: [],
-      };
-    }
-    return prepareVisualizationData(data, validEdges);
-  }, [data, validEdges]);
+  const preparation = useMemo<VisualizationPreparation>(
+    () => resolvePreparation(data, validEdges),
+    [data, validEdges],
+  );
 
   const { plotData, status, message } = preparation;
 
   const handlePlotClick = useCallback(
     (event: { points?: ReadonlyArray<{ customdata?: unknown }> }) => {
-      const point = event?.points?.[0];
-      if (typeof point?.customdata === "string") {
-        setSelectedKey(point.customdata);
-      }
+      const key = resolveClickedKey(event);
+      if (key) setSelectedKey(key);
     },
     [],
   );
 
-  // Always re-resolved from the current `validEdges`, so a stale key can never
-  // point at a relationship other than the one the user selected: if the
-  // dataset changes such that the key no longer exists, this naturally
-  // becomes `null` instead of silently resolving to an unrelated edge.
   const selectedEdge = useMemo(
-    () =>
-      validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null,
+    () => resolveSelectedEdge(validEdges, selectedKey),
     [validEdges, selectedKey],
   );
 
   if (status !== "ready") {
-    const isUrgent = status === "tooLarge";
-    return (
-      <div
-        className="text-center p-8 text-gray-600"
-        role={isUrgent ? "alert" : "status"}
-        aria-live={isUrgent ? "assertive" : "polite"}
-      >
-        {message}
-      </div>
-    );
+    return <StatusMessage status={status} message={message} />;
   }
 
   return (

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -326,10 +326,12 @@ function RelationshipListItem({
  * `data` directly.
  */
 function resolveValidEdges(data: VisualizationData | null | undefined) {
-  if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges)) {
+  const nodes = data?.nodes;
+  const edges = data?.edges;
+  if (!Array.isArray(nodes) || !Array.isArray(edges)) {
     return [];
   }
-  return buildValidEdges(data.nodes, data.edges);
+  return buildValidEdges(nodes, edges);
 }
 
 /**

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -246,11 +246,10 @@ function RelationshipList({
   onSelect,
 }: RelationshipListProps) {
   return (
-    <div
-      role="group"
-      aria-label="Relationships (keyboard-accessible list)"
-      className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2"
-    >
+    <fieldset className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2">
+      <legend className="sr-only">
+        Relationships (keyboard-accessible list)
+      </legend>
       <ul className="space-y-1">
         {validEdges.map(({ key, edge }) => (
           <RelationshipListItem
@@ -262,7 +261,7 @@ function RelationshipList({
           />
         ))}
       </ul>
-    </div>
+    </fieldset>
   );
 }
 

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -369,7 +369,9 @@ function resolveSelectedEdge(
   validEdges: readonly PreparedEdge[],
   selectedKey: string | null,
 ): PreparedEdge["edge"] | null {
-  return validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null;
+  return (
+    validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null
+  );
 }
 
 type StatusMessageProps = Readonly<{

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -2,7 +2,11 @@
 
 import { useCallback, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
-import type { VisualizationData, VisualizationEdge, VisualizationNode } from "../types/api";
+import type {
+  VisualizationData,
+  VisualizationEdge,
+  VisualizationNode,
+} from "../types/api";
 import RelationshipExplanationPanel from "./RelationshipExplanationPanel";
 
 // Dynamically import Plotly to avoid SSR issues
@@ -236,7 +240,11 @@ type RelationshipListProps = Readonly<{
  * in the plot. Provides a first-class selection route independent of clicking
  * a line in the 3D plot.
  */
-function RelationshipList({ validEdges, selectedKey, onSelect }: RelationshipListProps) {
+function RelationshipList({
+  validEdges,
+  selectedKey,
+  onSelect,
+}: RelationshipListProps) {
   return (
     <div
       role="group"
@@ -266,7 +274,12 @@ type RelationshipListItemProps = Readonly<{
 }>;
 
 /** A single selectable relationship row within the keyboard-accessible list. */
-function RelationshipListItem({ edgeKey: key, edge, isSelected, onSelect }: RelationshipListItemProps) {
+function RelationshipListItem({
+  edgeKey: key,
+  edge,
+  isSelected,
+  onSelect,
+}: RelationshipListItemProps) {
   const isGoverned = edge.governance_status === "governed";
   return (
     <li>
@@ -275,14 +288,20 @@ function RelationshipListItem({ edgeKey: key, edge, isSelected, onSelect }: Rela
         aria-pressed={isSelected}
         onClick={() => onSelect(key)}
         className={`w-full text-left text-sm px-2 py-1 rounded ${
-          isSelected ? "bg-blue-100 text-blue-900" : "hover:bg-gray-100 text-gray-700"
+          isSelected
+            ? "bg-blue-100 text-blue-900"
+            : "hover:bg-gray-100 text-gray-700"
         }`}
       >
         {edge.source} {"\u2192"} {edge.target}{" "}
-        <span className="text-xs text-gray-500">({edge.relationship_type})</span>{" "}
+        <span className="text-xs text-gray-500">
+          ({edge.relationship_type})
+        </span>{" "}
         <span
           className={`text-xs px-1.5 py-0.5 rounded ${
-            isGoverned ? "bg-blue-50 text-blue-700" : "bg-gray-100 text-gray-500"
+            isGoverned
+              ? "bg-blue-50 text-blue-700"
+              : "bg-gray-100 text-gray-500"
           }`}
         >
           {isGoverned ? "Governed" : "Legacy"}
@@ -308,7 +327,8 @@ export default function NetworkVisualization({
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
   const validEdges = useMemo<PreparedEdge[]>(() => {
-    if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges)) return [];
+    if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges))
+      return [];
     return buildValidEdges(data.nodes, data.edges);
   }, [data]);
 
@@ -340,7 +360,8 @@ export default function NetworkVisualization({
   // dataset changes such that the key no longer exists, this naturally
   // becomes `null` instead of silently resolving to an unrelated edge.
   const selectedEdge = useMemo(
-    () => validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null,
+    () =>
+      validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null,
     [validEdges, selectedKey],
   );
 
@@ -367,9 +388,21 @@ export default function NetworkVisualization({
             title: "3D Asset Relationship Network",
             showlegend: false,
             scene: {
-              xaxis: { showgrid: false, zeroline: false, showticklabels: false },
-              yaxis: { showgrid: false, zeroline: false, showticklabels: false },
-              zaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              xaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
+              yaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
+              zaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
               camera: {
                 eye: { x: 1.5, y: 1.5, z: 1.5 },
               },

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
-import type { VisualizationData, VisualizationEdge } from "../types/api";
+import type { VisualizationData, VisualizationEdge, VisualizationNode } from "../types/api";
 import RelationshipExplanationPanel from "./RelationshipExplanationPanel";
 
 // Dynamically import Plotly to avoid SSR issues
@@ -29,8 +29,8 @@ type EdgeTrace = {
   };
   hoverinfo: "none";
   showlegend: false;
-  /** Index into the original `edges` array, repeated for each of the two line points. */
-  customdata: [number, number];
+  /** Stable edge selection key, repeated for each of the two line points. */
+  customdata: [string, string];
 };
 
 type NodeTrace = {
@@ -64,8 +64,59 @@ type VisualizationPreparation = {
   plotData: Array<EdgeTrace | NodeTrace>;
 };
 
+/**
+ * One edge paired with its resolved endpoint nodes. Shared by the Plotly trace
+ * builder and the keyboard-accessible relationship list so both views always
+ * agree on which edges are renderable and how each is identified for selection.
+ */
+type PreparedEdge = {
+  key: string;
+  edge: VisualizationEdge;
+  sourceNode: VisualizationNode;
+  targetNode: VisualizationNode;
+};
+
 const MAX_NODES = Number(process.env.NEXT_PUBLIC_MAX_NODES) || 500;
 const MAX_EDGES = Number(process.env.NEXT_PUBLIC_MAX_EDGES) || 2000;
+
+/**
+ * Derive a stable selection key for an edge. Governed edges are keyed by their
+ * assertion ID (stable across data refreshes); legacy edges fall back to their
+ * endpoint/type triple, which is stable as long as the relationship itself
+ * does not change.
+ */
+function edgeKey(edge: VisualizationEdge): string {
+  if (edge.assertion_id) return `assertion:${edge.assertion_id}`;
+  return `edge:${edge.source}|${edge.target}|${edge.relationship_type}`;
+}
+
+/**
+ * Resolve edges against their endpoint nodes, skipping any edge whose source
+ * or target node is missing. This is the single source of truth for "valid"
+ * edges consumed by both the Plotly traces and the keyboard-accessible list.
+ */
+function buildValidEdges(
+  nodes: VisualizationData["nodes"],
+  edges: VisualizationData["edges"],
+): PreparedEdge[] {
+  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  return edges.reduce<PreparedEdge[]>((acc, edge) => {
+    const sourceNode = nodeMap.get(edge.source);
+    const targetNode = nodeMap.get(edge.target);
+
+    if (!sourceNode || !targetNode) {
+      if (process.env.NODE_ENV === "development") {
+        console.debug(
+          `[Development Only] Skipping invalid edge: source ${edge.source} or target ${edge.target} not found.`,
+        );
+      }
+      return acc;
+    }
+
+    acc.push({ key: edgeKey(edge), edge, sourceNode, targetNode });
+    return acc;
+  }, []);
+}
 
 /**
  * Build a Plotly 3D scatter trace that renders nodes as markers with inline labels.
@@ -105,55 +156,34 @@ function buildNodeTrace(nodes: VisualizationData["nodes"]): NodeTrace {
 }
 
 /**
- * Build Plotly 3D line traces for network edges from node and edge lists.
+ * Build Plotly 3D line traces from already-validated edges.
  *
- * Skips edges whose source or target node is missing.
- *
- * @param nodes - Nodes with unique `id` and numeric `x`, `y`, `z` coordinates.
- * @param edges - Edges with `source` and `target` node ids and a numeric `strength` between 0 and 1.
- * @returns An array of `EdgeTrace` objects; each trace is a two-point 3D line connecting source and target where line color and width are derived from the edge's `strength`.
+ * @param validEdges - Edges paired with their resolved endpoint nodes (see `buildValidEdges`).
+ * @returns An array of `EdgeTrace` objects; each trace is a two-point 3D line connecting
+ *   source and target, carrying the edge's stable selection key as `customdata`.
  */
-function buildEdgeTraces(
-  nodes: VisualizationData["nodes"],
-  edges: VisualizationData["edges"],
-): EdgeTrace[] {
-  const nodeMap = new Map(nodes.map((node) => [node.id, node]));
-  return edges.reduce<EdgeTrace[]>((acc, edge, edgeIndex) => {
-    const sourceNode = nodeMap.get(edge.source);
-    const targetNode = nodeMap.get(edge.target);
-
-    if (!sourceNode || !targetNode) {
-      if (process.env.NODE_ENV === "development") {
-        console.debug(
-          `[Development Only] Skipping invalid edge: source ${edge.source} or target ${edge.target} not found.`,
-        );
-      }
-      return acc;
-    }
-
-    acc.push({
-      type: "scatter3d",
-      mode: "lines",
-      x: [sourceNode.x, targetNode.x],
-      y: [sourceNode.y, targetNode.y],
-      z: [sourceNode.z, targetNode.z],
-      line: {
-        color: `rgba(125, 125, 125, ${edge.strength})`,
-        width: edge.strength * 3,
-      },
-      hoverinfo: "none",
-      showlegend: false,
-      customdata: [edgeIndex, edgeIndex],
-    });
-
-    return acc;
-  }, []);
+function buildEdgeTraces(validEdges: readonly PreparedEdge[]): EdgeTrace[] {
+  return validEdges.map(({ key, edge, sourceNode, targetNode }) => ({
+    type: "scatter3d",
+    mode: "lines",
+    x: [sourceNode.x, targetNode.x],
+    y: [sourceNode.y, targetNode.y],
+    z: [sourceNode.z, targetNode.z],
+    line: {
+      color: `rgba(125, 125, 125, ${edge.strength})`,
+      width: edge.strength * 3,
+    },
+    hoverinfo: "none",
+    showlegend: false,
+    customdata: [key, key],
+  }));
 }
 
 /**
  * Prepare Plotly traces and a rendering status from the provided visualization data.
  *
  * @param data - The visualization input containing `nodes` and `edges` to convert into traces.
+ * @param validEdges - Edges already resolved against their endpoint nodes (see `buildValidEdges`).
  * @returns A `VisualizationPreparation` describing the resulting `status`, a human-readable `message`, and `plotData`:
  * - `status` is `"empty"` when there are no nodes,
  * - `"tooLarge"` when node or edge counts exceed configured limits,
@@ -161,6 +191,7 @@ function buildEdgeTraces(
  */
 function prepareVisualizationData(
   data: VisualizationData,
+  validEdges: readonly PreparedEdge[],
 ): VisualizationPreparation {
   const nodes = Array.isArray(data.nodes) ? data.nodes : [];
   const edges = Array.isArray(data.edges) ? data.edges : [];
@@ -185,13 +216,80 @@ function prepareVisualizationData(
   }
 
   const nodeTrace = buildNodeTrace(nodes);
-  const edgeTraces = buildEdgeTraces(nodes, edges);
+  const edgeTraces = buildEdgeTraces(validEdges);
 
   return {
     status: "ready",
     message: "",
     plotData: [...edgeTraces, nodeTrace],
   };
+}
+
+type RelationshipListProps = Readonly<{
+  validEdges: readonly PreparedEdge[];
+  selectedKey: string | null;
+  onSelect: (key: string) => void;
+}>;
+
+/**
+ * Keyboard-accessible list of relationships, mirroring exactly the edges drawn
+ * in the plot. Provides a first-class selection route independent of clicking
+ * a line in the 3D plot.
+ */
+function RelationshipList({ validEdges, selectedKey, onSelect }: RelationshipListProps) {
+  return (
+    <div
+      role="group"
+      aria-label="Relationships (keyboard-accessible list)"
+      className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2"
+    >
+      <ul className="space-y-1">
+        {validEdges.map(({ key, edge }) => (
+          <RelationshipListItem
+            key={key}
+            edgeKey={key}
+            edge={edge}
+            isSelected={key === selectedKey}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+type RelationshipListItemProps = Readonly<{
+  edgeKey: string;
+  edge: VisualizationEdge;
+  isSelected: boolean;
+  onSelect: (key: string) => void;
+}>;
+
+/** A single selectable relationship row within the keyboard-accessible list. */
+function RelationshipListItem({ edgeKey: key, edge, isSelected, onSelect }: RelationshipListItemProps) {
+  const isGoverned = edge.governance_status === "governed";
+  return (
+    <li>
+      <button
+        type="button"
+        aria-pressed={isSelected}
+        onClick={() => onSelect(key)}
+        className={`w-full text-left text-sm px-2 py-1 rounded ${
+          isSelected ? "bg-blue-100 text-blue-900" : "hover:bg-gray-100 text-gray-700"
+        }`}
+      >
+        {edge.source} {"\u2192"} {edge.target}{" "}
+        <span className="text-xs text-gray-500">({edge.relationship_type})</span>{" "}
+        <span
+          className={`text-xs px-1.5 py-0.5 rounded ${
+            isGoverned ? "bg-blue-50 text-blue-700" : "bg-gray-100 text-gray-500"
+          }`}
+        >
+          {isGoverned ? "Governed" : "Legacy"}
+        </span>
+      </button>
+    </li>
+  );
 }
 
 /**
@@ -207,14 +305,12 @@ function prepareVisualizationData(
 export default function NetworkVisualization({
   data,
 }: NetworkVisualizationProps) {
-  const [selectedEdgeIndex, setSelectedEdgeIndex] = useState<number | null>(
-    null,
-  );
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
 
-  const edges = useMemo<VisualizationEdge[]>(
-    () => (data && Array.isArray(data.edges) ? data.edges : []),
-    [data],
-  );
+  const validEdges = useMemo<PreparedEdge[]>(() => {
+    if (!data || !Array.isArray(data.nodes) || !Array.isArray(data.edges)) return [];
+    return buildValidEdges(data.nodes, data.edges);
+  }, [data]);
 
   const preparation = useMemo<VisualizationPreparation>(() => {
     if (!data) {
@@ -224,25 +320,29 @@ export default function NetworkVisualization({
         plotData: [],
       };
     }
-    return prepareVisualizationData(data);
-  }, [data]);
+    return prepareVisualizationData(data, validEdges);
+  }, [data, validEdges]);
 
   const { plotData, status, message } = preparation;
 
   const handlePlotClick = useCallback(
     (event: { points?: ReadonlyArray<{ customdata?: unknown }> }) => {
       const point = event?.points?.[0];
-      const index =
-        typeof point?.customdata === "number" ? point.customdata : null;
-      if (index !== null && edges[index]) {
-        setSelectedEdgeIndex(index);
+      if (typeof point?.customdata === "string") {
+        setSelectedKey(point.customdata);
       }
     },
-    [edges],
+    [],
   );
 
-  const selectedEdge =
-    selectedEdgeIndex !== null ? (edges[selectedEdgeIndex] ?? null) : null;
+  // Always re-resolved from the current `validEdges`, so a stale key can never
+  // point at a relationship other than the one the user selected: if the
+  // dataset changes such that the key no longer exists, this naturally
+  // becomes `null` instead of silently resolving to an unrelated edge.
+  const selectedEdge = useMemo(
+    () => validEdges.find((prepared) => prepared.key === selectedKey)?.edge ?? null,
+    [validEdges, selectedKey],
+  );
 
   if (status !== "ready") {
     const isUrgent = status === "tooLarge";
@@ -267,21 +367,9 @@ export default function NetworkVisualization({
             title: "3D Asset Relationship Network",
             showlegend: false,
             scene: {
-              xaxis: {
-                showgrid: false,
-                zeroline: false,
-                showticklabels: false,
-              },
-              yaxis: {
-                showgrid: false,
-                zeroline: false,
-                showticklabels: false,
-              },
-              zaxis: {
-                showgrid: false,
-                zeroline: false,
-                showticklabels: false,
-              },
+              xaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              yaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              zaxis: { showgrid: false, zeroline: false, showticklabels: false },
               camera: {
                 eye: { x: 1.5, y: 1.5, z: 1.5 },
               },
@@ -303,49 +391,11 @@ export default function NetworkVisualization({
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-        <div
-          role="group"
-          aria-label="Relationships (keyboard-accessible list)"
-          className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2"
-        >
-          <ul className="space-y-1">
-            {edges.map((edge, index) => {
-              const isSelected = index === selectedEdgeIndex;
-              const isGoverned = edge.governance_status === "governed";
-              return (
-                <li
-                  key={`${edge.source}-${edge.target}-${edge.relationship_type}-${index}`}
-                >
-                  <button
-                    type="button"
-                    aria-pressed={isSelected}
-                    onClick={() => setSelectedEdgeIndex(index)}
-                    className={`w-full text-left text-sm px-2 py-1 rounded ${
-                      isSelected
-                        ? "bg-blue-100 text-blue-900"
-                        : "hover:bg-gray-100 text-gray-700"
-                    }`}
-                  >
-                    {edge.source} {"\u2192"} {edge.target}{" "}
-                    <span className="text-xs text-gray-500">
-                      ({edge.relationship_type})
-                    </span>{" "}
-                    <span
-                      className={`text-xs px-1.5 py-0.5 rounded ${
-                        isGoverned
-                          ? "bg-blue-50 text-blue-700"
-                          : "bg-gray-100 text-gray-500"
-                      }`}
-                    >
-                      {isGoverned ? "Governed" : "Legacy"}
-                    </span>
-                  </button>
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-
+        <RelationshipList
+          validEdges={validEdges}
+          selectedKey={selectedKey}
+          onSelect={setSelectedKey}
+        />
         <RelationshipExplanationPanel relationship={selectedEdge} />
       </div>
     </div>

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import dynamic from "next/dynamic";
-import type { VisualizationData } from "../types/api";
+import type { VisualizationData, VisualizationEdge } from "../types/api";
+import RelationshipExplanationPanel from "./RelationshipExplanationPanel";
 
 // Dynamically import Plotly to avoid SSR issues
 const Plot = dynamic(() => import("react-plotly.js"), {
@@ -28,6 +29,8 @@ type EdgeTrace = {
   };
   hoverinfo: "none";
   showlegend: false;
+  /** Index into the original `edges` array, repeated for each of the two line points. */
+  customdata: [number, number];
 };
 
 type NodeTrace = {
@@ -115,7 +118,7 @@ function buildEdgeTraces(
   edges: VisualizationData["edges"],
 ): EdgeTrace[] {
   const nodeMap = new Map(nodes.map((node) => [node.id, node]));
-  return edges.reduce<EdgeTrace[]>((acc, edge) => {
+  return edges.reduce<EdgeTrace[]>((acc, edge, edgeIndex) => {
     const sourceNode = nodeMap.get(edge.source);
     const targetNode = nodeMap.get(edge.target);
 
@@ -140,6 +143,7 @@ function buildEdgeTraces(
       },
       hoverinfo: "none",
       showlegend: false,
+      customdata: [edgeIndex, edgeIndex],
     });
 
     return acc;
@@ -203,6 +207,13 @@ function prepareVisualizationData(
 export default function NetworkVisualization({
   data,
 }: NetworkVisualizationProps) {
+  const [selectedEdgeIndex, setSelectedEdgeIndex] = useState<number | null>(null);
+
+  const edges = useMemo<VisualizationEdge[]>(
+    () => (data && Array.isArray(data.edges) ? data.edges : []),
+    [data],
+  );
+
   const preparation = useMemo<VisualizationPreparation>(() => {
     if (!data) {
       return {
@@ -215,6 +226,19 @@ export default function NetworkVisualization({
   }, [data]);
 
   const { plotData, status, message } = preparation;
+
+  const handlePlotClick = useCallback(
+    (event: { points?: ReadonlyArray<{ customdata?: unknown }> }) => {
+      const point = event?.points?.[0];
+      const index = typeof point?.customdata === "number" ? point.customdata : null;
+      if (index !== null && edges[index]) {
+        setSelectedEdgeIndex(index);
+      }
+    },
+    [edges],
+  );
+
+  const selectedEdge = selectedEdgeIndex !== null ? edges[selectedEdgeIndex] ?? null : null;
 
   if (status !== "ready") {
     const isUrgent = status === "tooLarge";
@@ -230,33 +254,78 @@ export default function NetworkVisualization({
   }
 
   return (
-    <div className="w-full h-[800px]">
-      <Plot
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        data={plotData as any}
-        layout={{
-          title: "3D Asset Relationship Network",
-          showlegend: false,
-          scene: {
-            xaxis: { showgrid: false, zeroline: false, showticklabels: false },
-            yaxis: { showgrid: false, zeroline: false, showticklabels: false },
-            zaxis: { showgrid: false, zeroline: false, showticklabels: false },
-            camera: {
-              eye: { x: 1.5, y: 1.5, z: 1.5 },
+    <div className="w-full space-y-4">
+      <div className="w-full h-[800px]">
+        <Plot
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          data={plotData as any}
+          layout={{
+            title: "3D Asset Relationship Network",
+            showlegend: false,
+            scene: {
+              xaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              yaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              zaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              camera: {
+                eye: { x: 1.5, y: 1.5, z: 1.5 },
+              },
             },
-          },
-          hovermode: "closest",
-          margin: { l: 0, r: 0, b: 0, t: 40 },
-          paper_bgcolor: "rgba(0,0,0,0)",
-          plot_bgcolor: "rgba(0,0,0,0)",
-        }}
-        config={{
-          displayModeBar: true,
-          displaylogo: false,
-          responsive: true,
-        }}
-        style={{ width: "100%", height: "100%" }}
-      />
+            hovermode: "closest",
+            margin: { l: 0, r: 0, b: 0, t: 40 },
+            paper_bgcolor: "rgba(0,0,0,0)",
+            plot_bgcolor: "rgba(0,0,0,0)",
+          }}
+          config={{
+            displayModeBar: true,
+            displaylogo: false,
+            responsive: true,
+          }}
+          style={{ width: "100%", height: "100%" }}
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          onClick={handlePlotClick as any}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div
+          role="group"
+          aria-label="Relationships (keyboard-accessible list)"
+          className="max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2"
+        >
+          <ul className="space-y-1">
+            {edges.map((edge, index) => {
+              const isSelected = index === selectedEdgeIndex;
+              const isGoverned = edge.governance_status === "governed";
+              return (
+                <li key={`${edge.source}-${edge.target}-${edge.relationship_type}-${index}`}>
+                  <button
+                    type="button"
+                    aria-pressed={isSelected}
+                    onClick={() => setSelectedEdgeIndex(index)}
+                    className={`w-full text-left text-sm px-2 py-1 rounded ${
+                      isSelected
+                        ? "bg-blue-100 text-blue-900"
+                        : "hover:bg-gray-100 text-gray-700"
+                    }`}
+                  >
+                    {edge.source} {"\u2192"} {edge.target}{" "}
+                    <span className="text-xs text-gray-500">({edge.relationship_type})</span>{" "}
+                    <span
+                      className={`text-xs px-1.5 py-0.5 rounded ${
+                        isGoverned ? "bg-blue-50 text-blue-700" : "bg-gray-100 text-gray-500"
+                      }`}
+                    >
+                      {isGoverned ? "Governed" : "Legacy"}
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+
+        <RelationshipExplanationPanel relationship={selectedEdge} />
+      </div>
     </div>
   );
 }

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -207,7 +207,9 @@ function prepareVisualizationData(
 export default function NetworkVisualization({
   data,
 }: NetworkVisualizationProps) {
-  const [selectedEdgeIndex, setSelectedEdgeIndex] = useState<number | null>(null);
+  const [selectedEdgeIndex, setSelectedEdgeIndex] = useState<number | null>(
+    null,
+  );
 
   const edges = useMemo<VisualizationEdge[]>(
     () => (data && Array.isArray(data.edges) ? data.edges : []),
@@ -230,7 +232,8 @@ export default function NetworkVisualization({
   const handlePlotClick = useCallback(
     (event: { points?: ReadonlyArray<{ customdata?: unknown }> }) => {
       const point = event?.points?.[0];
-      const index = typeof point?.customdata === "number" ? point.customdata : null;
+      const index =
+        typeof point?.customdata === "number" ? point.customdata : null;
       if (index !== null && edges[index]) {
         setSelectedEdgeIndex(index);
       }
@@ -238,7 +241,8 @@ export default function NetworkVisualization({
     [edges],
   );
 
-  const selectedEdge = selectedEdgeIndex !== null ? edges[selectedEdgeIndex] ?? null : null;
+  const selectedEdge =
+    selectedEdgeIndex !== null ? (edges[selectedEdgeIndex] ?? null) : null;
 
   if (status !== "ready") {
     const isUrgent = status === "tooLarge";
@@ -263,9 +267,21 @@ export default function NetworkVisualization({
             title: "3D Asset Relationship Network",
             showlegend: false,
             scene: {
-              xaxis: { showgrid: false, zeroline: false, showticklabels: false },
-              yaxis: { showgrid: false, zeroline: false, showticklabels: false },
-              zaxis: { showgrid: false, zeroline: false, showticklabels: false },
+              xaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
+              yaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
+              zaxis: {
+                showgrid: false,
+                zeroline: false,
+                showticklabels: false,
+              },
               camera: {
                 eye: { x: 1.5, y: 1.5, z: 1.5 },
               },
@@ -297,7 +313,9 @@ export default function NetworkVisualization({
               const isSelected = index === selectedEdgeIndex;
               const isGoverned = edge.governance_status === "governed";
               return (
-                <li key={`${edge.source}-${edge.target}-${edge.relationship_type}-${index}`}>
+                <li
+                  key={`${edge.source}-${edge.target}-${edge.relationship_type}-${index}`}
+                >
                   <button
                     type="button"
                     aria-pressed={isSelected}
@@ -309,10 +327,14 @@ export default function NetworkVisualization({
                     }`}
                   >
                     {edge.source} {"\u2192"} {edge.target}{" "}
-                    <span className="text-xs text-gray-500">({edge.relationship_type})</span>{" "}
+                    <span className="text-xs text-gray-500">
+                      ({edge.relationship_type})
+                    </span>{" "}
                     <span
                       className={`text-xs px-1.5 py-0.5 rounded ${
-                        isGoverned ? "bg-blue-50 text-blue-700" : "bg-gray-100 text-gray-500"
+                        isGoverned
+                          ? "bg-blue-50 text-blue-700"
+                          : "bg-gray-100 text-gray-500"
                       }`}
                     >
                       {isGoverned ? "Governed" : "Legacy"}

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -24,19 +24,25 @@ type RelationshipExplanationPanelProps = Readonly<{
   relationship: ExplainableRelationship | null;
 }>;
 
-type PanelStatus = "idle" | "loading" | "ready" | "not-found" | "unavailable";
+/**
+ * The settled (non-loading) outcome of a fetch for a given request key. Only
+ * completed results are ever stored in state; "loading" is derived by
+ * comparing the current `requestKey` against `result.requestKey` rather than
+ * stored as its own state value. This means the effect never needs to call
+ * `setState` synchronously at the start of a fetch -- it only calls it once,
+ * asynchronously, when the fetch settles -- so there is no render-cascading
+ * synchronous `setState` inside the effect body.
+ */
+type PanelResult =
+  | Readonly<{ status: "not-found"; requestKey: string }>
+  | Readonly<{ status: "unavailable"; requestKey: string }>
+  | Readonly<{
+      status: "ready";
+      requestKey: string;
+      explanation: AssertionExplanation;
+      history: AssertionHistory;
+    }>;
 
-type PanelState = Readonly<{
-  status: PanelStatus;
-  explanation: AssertionExplanation | null;
-  history: AssertionHistory | null;
-}>;
-
-const IDLE_STATE: PanelState = {
-  status: "idle",
-  explanation: null,
-  history: null,
-};
 
 const AUTHORITY_LABELS: Record<string, string> = {
   proposer: "Proposer of record",
@@ -45,9 +51,7 @@ const AUTHORITY_LABELS: Record<string, string> = {
   retractor: "Determining authority (retractor)",
 };
 
-/**
- * Format an ISO timestamp for display, or a bounded placeholder when absent.
- */
+/** Format an ISO timestamp for display, or a bounded placeholder when absent. */
 function formatTimestamp(value: string | null | undefined): string {
   if (!value) return "Not recorded";
   const parsed = new Date(value);
@@ -65,11 +69,9 @@ function deriveAuthoritySummary(events: readonly AssertionPublicEvent[]): {
   proposer: AssertionPublicEvent | null;
   determiner: AssertionPublicEvent | null;
 } {
-  const proposer =
-    events.find((event) => event.authority === "proposer") ?? null;
+  const proposer = events.find((event) => event.authority === "proposer") ?? null;
   const determiner =
-    [...events].reverse().find((event) => event.authority !== "proposer") ??
-    null;
+    [...events].reverse().find((event) => event.authority !== "proposer") ?? null;
   return { proposer, determiner };
 }
 
@@ -81,174 +83,249 @@ function findSupersessionEvent(
   events: readonly AssertionPublicEvent[],
 ): AssertionPublicEvent | null {
   return (
-    [...events]
-      .reverse()
-      .find((event) => Boolean(event.successor_assertion_id)) ?? null
+    [...events].reverse().find((event) => Boolean(event.successor_assertion_id)) ?? null
   );
 }
 
-/**
- * Renders the governed explanation (evidence, authority, time, confidence,
- * supersession, and publication scope) for a selected relationship edge, or a
- * bounded legacy/unavailable/loading state when governance facts cannot be
- * shown. Never displays evidence bodies, restricted references, or invented
- * `CURRENT`/production-proof claims.
- */
-export default function RelationshipExplanationPanel({
-  relationship,
-}: RelationshipExplanationPanelProps) {
-  const [state, setState] = useState<PanelState>(IDLE_STATE);
+function relationshipHeading(relationship: ExplainableRelationship): string {
+  return `${relationship.source} \u2192 ${relationship.target} (${relationship.relationship_type})`;
+}
 
-  const isGoverned = relationship?.governance_status === "governed";
-  const assertionId = isGoverned ? (relationship?.assertion_id ?? null) : null;
-
-  // Track which assertionId the current `state` reflects so a change in the
-  // selected relationship resets state synchronously during render, rather
-  // than via a setState call inside the effect body (see React docs on
-  // "adjusting state when a prop changes").
-  const [trackedAssertionId, setTrackedAssertionId] = useState<string | null>(
-    null,
+function PanelShell({
+  heading,
+  toneClassName,
+  children,
+}: Readonly<{
+  heading: string;
+  toneClassName: string;
+  children: React.ReactNode;
+}>) {
+  return (
+    <section aria-label="Relationship explanation" className={`p-4 border rounded-lg ${toneClassName}`}>
+      <h3 className="font-semibold text-gray-900">{heading}</h3>
+      {children}
+    </section>
   );
-  if (assertionId !== trackedAssertionId) {
-    setTrackedAssertionId(assertionId);
-    setState(
-      assertionId
-        ? { status: "loading", explanation: null, history: null }
-        : IDLE_STATE,
-    );
-  }
+}
 
-  useEffect(() => {
-    if (!assertionId) {
-      return;
-    }
+function EmptySelectionView() {
+  return (
+    <div className="p-4 text-sm text-gray-500" role="status">
+      Select a relationship to see how it was determined.
+    </div>
+  );
+}
 
-    const controller = new AbortController();
+function LegacyView({ heading }: Readonly<{ heading: string }>) {
+  return (
+    <PanelShell heading={heading} toneClassName="border-gray-200 bg-gray-50">
+      <p className="mt-2 text-sm text-gray-600" role="status">
+        <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
+          Legacy
+        </span>
+        This relationship is outside any governed scope. No assertion, evidence, or
+        lifecycle history is available for it.
+      </p>
+    </PanelShell>
+  );
+}
 
-    Promise.all([
-      api.getAssertion(assertionId, undefined, controller.signal),
-      api.getAssertionHistory(assertionId, undefined, controller.signal),
-    ])
-      .then(([explanation, history]) => {
-        if (controller.signal.aborted) return;
-        setState({ status: "ready", explanation, history });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted) return;
-        const httpStatus = err?.response?.status;
-        setState({
-          status: httpStatus === 404 ? "not-found" : "unavailable",
-          explanation: null,
-          history: null,
-        });
-      });
+function PendingMetadataView({ heading }: Readonly<{ heading: string }>) {
+  return (
+    <PanelShell heading={heading} toneClassName="border-amber-200 bg-amber-50">
+      <p className="mt-2 text-sm text-amber-800" role="status">
+        This relationship is governed, but its assertion metadata is not yet
+        available. It may still be synchronizing.
+      </p>
+    </PanelShell>
+  );
+}
 
-    return () => controller.abort();
-  }, [assertionId]);
+function LoadingView({ heading }: Readonly<{ heading: string }>) {
+  return (
+    <PanelShell heading={heading} toneClassName="border-gray-200">
+      <p className="mt-2 text-sm text-gray-500" role="status" aria-live="polite">
+        Loading governed explanation...
+      </p>
+    </PanelShell>
+  );
+}
 
-  const authoritySummary = useMemo(() => {
-    if (!state.history) return null;
-    return deriveAuthoritySummary(state.history.events);
-  }, [state.history]);
+function NotFoundView({ heading }: Readonly<{ heading: string }>) {
+  return (
+    <PanelShell heading={heading} toneClassName="border-amber-200 bg-amber-50">
+      <p className="mt-2 text-sm text-amber-800" role="alert">
+        The governed assertion behind this relationship could not be found. It may
+        be synchronizing with the latest publication.
+      </p>
+    </PanelShell>
+  );
+}
 
-  const supersessionEvent = useMemo(() => {
-    if (!state.history) return null;
-    return findSupersessionEvent(state.history.events);
-  }, [state.history]);
+function UnavailableView({ heading }: Readonly<{ heading: string }>) {
+  return (
+    <PanelShell heading={heading} toneClassName="border-red-200 bg-red-50">
+      <p className="mt-2 text-sm text-red-800" role="alert">
+        Governance explanation is temporarily unavailable. The graph remains usable;
+        please try again shortly.
+      </p>
+    </PanelShell>
+  );
+}
 
-  if (!relationship) {
-    return (
-      <div className="p-4 text-sm text-gray-500" role="status">
-        Select a relationship to see how it was determined.
+function ConfidenceAndTimeSummary({
+  explanation,
+  strength,
+}: Readonly<{ explanation: AssertionExplanation; strength: number }>) {
+  return (
+    <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+      <div>
+        <dt className="font-medium text-gray-500">Confidence</dt>
+        <dd className="text-gray-800">
+          {explanation.confidence_status === "assessed"
+            ? `${explanation.confidence_type ?? "assessed"} (${
+                explanation.confidence_bp ?? "n/a"
+              } bp, method: ${explanation.confidence_method ?? "unspecified"})`
+            : "Not assessed"}
+        </dd>
       </div>
-    );
-  }
+      <div>
+        <dt className="font-medium text-gray-500">Projection strength</dt>
+        <dd className="text-gray-800">
+          {strength.toFixed(2)}{" "}
+          <span className="text-xs text-gray-500">(distinct from confidence above)</span>
+        </dd>
+      </div>
+      <div>
+        <dt className="font-medium text-gray-500">Effective time</dt>
+        <dd className="text-gray-800">
+          {formatTimestamp(explanation.effective_from)}
+          {explanation.effective_to ? ` \u2013 ${formatTimestamp(explanation.effective_to)}` : " (ongoing)"}
+        </dd>
+      </div>
+      <div>
+        <dt className="font-medium text-gray-500">Recorded / known at</dt>
+        <dd className="text-gray-800">
+          {formatTimestamp(explanation.recorded_at)}
+          {explanation.known_at ? ` (known: ${formatTimestamp(explanation.known_at)})` : ""}
+        </dd>
+      </div>
+    </dl>
+  );
+}
 
-  const heading = `${relationship.source} \u2192 ${relationship.target} (${relationship.relationship_type})`;
+function AuthoritySummary({ history }: Readonly<{ history: AssertionHistory }>) {
+  const summary = useMemo(() => deriveAuthoritySummary(history.events), [history]);
+  if (!summary.proposer && !summary.determiner) return null;
 
-  if (!isGoverned) {
-    return (
-      <section
-        aria-label="Relationship explanation"
-        className="p-4 border border-gray-200 rounded-lg bg-gray-50"
-      >
-        <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p className="mt-2 text-sm text-gray-600" role="status">
-          <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
-            Legacy
-          </span>
-          This relationship is outside any governed scope. No assertion,
-          evidence, or lifecycle history is available for it.
+  return (
+    <div className="text-sm">
+      <h4 className="font-medium text-gray-500">Authority</h4>
+      <ul className="mt-1 space-y-1">
+        {summary.proposer && (
+          <li>
+            {AUTHORITY_LABELS.proposer} {"\u2014"} {formatTimestamp(summary.proposer.recorded_at)}
+          </li>
+        )}
+        {summary.determiner && (
+          <li>
+            {AUTHORITY_LABELS[summary.determiner.authority] ?? "Determining authority"} {"\u2014"}{" "}
+            {formatTimestamp(summary.determiner.recorded_at)}
+          </li>
+        )}
+      </ul>
+    </div>
+  );
+}
+
+function EvidenceSummary({ explanation }: Readonly<{ explanation: AssertionExplanation }>) {
+  return (
+    <div className="text-sm">
+      <h4 className="font-medium text-gray-500">Evidence</h4>
+      {explanation.evidence.length === 0 ? (
+        <p className="text-gray-500 italic">No evidence recorded.</p>
+      ) : (
+        <ul className="mt-1 space-y-2">
+          {explanation.evidence.map((item) => (
+            <li key={item.evidence_id} className="border border-gray-100 rounded p-2">
+              <span className="font-medium">{item.polarity}</span>{" "}
+              <span className="text-xs text-gray-500">({item.visibility})</span>
+              {item.redacted ? (
+                <p className="text-xs text-gray-500 italic">
+                  Evidence body and restricted references are not shown.
+                </p>
+              ) : (
+                <div className="text-xs text-gray-600 space-y-0.5">
+                  {item.source_ref && <p>Reference: {item.source_ref}</p>}
+                  {item.content_sha256 && <p>SHA-256: {item.content_sha256}</p>}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function LifecycleHistory({ history }: Readonly<{ history: AssertionHistory }>) {
+  const supersessionEvent = useMemo(() => findSupersessionEvent(history.events), [history]);
+  return (
+    <div className="text-sm">
+      <h4 className="font-medium text-gray-500">Lifecycle history</h4>
+      <ul className="mt-1 space-y-1">
+        {history.events.map((event) => (
+          <li key={event.event_id}>
+            #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"} {event.to_state}{" "}
+            <span className="text-xs text-gray-500">
+              ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
+              {formatTimestamp(event.recorded_at)})
+            </span>
+            {event.successor_assertion_id && (
+              <span className="text-xs text-gray-500">
+                {" "}
+                {"\u2014"} superseded by assertion {event.successor_assertion_id}
+              </span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {supersessionEvent?.successor_assertion_id && (
+        <p className="mt-1 text-xs text-amber-700" role="status">
+          This assertion has been superseded by assertion{" "}
+          {supersessionEvent.successor_assertion_id}. The public API does not expose a
+          backward predecessor reference, so if you are viewing that successor
+          assertion instead, its own predecessor cannot be looked up from here.
         </p>
-      </section>
-    );
-  }
+      )}
+    </div>
+  );
+}
 
-  if (!assertionId) {
-    return (
-      <section
-        aria-label="Relationship explanation"
-        className="p-4 border border-amber-200 rounded-lg bg-amber-50"
-      >
-        <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p className="mt-2 text-sm text-amber-800" role="status">
-          This relationship is governed, but its assertion metadata is not yet
-          available. It may still be synchronizing.
-        </p>
-      </section>
-    );
-  }
+function PublicationFooter({ relationship }: Readonly<{ relationship: ExplainableRelationship }>) {
+  return (
+    <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
+      <p>
+        Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
+        {relationship.scope_refs && relationship.scope_refs.length > 0
+          ? relationship.scope_refs.join(", ")
+          : "unknown"}
+      </p>
+    </div>
+  );
+}
 
-  if (state.status === "loading" || state.status === "idle") {
-    return (
-      <section
-        aria-label="Relationship explanation"
-        className="p-4 border border-gray-200 rounded-lg"
-      >
-        <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p
-          className="mt-2 text-sm text-gray-500"
-          role="status"
-          aria-live="polite"
-        >
-          Loading governed explanation...
-        </p>
-      </section>
-    );
-  }
-
-  if (state.status === "not-found") {
-    return (
-      <section
-        aria-label="Relationship explanation"
-        className="p-4 border border-amber-200 rounded-lg bg-amber-50"
-      >
-        <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p className="mt-2 text-sm text-amber-800" role="alert">
-          The governed assertion behind this relationship could not be found. It
-          may be synchronizing with the latest publication.
-        </p>
-      </section>
-    );
-  }
-
-  if (state.status === "unavailable" || !state.explanation || !state.history) {
-    return (
-      <section
-        aria-label="Relationship explanation"
-        className="p-4 border border-red-200 rounded-lg bg-red-50"
-      >
-        <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p className="mt-2 text-sm text-red-800" role="alert">
-          Governance explanation is temporarily unavailable. The graph remains
-          usable; please try again shortly.
-        </p>
-      </section>
-    );
-  }
-
-  const { explanation, history } = state;
-
+function ReadyView({
+  heading,
+  relationship,
+  explanation,
+  history,
+}: Readonly<{
+  heading: string;
+  relationship: ExplainableRelationship;
+  explanation: AssertionExplanation;
+  history: AssertionHistory;
+}>) {
   return (
     <section
       aria-label="Relationship explanation"
@@ -262,141 +339,99 @@ export default function RelationshipExplanationPanel({
         </span>
       </header>
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
-        <div>
-          <dt className="font-medium text-gray-500">Confidence</dt>
-          <dd className="text-gray-800">
-            {explanation.confidence_status === "assessed"
-              ? `${explanation.confidence_type ?? "assessed"} (${
-                  explanation.confidence_bp ?? "n/a"
-                } bp, method: ${explanation.confidence_method ?? "unspecified"})`
-              : "Not assessed"}
-          </dd>
-        </div>
-        <div>
-          <dt className="font-medium text-gray-500">Projection strength</dt>
-          <dd className="text-gray-800">
-            {relationship.strength.toFixed(2)}{" "}
-            <span className="text-xs text-gray-500">
-              (distinct from confidence above)
-            </span>
-          </dd>
-        </div>
-        <div>
-          <dt className="font-medium text-gray-500">Effective time</dt>
-          <dd className="text-gray-800">
-            {formatTimestamp(explanation.effective_from)}
-            {explanation.effective_to
-              ? ` \u2013 ${formatTimestamp(explanation.effective_to)}`
-              : " (ongoing)"}
-          </dd>
-        </div>
-        <div>
-          <dt className="font-medium text-gray-500">Recorded / known at</dt>
-          <dd className="text-gray-800">
-            {formatTimestamp(explanation.recorded_at)}
-            {explanation.known_at
-              ? ` (known: ${formatTimestamp(explanation.known_at)})`
-              : ""}
-          </dd>
-        </div>
-      </div>
-
-      {authoritySummary &&
-        (authoritySummary.proposer || authoritySummary.determiner) && (
-          <div className="text-sm">
-            <h4 className="font-medium text-gray-500">Authority</h4>
-            <ul className="mt-1 space-y-1">
-              {authoritySummary.proposer && (
-                <li>
-                  {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
-                  {formatTimestamp(authoritySummary.proposer.recorded_at)}
-                </li>
-              )}
-              {authoritySummary.determiner && (
-                <li>
-                  {AUTHORITY_LABELS[authoritySummary.determiner.authority] ??
-                    "Determining authority"}{" "}
-                  {"\u2014"}{" "}
-                  {formatTimestamp(authoritySummary.determiner.recorded_at)}
-                </li>
-              )}
-            </ul>
-          </div>
-        )}
-
-      <div className="text-sm">
-        <h4 className="font-medium text-gray-500">Evidence</h4>
-        {explanation.evidence.length === 0 ? (
-          <p className="text-gray-500 italic">No evidence recorded.</p>
-        ) : (
-          <ul className="mt-1 space-y-2">
-            {explanation.evidence.map((item) => (
-              <li
-                key={item.evidence_id}
-                className="border border-gray-100 rounded p-2"
-              >
-                <span className="font-medium">{item.polarity}</span>{" "}
-                <span className="text-xs text-gray-500">
-                  ({item.visibility})
-                </span>
-                {item.redacted ? (
-                  <p className="text-xs text-gray-500 italic">
-                    Evidence body and restricted references are not shown.
-                  </p>
-                ) : (
-                  <div className="text-xs text-gray-600 space-y-0.5">
-                    {item.source_ref && <p>Reference: {item.source_ref}</p>}
-                    {item.content_sha256 && (
-                      <p>SHA-256: {item.content_sha256}</p>
-                    )}
-                  </div>
-                )}
-              </li>
-            ))}
-          </ul>
-        )}
-      </div>
-
-      <div className="text-sm">
-        <h4 className="font-medium text-gray-500">Lifecycle history</h4>
-        <ul className="mt-1 space-y-1">
-          {history.events.map((event) => (
-            <li key={event.event_id}>
-              #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"}{" "}
-              {event.to_state}{" "}
-              <span className="text-xs text-gray-500">
-                ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
-                {formatTimestamp(event.recorded_at)})
-              </span>
-              {event.successor_assertion_id && (
-                <span className="text-xs text-gray-500">
-                  {" "}
-                  {"\u2014"} superseded by assertion{" "}
-                  {event.successor_assertion_id}
-                </span>
-              )}
-            </li>
-          ))}
-        </ul>
-        {supersessionEvent?.successor_assertion_id && (
-          <p className="mt-1 text-xs text-amber-700" role="status">
-            This assertion has been superseded by assertion{" "}
-            {supersessionEvent.successor_assertion_id}. Predecessor information
-            is only available from that successor&apos;s own governed scope, if
-            published.
-          </p>
-        )}
-      </div>
-
-      <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
-        <p>
-          Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
-          {relationship.scope_refs && relationship.scope_refs.length > 0
-            ? relationship.scope_refs.join(", ")
-            : "unknown"}
-        </p>
-      </div>
+      <ConfidenceAndTimeSummary explanation={explanation} strength={relationship.strength} />
+      <AuthoritySummary history={history} />
+      <EvidenceSummary explanation={explanation} />
+      <LifecycleHistory history={history} />
+      <PublicationFooter relationship={relationship} />
     </section>
   );
+}
+
+/**
+ * Renders the governed explanation (evidence, authority, time, confidence,
+ * supersession, and publication scope) for a selected relationship edge, or a
+ * bounded legacy/unavailable/loading state when governance facts cannot be
+ * shown. Never displays evidence bodies, restricted references, or invented
+ * `CURRENT`/production-proof claims.
+ */
+export default function RelationshipExplanationPanel({
+  relationship,
+}: RelationshipExplanationPanelProps) {
+  const isGoverned = relationship?.governance_status === "governed";
+  const assertionId = isGoverned ? relationship?.assertion_id ?? null : null;
+  const requestKey = assertionId;
+
+  const [result, setResult] = useState<PanelResult | null>(null);
+
+  useEffect(() => {
+    if (!requestKey) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    // Capture a single as-of snapshot and pass it to both calls so the
+    // explanation and history are resolved consistently with each other.
+    // NOTE: this does not yet guarantee consistency with the displayed
+    // graph's own publication snapshot -- see the `known_at`/`effective_at`
+    // limitation documented in `types/api.ts`.
+    const asOf = { known_at: new Date().toISOString() };
+
+    Promise.all([
+      api.getAssertion(requestKey, asOf, controller.signal),
+      api.getAssertionHistory(requestKey, asOf, controller.signal),
+    ])
+      .then(([explanation, history]) => {
+        if (controller.signal.aborted) return;
+        setResult({ status: "ready", requestKey, explanation, history });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const httpStatus = err?.response?.status;
+        setResult({
+          status: httpStatus === 404 ? "not-found" : "unavailable",
+          requestKey,
+        });
+      });
+
+    return () => controller.abort();
+  }, [requestKey]);
+
+  if (!relationship) {
+    return <EmptySelectionView />;
+  }
+
+  const heading = relationshipHeading(relationship);
+
+  if (!isGoverned) {
+    return <LegacyView heading={heading} />;
+  }
+
+  if (!assertionId) {
+    return <PendingMetadataView heading={heading} />;
+  }
+
+  // "Loading" is derived, not stored: if there is no settled result yet, or
+  // the settled result belongs to a superseded request key, render the
+  // loading view rather than briefly flashing stale content.
+  if (!result || result.requestKey !== assertionId) {
+    return <LoadingView heading={heading} />;
+  }
+
+  switch (result.status) {
+    case "not-found":
+      return <NotFoundView heading={heading} />;
+    case "unavailable":
+      return <UnavailableView heading={heading} />;
+    case "ready":
+      return (
+        <ReadyView
+          heading={heading}
+          relationship={relationship}
+          explanation={result.explanation}
+          history={result.history}
+        />
+      );
+  }
 }

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -32,7 +32,11 @@ type PanelState = Readonly<{
   history: AssertionHistory | null;
 }>;
 
-const IDLE_STATE: PanelState = { status: "idle", explanation: null, history: null };
+const IDLE_STATE: PanelState = {
+  status: "idle",
+  explanation: null,
+  history: null,
+};
 
 const AUTHORITY_LABELS: Record<string, string> = {
   proposer: "Proposer of record",
@@ -61,9 +65,11 @@ function deriveAuthoritySummary(events: readonly AssertionPublicEvent[]): {
   proposer: AssertionPublicEvent | null;
   determiner: AssertionPublicEvent | null;
 } {
-  const proposer = events.find((event) => event.authority === "proposer") ?? null;
+  const proposer =
+    events.find((event) => event.authority === "proposer") ?? null;
   const determiner =
-    [...events].reverse().find((event) => event.authority !== "proposer") ?? null;
+    [...events].reverse().find((event) => event.authority !== "proposer") ??
+    null;
   return { proposer, determiner };
 }
 
@@ -75,7 +81,9 @@ function findSupersessionEvent(
   events: readonly AssertionPublicEvent[],
 ): AssertionPublicEvent | null {
   return (
-    [...events].reverse().find((event) => Boolean(event.successor_assertion_id)) ?? null
+    [...events]
+      .reverse()
+      .find((event) => Boolean(event.successor_assertion_id)) ?? null
   );
 }
 
@@ -92,16 +100,22 @@ export default function RelationshipExplanationPanel({
   const [state, setState] = useState<PanelState>(IDLE_STATE);
 
   const isGoverned = relationship?.governance_status === "governed";
-  const assertionId = isGoverned ? relationship?.assertion_id ?? null : null;
+  const assertionId = isGoverned ? (relationship?.assertion_id ?? null) : null;
 
   // Track which assertionId the current `state` reflects so a change in the
   // selected relationship resets state synchronously during render, rather
   // than via a setState call inside the effect body (see React docs on
   // "adjusting state when a prop changes").
-  const [trackedAssertionId, setTrackedAssertionId] = useState<string | null>(null);
+  const [trackedAssertionId, setTrackedAssertionId] = useState<string | null>(
+    null,
+  );
   if (assertionId !== trackedAssertionId) {
     setTrackedAssertionId(assertionId);
-    setState(assertionId ? { status: "loading", explanation: null, history: null } : IDLE_STATE);
+    setState(
+      assertionId
+        ? { status: "loading", explanation: null, history: null }
+        : IDLE_STATE,
+    );
   }
 
   useEffect(() => {
@@ -163,8 +177,8 @@ export default function RelationshipExplanationPanel({
           <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
             Legacy
           </span>
-          This relationship is outside any governed scope. No assertion, evidence, or
-          lifecycle history is available for it.
+          This relationship is outside any governed scope. No assertion,
+          evidence, or lifecycle history is available for it.
         </p>
       </section>
     );
@@ -192,7 +206,11 @@ export default function RelationshipExplanationPanel({
         className="p-4 border border-gray-200 rounded-lg"
       >
         <h3 className="font-semibold text-gray-900">{heading}</h3>
-        <p className="mt-2 text-sm text-gray-500" role="status" aria-live="polite">
+        <p
+          className="mt-2 text-sm text-gray-500"
+          role="status"
+          aria-live="polite"
+        >
           Loading governed explanation...
         </p>
       </section>
@@ -207,8 +225,8 @@ export default function RelationshipExplanationPanel({
       >
         <h3 className="font-semibold text-gray-900">{heading}</h3>
         <p className="mt-2 text-sm text-amber-800" role="alert">
-          The governed assertion behind this relationship could not be found. It may
-          be synchronizing with the latest publication.
+          The governed assertion behind this relationship could not be found. It
+          may be synchronizing with the latest publication.
         </p>
       </section>
     );
@@ -222,8 +240,8 @@ export default function RelationshipExplanationPanel({
       >
         <h3 className="font-semibold text-gray-900">{heading}</h3>
         <p className="mt-2 text-sm text-red-800" role="alert">
-          Governance explanation is temporarily unavailable. The graph remains usable;
-          please try again shortly.
+          Governance explanation is temporarily unavailable. The graph remains
+          usable; please try again shortly.
         </p>
       </section>
     );
@@ -259,45 +277,53 @@ export default function RelationshipExplanationPanel({
           <dt className="font-medium text-gray-500">Projection strength</dt>
           <dd className="text-gray-800">
             {relationship.strength.toFixed(2)}{" "}
-            <span className="text-xs text-gray-500">(distinct from confidence above)</span>
+            <span className="text-xs text-gray-500">
+              (distinct from confidence above)
+            </span>
           </dd>
         </div>
         <div>
           <dt className="font-medium text-gray-500">Effective time</dt>
           <dd className="text-gray-800">
             {formatTimestamp(explanation.effective_from)}
-            {explanation.effective_to ? ` \u2013 ${formatTimestamp(explanation.effective_to)}` : " (ongoing)"}
+            {explanation.effective_to
+              ? ` \u2013 ${formatTimestamp(explanation.effective_to)}`
+              : " (ongoing)"}
           </dd>
         </div>
         <div>
           <dt className="font-medium text-gray-500">Recorded / known at</dt>
           <dd className="text-gray-800">
             {formatTimestamp(explanation.recorded_at)}
-            {explanation.known_at ? ` (known: ${formatTimestamp(explanation.known_at)})` : ""}
+            {explanation.known_at
+              ? ` (known: ${formatTimestamp(explanation.known_at)})`
+              : ""}
           </dd>
         </div>
       </div>
 
-      {authoritySummary && (authoritySummary.proposer || authoritySummary.determiner) && (
-        <div className="text-sm">
-          <h4 className="font-medium text-gray-500">Authority</h4>
-          <ul className="mt-1 space-y-1">
-            {authoritySummary.proposer && (
-              <li>
-                {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
-                {formatTimestamp(authoritySummary.proposer.recorded_at)}
-              </li>
-            )}
-            {authoritySummary.determiner && (
-              <li>
-                {AUTHORITY_LABELS[authoritySummary.determiner.authority] ??
-                  "Determining authority"}{" "}
-                {"\u2014"} {formatTimestamp(authoritySummary.determiner.recorded_at)}
-              </li>
-            )}
-          </ul>
-        </div>
-      )}
+      {authoritySummary &&
+        (authoritySummary.proposer || authoritySummary.determiner) && (
+          <div className="text-sm">
+            <h4 className="font-medium text-gray-500">Authority</h4>
+            <ul className="mt-1 space-y-1">
+              {authoritySummary.proposer && (
+                <li>
+                  {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
+                  {formatTimestamp(authoritySummary.proposer.recorded_at)}
+                </li>
+              )}
+              {authoritySummary.determiner && (
+                <li>
+                  {AUTHORITY_LABELS[authoritySummary.determiner.authority] ??
+                    "Determining authority"}{" "}
+                  {"\u2014"}{" "}
+                  {formatTimestamp(authoritySummary.determiner.recorded_at)}
+                </li>
+              )}
+            </ul>
+          </div>
+        )}
 
       <div className="text-sm">
         <h4 className="font-medium text-gray-500">Evidence</h4>
@@ -306,9 +332,14 @@ export default function RelationshipExplanationPanel({
         ) : (
           <ul className="mt-1 space-y-2">
             {explanation.evidence.map((item) => (
-              <li key={item.evidence_id} className="border border-gray-100 rounded p-2">
+              <li
+                key={item.evidence_id}
+                className="border border-gray-100 rounded p-2"
+              >
                 <span className="font-medium">{item.polarity}</span>{" "}
-                <span className="text-xs text-gray-500">({item.visibility})</span>
+                <span className="text-xs text-gray-500">
+                  ({item.visibility})
+                </span>
                 {item.redacted ? (
                   <p className="text-xs text-gray-500 italic">
                     Evidence body and restricted references are not shown.
@@ -316,7 +347,9 @@ export default function RelationshipExplanationPanel({
                 ) : (
                   <div className="text-xs text-gray-600 space-y-0.5">
                     {item.source_ref && <p>Reference: {item.source_ref}</p>}
-                    {item.content_sha256 && <p>SHA-256: {item.content_sha256}</p>}
+                    {item.content_sha256 && (
+                      <p>SHA-256: {item.content_sha256}</p>
+                    )}
                   </div>
                 )}
               </li>
@@ -330,7 +363,8 @@ export default function RelationshipExplanationPanel({
         <ul className="mt-1 space-y-1">
           {history.events.map((event) => (
             <li key={event.event_id}>
-              #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"} {event.to_state}{" "}
+              #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"}{" "}
+              {event.to_state}{" "}
               <span className="text-xs text-gray-500">
                 ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
                 {formatTimestamp(event.recorded_at)})
@@ -338,7 +372,8 @@ export default function RelationshipExplanationPanel({
               {event.successor_assertion_id && (
                 <span className="text-xs text-gray-500">
                   {" "}
-                  {"\u2014"} superseded by assertion {event.successor_assertion_id}
+                  {"\u2014"} superseded by assertion{" "}
+                  {event.successor_assertion_id}
                 </span>
               )}
             </li>
@@ -347,8 +382,9 @@ export default function RelationshipExplanationPanel({
         {supersessionEvent?.successor_assertion_id && (
           <p className="mt-1 text-xs text-amber-700" role="status">
             This assertion has been superseded by assertion{" "}
-            {supersessionEvent.successor_assertion_id}. Predecessor information is only
-            available from that successor&apos;s own governed scope, if published.
+            {supersessionEvent.successor_assertion_id}. Predecessor information
+            is only available from that successor&apos;s own governed scope, if
+            published.
           </p>
         )}
       </div>

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -116,22 +116,22 @@ function PanelShell({
 
 function EmptySelectionView() {
   return (
-    <div className="p-4 text-sm text-gray-500" role="status">
+    <output className="block p-4 text-sm text-gray-500">
       Select a relationship to see how it was determined.
-    </div>
+    </output>
   );
 }
 
 function LegacyView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-gray-200 bg-gray-50">
-      <p className="mt-2 text-sm text-gray-600" role="status">
+      <output className="block mt-2 text-sm text-gray-600">
         <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
           Legacy
-        </span>
+        </span>{" "}
         This relationship is outside any governed scope. No assertion, evidence,
         or lifecycle history is available for it.
-      </p>
+      </output>
     </PanelShell>
   );
 }
@@ -139,10 +139,10 @@ function LegacyView({ heading }: Readonly<{ heading: string }>) {
 function PendingMetadataView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-amber-200 bg-amber-50">
-      <p className="mt-2 text-sm text-amber-800" role="status">
+      <output className="block mt-2 text-sm text-amber-800">
         This relationship is governed, but its assertion metadata is not yet
         available. It may still be synchronizing.
-      </p>
+      </output>
     </PanelShell>
   );
 }
@@ -150,13 +150,9 @@ function PendingMetadataView({ heading }: Readonly<{ heading: string }>) {
 function LoadingView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-gray-200">
-      <p
-        className="mt-2 text-sm text-gray-500"
-        role="status"
-        aria-live="polite"
-      >
+      <output className="block mt-2 text-sm text-gray-500" aria-live="polite">
         Loading governed explanation...
-      </p>
+      </output>
     </PanelShell>
   );
 }
@@ -326,13 +322,13 @@ function LifecycleHistory({
         ))}
       </ul>
       {supersessionEvent?.successor_assertion_id && (
-        <p className="mt-1 text-xs text-amber-700" role="status">
+        <output className="block mt-1 text-xs text-amber-700">
           This assertion has been superseded by assertion{" "}
           {supersessionEvent.successor_assertion_id}. The public API does not
           expose a backward predecessor reference, so if you are viewing that
           successor assertion instead, its own predecessor cannot be looked up
           from here.
-        </p>
+        </output>
       )}
     </div>
   );
@@ -345,7 +341,7 @@ function PublicationFooter({
     <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
       <p>
         Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
-        {relationship.scope_refs && relationship.scope_refs.length > 0
+        {relationship.scope_refs?.length
           ? relationship.scope_refs.join(", ")
           : "unknown"}
       </p>

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -43,7 +43,6 @@ type PanelResult =
       history: AssertionHistory;
     }>;
 
-
 const AUTHORITY_LABELS: Record<string, string> = {
   proposer: "Proposer of record",
   acceptor: "Determining authority (acceptor)",
@@ -69,9 +68,11 @@ function deriveAuthoritySummary(events: readonly AssertionPublicEvent[]): {
   proposer: AssertionPublicEvent | null;
   determiner: AssertionPublicEvent | null;
 } {
-  const proposer = events.find((event) => event.authority === "proposer") ?? null;
+  const proposer =
+    events.find((event) => event.authority === "proposer") ?? null;
   const determiner =
-    [...events].reverse().find((event) => event.authority !== "proposer") ?? null;
+    [...events].reverse().find((event) => event.authority !== "proposer") ??
+    null;
   return { proposer, determiner };
 }
 
@@ -83,7 +84,9 @@ function findSupersessionEvent(
   events: readonly AssertionPublicEvent[],
 ): AssertionPublicEvent | null {
   return (
-    [...events].reverse().find((event) => Boolean(event.successor_assertion_id)) ?? null
+    [...events]
+      .reverse()
+      .find((event) => Boolean(event.successor_assertion_id)) ?? null
   );
 }
 
@@ -101,7 +104,10 @@ function PanelShell({
   children: React.ReactNode;
 }>) {
   return (
-    <section aria-label="Relationship explanation" className={`p-4 border rounded-lg ${toneClassName}`}>
+    <section
+      aria-label="Relationship explanation"
+      className={`p-4 border rounded-lg ${toneClassName}`}
+    >
       <h3 className="font-semibold text-gray-900">{heading}</h3>
       {children}
     </section>
@@ -123,8 +129,8 @@ function LegacyView({ heading }: Readonly<{ heading: string }>) {
         <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
           Legacy
         </span>
-        This relationship is outside any governed scope. No assertion, evidence, or
-        lifecycle history is available for it.
+        This relationship is outside any governed scope. No assertion, evidence,
+        or lifecycle history is available for it.
       </p>
     </PanelShell>
   );
@@ -144,7 +150,11 @@ function PendingMetadataView({ heading }: Readonly<{ heading: string }>) {
 function LoadingView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-gray-200">
-      <p className="mt-2 text-sm text-gray-500" role="status" aria-live="polite">
+      <p
+        className="mt-2 text-sm text-gray-500"
+        role="status"
+        aria-live="polite"
+      >
         Loading governed explanation...
       </p>
     </PanelShell>
@@ -155,8 +165,8 @@ function NotFoundView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-amber-200 bg-amber-50">
       <p className="mt-2 text-sm text-amber-800" role="alert">
-        The governed assertion behind this relationship could not be found. It may
-        be synchronizing with the latest publication.
+        The governed assertion behind this relationship could not be found. It
+        may be synchronizing with the latest publication.
       </p>
     </PanelShell>
   );
@@ -166,8 +176,8 @@ function UnavailableView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-red-200 bg-red-50">
       <p className="mt-2 text-sm text-red-800" role="alert">
-        Governance explanation is temporarily unavailable. The graph remains usable;
-        please try again shortly.
+        Governance explanation is temporarily unavailable. The graph remains
+        usable; please try again shortly.
       </p>
     </PanelShell>
   );
@@ -193,29 +203,40 @@ function ConfidenceAndTimeSummary({
         <dt className="font-medium text-gray-500">Projection strength</dt>
         <dd className="text-gray-800">
           {strength.toFixed(2)}{" "}
-          <span className="text-xs text-gray-500">(distinct from confidence above)</span>
+          <span className="text-xs text-gray-500">
+            (distinct from confidence above)
+          </span>
         </dd>
       </div>
       <div>
         <dt className="font-medium text-gray-500">Effective time</dt>
         <dd className="text-gray-800">
           {formatTimestamp(explanation.effective_from)}
-          {explanation.effective_to ? ` \u2013 ${formatTimestamp(explanation.effective_to)}` : " (ongoing)"}
+          {explanation.effective_to
+            ? ` \u2013 ${formatTimestamp(explanation.effective_to)}`
+            : " (ongoing)"}
         </dd>
       </div>
       <div>
         <dt className="font-medium text-gray-500">Recorded / known at</dt>
         <dd className="text-gray-800">
           {formatTimestamp(explanation.recorded_at)}
-          {explanation.known_at ? ` (known: ${formatTimestamp(explanation.known_at)})` : ""}
+          {explanation.known_at
+            ? ` (known: ${formatTimestamp(explanation.known_at)})`
+            : ""}
         </dd>
       </div>
     </dl>
   );
 }
 
-function AuthoritySummary({ history }: Readonly<{ history: AssertionHistory }>) {
-  const summary = useMemo(() => deriveAuthoritySummary(history.events), [history]);
+function AuthoritySummary({
+  history,
+}: Readonly<{ history: AssertionHistory }>) {
+  const summary = useMemo(
+    () => deriveAuthoritySummary(history.events),
+    [history],
+  );
   if (!summary.proposer && !summary.determiner) return null;
 
   return (
@@ -224,13 +245,15 @@ function AuthoritySummary({ history }: Readonly<{ history: AssertionHistory }>) 
       <ul className="mt-1 space-y-1">
         {summary.proposer && (
           <li>
-            {AUTHORITY_LABELS.proposer} {"\u2014"} {formatTimestamp(summary.proposer.recorded_at)}
+            {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
+            {formatTimestamp(summary.proposer.recorded_at)}
           </li>
         )}
         {summary.determiner && (
           <li>
-            {AUTHORITY_LABELS[summary.determiner.authority] ?? "Determining authority"} {"\u2014"}{" "}
-            {formatTimestamp(summary.determiner.recorded_at)}
+            {AUTHORITY_LABELS[summary.determiner.authority] ??
+              "Determining authority"}{" "}
+            {"\u2014"} {formatTimestamp(summary.determiner.recorded_at)}
           </li>
         )}
       </ul>
@@ -238,7 +261,9 @@ function AuthoritySummary({ history }: Readonly<{ history: AssertionHistory }>) 
   );
 }
 
-function EvidenceSummary({ explanation }: Readonly<{ explanation: AssertionExplanation }>) {
+function EvidenceSummary({
+  explanation,
+}: Readonly<{ explanation: AssertionExplanation }>) {
   return (
     <div className="text-sm">
       <h4 className="font-medium text-gray-500">Evidence</h4>
@@ -247,7 +272,10 @@ function EvidenceSummary({ explanation }: Readonly<{ explanation: AssertionExpla
       ) : (
         <ul className="mt-1 space-y-2">
           {explanation.evidence.map((item) => (
-            <li key={item.evidence_id} className="border border-gray-100 rounded p-2">
+            <li
+              key={item.evidence_id}
+              className="border border-gray-100 rounded p-2"
+            >
               <span className="font-medium">{item.polarity}</span>{" "}
               <span className="text-xs text-gray-500">({item.visibility})</span>
               {item.redacted ? (
@@ -268,15 +296,21 @@ function EvidenceSummary({ explanation }: Readonly<{ explanation: AssertionExpla
   );
 }
 
-function LifecycleHistory({ history }: Readonly<{ history: AssertionHistory }>) {
-  const supersessionEvent = useMemo(() => findSupersessionEvent(history.events), [history]);
+function LifecycleHistory({
+  history,
+}: Readonly<{ history: AssertionHistory }>) {
+  const supersessionEvent = useMemo(
+    () => findSupersessionEvent(history.events),
+    [history],
+  );
   return (
     <div className="text-sm">
       <h4 className="font-medium text-gray-500">Lifecycle history</h4>
       <ul className="mt-1 space-y-1">
         {history.events.map((event) => (
           <li key={event.event_id}>
-            #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"} {event.to_state}{" "}
+            #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"}{" "}
+            {event.to_state}{" "}
             <span className="text-xs text-gray-500">
               ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
               {formatTimestamp(event.recorded_at)})
@@ -284,7 +318,8 @@ function LifecycleHistory({ history }: Readonly<{ history: AssertionHistory }>) 
             {event.successor_assertion_id && (
               <span className="text-xs text-gray-500">
                 {" "}
-                {"\u2014"} superseded by assertion {event.successor_assertion_id}
+                {"\u2014"} superseded by assertion{" "}
+                {event.successor_assertion_id}
               </span>
             )}
           </li>
@@ -293,16 +328,19 @@ function LifecycleHistory({ history }: Readonly<{ history: AssertionHistory }>) 
       {supersessionEvent?.successor_assertion_id && (
         <p className="mt-1 text-xs text-amber-700" role="status">
           This assertion has been superseded by assertion{" "}
-          {supersessionEvent.successor_assertion_id}. The public API does not expose a
-          backward predecessor reference, so if you are viewing that successor
-          assertion instead, its own predecessor cannot be looked up from here.
+          {supersessionEvent.successor_assertion_id}. The public API does not
+          expose a backward predecessor reference, so if you are viewing that
+          successor assertion instead, its own predecessor cannot be looked up
+          from here.
         </p>
       )}
     </div>
   );
 }
 
-function PublicationFooter({ relationship }: Readonly<{ relationship: ExplainableRelationship }>) {
+function PublicationFooter({
+  relationship,
+}: Readonly<{ relationship: ExplainableRelationship }>) {
   return (
     <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
       <p>
@@ -339,7 +377,10 @@ function ReadyView({
         </span>
       </header>
 
-      <ConfidenceAndTimeSummary explanation={explanation} strength={relationship.strength} />
+      <ConfidenceAndTimeSummary
+        explanation={explanation}
+        strength={relationship.strength}
+      />
       <AuthoritySummary history={history} />
       <EvidenceSummary explanation={explanation} />
       <LifecycleHistory history={history} />
@@ -359,7 +400,7 @@ export default function RelationshipExplanationPanel({
   relationship,
 }: RelationshipExplanationPanelProps) {
   const isGoverned = relationship?.governance_status === "governed";
-  const assertionId = isGoverned ? relationship?.assertion_id ?? null : null;
+  const assertionId = isGoverned ? (relationship?.assertion_id ?? null) : null;
   const requestKey = assertionId;
 
   const [result, setResult] = useState<PanelResult | null>(null);

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -1,0 +1,366 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../lib/api";
+import type {
+  AssertionExplanation,
+  AssertionHistory,
+  AssertionPublicEvent,
+} from "../types/api";
+
+/** The minimal edge shape the panel needs to explain a selected relationship. */
+export type ExplainableRelationship = Readonly<{
+  source: string;
+  target: string;
+  relationship_type: string;
+  strength: number;
+  assertion_id?: string | null;
+  governance_status?: "governed" | null;
+  revision_id?: string | null;
+  scope_refs?: string[] | null;
+}>;
+
+type RelationshipExplanationPanelProps = Readonly<{
+  relationship: ExplainableRelationship | null;
+}>;
+
+type PanelStatus = "idle" | "loading" | "ready" | "not-found" | "unavailable";
+
+type PanelState = Readonly<{
+  status: PanelStatus;
+  explanation: AssertionExplanation | null;
+  history: AssertionHistory | null;
+}>;
+
+const IDLE_STATE: PanelState = { status: "idle", explanation: null, history: null };
+
+const AUTHORITY_LABELS: Record<string, string> = {
+  proposer: "Proposer of record",
+  acceptor: "Determining authority (acceptor)",
+  disputer: "Determining authority (disputer)",
+  retractor: "Determining authority (retractor)",
+};
+
+/**
+ * Format an ISO timestamp for display, or a bounded placeholder when absent.
+ */
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "Not recorded";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toLocaleString();
+}
+
+/**
+ * Derive the recorded proposer event and the most recent determining-authority
+ * event from an assertion's public (identity-redacted) event history. Only the
+ * authority role is available on public reads -- actor identity is never
+ * fabricated here.
+ */
+function deriveAuthoritySummary(events: readonly AssertionPublicEvent[]): {
+  proposer: AssertionPublicEvent | null;
+  determiner: AssertionPublicEvent | null;
+} {
+  const proposer = events.find((event) => event.authority === "proposer") ?? null;
+  const determiner =
+    [...events].reverse().find((event) => event.authority !== "proposer") ?? null;
+  return { proposer, determiner };
+}
+
+/**
+ * Find the most recent event carrying a successor_assertion_id, if this
+ * assertion has been superseded.
+ */
+function findSupersessionEvent(
+  events: readonly AssertionPublicEvent[],
+): AssertionPublicEvent | null {
+  return (
+    [...events].reverse().find((event) => Boolean(event.successor_assertion_id)) ?? null
+  );
+}
+
+/**
+ * Renders the governed explanation (evidence, authority, time, confidence,
+ * supersession, and publication scope) for a selected relationship edge, or a
+ * bounded legacy/unavailable/loading state when governance facts cannot be
+ * shown. Never displays evidence bodies, restricted references, or invented
+ * `CURRENT`/production-proof claims.
+ */
+export default function RelationshipExplanationPanel({
+  relationship,
+}: RelationshipExplanationPanelProps) {
+  const [state, setState] = useState<PanelState>(IDLE_STATE);
+
+  const isGoverned = relationship?.governance_status === "governed";
+  const assertionId = isGoverned ? relationship?.assertion_id ?? null : null;
+
+  // Track which assertionId the current `state` reflects so a change in the
+  // selected relationship resets state synchronously during render, rather
+  // than via a setState call inside the effect body (see React docs on
+  // "adjusting state when a prop changes").
+  const [trackedAssertionId, setTrackedAssertionId] = useState<string | null>(null);
+  if (assertionId !== trackedAssertionId) {
+    setTrackedAssertionId(assertionId);
+    setState(assertionId ? { status: "loading", explanation: null, history: null } : IDLE_STATE);
+  }
+
+  useEffect(() => {
+    if (!assertionId) {
+      return;
+    }
+
+    const controller = new AbortController();
+
+    Promise.all([
+      api.getAssertion(assertionId, undefined, controller.signal),
+      api.getAssertionHistory(assertionId, undefined, controller.signal),
+    ])
+      .then(([explanation, history]) => {
+        if (controller.signal.aborted) return;
+        setState({ status: "ready", explanation, history });
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        const httpStatus = err?.response?.status;
+        setState({
+          status: httpStatus === 404 ? "not-found" : "unavailable",
+          explanation: null,
+          history: null,
+        });
+      });
+
+    return () => controller.abort();
+  }, [assertionId]);
+
+  const authoritySummary = useMemo(() => {
+    if (!state.history) return null;
+    return deriveAuthoritySummary(state.history.events);
+  }, [state.history]);
+
+  const supersessionEvent = useMemo(() => {
+    if (!state.history) return null;
+    return findSupersessionEvent(state.history.events);
+  }, [state.history]);
+
+  if (!relationship) {
+    return (
+      <div className="p-4 text-sm text-gray-500" role="status">
+        Select a relationship to see how it was determined.
+      </div>
+    );
+  }
+
+  const heading = `${relationship.source} \u2192 ${relationship.target} (${relationship.relationship_type})`;
+
+  if (!isGoverned) {
+    return (
+      <section
+        aria-label="Relationship explanation"
+        className="p-4 border border-gray-200 rounded-lg bg-gray-50"
+      >
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="mt-2 text-sm text-gray-600" role="status">
+          <span className="inline-block px-2 py-0.5 mr-2 text-xs font-medium rounded bg-gray-200 text-gray-700">
+            Legacy
+          </span>
+          This relationship is outside any governed scope. No assertion, evidence, or
+          lifecycle history is available for it.
+        </p>
+      </section>
+    );
+  }
+
+  if (!assertionId) {
+    return (
+      <section
+        aria-label="Relationship explanation"
+        className="p-4 border border-amber-200 rounded-lg bg-amber-50"
+      >
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="mt-2 text-sm text-amber-800" role="status">
+          This relationship is governed, but its assertion metadata is not yet
+          available. It may still be synchronizing.
+        </p>
+      </section>
+    );
+  }
+
+  if (state.status === "loading" || state.status === "idle") {
+    return (
+      <section
+        aria-label="Relationship explanation"
+        className="p-4 border border-gray-200 rounded-lg"
+      >
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="mt-2 text-sm text-gray-500" role="status" aria-live="polite">
+          Loading governed explanation...
+        </p>
+      </section>
+    );
+  }
+
+  if (state.status === "not-found") {
+    return (
+      <section
+        aria-label="Relationship explanation"
+        className="p-4 border border-amber-200 rounded-lg bg-amber-50"
+      >
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="mt-2 text-sm text-amber-800" role="alert">
+          The governed assertion behind this relationship could not be found. It may
+          be synchronizing with the latest publication.
+        </p>
+      </section>
+    );
+  }
+
+  if (state.status === "unavailable" || !state.explanation || !state.history) {
+    return (
+      <section
+        aria-label="Relationship explanation"
+        className="p-4 border border-red-200 rounded-lg bg-red-50"
+      >
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="mt-2 text-sm text-red-800" role="alert">
+          Governance explanation is temporarily unavailable. The graph remains usable;
+          please try again shortly.
+        </p>
+      </section>
+    );
+  }
+
+  const { explanation, history } = state;
+
+  return (
+    <section
+      aria-label="Relationship explanation"
+      className="p-4 border border-gray-200 rounded-lg space-y-4"
+    >
+      <header>
+        <h3 className="font-semibold text-gray-900">{heading}</h3>
+        <p className="text-sm text-gray-700 mt-1">{explanation.proposition}</p>
+        <span className="inline-block mt-2 px-2 py-0.5 text-xs font-medium rounded bg-blue-100 text-blue-800">
+          {explanation.state}
+        </span>
+      </header>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+        <div>
+          <dt className="font-medium text-gray-500">Confidence</dt>
+          <dd className="text-gray-800">
+            {explanation.confidence_status === "assessed"
+              ? `${explanation.confidence_type ?? "assessed"} (${
+                  explanation.confidence_bp ?? "n/a"
+                } bp, method: ${explanation.confidence_method ?? "unspecified"})`
+              : "Not assessed"}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-gray-500">Projection strength</dt>
+          <dd className="text-gray-800">
+            {relationship.strength.toFixed(2)}{" "}
+            <span className="text-xs text-gray-500">(distinct from confidence above)</span>
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-gray-500">Effective time</dt>
+          <dd className="text-gray-800">
+            {formatTimestamp(explanation.effective_from)}
+            {explanation.effective_to ? ` \u2013 ${formatTimestamp(explanation.effective_to)}` : " (ongoing)"}
+          </dd>
+        </div>
+        <div>
+          <dt className="font-medium text-gray-500">Recorded / known at</dt>
+          <dd className="text-gray-800">
+            {formatTimestamp(explanation.recorded_at)}
+            {explanation.known_at ? ` (known: ${formatTimestamp(explanation.known_at)})` : ""}
+          </dd>
+        </div>
+      </div>
+
+      {authoritySummary && (authoritySummary.proposer || authoritySummary.determiner) && (
+        <div className="text-sm">
+          <h4 className="font-medium text-gray-500">Authority</h4>
+          <ul className="mt-1 space-y-1">
+            {authoritySummary.proposer && (
+              <li>
+                {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
+                {formatTimestamp(authoritySummary.proposer.recorded_at)}
+              </li>
+            )}
+            {authoritySummary.determiner && (
+              <li>
+                {AUTHORITY_LABELS[authoritySummary.determiner.authority] ??
+                  "Determining authority"}{" "}
+                {"\u2014"} {formatTimestamp(authoritySummary.determiner.recorded_at)}
+              </li>
+            )}
+          </ul>
+        </div>
+      )}
+
+      <div className="text-sm">
+        <h4 className="font-medium text-gray-500">Evidence</h4>
+        {explanation.evidence.length === 0 ? (
+          <p className="text-gray-500 italic">No evidence recorded.</p>
+        ) : (
+          <ul className="mt-1 space-y-2">
+            {explanation.evidence.map((item) => (
+              <li key={item.evidence_id} className="border border-gray-100 rounded p-2">
+                <span className="font-medium">{item.polarity}</span>{" "}
+                <span className="text-xs text-gray-500">({item.visibility})</span>
+                {item.redacted ? (
+                  <p className="text-xs text-gray-500 italic">
+                    Evidence body and restricted references are not shown.
+                  </p>
+                ) : (
+                  <div className="text-xs text-gray-600 space-y-0.5">
+                    {item.source_ref && <p>Reference: {item.source_ref}</p>}
+                    {item.content_sha256 && <p>SHA-256: {item.content_sha256}</p>}
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <div className="text-sm">
+        <h4 className="font-medium text-gray-500">Lifecycle history</h4>
+        <ul className="mt-1 space-y-1">
+          {history.events.map((event) => (
+            <li key={event.event_id}>
+              #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"} {event.to_state}{" "}
+              <span className="text-xs text-gray-500">
+                ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
+                {formatTimestamp(event.recorded_at)})
+              </span>
+              {event.successor_assertion_id && (
+                <span className="text-xs text-gray-500">
+                  {" "}
+                  {"\u2014"} superseded by assertion {event.successor_assertion_id}
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+        {supersessionEvent?.successor_assertion_id && (
+          <p className="mt-1 text-xs text-amber-700" role="status">
+            This assertion has been superseded by assertion{" "}
+            {supersessionEvent.successor_assertion_id}. Predecessor information is only
+            available from that successor&apos;s own governed scope, if published.
+          </p>
+        )}
+      </div>
+
+      <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
+        <p>
+          Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
+          {relationship.scope_refs && relationship.scope_refs.length > 0
+            ? relationship.scope_refs.join(", ")
+            : "unknown"}
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -462,6 +462,14 @@ type ViewState =
       history: AssertionHistory;
     }>;
 
+/** Resolve the governed assertion id (if any) that a relationship refers to. */
+function resolveAssertionId(
+  relationship: ExplainableRelationship | null,
+): string | null {
+  if (relationship?.governance_status !== "governed") return null;
+  return relationship.assertion_id ?? null;
+}
+
 /**
  * Pure derivation of the panel's view state from its inputs. Extracted so
  * `RelationshipExplanationPanel` itself only has to switch on the result,
@@ -474,10 +482,10 @@ function resolveViewState(
   if (!relationship) return { kind: "empty" };
 
   const heading = relationshipHeading(relationship);
-  const isGoverned = relationship.governance_status === "governed";
-  if (!isGoverned) return { kind: "legacy", heading };
-
-  const assertionId = relationship.assertion_id ?? null;
+  const assertionId = resolveAssertionId(relationship);
+  if (relationship.governance_status !== "governed") {
+    return { kind: "legacy", heading };
+  }
   if (!assertionId) return { kind: "pending", heading };
 
   // "Loading" is derived, not stored: if there is no settled result yet, or
@@ -499,20 +507,11 @@ function resolveViewState(
 }
 
 /**
- * Renders the governed explanation (evidence, authority, time, confidence,
- * supersession, and publication scope) for a selected relationship edge, or a
- * bounded legacy/unavailable/loading state when governance facts cannot be
- * shown. Never displays evidence bodies, restricted references, or invented
- * `CURRENT`/production-proof claims.
+ * Render the subcomponent matching a resolved `ViewState`. Kept as its own
+ * function so the switch's branches contribute to this function's
+ * complexity budget, not `RelationshipExplanationPanel`'s.
  */
-export default function RelationshipExplanationPanel({
-  relationship,
-}: RelationshipExplanationPanelProps) {
-  const isGoverned = relationship?.governance_status === "governed";
-  const assertionId = isGoverned ? (relationship?.assertion_id ?? null) : null;
-  const result = useAssertionResult(assertionId);
-  const view = resolveViewState(relationship, result);
-
+function renderView(view: ViewState) {
   switch (view.kind) {
     case "empty":
       return <EmptySelectionView />;
@@ -536,4 +535,20 @@ export default function RelationshipExplanationPanel({
         />
       );
   }
+}
+
+/**
+ * Renders the governed explanation (evidence, authority, time, confidence,
+ * supersession, and publication scope) for a selected relationship edge, or a
+ * bounded legacy/unavailable/loading state when governance facts cannot be
+ * shown. Never displays evidence bodies, restricted references, or invented
+ * `CURRENT`/production-proof claims.
+ */
+export default function RelationshipExplanationPanel({
+  relationship,
+}: RelationshipExplanationPanelProps) {
+  const assertionId = resolveAssertionId(relationship);
+  const result = useAssertionResult(assertionId);
+  const view = resolveViewState(relationship, result);
+  return renderView(view);
 }

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -452,7 +452,7 @@ export default function RelationshipExplanationPanel({
   // "Loading" is derived, not stored: if there is no settled result yet, or
   // the settled result belongs to a superseded request key, render the
   // loading view rather than briefly flashing stale content.
-  if (!result || result.requestKey !== assertionId) {
+  if (result?.requestKey !== assertionId) {
     return <LoadingView heading={heading} />;
   }
 

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -386,6 +386,119 @@ function ReadyView({
 }
 
 /**
+ * Fetch the explanation and history for a governed assertion, resolving to a
+ * settled `PanelResult` (or `null` if the request was aborted). Kept as its
+ * own top-level function (rather than inline in an effect) so the fetch,
+ * abort-handling, and error-classification logic contributes to its own
+ * cyclomatic complexity budget, not the rendering component's.
+ */
+async function fetchAssertionResult(
+  requestKey: string,
+  signal: AbortSignal,
+): Promise<PanelResult | null> {
+  // Capture a single as-of snapshot and pass it to both calls so the
+  // explanation and history are resolved consistently with each other.
+  // NOTE: this does not yet guarantee consistency with the displayed
+  // graph's own publication snapshot -- see the `known_at`/`effective_at`
+  // limitation documented in `types/api.ts`.
+  const asOf = { known_at: new Date().toISOString() };
+
+  try {
+    const [explanation, history] = await Promise.all([
+      api.getAssertion(requestKey, asOf, signal),
+      api.getAssertionHistory(requestKey, asOf, signal),
+    ]);
+    return signal.aborted
+      ? null
+      : { status: "ready", requestKey, explanation, history };
+  } catch (err) {
+    if (signal.aborted) return null;
+    const httpStatus = (err as { response?: { status?: number } })?.response
+      ?.status;
+    return {
+      status: httpStatus === 404 ? "not-found" : "unavailable",
+      requestKey,
+    };
+  }
+}
+
+/**
+ * Fetch and hold the settled result for a governed assertion's explanation
+ * and history, keyed by `requestKey`, or `null` while not applicable/pending.
+ * Aborts the in-flight request on unmount or when `requestKey` changes.
+ */
+function useAssertionResult(requestKey: string | null): PanelResult | null {
+  const [result, setResult] = useState<PanelResult | null>(null);
+
+  useEffect(() => {
+    if (!requestKey) {
+      return;
+    }
+
+    const controller = new AbortController();
+    fetchAssertionResult(requestKey, controller.signal).then((settled) => {
+      if (settled) setResult(settled);
+    });
+
+    return () => controller.abort();
+  }, [requestKey]);
+
+  return result;
+}
+
+/** Discriminated description of what the panel should render next. */
+type ViewState =
+  | Readonly<{ kind: "empty" }>
+  | Readonly<{ kind: "legacy"; heading: string }>
+  | Readonly<{ kind: "pending"; heading: string }>
+  | Readonly<{ kind: "loading"; heading: string }>
+  | Readonly<{ kind: "not-found"; heading: string }>
+  | Readonly<{ kind: "unavailable"; heading: string }>
+  | Readonly<{
+      kind: "ready";
+      heading: string;
+      relationship: ExplainableRelationship;
+      explanation: AssertionExplanation;
+      history: AssertionHistory;
+    }>;
+
+/**
+ * Pure derivation of the panel's view state from its inputs. Extracted so
+ * `RelationshipExplanationPanel` itself only has to switch on the result,
+ * rather than repeat this branching inline.
+ */
+function resolveViewState(
+  relationship: ExplainableRelationship | null,
+  result: PanelResult | null,
+): ViewState {
+  if (!relationship) return { kind: "empty" };
+
+  const heading = relationshipHeading(relationship);
+  const isGoverned = relationship.governance_status === "governed";
+  if (!isGoverned) return { kind: "legacy", heading };
+
+  const assertionId = relationship.assertion_id ?? null;
+  if (!assertionId) return { kind: "pending", heading };
+
+  // "Loading" is derived, not stored: if there is no settled result yet, or
+  // the settled result belongs to a superseded request key, treat it as
+  // loading rather than briefly flashing stale content.
+  if (result?.requestKey !== assertionId) return { kind: "loading", heading };
+
+  if (result.status === "ready") {
+    return {
+      kind: "ready",
+      heading,
+      relationship,
+      explanation: result.explanation,
+      history: result.history,
+    };
+  }
+
+  return { kind: result.status, heading };
+}
+
+/**
  * Renders the governed explanation (evidence, authority, time, confidence,
  * supersession, and publication scope) for a selected relationship edge, or a
  * bounded legacy/unavailable/loading state when governance facts cannot be
@@ -397,77 +510,29 @@ export default function RelationshipExplanationPanel({
 }: RelationshipExplanationPanelProps) {
   const isGoverned = relationship?.governance_status === "governed";
   const assertionId = isGoverned ? (relationship?.assertion_id ?? null) : null;
-  const requestKey = assertionId;
+  const result = useAssertionResult(assertionId);
+  const view = resolveViewState(relationship, result);
 
-  const [result, setResult] = useState<PanelResult | null>(null);
-
-  useEffect(() => {
-    if (!requestKey) {
-      return;
-    }
-
-    const controller = new AbortController();
-
-    // Capture a single as-of snapshot and pass it to both calls so the
-    // explanation and history are resolved consistently with each other.
-    // NOTE: this does not yet guarantee consistency with the displayed
-    // graph's own publication snapshot -- see the `known_at`/`effective_at`
-    // limitation documented in `types/api.ts`.
-    const asOf = { known_at: new Date().toISOString() };
-
-    Promise.all([
-      api.getAssertion(requestKey, asOf, controller.signal),
-      api.getAssertionHistory(requestKey, asOf, controller.signal),
-    ])
-      .then(([explanation, history]) => {
-        if (controller.signal.aborted) return;
-        setResult({ status: "ready", requestKey, explanation, history });
-      })
-      .catch((err) => {
-        if (controller.signal.aborted) return;
-        const httpStatus = err?.response?.status;
-        setResult({
-          status: httpStatus === 404 ? "not-found" : "unavailable",
-          requestKey,
-        });
-      });
-
-    return () => controller.abort();
-  }, [requestKey]);
-
-  if (!relationship) {
-    return <EmptySelectionView />;
-  }
-
-  const heading = relationshipHeading(relationship);
-
-  if (!isGoverned) {
-    return <LegacyView heading={heading} />;
-  }
-
-  if (!assertionId) {
-    return <PendingMetadataView heading={heading} />;
-  }
-
-  // "Loading" is derived, not stored: if there is no settled result yet, or
-  // the settled result belongs to a superseded request key, render the
-  // loading view rather than briefly flashing stale content.
-  if (result?.requestKey !== assertionId) {
-    return <LoadingView heading={heading} />;
-  }
-
-  switch (result.status) {
+  switch (view.kind) {
+    case "empty":
+      return <EmptySelectionView />;
+    case "legacy":
+      return <LegacyView heading={view.heading} />;
+    case "pending":
+      return <PendingMetadataView heading={view.heading} />;
+    case "loading":
+      return <LoadingView heading={view.heading} />;
     case "not-found":
-      return <NotFoundView heading={heading} />;
+      return <NotFoundView heading={view.heading} />;
     case "unavailable":
-      return <UnavailableView heading={heading} />;
+      return <UnavailableView heading={view.heading} />;
     case "ready":
       return (
         <ReadyView
-          heading={heading}
-          relationship={relationship}
-          explanation={result.explanation}
-          history={result.history}
+          heading={view.heading}
+          relationship={view.relationship}
+          explanation={view.explanation}
+          history={view.history}
         />
       );
   }

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -56,6 +56,22 @@ function getAssertionResource<T>(
   );
 }
 
+/**
+ * Build a single-purpose fetcher bound to one governed-assertion resource
+ * path (the explanation itself, or its history). Generating both
+ * `getAssertion`/`getAssertionHistory` from this one factory -- rather than
+ * hand-writing two structurally identical wrapper functions -- keeps there
+ * from being two near-duplicate function bodies to maintain in parallel.
+ */
+function makeAssertionFetcher<T>(resourcePath: "" | "/history") {
+  return (
+    assertionId: string,
+    params?: AssertionAsOfParams,
+    signal?: AbortSignal,
+  ): Promise<T> =>
+    getAssertionResource<T>(assertionId, resourcePath, params, signal);
+}
+
 export const api = {
   // Health check
   healthCheck: () => {
@@ -123,29 +139,7 @@ export const api = {
   // it to both calls below, so the explanation and history are resolved
   // against the same as-of snapshot rather than two independent server
   // "now" defaults.
-  getAssertion: (
-    assertionId: string,
-    params?: AssertionAsOfParams,
-    signal?: AbortSignal,
-  ): Promise<AssertionExplanation> => {
-    return getAssertionResource<AssertionExplanation>(
-      assertionId,
-      "",
-      params,
-      signal,
-    );
-  },
+  getAssertion: makeAssertionFetcher<AssertionExplanation>(""),
 
-  getAssertionHistory: (
-    assertionId: string,
-    params?: AssertionAsOfParams,
-    signal?: AbortSignal,
-  ): Promise<AssertionHistory> => {
-    return getAssertionResource<AssertionHistory>(
-      assertionId,
-      "/history",
-      params,
-      signal,
-    );
-  },
+  getAssertionHistory: makeAssertionFetcher<AssertionHistory>("/history"),
 };

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -128,7 +128,12 @@ export const api = {
     params?: AssertionAsOfParams,
     signal?: AbortSignal,
   ): Promise<AssertionExplanation> => {
-    return getAssertionResource<AssertionExplanation>(assertionId, "", params, signal);
+    return getAssertionResource<AssertionExplanation>(
+      assertionId,
+      "",
+      params,
+      signal,
+    );
   },
 
   getAssertionHistory: (
@@ -136,6 +141,11 @@ export const api = {
     params?: AssertionAsOfParams,
     signal?: AbortSignal,
   ): Promise<AssertionHistory> => {
-    return getAssertionResource<AssertionHistory>(assertionId, "/history", params, signal);
+    return getAssertionResource<AssertionHistory>(
+      assertionId,
+      "/history",
+      params,
+      signal,
+    );
   },
 };

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -3,6 +3,8 @@ import type { AxiosRequestConfig } from "axios";
 import type {
   Asset,
   AssetPageResponse,
+  AssertionExplanation,
+  AssertionHistory,
   Relationship,
   Metrics,
   VisualizationData,
@@ -95,5 +97,28 @@ export const api = {
 
   getSectors: (): Promise<{ sectors: string[] }> => {
     return getData<{ sectors: string[] }>("/api/sectors");
+  },
+
+  // Governed assertion explanation (GRAC v1)
+  getAssertion: (
+    assertionId: string,
+    params?: { known_at?: string; effective_at?: string },
+    signal?: AbortSignal,
+  ): Promise<AssertionExplanation> => {
+    return getData<AssertionExplanation>(
+      `/api/assertions/${encodeURIComponent(assertionId)}`,
+      { params, signal },
+    );
+  },
+
+  getAssertionHistory: (
+    assertionId: string,
+    params?: { known_at?: string; effective_at?: string },
+    signal?: AbortSignal,
+  ): Promise<AssertionHistory> => {
+    return getData<AssertionHistory>(
+      `/api/assertions/${encodeURIComponent(assertionId)}/history`,
+      { params, signal },
+    );
   },
 };

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -32,7 +32,9 @@ async function getData<T>(
   path: string,
   config?: AxiosRequestConfig,
 ): Promise<T> {
-  const response = config ? await apiClient.get<T>(path, config) : await apiClient.get<T>(path);
+  const response = config
+    ? await apiClient.get<T>(path, config)
+    : await apiClient.get<T>(path);
   return response.data;
 }
 
@@ -55,26 +57,26 @@ export const api = {
     return getData<AssetPageResponse>("/api/assets", { params, signal });
   },
 
-  getAssetDetail: (
-    assetId: string,
-    signal?: AbortSignal,
-  ): Promise<Asset> => {
-    return getData<Asset>(`/api/assets/${encodeURIComponent(assetId)}`, { signal });
+  getAssetDetail: (assetId: string, signal?: AbortSignal): Promise<Asset> => {
+    return getData<Asset>(`/api/assets/${encodeURIComponent(assetId)}`, {
+      signal,
+    });
   },
 
   getAssetRelationships: (
     assetId: string,
     signal?: AbortSignal,
   ): Promise<Relationship[]> => {
-    return getData<Relationship[]>(`/api/assets/${encodeURIComponent(assetId)}/relationships`, {
-      signal,
-    });
+    return getData<Relationship[]>(
+      `/api/assets/${encodeURIComponent(assetId)}/relationships`,
+      {
+        signal,
+      },
+    );
   },
 
   // Relationships
-  getAllRelationships: (
-    signal?: AbortSignal,
-  ): Promise<Relationship[]> => {
+  getAllRelationships: (signal?: AbortSignal): Promise<Relationship[]> => {
     return getData<Relationship[]>("/api/relationships", { signal });
   },
 
@@ -84,9 +86,7 @@ export const api = {
   },
 
   // Visualization
-  getVisualizationData: (
-    signal?: AbortSignal,
-  ): Promise<VisualizationData> => {
+  getVisualizationData: (signal?: AbortSignal): Promise<VisualizationData> => {
     return getData<VisualizationData>("/api/visualization", { signal });
   },
 

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -3,6 +3,7 @@ import type { AxiosRequestConfig } from "axios";
 import type {
   Asset,
   AssetPageResponse,
+  AssertionAsOfParams,
   AssertionExplanation,
   AssertionHistory,
   Relationship,
@@ -36,6 +37,23 @@ async function getData<T>(
     ? await apiClient.get<T>(path, config)
     : await apiClient.get<T>(path);
   return response.data;
+}
+
+/**
+ * Fetch a governed assertion read model (explanation or history) at the given
+ * bitemporal path, forwarding identical `known_at`/`effective_at` bounds so
+ * that callers can request both endpoints against the same as-of snapshot.
+ */
+function getAssertionResource<T>(
+  assertionId: string,
+  resourcePath: "" | "/history",
+  params?: AssertionAsOfParams,
+  signal?: AbortSignal,
+): Promise<T> {
+  return getData<T>(
+    `/api/assertions/${encodeURIComponent(assertionId)}${resourcePath}`,
+    { params, signal },
+  );
 }
 
 export const api = {
@@ -100,25 +118,24 @@ export const api = {
   },
 
   // Governed assertion explanation (GRAC v1)
+  //
+  // Callers should capture a single `known_at`/`effective_at` pair and pass
+  // it to both calls below, so the explanation and history are resolved
+  // against the same as-of snapshot rather than two independent server
+  // "now" defaults.
   getAssertion: (
     assertionId: string,
-    params?: { known_at?: string; effective_at?: string },
+    params?: AssertionAsOfParams,
     signal?: AbortSignal,
   ): Promise<AssertionExplanation> => {
-    return getData<AssertionExplanation>(
-      `/api/assertions/${encodeURIComponent(assertionId)}`,
-      { params, signal },
-    );
+    return getAssertionResource<AssertionExplanation>(assertionId, "", params, signal);
   },
 
   getAssertionHistory: (
     assertionId: string,
-    params?: { known_at?: string; effective_at?: string },
+    params?: AssertionAsOfParams,
     signal?: AbortSignal,
   ): Promise<AssertionHistory> => {
-    return getData<AssertionHistory>(
-      `/api/assertions/${encodeURIComponent(assertionId)}/history`,
-      { params, signal },
-    );
+    return getAssertionResource<AssertionHistory>(assertionId, "/history", params, signal);
   },
 };

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -12,19 +12,32 @@ export interface Asset {
   additional_fields: Record<string, unknown>;
 }
 
-export interface Relationship {
-  source_id: string;
-  target_id: string;
-  relationship_type: string;
-  strength: number;
+/**
+ * Governed-edge metadata shared by `Relationship` and `VisualizationEdge`.
+ * Kept as a single interface so the two response shapes cannot drift from
+ * each other as the underlying API evolves.
+ *
+ * Note: despite the name, `scope_refs` currently contains only the governed
+ * `predicate_id` for the edge (see `api/services/relationship_index.py`,
+ * `"scope_refs": [predicate_id]`) -- it does NOT include the governed
+ * `purpose`, which is not exposed at the edge/visualization level today.
+ */
+export interface GovernedEdgeMetadata {
   /** Present only when this edge is backed by a governed assertion. */
   assertion_id?: string | null;
   /** `"governed"` when backed by a published assertion; absent/`null` means legacy. */
   governance_status?: "governed" | null;
   /** Publication revision this governance metadata was resolved from. */
   revision_id?: string | null;
-  /** Governed `(purpose, predicate_id)` scope references for this edge. */
+  /** Governed predicate-id scope reference(s) for this edge (see note above: no purpose is included). */
   scope_refs?: string[] | null;
+}
+
+export interface Relationship extends GovernedEdgeMetadata {
+  source_id: string;
+  target_id: string;
+  relationship_type: string;
+  strength: number;
 }
 
 export interface Metrics {
@@ -57,20 +70,12 @@ export interface VisualizationNode {
 }
 
 /** An edge in the 3-D visualisation graph. `strength` is normalised 0.0–1.0. */
-export interface VisualizationEdge {
+export interface VisualizationEdge extends GovernedEdgeMetadata {
   source: string;
   target: string;
   relationship_type: string;
   /** Relationship strength, normalised to the range 0.0–1.0. */
   strength: number;
-  /** Present only when this edge is backed by a governed assertion. */
-  assertion_id?: string | null;
-  /** `"governed"` when backed by a published assertion; absent/`null` means legacy. */
-  governance_status?: "governed" | null;
-  /** Publication revision this governance metadata was resolved from. */
-  revision_id?: string | null;
-  /** Governed `(purpose, predicate_id)` scope references for this edge. */
-  scope_refs?: string[] | null;
 }
 
 export interface VisualizationData {
@@ -103,6 +108,15 @@ export interface AssetPageResponse {
 // `GET /api/assertions/{assertion_id}` and `GET /api/assertions/{assertion_id}/history`
 // (see `api/assertion_models.py`). Actor identity is never exposed on these public
 // reads; only the authenticated command APIs (out of scope for this UI) carry actor_id.
+//
+// KNOWN LIMITATION (tracked for a follow-up backend change, out of scope here):
+// both endpoints default `known_at`/`effective_at` to "now" server-side when the
+// caller omits them. Neither response currently carries the graph publication's
+// own `known_at`/`effective_at`/`published_at`, so a panel driven purely by
+// `assertion_id` cannot guarantee its explanation matches the lifecycle state
+// that was true when the displayed graph edge was published. Until the
+// visualization/relationship API exposes that publication envelope, callers
+// should treat this explanation as "as of now", not "as of the displayed graph".
 
 export type LifecycleState =
   | "Proposed"
@@ -141,9 +155,23 @@ export interface AssertionEvidence {
   recorded_at?: string | null;
 }
 
-/** Public redacted explanation of one assertion as-of the requested bitemporal bounds. */
-export interface AssertionExplanation {
+/**
+ * Bitemporal lifecycle fields shared by the explanation and history read
+ * models. Kept as a single interface so the two public response contracts
+ * cannot diverge as the underlying API evolves.
+ */
+export interface AssertionLifecycleMetadata {
   assertion_id: string;
+  effective_from: string;
+  effective_to: string | null;
+  recorded_at: string;
+  state: LifecycleState;
+  known_at: string | null;
+  effective_at: string | null;
+}
+
+/** Public redacted explanation of one assertion as-of the requested bitemporal bounds. */
+export interface AssertionExplanation extends AssertionLifecycleMetadata {
   predicate_id: string;
   subject_id: string;
   object_id: string;
@@ -153,12 +181,6 @@ export interface AssertionExplanation {
   confidence_bp: number | null;
   confidence_type: string | null;
   confidence_method: string | null;
-  effective_from: string;
-  effective_to: string | null;
-  recorded_at: string;
-  state: LifecycleState;
-  known_at: string | null;
-  effective_at: string | null;
   sequence: number;
   evidence: AssertionEvidence[];
 }
@@ -176,13 +198,12 @@ export interface AssertionPublicEvent {
 }
 
 /** Public immutable assertion lifecycle history. */
-export interface AssertionHistory {
-  assertion_id: string;
-  effective_from: string;
-  effective_to: string | null;
-  recorded_at: string;
-  state: LifecycleState;
-  known_at: string | null;
-  effective_at: string | null;
+export interface AssertionHistory extends AssertionLifecycleMetadata {
   events: AssertionPublicEvent[];
+}
+
+/** Optional bitemporal bounds accepted by the assertion read endpoints. */
+export interface AssertionAsOfParams {
+  known_at?: string;
+  effective_at?: string;
 }

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -119,7 +119,11 @@ export type EvidencePolarity = "supporting" | "opposing" | "contextual";
 
 export type ConfidenceStatus = "assessed" | "not_assessed";
 
-export type EvidenceVisibility = "public" | "internal" | "restricted" | "confidential";
+export type EvidenceVisibility =
+  | "public"
+  | "internal"
+  | "restricted"
+  | "confidential";
 
 /** Redacted evidence metadata: bodies and restricted references are never included. */
 export interface AssertionEvidence {

--- a/frontend/app/types/api.ts
+++ b/frontend/app/types/api.ts
@@ -17,6 +17,14 @@ export interface Relationship {
   target_id: string;
   relationship_type: string;
   strength: number;
+  /** Present only when this edge is backed by a governed assertion. */
+  assertion_id?: string | null;
+  /** `"governed"` when backed by a published assertion; absent/`null` means legacy. */
+  governance_status?: "governed" | null;
+  /** Publication revision this governance metadata was resolved from. */
+  revision_id?: string | null;
+  /** Governed `(purpose, predicate_id)` scope references for this edge. */
+  scope_refs?: string[] | null;
 }
 
 export interface Metrics {
@@ -55,6 +63,14 @@ export interface VisualizationEdge {
   relationship_type: string;
   /** Relationship strength, normalised to the range 0.0–1.0. */
   strength: number;
+  /** Present only when this edge is backed by a governed assertion. */
+  assertion_id?: string | null;
+  /** `"governed"` when backed by a published assertion; absent/`null` means legacy. */
+  governance_status?: "governed" | null;
+  /** Publication revision this governance metadata was resolved from. */
+  revision_id?: string | null;
+  /** Governed `(purpose, predicate_id)` scope references for this edge. */
+  scope_refs?: string[] | null;
 }
 
 export interface VisualizationData {
@@ -79,4 +95,90 @@ export interface AssetPageResponse {
   page: number;
   per_page: number;
   hasMore: boolean;
+}
+
+// --- Governed assertion explanation (GRAC v1) ---
+//
+// These mirror the public, identity-redacted read models exposed by
+// `GET /api/assertions/{assertion_id}` and `GET /api/assertions/{assertion_id}/history`
+// (see `api/assertion_models.py`). Actor identity is never exposed on these public
+// reads; only the authenticated command APIs (out of scope for this UI) carry actor_id.
+
+export type LifecycleState =
+  | "Proposed"
+  | "Accepted"
+  | "Rejected"
+  | "Withdrawn"
+  | "Disputed"
+  | "Retracted"
+  | "Superseded";
+
+export type AuthorityRole = "proposer" | "acceptor" | "disputer" | "retractor";
+
+export type EvidencePolarity = "supporting" | "opposing" | "contextual";
+
+export type ConfidenceStatus = "assessed" | "not_assessed";
+
+export type EvidenceVisibility = "public" | "internal" | "restricted" | "confidential";
+
+/** Redacted evidence metadata: bodies and restricted references are never included. */
+export interface AssertionEvidence {
+  evidence_id: string;
+  polarity: EvidencePolarity;
+  visibility: EvidenceVisibility;
+  redacted: boolean;
+  source_ref?: string | null;
+  media_type?: string | null;
+  content_sha256?: string | null;
+  observed_at?: string | null;
+  issued_at?: string | null;
+  licensing?: string | null;
+  reuse_policy?: string | null;
+  recorded_at?: string | null;
+}
+
+/** Public redacted explanation of one assertion as-of the requested bitemporal bounds. */
+export interface AssertionExplanation {
+  assertion_id: string;
+  predicate_id: string;
+  subject_id: string;
+  object_id: string;
+  method_id: string;
+  proposition: string;
+  confidence_status: ConfidenceStatus;
+  confidence_bp: number | null;
+  confidence_type: string | null;
+  confidence_method: string | null;
+  effective_from: string;
+  effective_to: string | null;
+  recorded_at: string;
+  state: LifecycleState;
+  known_at: string | null;
+  effective_at: string | null;
+  sequence: number;
+  evidence: AssertionEvidence[];
+}
+
+/** Identity-redacted lifecycle event: only the authority role, never actor_id. */
+export interface AssertionPublicEvent {
+  event_id: string;
+  assertion_id: string;
+  sequence: number;
+  from_state: LifecycleState | null;
+  to_state: LifecycleState;
+  authority: AuthorityRole;
+  recorded_at: string;
+  successor_assertion_id?: string | null;
+}
+
+/** Public immutable assertion lifecycle history. */
+export interface AssertionHistory {
+  assertion_id: string;
+  effective_from: string;
+  effective_to: string | null;
+  recorded_at: string;
+  state: LifecycleState;
+  known_at: string | null;
+  effective_at: string | null;
+  events: AssertionPublicEvent[];
 }


### PR DESCRIPTION
## **User description**
# Pull Request Template

## Architectural Alignment

- Backend: FastAPI (production path) — **unchanged** in this PR
- Frontend: Next.js (production path) — **only surface changed**
- Gradio: non-production (demo/testing only) — not touched

No changes contradict the defined production architecture.

## Primary Objective

Add a frontend-only `RelationshipExplanationPanel` that lets a user select a relationship in the 3D visualization and see the governed explanation behind it (proposition, lifecycle state, evidence summaries, confidence vs. projection strength, effective/recorded time, authority role, supersession chain, and publication/scope references), consuming the public redacted assertion read APIs delivered in #1570.

Closes #1538.

## Scope

### In Scope

- New `RelationshipExplanationPanel` component with bounded states: legacy (ungoverned), governed-but-metadata-pending, not-found, unavailable, loading, and ready.
- Typed client methods `getAssertion` / `getAssertionHistory` in `lib/api.ts` and matching types in `types/api.ts` (mirroring `api/assertion_models.py` exactly — no invented fields).
- Edge selection in `NetworkVisualization.tsx`: Plotly click handling plus a keyboard-accessible list fallback (click-only selection is explicitly disallowed by the issue).
- Focused Jest + accessibility tests for both components covering legacy, governed, not-found (404), unavailable (503), superseded/supersession-chain, and keyboard-selection states.

### Out of Scope

- Any backend/API/schema/lifecycle/publication change (already delivered in #1570).
- `frontend/app/page.tsx` or any other wiring outside the allowed file list.
- Dependency upgrades or design-system/broad component refactors.
- Rendering evidence bodies, restricted references, or `CURRENT`/production-proof copy.
- Reconstructing a predecessor link for a superseded assertion: the public API only exposes a forward `successor_assertion_id` on the predecessor's `Superseded` event, not a backward pointer on the successor, so the panel states this limitation explicitly rather than fabricating it.

### Files Expected to Change

- `frontend/app/types/api.ts` — governance fields on `Relationship`/`VisualizationEdge`; new assertion explanation/history types.
- `frontend/app/lib/api.ts` — `getAssertion` / `getAssertionHistory` client methods.
- `frontend/app/components/RelationshipExplanationPanel.tsx` — new component (this PR's primary deliverable).
- `frontend/app/components/NetworkVisualization.tsx` — edge selection (click + keyboard list) wired to the new panel.
- `frontend/__tests__/components/RelationshipExplanationPanel.test.tsx` — new focused tests.
- `frontend/__tests__/components/NetworkVisualization.test.tsx` — added edge-selection/accessibility tests.

All files are within the allowlist in #1538.

## Base / preceding merge SHA

Branched from `origin/main` at `f734adc70b115213083705078ad1d6c38dffeab3` (#1570, "feat: expose governed assertion command and explanation APIs"), which merged #1537.

## Validation Commands

```bash
cd frontend
npm test -- --runInBand
npm run lint
npm run build
```

All three pass locally (505/505 tests, 0 lint errors, production build succeeds with TypeScript checks).

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Validation commands pass locally
- [ ] CI passes
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`
- [ ] Not applicable: this PR does not change governed rebuild/recovery/persistence behaviour

### Testing Best Practices

- [x] Tests verify observable behavior (rendered text/state, API calls made) rather than implementation details
- [x] Tests avoid coupling to exact log message strings
- [x] N/A: no timing-dependent polling loops introduced
- [x] Tests clean up via React Testing Library's automatic unmount/cleanup; fetch `AbortController` is aborted on unmount/re-selection

**Related Documentation**:

- [PR Scope Guardrails](../docs/PR_SCOPE_GUARDRAILS.md)
- [Automation Scope Policy](./AUTOMATION_SCOPE_POLICY.md)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `RelationshipExplanationPanel` that shows governed evidence, lifecycle, and publication scope for a selected relationship. Adds click and keyboard selection, stabilizes selection across refreshes, and aligns both assertion reads to one as‑of timestamp. Fulfills #1538.

- **New Features**
  - `RelationshipExplanationPanel` with states: legacy, metadata-pending, not-found, unavailable, loading, ready.
  - Relationship selection via Plotly click and a keyboard-accessible list.
  - API: `api.getAssertion` and `api.getAssertionHistory` (public redacted `GET /api/assertions/{id}` and `/history`).
  - Evidence bodies and actor identities never shown; no fabricated predecessor link.
  - Jest + a11y tests for governed, legacy, 404, 503, superseded, and keyboard selection.

- **Refactors**
  - Stable edge keys prevent reselection after reordering; shared `PreparedEdge`/`buildValidEdges` used by plot and list; Plotly lines carry the key via `customdata`.
  - One captured `known_at` passed to both assertion calls; panel uses a settled-result state with derived loading.
  - Further extractions reduce component complexity (e.g., `resolveAssertionId`, `renderView`, simplified valid-edges guard); shared types (`GovernedEdgeMetadata`, `AssertionLifecycleMetadata`) and an API helper factory keep contracts in sync.
  - Semantic HTML/a11y fixes: `<output>` for status, `<fieldset>/<legend>` for lists, optional chaining.

<sup>Written for commit f7d66b9cf59fb81913a9d4cad54764ac3894792a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Add governed explanations and lifecycle history for selected network relationships

### What Changed
- Users can select relationships in the 3D graph or through a keyboard-accessible list and view their governance status.
- Governed relationships show the proposition, lifecycle state and history, confidence, projection strength, timing, authority roles, evidence summaries, revision, and scope.
- Legacy relationships and governed relationships with missing metadata show clear bounded messages instead of fabricated governance details.
- Restricted evidence remains redacted, while public evidence references and content digests are shown when available.
- Missing assertions and temporary service failures receive distinct messages without blocking graph use.
- Explanation and history requests use the same as-of timestamp, and selection remains tied to the chosen relationship when graph data changes.
- Added focused tests covering loading, legacy, error, supersession, as-of consistency, and keyboard selection states.

### Impact
`✅ Clearer relationship explanations`
`✅ Keyboard-accessible relationship selection`
`✅ Safer evidence and governance disclosures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change adds a governed relationship explanation and lifecycle-history panel to the network view, with keyboard-accessible relationship selection, redacted evidence display, and bounded loading, unavailable, and not-found states.

No product defect was confirmed. The paired assertion reads share a single `known_at` value, and the backend preserves an omitted `effective_at` as unset rather than independently assigning a timestamp for each request.

### T-Rex validation blocked
A focused API reproduction could not start because the required Python package `numpy` is missing. A prior FastAPI TestClient attempt was also unavailable because `httpx2` is missing, so no live assertion endpoint responses were observed.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

No final defects were identified. The unavailable runtime dependencies prevented a live API check but did not reveal a product failure.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- I authored a focused isolated-database reproduction to invoke the explanation and history handlers with a shared known\_at and omitted effective\_at, including explicit effective-time boundary controls.
- The reproduction stopped during app import with ModuleNotFoundError: No module named 'numpy', so no endpoint responses were observed; a prior FastAPI TestClient attempt was unavailable because httpx2 is missing.
- Code inspection identified that api/routers/assertions.py defaults known\_at to datetime.now and \_resolve\_as\_of\_bounds returns (known, None) when effective time is omitted, as seen in related source files.

<a href="https://app.greptile.com/trex/runs/17115138/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["refactor: shave remaining CodeScene comp..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/f7d66b9cf59fb81913a9d4cad54764ac3894792a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49740856)</sub>

<!-- /greptile_comment -->