### PR TITLE
fix: migrate relationship panel to published-edge explanations

### DIFF
--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -288,7 +288,12 @@ describe("NetworkVisualization Component", () => {
 
     it("selects a relationship via keyboard navigation using tab and Enter/Space key", async () => {
       mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
-        createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1")
+        createMockExplanation(
+          "pedge-1",
+          "ASSET_2",
+          "ASSET_1",
+          "ASSET_2 is the issuer of ASSET_1",
+        ),
       );
 
       const user = userEvent.setup();
@@ -328,7 +333,12 @@ describe("NetworkVisualization Component", () => {
 
     it("selects a relationship via Plotly customdata click", async () => {
       mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
-        createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1")
+        createMockExplanation(
+          "pedge-1",
+          "ASSET_2",
+          "ASSET_1",
+          "ASSET_2 is the issuer of ASSET_1",
+        ),
       );
 
       const user = userEvent.setup();
@@ -352,12 +362,28 @@ describe("NetworkVisualization Component", () => {
     });
 
     it("allows canonical and reverse representations to select independently by their edge_id", async () => {
-      mockedApi.getPublishedEdgeExplanation.mockImplementation((pubId, projectionEdgeId) => {
-        if (projectionEdgeId === "pedge-1") {
-          return Promise.resolve(createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1"));
-        }
-        return Promise.resolve(createMockExplanation("pedge-2", "ASSET_1", "ASSET_2", "ASSET_1 is the issuer of ASSET_2"));
-      });
+      mockedApi.getPublishedEdgeExplanation.mockImplementation(
+        (pubId, projectionEdgeId) => {
+          if (projectionEdgeId === "pedge-1") {
+            return Promise.resolve(
+              createMockExplanation(
+                "pedge-1",
+                "ASSET_2",
+                "ASSET_1",
+                "ASSET_2 is the issuer of ASSET_1",
+              ),
+            );
+          }
+          return Promise.resolve(
+            createMockExplanation(
+              "pedge-2",
+              "ASSET_1",
+              "ASSET_2",
+              "ASSET_1 is the issuer of ASSET_2",
+            ),
+          );
+        },
+      );
 
       const user = userEvent.setup();
       render(<NetworkVisualization data={governedData} />);
@@ -375,7 +401,9 @@ describe("NetworkVisualization Component", () => {
       expect(canonicalButton).toHaveAttribute("aria-pressed", "false");
 
       await waitFor(() => {
-        expect(screen.getByText("ASSET_1 is the issuer of ASSET_2")).toBeInTheDocument();
+        expect(
+          screen.getByText("ASSET_1 is the issuer of ASSET_2"),
+        ).toBeInTheDocument();
       });
 
       // Select canonical representation
@@ -384,7 +412,9 @@ describe("NetworkVisualization Component", () => {
       expect(reverseButton).toHaveAttribute("aria-pressed", "false");
 
       await waitFor(() => {
-        expect(screen.getByText("ASSET_2 is the issuer of ASSET_1")).toBeInTheDocument();
+        expect(
+          screen.getByText("ASSET_2 is the issuer of ASSET_1"),
+        ).toBeInTheDocument();
       });
     });
   });

--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -124,17 +124,20 @@ describe("NetworkVisualization Component", () => {
     ).toBeInTheDocument();
   });
 
-  describe("keyboard-accessible relationship selection", () => {
+  describe("keyboard-accessible relationship selection and opaque edge_id selection", () => {
     const governedData: VisualizationData = {
       nodes: mockVisualizationData.nodes,
       edges: [
         {
+          edge_id: "legacy-edge-1",
           source: "ASSET_1",
           target: "ASSET_2",
           relationship_type: "SAME_SECTOR",
           strength: 0.7,
         },
         {
+          edge_id: "edge-canonical",
+          projection_edge_id: "pedge-1",
           source: "ASSET_2",
           target: "ASSET_1",
           relationship_type: "CORPORATE_LINK",
@@ -144,15 +147,54 @@ describe("NetworkVisualization Component", () => {
           revision_id: "rev-1",
           scope_refs: ["predicate-issuer"],
         },
+        {
+          edge_id: "edge-reverse",
+          projection_edge_id: "pedge-2",
+          source: "ASSET_1",
+          target: "ASSET_2",
+          relationship_type: "CORPORATE_LINK",
+          strength: 0.9,
+          assertion_id: "assertion-1",
+          governance_status: "governed",
+          revision_id: "rev-1",
+          scope_refs: ["predicate-issuer"],
+        },
+        {
+          // Edge missing edge_id should be skipped
+          source: "ASSET_1",
+          target: "ASSET_2",
+          relationship_type: "INVALID_MALFORMED",
+          strength: 0.5,
+        } as unknown as VisualizationData["edges"][number],
       ],
       network_density: 0.5,
+      publication: {
+        publication_id: "pub-1",
+        revision_id: "rev-1",
+        rebuild_job_id: "job-1",
+        execution_id: "exec-1",
+        published_at: "2024-01-01T00:00:00Z",
+        purpose: "financial-relationship-graph",
+        effective_at: "2024-01-01T00:00:00Z",
+        known_at: "2024-01-01T00:00:00Z",
+        contract_version: "grac-v1",
+        projector_version: "v1.0.0",
+        edge_set_hash: "hash-edges-123",
+        projection_hash: "hash-proj-456",
+        governed_scopes: [
+          {
+            purpose: "financial-relationship-graph",
+            predicate_id: "predicate-issuer",
+          },
+        ],
+      },
     };
 
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it("lists every relationship with a governed/legacy badge", () => {
+    it("lists valid relationships and skips malformed edges missing edge_id", () => {
       render(<NetworkVisualization data={governedData} />);
 
       expect(
@@ -161,66 +203,77 @@ describe("NetworkVisualization Component", () => {
         }),
       ).toBeInTheDocument();
       expect(screen.getByText("Legacy")).toBeInTheDocument();
-      expect(screen.getByText("Governed")).toBeInTheDocument();
+      expect(screen.getAllByText("Governed")).toHaveLength(2);
+      expect(screen.queryByText(/INVALID_MALFORMED/)).not.toBeInTheDocument();
     });
 
-    it("selects a relationship via keyboard/click on the list, not only line-clicking", async () => {
-      mockedApi.getAssertion.mockResolvedValue({
-        assertion_id: "assertion-1",
-        predicate_id: "predicate-issuer",
-        subject_id: "ASSET_2",
-        object_id: "ASSET_1",
-        method_id: "method-1",
-        proposition: "ASSET_2 is the issuer of ASSET_1",
-        confidence_status: "not_assessed",
-        confidence_bp: null,
-        confidence_type: null,
-        confidence_method: null,
-        effective_from: "2024-01-01T00:00:00Z",
-        effective_to: null,
-        recorded_at: "2024-01-01T00:00:00Z",
-        state: "Accepted",
-        known_at: "2024-01-01T00:00:00Z",
-        effective_at: "2024-01-01T00:00:00Z",
-        sequence: 1,
-        evidence: [],
-      });
-      mockedApi.getAssertionHistory.mockResolvedValue({
-        assertion_id: "assertion-1",
-        effective_from: "2024-01-01T00:00:00Z",
-        effective_to: null,
-        recorded_at: "2024-01-01T00:00:00Z",
-        state: "Accepted",
-        known_at: "2024-01-01T00:00:00Z",
-        effective_at: "2024-01-01T00:00:00Z",
-        events: [
-          {
-            event_id: "event-1",
+    it("selects a relationship via keyboard navigation using tab and Enter/Space key", async () => {
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue({
+        publication: governedData.publication!,
+        edge: {
+          projection_edge_id: "pedge-1",
+          source: "ASSET_2",
+          target: "ASSET_1",
+          relationship_type: "CORPORATE_LINK",
+          strength: "0.90",
+          direction: "directional",
+          assertion_id: "assertion-1",
+        },
+        assertion: {
+          explanation: {
             assertion_id: "assertion-1",
-            sequence: 1,
-            from_state: null,
-            to_state: "Proposed",
-            authority: "proposer",
+            predicate_id: "predicate-issuer",
+            subject_id: "ASSET_2",
+            object_id: "ASSET_1",
+            method_id: "method-1",
+            proposition: "ASSET_2 is the issuer of ASSET_1",
+            confidence_status: "not_assessed",
+            confidence_bp: null,
+            confidence_type: null,
+            confidence_method: null,
+            effective_from: "2024-01-01T00:00:00Z",
+            effective_to: null,
             recorded_at: "2024-01-01T00:00:00Z",
+            state: "Accepted",
+            known_at: "2024-01-01T00:00:00Z",
+            effective_at: "2024-01-01T00:00:00Z",
+            sequence: 1,
+            evidence: [],
           },
-        ],
+          history: {
+            assertion_id: "assertion-1",
+            effective_from: "2024-01-01T00:00:00Z",
+            effective_to: null,
+            recorded_at: "2024-01-01T00:00:00Z",
+            state: "Accepted",
+            known_at: "2024-01-01T00:00:00Z",
+            effective_at: "2024-01-01T00:00:00Z",
+            events: [
+              {
+                event_id: "event-1",
+                assertion_id: "assertion-1",
+                sequence: 1,
+                from_state: null,
+                to_state: "Proposed",
+                authority: "proposer",
+                recorded_at: "2024-01-01T00:00:00Z",
+              },
+            ],
+          },
+        },
       });
 
       const user = userEvent.setup();
       render(<NetworkVisualization data={governedData} />);
 
-      const governedButton = screen.getByRole("button", {
+      const canonicalButton = screen.getByRole("button", {
         name: /ASSET_2.*ASSET_1.*CORPORATE_LINK.*Governed/,
       });
 
-      // Exercise a genuine tab sequence (rather than calling `.focus()`
-      // directly) so this test actually proves the button is reachable via
-      // keyboard navigation, not merely programmatically focusable.
-      const MAX_TAB_STOPS = 25;
       let reachedButton = false;
-      for (let tabStop = 0; tabStop < MAX_TAB_STOPS; tabStop += 1) {
+      for (let tabStop = 0; tabStop < 25; tabStop += 1) {
         await user.tab();
-        if (document.activeElement === governedButton) {
+        if (document.activeElement === canonicalButton) {
           reachedButton = true;
           break;
         }
@@ -229,11 +282,11 @@ describe("NetworkVisualization Component", () => {
 
       await user.keyboard("{Enter}");
 
-      expect(governedButton).toHaveAttribute("aria-pressed", "true");
+      expect(canonicalButton).toHaveAttribute("aria-pressed", "true");
       await waitFor(() => {
-        expect(mockedApi.getAssertion).toHaveBeenCalledWith(
-          "assertion-1",
-          expect.objectContaining({ known_at: expect.any(String) }),
+        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+          "pub-1",
+          "pedge-1",
           expect.anything(),
         );
       });
@@ -241,6 +294,75 @@ describe("NetworkVisualization Component", () => {
         expect(
           screen.getByText("ASSET_2 is the issuer of ASSET_1"),
         ).toBeInTheDocument();
+      });
+    });
+
+    it("allows canonical and reverse representations to select independently by their edge_id", async () => {
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue({
+        publication: governedData.publication!,
+        edge: {
+          projection_edge_id: "pedge-2",
+          source: "ASSET_1",
+          target: "ASSET_2",
+          relationship_type: "CORPORATE_LINK",
+          strength: "0.90",
+          direction: "directional",
+          assertion_id: "assertion-1",
+        },
+        assertion: {
+          explanation: {
+            assertion_id: "assertion-1",
+            predicate_id: "predicate-issuer",
+            subject_id: "ASSET_2",
+            object_id: "ASSET_1",
+            method_id: "method-1",
+            proposition: "ASSET_2 is the issuer of ASSET_1",
+            confidence_status: "not_assessed",
+            confidence_bp: null,
+            confidence_type: null,
+            confidence_method: null,
+            effective_from: "2024-01-01T00:00:00Z",
+            effective_to: null,
+            recorded_at: "2024-01-01T00:00:00Z",
+            state: "Accepted",
+            known_at: "2024-01-01T00:00:00Z",
+            effective_at: "2024-01-01T00:00:00Z",
+            sequence: 1,
+            evidence: [],
+          },
+          history: {
+            assertion_id: "assertion-1",
+            effective_from: "2024-01-01T00:00:00Z",
+            effective_to: null,
+            recorded_at: "2024-01-01T00:00:00Z",
+            state: "Accepted",
+            known_at: "2024-01-01T00:00:00Z",
+            effective_at: "2024-01-01T00:00:00Z",
+            events: [],
+          },
+        },
+      });
+
+      const user = userEvent.setup();
+      render(<NetworkVisualization data={governedData} />);
+
+      const canonicalButton = screen.getByRole("button", {
+        name: /ASSET_2.*ASSET_1.*CORPORATE_LINK.*Governed/,
+      });
+      const reverseButton = screen.getByRole("button", {
+        name: /ASSET_1.*ASSET_2.*CORPORATE_LINK.*Governed/,
+      });
+
+      await user.click(reverseButton);
+      expect(reverseButton).toHaveAttribute("aria-pressed", "true");
+      expect(canonicalButton).toHaveAttribute("aria-pressed", "false");
+
+      await waitFor(() => {
+        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+          "pub-1",
+          "pedge-2",
+          expect.anything(),
+        );
       });
     });
   });

--- a/frontend/__tests__/components/NetworkVisualization.test.tsx
+++ b/frontend/__tests__/components/NetworkVisualization.test.tsx
@@ -15,10 +15,29 @@ jest.mock("../../app/lib/api");
 const mockedApi = api as jest.Mocked<typeof api>;
 
 jest.mock("react-plotly.js", () => {
-  return function MockPlot({ data }: { data: unknown }) {
+  return function MockPlot({
+    data,
+    onClick,
+  }: {
+    data: unknown;
+    onClick?: (event: unknown) => void;
+  }) {
     return (
       <div data-testid="mock-plot">
         <div data-testid="plot-data">{JSON.stringify(data)}</div>
+        <button
+          type="button"
+          data-testid="plot-click-trigger"
+          onClick={() => {
+            if (onClick) {
+              onClick({
+                points: [{ customdata: "edge-canonical" }],
+              });
+            }
+          }}
+        >
+          Click Plot Edge
+        </button>
       </div>
     );
   };
@@ -207,61 +226,70 @@ describe("NetworkVisualization Component", () => {
       expect(screen.queryByText(/INVALID_MALFORMED/)).not.toBeInTheDocument();
     });
 
-    it("selects a relationship via keyboard navigation using tab and Enter/Space key", async () => {
-      mockedApi.getPublishedEdgeExplanation.mockResolvedValue({
-        publication: governedData.publication!,
-        edge: {
-          projection_edge_id: "pedge-1",
-          source: "ASSET_2",
-          target: "ASSET_1",
-          relationship_type: "CORPORATE_LINK",
-          strength: "0.90",
-          direction: "directional",
+    const createMockExplanation = (
+      projectionEdgeId: string,
+      source: string,
+      target: string,
+      proposition: string,
+    ): PublishedEdgeExplanationResponse => ({
+      publication: governedData.publication!,
+      edge: {
+        projection_edge_id: projectionEdgeId,
+        source,
+        target,
+        relationship_type: "CORPORATE_LINK",
+        strength: "0.90",
+        direction: "directional",
+        assertion_id: "assertion-1",
+      },
+      assertion: {
+        explanation: {
           assertion_id: "assertion-1",
+          predicate_id: "predicate-issuer",
+          subject_id: source,
+          object_id: target,
+          method_id: "method-1",
+          proposition,
+          confidence_status: "not_assessed",
+          confidence_bp: null,
+          confidence_type: null,
+          confidence_method: null,
+          effective_from: "2024-01-01T00:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T00:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T00:00:00Z",
+          effective_at: "2024-01-01T00:00:00Z",
+          sequence: 1,
+          evidence: [],
         },
-        assertion: {
-          explanation: {
-            assertion_id: "assertion-1",
-            predicate_id: "predicate-issuer",
-            subject_id: "ASSET_2",
-            object_id: "ASSET_1",
-            method_id: "method-1",
-            proposition: "ASSET_2 is the issuer of ASSET_1",
-            confidence_status: "not_assessed",
-            confidence_bp: null,
-            confidence_type: null,
-            confidence_method: null,
-            effective_from: "2024-01-01T00:00:00Z",
-            effective_to: null,
-            recorded_at: "2024-01-01T00:00:00Z",
-            state: "Accepted",
-            known_at: "2024-01-01T00:00:00Z",
-            effective_at: "2024-01-01T00:00:00Z",
-            sequence: 1,
-            evidence: [],
-          },
-          history: {
-            assertion_id: "assertion-1",
-            effective_from: "2024-01-01T00:00:00Z",
-            effective_to: null,
-            recorded_at: "2024-01-01T00:00:00Z",
-            state: "Accepted",
-            known_at: "2024-01-01T00:00:00Z",
-            effective_at: "2024-01-01T00:00:00Z",
-            events: [
-              {
-                event_id: "event-1",
-                assertion_id: "assertion-1",
-                sequence: 1,
-                from_state: null,
-                to_state: "Proposed",
-                authority: "proposer",
-                recorded_at: "2024-01-01T00:00:00Z",
-              },
-            ],
-          },
+        history: {
+          assertion_id: "assertion-1",
+          effective_from: "2024-01-01T00:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T00:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T00:00:00Z",
+          effective_at: "2024-01-01T00:00:00Z",
+          events: [
+            {
+              event_id: "event-1",
+              assertion_id: "assertion-1",
+              sequence: 1,
+              from_state: null,
+              to_state: "Proposed",
+              authority: "proposer",
+              recorded_at: "2024-01-01T00:00:00Z",
+            },
+          ],
         },
-      });
+      },
+    });
+
+    it("selects a relationship via keyboard navigation using tab and Enter/Space key", async () => {
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
+        createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1")
+      );
 
       const user = userEvent.setup();
       render(<NetworkVisualization data={governedData} />);
@@ -280,7 +308,8 @@ describe("NetworkVisualization Component", () => {
       }
       expect(reachedButton).toBe(true);
 
-      await user.keyboard("{Enter}");
+      // Verify Space key activation
+      await user.keyboard(" ");
 
       expect(canonicalButton).toHaveAttribute("aria-pressed", "true");
       await waitFor(() => {
@@ -297,50 +326,37 @@ describe("NetworkVisualization Component", () => {
       });
     });
 
+    it("selects a relationship via Plotly customdata click", async () => {
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
+        createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1")
+      );
+
+      const user = userEvent.setup();
+      render(<NetworkVisualization data={governedData} />);
+
+      const trigger = screen.getByTestId("plot-click-trigger");
+      await user.click(trigger);
+
+      const canonicalButton = screen.getByRole("button", {
+        name: /ASSET_2.*ASSET_1.*CORPORATE_LINK.*Governed/,
+      });
+      expect(canonicalButton).toHaveAttribute("aria-pressed", "true");
+
+      await waitFor(() => {
+        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+          "pub-1",
+          "pedge-1",
+          expect.anything(),
+        );
+      });
+    });
+
     it("allows canonical and reverse representations to select independently by their edge_id", async () => {
-      mockedApi.getPublishedEdgeExplanation.mockResolvedValue({
-        publication: governedData.publication!,
-        edge: {
-          projection_edge_id: "pedge-2",
-          source: "ASSET_1",
-          target: "ASSET_2",
-          relationship_type: "CORPORATE_LINK",
-          strength: "0.90",
-          direction: "directional",
-          assertion_id: "assertion-1",
-        },
-        assertion: {
-          explanation: {
-            assertion_id: "assertion-1",
-            predicate_id: "predicate-issuer",
-            subject_id: "ASSET_2",
-            object_id: "ASSET_1",
-            method_id: "method-1",
-            proposition: "ASSET_2 is the issuer of ASSET_1",
-            confidence_status: "not_assessed",
-            confidence_bp: null,
-            confidence_type: null,
-            confidence_method: null,
-            effective_from: "2024-01-01T00:00:00Z",
-            effective_to: null,
-            recorded_at: "2024-01-01T00:00:00Z",
-            state: "Accepted",
-            known_at: "2024-01-01T00:00:00Z",
-            effective_at: "2024-01-01T00:00:00Z",
-            sequence: 1,
-            evidence: [],
-          },
-          history: {
-            assertion_id: "assertion-1",
-            effective_from: "2024-01-01T00:00:00Z",
-            effective_to: null,
-            recorded_at: "2024-01-01T00:00:00Z",
-            state: "Accepted",
-            known_at: "2024-01-01T00:00:00Z",
-            effective_at: "2024-01-01T00:00:00Z",
-            events: [],
-          },
-        },
+      mockedApi.getPublishedEdgeExplanation.mockImplementation((pubId, projectionEdgeId) => {
+        if (projectionEdgeId === "pedge-1") {
+          return Promise.resolve(createMockExplanation("pedge-1", "ASSET_2", "ASSET_1", "ASSET_2 is the issuer of ASSET_1"));
+        }
+        return Promise.resolve(createMockExplanation("pedge-2", "ASSET_1", "ASSET_2", "ASSET_1 is the issuer of ASSET_2"));
       });
 
       const user = userEvent.setup();
@@ -353,16 +369,22 @@ describe("NetworkVisualization Component", () => {
         name: /ASSET_1.*ASSET_2.*CORPORATE_LINK.*Governed/,
       });
 
+      // Select reverse representation
       await user.click(reverseButton);
       expect(reverseButton).toHaveAttribute("aria-pressed", "true");
       expect(canonicalButton).toHaveAttribute("aria-pressed", "false");
 
       await waitFor(() => {
-        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
-          "pub-1",
-          "pedge-2",
-          expect.anything(),
-        );
+        expect(screen.getByText("ASSET_1 is the issuer of ASSET_2")).toBeInTheDocument();
+      });
+
+      // Select canonical representation
+      await user.click(canonicalButton);
+      expect(canonicalButton).toHaveAttribute("aria-pressed", "true");
+      expect(reverseButton).toHaveAttribute("aria-pressed", "false");
+
+      await waitFor(() => {
+        expect(screen.getByText("ASSET_2 is the issuer of ASSET_1")).toBeInTheDocument();
       });
     });
   });

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -37,6 +37,16 @@ const governedWithoutProjectionEdgeId: ExplainableRelationship = {
   projection_edge_id: null,
 };
 
+const governedWithoutAssertionId: ExplainableRelationship = {
+  ...governedRelationship,
+  assertion_id: null,
+};
+
+const governedWithoutRevisionId: ExplainableRelationship = {
+  ...governedRelationship,
+  revision_id: null,
+};
+
 const mockPublication: PublishedProjectionContextResponse = {
   publication_id: "pub-1",
   revision_id: "rev-1",
@@ -158,10 +168,14 @@ describe("RelationshipExplanationPanel", () => {
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
-  it("shows a pending metadata view for a governed edge with incomplete projection edge metadata", () => {
+  it.each([
+    ["projection_edge_id", governedWithoutProjectionEdgeId],
+    ["assertion_id", governedWithoutAssertionId],
+    ["revision_id", governedWithoutRevisionId],
+  ])("shows a pending metadata view for a governed edge with incomplete %s", (_, relationshipFixture) => {
     render(
       <RelationshipExplanationPanel
-        relationship={governedWithoutProjectionEdgeId}
+        relationship={relationshipFixture}
         publicationId="pub-1"
       />,
     );
@@ -366,5 +380,41 @@ describe("RelationshipExplanationPanel", () => {
     );
 
     expect(screen.getByText("Legacy")).toBeInTheDocument();
+
+    // Rerender with governedRelationship and a different publicationId ("pub-2") after legacy transition
+    const pub2ExplanationResponse = {
+      ...baseExplanationResponse,
+      publication: {
+        ...baseExplanationResponse.publication,
+        publication_id: "pub-2",
+      },
+    };
+
+    let resolvePub2: (value: PublishedEdgeExplanationResponse) => void = () => {};
+    const pub2Promise = new Promise<PublishedEdgeExplanationResponse>((resolve) => {
+      resolvePub2 = resolve;
+    });
+    mockedApi.getPublishedEdgeExplanation.mockReturnValue(pub2Promise);
+
+    rerender(
+      <RelationshipExplanationPanel
+        relationship={governedRelationship}
+        publicationId="pub-2"
+      />,
+    );
+
+    // Stale-state suppression: should show the loading view because requestKey has changed
+    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
+
+    // Resolve the second fetch
+    resolvePub2(pub2ExplanationResponse);
+
+    await waitFor(() => {
+      expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenLastCalledWith(
+        "pub-2",
+        "pedge-1",
+        expect.anything(),
+      );
+    });
   });
 });

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -172,20 +172,23 @@ describe("RelationshipExplanationPanel", () => {
     ["projection_edge_id", governedWithoutProjectionEdgeId],
     ["assertion_id", governedWithoutAssertionId],
     ["revision_id", governedWithoutRevisionId],
-  ])("shows a pending metadata view for a governed edge with incomplete %s", (_, relationshipFixture) => {
-    render(
-      <RelationshipExplanationPanel
-        relationship={relationshipFixture}
-        publicationId="pub-1"
-      />,
-    );
-    expect(
-      screen.getByText(
-        /governed, but its publication or edge metadata is incomplete/,
-      ),
-    ).toBeInTheDocument();
-    expect(mockedApi.getPublishedEdgeExplanation).not.toHaveBeenCalled();
-  });
+  ])(
+    "shows a pending metadata view for a governed edge with incomplete %s",
+    (_, relationshipFixture) => {
+      render(
+        <RelationshipExplanationPanel
+          relationship={relationshipFixture}
+          publicationId="pub-1"
+        />,
+      );
+      expect(
+        screen.getByText(
+          /governed, but its publication or edge metadata is incomplete/,
+        ),
+      ).toBeInTheDocument();
+      expect(mockedApi.getPublishedEdgeExplanation).not.toHaveBeenCalled();
+    },
+  );
 
   it("renders the full publication-bound governed explanation once fetched", async () => {
     mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
@@ -390,10 +393,14 @@ describe("RelationshipExplanationPanel", () => {
       },
     };
 
-    let resolvePub2: (value: PublishedEdgeExplanationResponse) => void = () => {};
-    const pub2Promise = new Promise<PublishedEdgeExplanationResponse>((resolve) => {
-      resolvePub2 = resolve;
-    });
+    let resolvePub2: (
+      value: PublishedEdgeExplanationResponse,
+    ) => void = () => {};
+    const pub2Promise = new Promise<PublishedEdgeExplanationResponse>(
+      (resolve) => {
+        resolvePub2 = resolve;
+      },
+    );
     mockedApi.getPublishedEdgeExplanation.mockReturnValue(pub2Promise);
 
     rerender(
@@ -404,7 +411,9 @@ describe("RelationshipExplanationPanel", () => {
     );
 
     // Stale-state suppression: should show the loading view because requestKey has changed
-    expect(screen.getByText("Loading governed explanation...")).toBeInTheDocument();
+    expect(
+      screen.getByText("Loading governed explanation..."),
+    ).toBeInTheDocument();
 
     // Resolve the second fetch
     resolvePub2(pub2ExplanationResponse);

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -1,7 +1,3 @@
-/**
- * Focused unit + accessibility tests for RelationshipExplanationPanel.
- */
-
 import React from "react";
 import { render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
@@ -10,8 +6,8 @@ import RelationshipExplanationPanel, {
 } from "../../app/components/RelationshipExplanationPanel";
 import { api } from "../../app/lib/api";
 import type {
-  AssertionExplanation,
-  AssertionHistory,
+  PublishedEdgeExplanationResponse,
+  PublishedProjectionContextResponse,
 } from "../../app/types/api";
 
 jest.mock("../../app/lib/api");
@@ -33,77 +29,111 @@ const governedRelationship: ExplainableRelationship = {
   governance_status: "governed",
   revision_id: "rev-1",
   scope_refs: ["predicate-issuer"],
+  projection_edge_id: "pedge-1",
 };
 
-const governedWithoutAssertionId: ExplainableRelationship = {
+const governedWithoutProjectionEdgeId: ExplainableRelationship = {
   ...governedRelationship,
-  assertion_id: null,
+  projection_edge_id: null,
 };
 
-const baseExplanation: AssertionExplanation = {
-  assertion_id: "assertion-1",
-  predicate_id: "predicate-issuer",
-  subject_id: "ASSET_1",
-  object_id: "ASSET_3",
-  method_id: "method-1",
-  proposition: "ASSET_1 is the issuer of ASSET_3",
-  confidence_status: "assessed",
-  confidence_bp: 9500,
-  confidence_type: "statistical",
-  confidence_method: "manual-review",
-  effective_from: "2024-01-01T00:00:00Z",
-  effective_to: null,
-  recorded_at: "2024-01-01T00:00:00Z",
-  state: "Accepted",
-  known_at: "2024-01-01T00:00:00Z",
-  effective_at: "2024-01-01T00:00:00Z",
-  sequence: 2,
-  evidence: [
+const mockPublication: PublishedProjectionContextResponse = {
+  publication_id: "pub-1",
+  revision_id: "rev-1",
+  rebuild_job_id: "job-100",
+  execution_id: "exec-200",
+  published_at: "2024-01-01T12:00:00Z",
+  purpose: "financial-relationship-graph",
+  effective_at: "2024-01-01T12:00:00Z",
+  known_at: "2024-01-01T12:00:00Z",
+  contract_version: "grac-v1",
+  projector_version: "v1.2.3",
+  edge_set_hash: "sha256-edge-hash-val",
+  projection_hash: "sha256-proj-hash-val",
+  governed_scopes: [
     {
-      evidence_id: "evidence-public",
-      polarity: "supporting",
-      visibility: "public",
-      redacted: false,
-      source_ref: "https://example.com/filing",
-      content_sha256: "abc123",
-    },
-    {
-      evidence_id: "evidence-restricted",
-      polarity: "supporting",
-      visibility: "restricted",
-      redacted: true,
+      purpose: "financial-relationship-graph",
+      predicate_id: "predicate-issuer",
     },
   ],
 };
 
-const baseHistory: AssertionHistory = {
-  assertion_id: "assertion-1",
-  effective_from: "2024-01-01T00:00:00Z",
-  effective_to: null,
-  recorded_at: "2024-01-01T00:00:00Z",
-  state: "Accepted",
-  known_at: "2024-01-01T00:00:00Z",
-  effective_at: "2024-01-01T00:00:00Z",
-  events: [
-    {
-      event_id: "event-1",
+const baseExplanationResponse: PublishedEdgeExplanationResponse = {
+  publication: mockPublication,
+  edge: {
+    projection_edge_id: "pedge-1",
+    source: "ASSET_1",
+    target: "ASSET_3",
+    relationship_type: "CORPORATE_LINK",
+    strength: "0.50",
+    direction: "directional",
+    assertion_id: "assertion-1",
+  },
+  assertion: {
+    explanation: {
       assertion_id: "assertion-1",
-      sequence: 1,
-      from_state: null,
-      to_state: "Proposed",
-      authority: "proposer",
+      predicate_id: "predicate-issuer",
+      subject_id: "ASSET_1",
+      object_id: "ASSET_3",
+      method_id: "method-1",
+      proposition: "ASSET_1 is the issuer of ASSET_3",
+      confidence_status: "assessed",
+      confidence_bp: 9500,
+      confidence_type: "statistical",
+      confidence_method: "manual-review",
+      effective_from: "2024-01-01T00:00:00Z",
+      effective_to: null,
       recorded_at: "2024-01-01T00:00:00Z",
-    },
-    {
-      event_id: "event-2",
-      assertion_id: "assertion-1",
+      state: "Accepted",
+      known_at: "2024-01-01T00:00:00Z",
+      effective_at: "2024-01-01T00:00:00Z",
       sequence: 2,
-      from_state: "Proposed",
-      to_state: "Accepted",
-      authority: "acceptor",
-      recorded_at: "2024-01-02T00:00:00Z",
+      evidence: [
+        {
+          evidence_id: "evidence-public",
+          polarity: "supporting",
+          visibility: "public",
+          redacted: false,
+          source_ref: "https://example.com/filing",
+        },
+        {
+          evidence_id: "evidence-restricted",
+          polarity: "supporting",
+          visibility: "restricted",
+          redacted: true,
+        },
+      ],
     },
-  ],
+    history: {
+      assertion_id: "assertion-1",
+      effective_from: "2024-01-01T00:00:00Z",
+      effective_to: null,
+      recorded_at: "2024-01-01T00:00:00Z",
+      state: "Accepted",
+      known_at: "2024-01-01T00:00:00Z",
+      effective_at: "2024-01-01T00:00:00Z",
+      events: [
+        {
+          event_id: "event-1",
+          assertion_id: "assertion-1",
+          sequence: 1,
+          from_state: null,
+          to_state: "Proposed",
+          authority: "proposer",
+          recorded_at: "2024-01-01T00:00:00Z",
+        },
+        {
+          event_id: "event-2",
+          assertion_id: "assertion-1",
+          sequence: 2,
+          from_state: "Proposed",
+          to_state: "Accepted",
+          authority: "acceptor",
+          recorded_at: "2024-01-02T00:00:00Z",
+        },
+      ],
+    },
+  },
 };
 
 describe("RelationshipExplanationPanel", () => {
@@ -116,6 +146,7 @@ describe("RelationshipExplanationPanel", () => {
     expect(
       screen.getByText("Select a relationship to see how it was determined."),
     ).toBeInTheDocument();
+    expect(mockedApi.getPublishedEdgeExplanation).not.toHaveBeenCalled();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
@@ -123,29 +154,33 @@ describe("RelationshipExplanationPanel", () => {
     render(<RelationshipExplanationPanel relationship={legacyRelationship} />);
     expect(screen.getByText("Legacy")).toBeInTheDocument();
     expect(screen.getByText(/outside any governed scope/)).toBeInTheDocument();
+    expect(mockedApi.getPublishedEdgeExplanation).not.toHaveBeenCalled();
     expect(mockedApi.getAssertion).not.toHaveBeenCalled();
   });
 
-  it("shows a bounded unavailable state for a governed edge with no assertion id", () => {
+  it("shows a pending metadata view for a governed edge with incomplete projection edge metadata", () => {
     render(
       <RelationshipExplanationPanel
-        relationship={governedWithoutAssertionId}
+        relationship={governedWithoutProjectionEdgeId}
+        publicationId="pub-1"
       />,
     );
     expect(
       screen.getByText(
-        /governed, but its assertion metadata is not yet available/,
+        /governed, but its publication or edge metadata is incomplete/,
       ),
     ).toBeInTheDocument();
-    expect(mockedApi.getAssertion).not.toHaveBeenCalled();
+    expect(mockedApi.getPublishedEdgeExplanation).not.toHaveBeenCalled();
   });
 
-  it("renders the full governed explanation once fetched", async () => {
-    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
-    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
+  it("renders the full publication-bound governed explanation once fetched", async () => {
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(baseExplanationResponse);
 
     render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
+      <RelationshipExplanationPanel
+        relationship={governedRelationship}
+        publicationId="pub-1"
+      />,
     );
 
     expect(
@@ -158,71 +193,123 @@ describe("RelationshipExplanationPanel", () => {
       ).toBeInTheDocument();
     });
 
-    // Confidence vs. projection strength are shown as distinct facts.
-    expect(screen.getByText(/statistical/)).toBeInTheDocument();
-    expect(screen.getByText(/0\.50/)).toBeInTheDocument();
+    // Proves single bundled request called without generic assertion fallback or client temporal authority
+    expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledTimes(1);
+    expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+      "pub-1",
+      "pedge-1",
+      expect.anything(),
+    );
+    expect(mockedApi.getAssertion).not.toHaveBeenCalled();
 
-    // Public evidence shows its digest; restricted evidence never leaks a body/reference.
-    expect(screen.getByText(/SHA-256: abc123/)).toBeInTheDocument();
+    // Confidence vs projection strength distinct facts
+    expect(screen.getByText(/statistical/)).toBeInTheDocument();
+    expect(screen.getAllByText(/0\.50/).length).toBeGreaterThan(0);
+
+    // Public evidence shows source ref; restricted evidence never leaks a body
+    expect(screen.getByText(/Source ref: https:\/\/example\.com\/filing/)).toBeInTheDocument();
     expect(
       screen.getByText(/Evidence body and restricted references are not shown/),
     ).toBeInTheDocument();
 
-    // Proposer and determining authority are distinct, identity-redacted roles.
+    // Authority roles
     expect(screen.getAllByText(/Proposer of record/).length).toBeGreaterThan(0);
     expect(
       screen.getAllByText(/Determining authority \(acceptor\)/).length,
     ).toBeGreaterThan(0);
+
+    // Publication provenance details rendered
+    expect(screen.getByText("pub-1")).toBeInTheDocument();
+    expect(screen.getByText("job-100")).toBeInTheDocument();
+    expect(screen.getByText("exec-200")).toBeInTheDocument();
+    expect(screen.getByText("grac-v1")).toBeInTheDocument();
+    expect(screen.getByText("v1.2.3")).toBeInTheDocument();
+    expect(screen.getByText("sha256-edge-hash-val")).toBeInTheDocument();
+    expect(screen.getByText("sha256-proj-hash-val")).toBeInTheDocument();
+    expect(screen.getByText("(financial-relationship-graph, predicate-issuer)")).toBeInTheDocument();
   });
 
   it.each([
     { httpStatus: 404, expectedText: /could not be found/ },
     { httpStatus: 503, expectedText: /temporarily unavailable/ },
   ])(
-    "shows a bounded state without fabricating governance facts on a $httpStatus failure",
+    "shows a bounded state without fallback to generic assertion endpoints on $httpStatus failure",
     async ({ httpStatus, expectedText }) => {
-      mockedApi.getAssertion.mockRejectedValue({
-        response: { status: httpStatus },
-      });
-      mockedApi.getAssertionHistory.mockRejectedValue({
+      mockedApi.getPublishedEdgeExplanation.mockRejectedValue({
         response: { status: httpStatus },
       });
 
       render(
-        <RelationshipExplanationPanel relationship={governedRelationship} />,
+        <RelationshipExplanationPanel
+          relationship={governedRelationship}
+          publicationId="pub-1"
+        />,
       );
 
       await waitFor(() => {
         expect(screen.getByText(expectedText)).toBeInTheDocument();
       });
+      expect(mockedApi.getAssertion).not.toHaveBeenCalled();
     },
   );
 
-  it("shows superseded chain information when a successor is recorded", async () => {
-    mockedApi.getAssertion.mockResolvedValue({
-      ...baseExplanation,
-      state: "Superseded",
+  it("maps defensive response-identity mismatches to unavailable view", async () => {
+    const mismatchedResponse: PublishedEdgeExplanationResponse = {
+      ...baseExplanationResponse,
+      edge: {
+        ...baseExplanationResponse.edge,
+        projection_edge_id: "mismatched-edge-id",
+      },
+    };
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(mismatchedResponse);
+
+    render(
+      <RelationshipExplanationPanel
+        relationship={governedRelationship}
+        publicationId="pub-1"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Governance explanation is temporarily unavailable/),
+      ).toBeInTheDocument();
     });
-    mockedApi.getAssertionHistory.mockResolvedValue({
-      ...baseHistory,
-      state: "Superseded",
-      events: [
-        ...baseHistory.events,
-        {
-          event_id: "event-3",
-          assertion_id: "assertion-1",
-          sequence: 3,
-          from_state: "Accepted",
-          to_state: "Superseded",
-          authority: "acceptor",
-          recorded_at: "2024-02-01T00:00:00Z",
-          successor_assertion_id: "assertion-2",
+  });
+
+  it("shows superseded chain information when a successor is recorded", async () => {
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue({
+      ...baseExplanationResponse,
+      assertion: {
+        explanation: {
+          ...baseExplanationResponse.assertion.explanation,
+          state: "Superseded",
         },
-      ],
+        history: {
+          ...baseExplanationResponse.assertion.history,
+          state: "Superseded",
+          events: [
+            ...baseExplanationResponse.assertion.history.events,
+            {
+              event_id: "event-3",
+              assertion_id: "assertion-1",
+              sequence: 3,
+              from_state: "Accepted",
+              to_state: "Superseded",
+              authority: "acceptor",
+              recorded_at: "2024-02-01T00:00:00Z",
+              successor_assertion_id: "assertion-2",
+            },
+          ],
+        },
+      },
     });
 
     render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
+      <RelationshipExplanationPanel
+        relationship={governedRelationship}
+        publicationId="pub-1"
+      />,
     );
 
     await waitFor(() => {
@@ -245,43 +332,29 @@ describe("RelationshipExplanationPanel", () => {
     ).toBeGreaterThan(0);
   });
 
-  it("passes identical as-of bounds to both the explanation and history requests", async () => {
-    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
-    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
-
-    render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
-    );
-
-    await waitFor(() => {
-      expect(mockedApi.getAssertion).toHaveBeenCalledTimes(1);
-      expect(mockedApi.getAssertionHistory).toHaveBeenCalledTimes(1);
-    });
-
-    const explanationParams = mockedApi.getAssertion.mock.calls[0][1];
-    const historyParams = mockedApi.getAssertionHistory.mock.calls[0][1];
-    expect(explanationParams).toBeDefined();
-    expect(explanationParams).toEqual(historyParams);
-  });
-
-  it("re-fetches when the selected relationship changes and no stale state leaks through", async () => {
-    mockedApi.getAssertion.mockResolvedValue(baseExplanation);
-    mockedApi.getAssertionHistory.mockResolvedValue(baseHistory);
+  it("re-fetches when the selected relationship or publication changes and suppresses stale state", async () => {
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(baseExplanationResponse);
 
     const { rerender } = render(
-      <RelationshipExplanationPanel relationship={governedRelationship} />,
+      <RelationshipExplanationPanel
+        relationship={governedRelationship}
+        publicationId="pub-1"
+      />,
     );
 
     await waitFor(() => {
-      expect(mockedApi.getAssertion).toHaveBeenCalledWith(
-        "assertion-1",
-        expect.objectContaining({ known_at: expect.any(String) }),
+      expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+        "pub-1",
+        "pedge-1",
         expect.anything(),
       );
     });
 
     rerender(
-      <RelationshipExplanationPanel relationship={legacyRelationship} />,
+      <RelationshipExplanationPanel
+        relationship={legacyRelationship}
+        publicationId="pub-1"
+      />,
     );
 
     expect(screen.getByText("Legacy")).toBeInTheDocument();

--- a/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
+++ b/frontend/__tests__/components/RelationshipExplanationPanel.test.tsx
@@ -174,7 +174,9 @@ describe("RelationshipExplanationPanel", () => {
   });
 
   it("renders the full publication-bound governed explanation once fetched", async () => {
-    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(baseExplanationResponse);
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
+      baseExplanationResponse,
+    );
 
     render(
       <RelationshipExplanationPanel
@@ -207,7 +209,9 @@ describe("RelationshipExplanationPanel", () => {
     expect(screen.getAllByText(/0\.50/).length).toBeGreaterThan(0);
 
     // Public evidence shows source ref; restricted evidence never leaks a body
-    expect(screen.getByText(/Source ref: https:\/\/example\.com\/filing/)).toBeInTheDocument();
+    expect(
+      screen.getByText(/Source ref: https:\/\/example\.com\/filing/),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(/Evidence body and restricted references are not shown/),
     ).toBeInTheDocument();
@@ -226,7 +230,9 @@ describe("RelationshipExplanationPanel", () => {
     expect(screen.getByText("v1.2.3")).toBeInTheDocument();
     expect(screen.getByText("sha256-edge-hash-val")).toBeInTheDocument();
     expect(screen.getByText("sha256-proj-hash-val")).toBeInTheDocument();
-    expect(screen.getByText("(financial-relationship-graph, predicate-issuer)")).toBeInTheDocument();
+    expect(
+      screen.getByText("(financial-relationship-graph, predicate-issuer)"),
+    ).toBeInTheDocument();
   });
 
   it.each([
@@ -333,7 +339,9 @@ describe("RelationshipExplanationPanel", () => {
   });
 
   it("re-fetches when the selected relationship or publication changes and suppresses stale state", async () => {
-    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(baseExplanationResponse);
+    mockedApi.getPublishedEdgeExplanation.mockResolvedValue(
+      baseExplanationResponse,
+    );
 
     const { rerender } = render(
       <RelationshipExplanationPanel

--- a/frontend/__tests__/integration/component-integration.test.tsx
+++ b/frontend/__tests__/integration/component-integration.test.tsx
@@ -392,8 +392,28 @@ describe("Component Integration Tests", () => {
 
     const dataA = {
       nodes: [
-        { id: "A1", name: "Asset 1", symbol: "A1", asset_class: "EQUITY", x: 1, y: 1, z: 1, color: "red", size: 1 },
-        { id: "A2", name: "Asset 2", symbol: "A2", asset_class: "EQUITY", x: 2, y: 2, z: 2, color: "blue", size: 1 },
+        {
+          id: "A1",
+          name: "Asset 1",
+          symbol: "A1",
+          asset_class: "EQUITY",
+          x: 1,
+          y: 1,
+          z: 1,
+          color: "red",
+          size: 1,
+        },
+        {
+          id: "A2",
+          name: "Asset 2",
+          symbol: "A2",
+          asset_class: "EQUITY",
+          x: 2,
+          y: 2,
+          z: 2,
+          color: "blue",
+          size: 1,
+        },
       ],
       edges: [
         {
@@ -415,8 +435,28 @@ describe("Component Integration Tests", () => {
 
     const dataB = {
       nodes: [
-        { id: "A1", name: "Asset 1", symbol: "A1", asset_class: "EQUITY", x: 1, y: 1, z: 1, color: "red", size: 1 },
-        { id: "A2", name: "Asset 2", symbol: "A2", asset_class: "EQUITY", x: 2, y: 2, z: 2, color: "blue", size: 1 },
+        {
+          id: "A1",
+          name: "Asset 1",
+          symbol: "A1",
+          asset_class: "EQUITY",
+          x: 1,
+          y: 1,
+          z: 1,
+          color: "red",
+          size: 1,
+        },
+        {
+          id: "A2",
+          name: "Asset 2",
+          symbol: "A2",
+          asset_class: "EQUITY",
+          x: 2,
+          y: 2,
+          z: 2,
+          color: "blue",
+          size: 1,
+        },
       ],
       edges: [
         {
@@ -561,7 +601,9 @@ describe("Component Integration Tests", () => {
       });
 
       // 6. Verifies no replacement edge is silently selected
-      expect(screen.getByText("Select a relationship to see how it was determined.")).toBeInTheDocument();
+      expect(
+        screen.getByText("Select a relationship to see how it was determined."),
+      ).toBeInTheDocument();
 
       // 7. Selects publication-B’s edge and confirms the request and displayed provenance use publication B
       const edgeBButton = screen.getByRole("button", {

--- a/frontend/__tests__/integration/component-integration.test.tsx
+++ b/frontend/__tests__/integration/component-integration.test.tsx
@@ -355,4 +355,231 @@ describe("Component Integration Tests", () => {
       });
     });
   });
+
+  describe("Parent-to-Child Publication-Envelope Integration", () => {
+    const ActualNetworkVisualization = jest.requireActual(
+      "../../app/components/NetworkVisualization",
+    ).default;
+
+    const publicationA = {
+      publication_id: "pub-A",
+      revision_id: "rev-A",
+      rebuild_job_id: "job-100",
+      execution_id: "exec-200",
+      published_at: "2024-01-01T12:00:00Z",
+      purpose: "financial-relationship-graph",
+      effective_at: "2024-01-01T12:00:00Z",
+      known_at: "2024-01-01T12:00:00Z",
+      contract_version: "grac-v1",
+      projector_version: "v1.2.3",
+      edge_set_hash: "hash-edges-A",
+      projection_hash: "hash-proj-A",
+      governed_scopes: [
+        {
+          purpose: "financial-relationship-graph",
+          predicate_id: "predicate-issuer",
+        },
+      ],
+    };
+
+    const publicationB = {
+      ...publicationA,
+      publication_id: "pub-B",
+      revision_id: "rev-B",
+      edge_set_hash: "hash-edges-B",
+      projection_hash: "hash-proj-B",
+    };
+
+    const dataA = {
+      nodes: [
+        { id: "A1", name: "Asset 1", symbol: "A1", asset_class: "EQUITY", x: 1, y: 1, z: 1, color: "red", size: 1 },
+        { id: "A2", name: "Asset 2", symbol: "A2", asset_class: "EQUITY", x: 2, y: 2, z: 2, color: "blue", size: 1 },
+      ],
+      edges: [
+        {
+          edge_id: "edge-A",
+          projection_edge_id: "pedge-A",
+          source: "A1",
+          target: "A2",
+          relationship_type: "CORPORATE_LINK",
+          strength: 0.9,
+          assertion_id: "assert-A",
+          governance_status: "governed",
+          revision_id: "rev-A",
+          scope_refs: ["predicate-issuer"],
+        },
+      ],
+      network_density: 0.5,
+      publication: publicationA,
+    };
+
+    const dataB = {
+      nodes: [
+        { id: "A1", name: "Asset 1", symbol: "A1", asset_class: "EQUITY", x: 1, y: 1, z: 1, color: "red", size: 1 },
+        { id: "A2", name: "Asset 2", symbol: "A2", asset_class: "EQUITY", x: 2, y: 2, z: 2, color: "blue", size: 1 },
+      ],
+      edges: [
+        {
+          edge_id: "edge-B",
+          projection_edge_id: "pedge-B",
+          source: "A1",
+          target: "A2",
+          relationship_type: "CORPORATE_LINK",
+          strength: 0.85,
+          assertion_id: "assert-B",
+          governance_status: "governed",
+          revision_id: "rev-B",
+          scope_refs: ["predicate-issuer"],
+        },
+      ],
+      network_density: 0.5,
+      publication: publicationB,
+    };
+
+    const explanationA = {
+      publication: publicationA,
+      edge: {
+        projection_edge_id: "pedge-A",
+        source: "A1",
+        target: "A2",
+        relationship_type: "CORPORATE_LINK",
+        strength: "0.90",
+        direction: "directional",
+        assertion_id: "assert-A",
+      },
+      assertion: {
+        explanation: {
+          assertion_id: "assert-A",
+          predicate_id: "predicate-issuer",
+          subject_id: "A1",
+          object_id: "A2",
+          method_id: "m-1",
+          proposition: "A1 controls A2",
+          confidence_status: "assessed",
+          confidence_bp: 9000,
+          confidence_type: "statistical",
+          confidence_method: "filings",
+          effective_from: "2024-01-01T12:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T12:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T12:00:00Z",
+          effective_at: "2024-01-01T12:00:00Z",
+          sequence: 1,
+          evidence: [],
+        },
+        history: {
+          assertion_id: "assert-A",
+          effective_from: "2024-01-01T12:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T12:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T12:00:00Z",
+          effective_at: "2024-01-01T12:00:00Z",
+          events: [],
+        },
+      },
+    };
+
+    const explanationB = {
+      publication: publicationB,
+      edge: {
+        projection_edge_id: "pedge-B",
+        source: "A1",
+        target: "A2",
+        relationship_type: "CORPORATE_LINK",
+        strength: "0.85",
+        direction: "directional",
+        assertion_id: "assert-B",
+      },
+      assertion: {
+        explanation: {
+          assertion_id: "assert-B",
+          predicate_id: "predicate-issuer",
+          subject_id: "A1",
+          object_id: "A2",
+          method_id: "m-1",
+          proposition: "A1 has exposure to A2",
+          confidence_status: "assessed",
+          confidence_bp: 8500,
+          confidence_type: "statistical",
+          confidence_method: "filings",
+          effective_from: "2024-01-01T12:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T12:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T12:00:00Z",
+          effective_at: "2024-01-01T12:00:00Z",
+          sequence: 1,
+          evidence: [],
+        },
+        history: {
+          assertion_id: "assert-B",
+          effective_from: "2024-01-01T12:00:00Z",
+          effective_to: null,
+          recorded_at: "2024-01-01T12:00:00Z",
+          state: "Accepted",
+          known_at: "2024-01-01T12:00:00Z",
+          effective_at: "2024-01-01T12:00:00Z",
+          events: [],
+        },
+      },
+    };
+
+    it("verifies the parent-to-child publication envelope lifecycle", async () => {
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue(explanationA);
+
+      // 1. Render NetworkVisualization with publication A
+      const { rerender } = render(<ActualNetworkVisualization data={dataA} />);
+
+      // 2. Select its governed edge
+      const edgeAButton = screen.getByRole("button", {
+        name: /A1.*A2.*CORPORATE_LINK.*Governed/,
+      });
+      fireEvent.click(edgeAButton);
+
+      // 3. Resolves and displays publication-A explanation data
+      await waitFor(() => {
+        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenCalledWith(
+          "pub-A",
+          "pedge-A",
+          expect.anything(),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText("A1 controls A2")).toBeInTheDocument();
+        expect(screen.getByText("pub-A")).toBeInTheDocument();
+      });
+
+      // 4. Rerender with publication B, whose edge IDs differ
+      mockedApi.getPublishedEdgeExplanation.mockResolvedValue(explanationB);
+      rerender(<ActualNetworkVisualization data={dataB} />);
+
+      // 5. Verifies the publication-A explanation disappears
+      await waitFor(() => {
+        expect(screen.queryByText("A1 controls A2")).not.toBeInTheDocument();
+      });
+
+      // 6. Verifies no replacement edge is silently selected
+      expect(screen.getByText("Select a relationship to see how it was determined.")).toBeInTheDocument();
+
+      // 7. Selects publication-B’s edge and confirms the request and displayed provenance use publication B
+      const edgeBButton = screen.getByRole("button", {
+        name: /A1.*A2.*CORPORATE_LINK.*Governed/,
+      });
+      fireEvent.click(edgeBButton);
+
+      await waitFor(() => {
+        expect(mockedApi.getPublishedEdgeExplanation).toHaveBeenLastCalledWith(
+          "pub-B",
+          "pedge-B",
+          expect.anything(),
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText("A1 has exposure to A2")).toBeInTheDocument();
+        expect(screen.getByText("pub-B")).toBeInTheDocument();
+      });
+    });
+  });
 });

--- a/frontend/__tests__/test-utils.test.ts
+++ b/frontend/__tests__/test-utils.test.ts
@@ -505,6 +505,7 @@ describe("test-utils Mock Data Validation", () => {
 
     it("should have valid edge structure", () => {
       mockVizData.edges.forEach((edge) => {
+        expect(typeof edge.edge_id).toBe("string");
         expect(typeof edge.source).toBe("string");
         expect(typeof edge.target).toBe("string");
         expect(typeof edge.relationship_type).toBe("string");

--- a/frontend/__tests__/test-utils.test.ts
+++ b/frontend/__tests__/test-utils.test.ts
@@ -450,6 +450,8 @@ describe("test-utils Mock Data Validation", () => {
 
     it("should have edges with valid data types", () => {
       mockVisualizationData.edges.forEach((edge) => {
+        expect(typeof edge.edge_id).toBe("string");
+        expect(edge.edge_id.trim().length).toBeGreaterThan(0);
         expect(typeof edge.source).toBe("string");
         expect(typeof edge.target).toBe("string");
         expect(typeof edge.relationship_type).toBe("string");
@@ -506,6 +508,7 @@ describe("test-utils Mock Data Validation", () => {
     it("should have valid edge structure", () => {
       mockVizData.edges.forEach((edge) => {
         expect(typeof edge.edge_id).toBe("string");
+        expect(edge.edge_id.trim().length).toBeGreaterThan(0);
         expect(typeof edge.source).toBe("string");
         expect(typeof edge.target).toBe("string");
         expect(typeof edge.relationship_type).toBe("string");

--- a/frontend/__tests__/test-utils.ts
+++ b/frontend/__tests__/test-utils.ts
@@ -133,6 +133,7 @@ export const mockVisualizationData: VisualizationData = {
   ],
   edges: [
     {
+      edge_id: "edge-1",
       source: "ASSET_1",
       target: "ASSET_2",
       relationship_type: "TEST",
@@ -169,6 +170,7 @@ export const mockVizData: VisualizationData = {
   ],
   edges: [
     {
+      edge_id: "edge-viz-1",
       source: "ASSET_1",
       target: "ASSET_2",
       relationship_type: "COMMODITY_EXPOSURE",
@@ -176,4 +178,93 @@ export const mockVizData: VisualizationData = {
     },
   ],
   network_density: 0.42,
+};
+
+export const mockPublishedProjectionContext = {
+  publication_id: "pub-1",
+  revision_id: "rev-1",
+  rebuild_job_id: "job-1",
+  execution_id: "exec-1",
+  published_at: "2024-01-01T00:00:00Z",
+  purpose: "financial-relationship-graph",
+  effective_at: "2024-01-01T00:00:00Z",
+  known_at: "2024-01-01T00:00:00Z",
+  contract_version: "grac-v1",
+  projector_version: "v1.0.0",
+  edge_set_hash: "sha256-edges-123",
+  projection_hash: "sha256-proj-456",
+  governed_scopes: [
+    {
+      purpose: "financial-relationship-graph",
+      predicate_id: "predicate-issuer",
+    },
+  ],
+};
+
+export const mockPublishedProjectionEdge = {
+  projection_edge_id: "pedge-1",
+  source: "ASSET_2",
+  target: "ASSET_1",
+  relationship_type: "CORPORATE_LINK",
+  strength: "0.90",
+  direction: "directional",
+  assertion_id: "assertion-1",
+};
+
+export const mockPublishedAssertionBundle = {
+  explanation: {
+    assertion_id: "assertion-1",
+    predicate_id: "predicate-issuer",
+    subject_id: "ASSET_2",
+    object_id: "ASSET_1",
+    method_id: "method-1",
+    proposition: "ASSET_2 is the issuer of ASSET_1",
+    confidence_status: "assessed" as const,
+    confidence_bp: 9500,
+    confidence_type: "statistical",
+    confidence_method: "historical_filings",
+    effective_from: "2024-01-01T00:00:00Z",
+    effective_to: null,
+    recorded_at: "2024-01-01T00:00:00Z",
+    state: "Accepted" as const,
+    known_at: "2024-01-01T00:00:00Z",
+    effective_at: "2024-01-01T00:00:00Z",
+    sequence: 1,
+    evidence: [],
+  },
+  history: {
+    assertion_id: "assertion-1",
+    effective_from: "2024-01-01T00:00:00Z",
+    effective_to: null,
+    recorded_at: "2024-01-01T00:00:00Z",
+    state: "Accepted" as const,
+    known_at: "2024-01-01T00:00:00Z",
+    effective_at: "2024-01-01T00:00:00Z",
+    events: [
+      {
+        event_id: "event-1",
+        assertion_id: "assertion-1",
+        sequence: 1,
+        from_state: null,
+        to_state: "Proposed" as const,
+        authority: "proposer" as const,
+        recorded_at: "2024-01-01T00:00:00Z",
+      },
+      {
+        event_id: "event-2",
+        assertion_id: "assertion-1",
+        sequence: 2,
+        from_state: "Proposed" as const,
+        to_state: "Accepted" as const,
+        authority: "acceptor" as const,
+        recorded_at: "2024-01-01T00:00:00Z",
+      },
+    ],
+  },
+};
+
+export const mockPublishedEdgeExplanation = {
+  publication: mockPublishedProjectionContext,
+  edge: mockPublishedProjectionEdge,
+  assertion: mockPublishedAssertionBundle,
 };

--- a/frontend/__tests__/test-utils.ts
+++ b/frontend/__tests__/test-utils.ts
@@ -4,6 +4,10 @@ import type {
   Relationship,
   Metrics,
   VisualizationData,
+  PublishedProjectionContextResponse,
+  PublishedProjectionEdgeResponse,
+  PublishedAssertionBundleResponse,
+  PublishedEdgeExplanationResponse,
 } from "../../app/types/api";
 
 export const mockAssets: Asset[] = [
@@ -180,7 +184,7 @@ export const mockVizData: VisualizationData = {
   network_density: 0.42,
 };
 
-export const mockPublishedProjectionContext = {
+export const mockPublishedProjectionContext: PublishedProjectionContextResponse = {
   publication_id: "pub-1",
   revision_id: "rev-1",
   rebuild_job_id: "job-1",
@@ -201,7 +205,7 @@ export const mockPublishedProjectionContext = {
   ],
 };
 
-export const mockPublishedProjectionEdge = {
+export const mockPublishedProjectionEdge: PublishedProjectionEdgeResponse = {
   projection_edge_id: "pedge-1",
   source: "ASSET_2",
   target: "ASSET_1",
@@ -211,7 +215,7 @@ export const mockPublishedProjectionEdge = {
   assertion_id: "assertion-1",
 };
 
-export const mockPublishedAssertionBundle = {
+export const mockPublishedAssertionBundle: PublishedAssertionBundleResponse = {
   explanation: {
     assertion_id: "assertion-1",
     predicate_id: "predicate-issuer",
@@ -219,14 +223,14 @@ export const mockPublishedAssertionBundle = {
     object_id: "ASSET_1",
     method_id: "method-1",
     proposition: "ASSET_2 is the issuer of ASSET_1",
-    confidence_status: "assessed" as const,
+    confidence_status: "assessed",
     confidence_bp: 9500,
     confidence_type: "statistical",
     confidence_method: "historical_filings",
     effective_from: "2024-01-01T00:00:00Z",
     effective_to: null,
     recorded_at: "2024-01-01T00:00:00Z",
-    state: "Accepted" as const,
+    state: "Accepted",
     known_at: "2024-01-01T00:00:00Z",
     effective_at: "2024-01-01T00:00:00Z",
     sequence: 1,
@@ -237,7 +241,7 @@ export const mockPublishedAssertionBundle = {
     effective_from: "2024-01-01T00:00:00Z",
     effective_to: null,
     recorded_at: "2024-01-01T00:00:00Z",
-    state: "Accepted" as const,
+    state: "Accepted",
     known_at: "2024-01-01T00:00:00Z",
     effective_at: "2024-01-01T00:00:00Z",
     events: [
@@ -246,24 +250,24 @@ export const mockPublishedAssertionBundle = {
         assertion_id: "assertion-1",
         sequence: 1,
         from_state: null,
-        to_state: "Proposed" as const,
-        authority: "proposer" as const,
+        to_state: "Proposed",
+        authority: "proposer",
         recorded_at: "2024-01-01T00:00:00Z",
       },
       {
         event_id: "event-2",
         assertion_id: "assertion-1",
         sequence: 2,
-        from_state: "Proposed" as const,
-        to_state: "Accepted" as const,
-        authority: "acceptor" as const,
+        from_state: "Proposed",
+        to_state: "Accepted",
+        authority: "acceptor",
         recorded_at: "2024-01-01T00:00:00Z",
       },
     ],
   },
 };
 
-export const mockPublishedEdgeExplanation = {
+export const mockPublishedEdgeExplanation: PublishedEdgeExplanationResponse = {
   publication: mockPublishedProjectionContext,
   edge: mockPublishedProjectionEdge,
   assertion: mockPublishedAssertionBundle,

--- a/frontend/__tests__/test-utils.ts
+++ b/frontend/__tests__/test-utils.ts
@@ -184,26 +184,27 @@ export const mockVizData: VisualizationData = {
   network_density: 0.42,
 };
 
-export const mockPublishedProjectionContext: PublishedProjectionContextResponse = {
-  publication_id: "pub-1",
-  revision_id: "rev-1",
-  rebuild_job_id: "job-1",
-  execution_id: "exec-1",
-  published_at: "2024-01-01T00:00:00Z",
-  purpose: "financial-relationship-graph",
-  effective_at: "2024-01-01T00:00:00Z",
-  known_at: "2024-01-01T00:00:00Z",
-  contract_version: "grac-v1",
-  projector_version: "v1.0.0",
-  edge_set_hash: "sha256-edges-123",
-  projection_hash: "sha256-proj-456",
-  governed_scopes: [
-    {
-      purpose: "financial-relationship-graph",
-      predicate_id: "predicate-issuer",
-    },
-  ],
-};
+export const mockPublishedProjectionContext: PublishedProjectionContextResponse =
+  {
+    publication_id: "pub-1",
+    revision_id: "rev-1",
+    rebuild_job_id: "job-1",
+    execution_id: "exec-1",
+    published_at: "2024-01-01T00:00:00Z",
+    purpose: "financial-relationship-graph",
+    effective_at: "2024-01-01T00:00:00Z",
+    known_at: "2024-01-01T00:00:00Z",
+    contract_version: "grac-v1",
+    projector_version: "v1.0.0",
+    edge_set_hash: "sha256-edges-123",
+    projection_hash: "sha256-proj-456",
+    governed_scopes: [
+      {
+        purpose: "financial-relationship-graph",
+        predicate_id: "predicate-issuer",
+      },
+    ],
+  };
 
 export const mockPublishedProjectionEdge: PublishedProjectionEdgeResponse = {
   projection_edge_id: "pedge-1",

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -84,20 +84,10 @@ const MAX_NODES = Number(process.env.NEXT_PUBLIC_MAX_NODES) || 500;
 const MAX_EDGES = Number(process.env.NEXT_PUBLIC_MAX_EDGES) || 2000;
 
 /**
- * Derive a stable selection key for an edge. Governed edges are keyed by their
- * assertion ID (stable across data refreshes); legacy edges fall back to their
- * endpoint/type triple, which is stable as long as the relationship itself
- * does not change.
- */
-function edgeKey(edge: VisualizationEdge): string {
-  if (edge.assertion_id) return `assertion:${edge.assertion_id}`;
-  return `edge:${edge.source}|${edge.target}|${edge.relationship_type}`;
-}
-
-/**
  * Resolve edges against their endpoint nodes, skipping any edge whose source
- * or target node is missing. This is the single source of truth for "valid"
- * edges consumed by both the Plotly traces and the keyboard-accessible list.
+ * or target node is missing or whose edge_id is missing/empty. This is the single
+ * source of truth for "valid" edges consumed by both Plotly traces and the
+ * keyboard-accessible list.
  */
 function buildValidEdges(
   nodes: VisualizationData["nodes"],
@@ -107,17 +97,24 @@ function buildValidEdges(
   return edges.reduce<PreparedEdge[]>((acc, edge) => {
     const sourceNode = nodeMap.get(edge.source);
     const targetNode = nodeMap.get(edge.target);
+    const edgeId = edge.edge_id;
 
-    if (!sourceNode || !targetNode) {
+    if (
+      !sourceNode ||
+      !targetNode ||
+      !edgeId ||
+      typeof edgeId !== "string" ||
+      edgeId.trim() === ""
+    ) {
       if (process.env.NODE_ENV === "development") {
         console.debug(
-          `[Development Only] Skipping invalid edge: source ${edge.source} or target ${edge.target} not found.`,
+          `[Development Only] Skipping invalid edge: source ${edge.source}, target ${edge.target}, edge_id ${edgeId}.`,
         );
       }
       return acc;
     }
 
-    acc.push({ key: edgeKey(edge), edge, sourceNode, targetNode });
+    acc.push({ key: edgeId, edge, sourceNode, targetNode });
     return acc;
   }, []);
 }
@@ -482,6 +479,7 @@ export default function NetworkVisualization({
         />
         <RelationshipExplanationPanel
           relationship={selectedEdge}
+          publication={data?.publication ?? null}
           publicationId={data?.publication?.publication_id}
         />
       </div>

--- a/frontend/app/components/NetworkVisualization.tsx
+++ b/frontend/app/components/NetworkVisualization.tsx
@@ -94,6 +94,8 @@ function buildValidEdges(
   edges: VisualizationData["edges"],
 ): PreparedEdge[] {
   const nodeMap = new Map(nodes.map((node) => [node.id, node]));
+  const seenEdgeIds = new Set<string>();
+
   return edges.reduce<PreparedEdge[]>((acc, edge) => {
     const sourceNode = nodeMap.get(edge.source);
     const targetNode = nodeMap.get(edge.target);
@@ -104,7 +106,8 @@ function buildValidEdges(
       !targetNode ||
       !edgeId ||
       typeof edgeId !== "string" ||
-      edgeId.trim() === ""
+      edgeId.trim() === "" ||
+      seenEdgeIds.has(edgeId)
     ) {
       if (process.env.NODE_ENV === "development") {
         console.debug(
@@ -114,6 +117,7 @@ function buildValidEdges(
       return acc;
     }
 
+    seenEdgeIds.add(edgeId);
     acc.push({ key: edgeId, edge, sourceNode, targetNode });
     return acc;
   }, []);

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -189,7 +189,10 @@ function buildRequestKey(
   return `pub:${publicationId}:edge:${projectionEdgeId}:rev:${revisionId}:assert:${assertionId}`;
 }
 
-function formatStrength(persistedStrength?: string | null, strength?: number): string {
+function formatStrength(
+  persistedStrength?: string | null,
+  strength?: number,
+): string {
   if (persistedStrength !== undefined && persistedStrength !== null) {
     const parsed = Number(persistedStrength);
     if (!Number.isNaN(parsed)) return parsed.toFixed(2);
@@ -501,14 +504,17 @@ async function fetchPublishedEdgeExplanation(
   // Defensive response-identity validation
   const isPubValid =
     response.publication.publication_id === publicationId &&
-    (!expectedRevisionId || response.publication.revision_id === expectedRevisionId);
+    (!expectedRevisionId ||
+      response.publication.revision_id === expectedRevisionId);
 
   const isEdgeValid =
     response.edge.projection_edge_id === projectionEdgeId &&
-    (!expectedAssertionId || response.edge.assertion_id === expectedAssertionId);
+    (!expectedAssertionId ||
+      response.edge.assertion_id === expectedAssertionId);
 
   const isAssertionValid =
-    response.assertion.explanation.assertion_id === response.edge.assertion_id &&
+    response.assertion.explanation.assertion_id ===
+      response.edge.assertion_id &&
     response.assertion.history.assertion_id === response.edge.assertion_id;
 
   if (!isPubValid || !isEdgeValid || !isAssertionValid) {

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -177,6 +177,27 @@ function UnavailableView({ heading }: Readonly<{ heading: string }>) {
   );
 }
 
+function buildRequestKey(
+  publicationId: string | null | undefined,
+  projectionEdgeId: string | null | undefined,
+  revisionId?: string | null | undefined,
+  assertionId?: string | null | undefined,
+): string | null {
+  if (!publicationId || !projectionEdgeId || !revisionId || !assertionId) {
+    return null;
+  }
+  return `pub:${publicationId}:edge:${projectionEdgeId}:rev:${revisionId}:assert:${assertionId}`;
+}
+
+function formatStrength(persistedStrength?: string | null, strength?: number): string {
+  if (persistedStrength !== undefined && persistedStrength !== null) {
+    const parsed = Number(persistedStrength);
+    if (!Number.isNaN(parsed)) return parsed.toFixed(2);
+    return persistedStrength;
+  }
+  return (strength ?? 0).toFixed(2);
+}
+
 function ConfidenceAndTimeSummary({
   explanation,
   strength,
@@ -201,7 +222,7 @@ function ConfidenceAndTimeSummary({
       <div>
         <dt className="font-medium text-gray-500">Projection strength</dt>
         <dd className="text-gray-800">
-          {persistedStrength ?? strength.toFixed(2)}{" "}
+          {formatStrength(persistedStrength, strength)}{" "}
           <span className="text-xs text-gray-500">
             (distinct from confidence above)
           </span>
@@ -282,11 +303,10 @@ function EvidenceSummary({
                   Evidence body and restricted references are not shown.
                 </p>
               ) : (
-                item.source_ref && (
-                  <p className="text-xs text-gray-700 mt-1">
-                    Source ref: {item.source_ref}
-                  </p>
-                )
+                <div className="text-xs text-gray-700 mt-1 space-y-0.5">
+                  {item.source_ref && <p>Source ref: {item.source_ref}</p>}
+                  {item.content_sha256 && <p>SHA-256: {item.content_sha256}</p>}
+                </div>
               )}
             </li>
           ))}
@@ -340,106 +360,89 @@ function LifecycleHistory({
 
 function PublicationFooter({
   payload,
-  relationship,
 }: Readonly<{
-  payload?: PublishedEdgeExplanationResponse | null;
-  relationship: ExplainableRelationship;
+  payload: PublishedEdgeExplanationResponse;
 }>) {
-  const publication = payload?.publication;
-  const edge = payload?.edge;
+  const publication = payload.publication;
+  const edge = payload.edge;
 
   return (
     <div className="text-xs text-gray-500 border-t border-gray-100 pt-2 space-y-1">
       <p className="font-medium text-gray-700">Publication Provenance</p>
-      {publication ? (
-        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
-          <div>
-            <dt className="inline font-medium">Publication ID: </dt>
-            <dd className="inline font-mono">{publication.publication_id}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Revision ID: </dt>
-            <dd className="inline font-mono">{publication.revision_id}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Rebuild Job ID: </dt>
-            <dd className="inline font-mono">{publication.rebuild_job_id}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Execution ID: </dt>
-            <dd className="inline font-mono">{publication.execution_id}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Published At: </dt>
-            <dd className="inline">
-              {formatTimestamp(publication.published_at)}
-            </dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Purpose: </dt>
-            <dd className="inline">{publication.purpose}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Contract Version: </dt>
-            <dd className="inline">{publication.contract_version}</dd>
-          </div>
-          <div>
-            <dt className="inline font-medium">Projector Version: </dt>
-            <dd className="inline">{publication.projector_version}</dd>
-          </div>
-          <div className="col-span-1 sm:col-span-2">
-            <dt className="inline font-medium">Edge-set Hash: </dt>
-            <dd className="inline font-mono text-[10px] break-all">
-              {publication.edge_set_hash}
-            </dd>
-          </div>
-          <div className="col-span-1 sm:col-span-2">
-            <dt className="inline font-medium">Projection Hash: </dt>
-            <dd className="inline font-mono text-[10px] break-all">
-              {publication.projection_hash}
-            </dd>
-          </div>
-          {edge && (
-            <>
-              <div>
-                <dt className="inline font-medium">Projection Edge ID: </dt>
-                <dd className="inline font-mono">{edge.projection_edge_id}</dd>
-              </div>
-              <div>
-                <dt className="inline font-medium">Direction: </dt>
-                <dd className="inline">{edge.direction}</dd>
-              </div>
-              <div>
-                <dt className="inline font-medium">Persisted Strength: </dt>
-                <dd className="inline">{edge.strength}</dd>
-              </div>
-              <div>
-                <dt className="inline font-medium">Assertion ID: </dt>
-                <dd className="inline font-mono">{edge.assertion_id}</dd>
-              </div>
-            </>
-          )}
-          <div className="col-span-1 sm:col-span-2">
-            <dt className="inline font-medium">Governed Scopes: </dt>
-            <dd className="inline">
-              {publication.governed_scopes?.length
-                ? publication.governed_scopes
-                    .map((s) => `(${s.purpose}, ${s.predicate_id})`)
-                    .join(", ")
-                : "none"}
-            </dd>
-          </div>
-        </dl>
-      ) : (
-        <p>
-          Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
-          {relationship.scope_refs?.length
-            ? relationship.scope_refs.join(", ")
-            : "unknown"}
-          {relationship.projection_edge_id &&
-            ` | Edge ID: ${relationship.projection_edge_id}`}
-        </p>
-      )}
+      <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
+        <div>
+          <dt className="inline font-medium">Publication ID: </dt>
+          <dd className="inline font-mono">{publication.publication_id}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Revision ID: </dt>
+          <dd className="inline font-mono">{publication.revision_id}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Rebuild Job ID: </dt>
+          <dd className="inline font-mono">{publication.rebuild_job_id}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Execution ID: </dt>
+          <dd className="inline font-mono">{publication.execution_id}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Published At: </dt>
+          <dd className="inline">
+            {formatTimestamp(publication.published_at)}
+          </dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Purpose: </dt>
+          <dd className="inline">{publication.purpose}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Contract Version: </dt>
+          <dd className="inline">{publication.contract_version}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Projector Version: </dt>
+          <dd className="inline">{publication.projector_version}</dd>
+        </div>
+        <div className="col-span-1 sm:col-span-2">
+          <dt className="inline font-medium">Edge-set Hash: </dt>
+          <dd className="inline font-mono text-[10px] break-all">
+            {publication.edge_set_hash}
+          </dd>
+        </div>
+        <div className="col-span-1 sm:col-span-2">
+          <dt className="inline font-medium">Projection Hash: </dt>
+          <dd className="inline font-mono text-[10px] break-all">
+            {publication.projection_hash}
+          </dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Projection Edge ID: </dt>
+          <dd className="inline font-mono">{edge.projection_edge_id}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Direction: </dt>
+          <dd className="inline">{edge.direction}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Persisted Strength: </dt>
+          <dd className="inline">{edge.strength}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">Assertion ID: </dt>
+          <dd className="inline font-mono">{edge.assertion_id}</dd>
+        </div>
+        <div className="col-span-1 sm:col-span-2">
+          <dt className="inline font-medium">Governed Scopes: </dt>
+          <dd className="inline">
+            {publication.governed_scopes.length
+              ? publication.governed_scopes
+                  .map((s) => `(${s.purpose}, ${s.predicate_id})`)
+                  .join(", ")
+              : "none"}
+          </dd>
+        </div>
+      </dl>
     </div>
   );
 }
@@ -475,7 +478,7 @@ function ReadyView({
       <AuthoritySummary history={history} />
       <EvidenceSummary explanation={explanation} />
       <LifecycleHistory history={history} />
-      <PublicationFooter payload={payload} relationship={relationship} />
+      <PublicationFooter payload={payload} />
     </section>
   );
 }
@@ -496,17 +499,19 @@ async function fetchPublishedEdgeExplanation(
   if (signal.aborted) return null;
 
   // Defensive response-identity validation
-  if (
-    response.publication.publication_id !== publicationId ||
-    (expectedRevisionId &&
-      response.publication.revision_id !== expectedRevisionId) ||
-    response.edge.projection_edge_id !== projectionEdgeId ||
-    (expectedAssertionId &&
-      response.edge.assertion_id !== expectedAssertionId) ||
-    response.assertion.explanation.assertion_id !==
-      response.edge.assertion_id ||
-    response.assertion.history.assertion_id !== response.edge.assertion_id
-  ) {
+  const isPubValid =
+    response.publication.publication_id === publicationId &&
+    (!expectedRevisionId || response.publication.revision_id === expectedRevisionId);
+
+  const isEdgeValid =
+    response.edge.projection_edge_id === projectionEdgeId &&
+    (!expectedAssertionId || response.edge.assertion_id === expectedAssertionId);
+
+  const isAssertionValid =
+    response.assertion.explanation.assertion_id === response.edge.assertion_id &&
+    response.assertion.history.assertion_id === response.edge.assertion_id;
+
+  if (!isPubValid || !isEdgeValid || !isAssertionValid) {
     return { status: "unavailable", requestKey };
   }
 
@@ -517,18 +522,31 @@ async function fetchPublishedEdgeExplanation(
   };
 }
 
+interface FetchAssertionResultOptions {
+  projectionEdgeId: string | null | undefined;
+  publicationId: string | null | undefined;
+  expectedRevisionId: string | null | undefined;
+  expectedAssertionId: string | null | undefined;
+  signal: AbortSignal;
+}
+
 /**
  * Fetch the explanation for a published governed edge, resolving to a settled `PanelResult`.
  */
-async function fetchAssertionResult(
-  projectionEdgeId: string | null | undefined,
-  publicationId: string | null | undefined,
-  expectedRevisionId: string | null | undefined,
-  expectedAssertionId: string | null | undefined,
-  signal: AbortSignal,
-): Promise<PanelResult | null> {
-  if (!publicationId || !projectionEdgeId) return null;
-  const requestKey = `pub:${publicationId}:edge:${projectionEdgeId}`;
+async function fetchAssertionResult({
+  projectionEdgeId,
+  publicationId,
+  expectedRevisionId,
+  expectedAssertionId,
+  signal,
+}: FetchAssertionResultOptions): Promise<PanelResult | null> {
+  const requestKey = buildRequestKey(
+    publicationId,
+    projectionEdgeId,
+    expectedRevisionId,
+    expectedAssertionId,
+  );
+  if (!requestKey || !publicationId || !projectionEdgeId) return null;
 
   try {
     return await fetchPublishedEdgeExplanation(
@@ -558,24 +576,26 @@ function useAssertionResult(
 ): PanelResult | null {
   const [result, setResult] = useState<PanelResult | null>(null);
 
-  const requestKey =
-    publicationId && projectionEdgeId
-      ? `pub:${publicationId}:edge:${projectionEdgeId}`
-      : null;
+  const requestKey = buildRequestKey(
+    publicationId,
+    projectionEdgeId,
+    expectedRevisionId,
+    expectedAssertionId,
+  );
 
   useEffect(() => {
-    if (!requestKey || !publicationId || !projectionEdgeId) {
+    if (!requestKey) {
       return;
     }
 
     const controller = new AbortController();
-    fetchAssertionResult(
+    fetchAssertionResult({
       projectionEdgeId,
       publicationId,
       expectedRevisionId,
       expectedAssertionId,
-      controller.signal,
-    ).then((settled) => {
+      signal: controller.signal,
+    }).then((settled) => {
       if (settled) setResult(settled);
     });
 
@@ -622,16 +642,16 @@ function resolveViewState(
   }
 
   const projectionEdgeId = relationship.projection_edge_id;
-  if (
-    !publicationId ||
-    !projectionEdgeId ||
-    !relationship.assertion_id ||
-    !relationship.revision_id
-  ) {
+  const requestKey = buildRequestKey(
+    publicationId,
+    projectionEdgeId,
+    relationship.revision_id,
+    relationship.assertion_id,
+  );
+
+  if (!requestKey) {
     return { kind: "pending", heading };
   }
-
-  const requestKey = `pub:${publicationId}:edge:${projectionEdgeId}`;
 
   // "Loading" is derived, not stored
   if (result?.requestKey !== requestKey) return { kind: "loading", heading };

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -6,6 +6,8 @@ import type {
   AssertionExplanation,
   AssertionHistory,
   AssertionPublicEvent,
+  PublishedEdgeExplanationResponse,
+  PublishedProjectionContextResponse,
 } from "../types/api";
 
 export type ExplainableRelationship = Readonly<{
@@ -22,6 +24,7 @@ export type ExplainableRelationship = Readonly<{
 
 type RelationshipExplanationPanelProps = Readonly<{
   relationship: ExplainableRelationship | null;
+  publication?: PublishedProjectionContextResponse | null;
   publicationId?: string | null;
 }>;
 
@@ -29,10 +32,7 @@ type RelationshipExplanationPanelProps = Readonly<{
  * The settled (non-loading) outcome of a fetch for a given request key. Only
  * completed results are ever stored in state; "loading" is derived by
  * comparing the current `requestKey` against `result.requestKey` rather than
- * stored as its own state value. This means the effect never needs to call
- * `setState` synchronously at the start of a fetch -- it only calls it once,
- * asynchronously, when the fetch settles -- so there is no render-cascading
- * synchronous `setState` inside the effect body.
+ * stored as its own state value.
  */
 type PanelResult =
   | Readonly<{ status: "not-found"; requestKey: string }>
@@ -40,8 +40,7 @@ type PanelResult =
   | Readonly<{
       status: "ready";
       requestKey: string;
-      explanation: AssertionExplanation;
-      history: AssertionHistory;
+      payload: PublishedEdgeExplanationResponse;
     }>;
 
 const AUTHORITY_LABELS: Record<string, string> = {
@@ -61,9 +60,7 @@ function formatTimestamp(value: string | null | undefined): string {
 
 /**
  * Derive the recorded proposer event and the most recent determining-authority
- * event from an assertion's public (identity-redacted) event history. Only the
- * authority role is available on public reads -- actor identity is never
- * fabricated here.
+ * event from an assertion's public (identity-redacted) event history.
  */
 function deriveAuthoritySummary(events: readonly AssertionPublicEvent[]): {
   proposer: AssertionPublicEvent | null;
@@ -141,8 +138,8 @@ function PendingMetadataView({ heading }: Readonly<{ heading: string }>) {
   return (
     <PanelShell heading={heading} toneClassName="border-amber-200 bg-amber-50">
       <output className="block mt-2 text-sm text-amber-800">
-        This relationship is governed, but its assertion metadata is not yet
-        available. It may still be synchronizing.
+        This relationship is governed, but its publication or edge metadata is
+        incomplete. It may still be synchronizing.
       </output>
     </PanelShell>
   );
@@ -183,7 +180,12 @@ function UnavailableView({ heading }: Readonly<{ heading: string }>) {
 function ConfidenceAndTimeSummary({
   explanation,
   strength,
-}: Readonly<{ explanation: AssertionExplanation; strength: number }>) {
+  persistedStrength,
+}: Readonly<{
+  explanation: AssertionExplanation;
+  strength: number;
+  persistedStrength?: string | null;
+}>) {
   return (
     <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
       <div>
@@ -199,7 +201,7 @@ function ConfidenceAndTimeSummary({
       <div>
         <dt className="font-medium text-gray-500">Projection strength</dt>
         <dd className="text-gray-800">
-          {strength.toFixed(2)}{" "}
+          {persistedStrength ?? strength.toFixed(2)}{" "}
           <span className="text-xs text-gray-500">
             (distinct from confidence above)
           </span>
@@ -280,10 +282,11 @@ function EvidenceSummary({
                   Evidence body and restricted references are not shown.
                 </p>
               ) : (
-                <div className="text-xs text-gray-600 space-y-0.5">
-                  {item.source_ref && <p>Reference: {item.source_ref}</p>}
-                  {item.content_sha256 && <p>SHA-256: {item.content_sha256}</p>}
-                </div>
+                item.source_ref && (
+                  <p className="text-xs text-gray-700 mt-1">
+                    Source ref: {item.source_ref}
+                  </p>
+                )
               )}
             </li>
           ))}
@@ -336,18 +339,107 @@ function LifecycleHistory({
 }
 
 function PublicationFooter({
+  payload,
   relationship,
-}: Readonly<{ relationship: ExplainableRelationship }>) {
+}: Readonly<{
+  payload?: PublishedEdgeExplanationResponse | null;
+  relationship: ExplainableRelationship;
+}>) {
+  const publication = payload?.publication;
+  const edge = payload?.edge;
+
   return (
-    <div className="text-xs text-gray-500 border-t border-gray-100 pt-2">
-      <p>
-        Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
-        {relationship.scope_refs?.length
-          ? relationship.scope_refs.join(", ")
-          : "unknown"}
-        {relationship.projection_edge_id &&
-          ` | Edge ID: ${relationship.projection_edge_id}`}
-      </p>
+    <div className="text-xs text-gray-500 border-t border-gray-100 pt-2 space-y-1">
+      <p className="font-medium text-gray-700">Publication Provenance</p>
+      {publication ? (
+        <dl className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-1 text-xs">
+          <div>
+            <dt className="inline font-medium">Publication ID: </dt>
+            <dd className="inline font-mono">{publication.publication_id}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Revision ID: </dt>
+            <dd className="inline font-mono">{publication.revision_id}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Rebuild Job ID: </dt>
+            <dd className="inline font-mono">{publication.rebuild_job_id}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Execution ID: </dt>
+            <dd className="inline font-mono">{publication.execution_id}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Published At: </dt>
+            <dd className="inline">
+              {formatTimestamp(publication.published_at)}
+            </dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Purpose: </dt>
+            <dd className="inline">{publication.purpose}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Contract Version: </dt>
+            <dd className="inline">{publication.contract_version}</dd>
+          </div>
+          <div>
+            <dt className="inline font-medium">Projector Version: </dt>
+            <dd className="inline">{publication.projector_version}</dd>
+          </div>
+          <div className="col-span-1 sm:col-span-2">
+            <dt className="inline font-medium">Edge-set Hash: </dt>
+            <dd className="inline font-mono text-[10px] break-all">
+              {publication.edge_set_hash}
+            </dd>
+          </div>
+          <div className="col-span-1 sm:col-span-2">
+            <dt className="inline font-medium">Projection Hash: </dt>
+            <dd className="inline font-mono text-[10px] break-all">
+              {publication.projection_hash}
+            </dd>
+          </div>
+          {edge && (
+            <>
+              <div>
+                <dt className="inline font-medium">Projection Edge ID: </dt>
+                <dd className="inline font-mono">{edge.projection_edge_id}</dd>
+              </div>
+              <div>
+                <dt className="inline font-medium">Direction: </dt>
+                <dd className="inline">{edge.direction}</dd>
+              </div>
+              <div>
+                <dt className="inline font-medium">Persisted Strength: </dt>
+                <dd className="inline">{edge.strength}</dd>
+              </div>
+              <div>
+                <dt className="inline font-medium">Assertion ID: </dt>
+                <dd className="inline font-mono">{edge.assertion_id}</dd>
+              </div>
+            </>
+          )}
+          <div className="col-span-1 sm:col-span-2">
+            <dt className="inline font-medium">Governed Scopes: </dt>
+            <dd className="inline">
+              {publication.governed_scopes?.length
+                ? publication.governed_scopes
+                    .map((s) => `(${s.purpose}, ${s.predicate_id})`)
+                    .join(", ")
+                : "none"}
+            </dd>
+          </div>
+        </dl>
+      ) : (
+        <p>
+          Revision: {relationship.revision_id ?? "unknown"} | Scope:{" "}
+          {relationship.scope_refs?.length
+            ? relationship.scope_refs.join(", ")
+            : "unknown"}
+          {relationship.projection_edge_id &&
+            ` | Edge ID: ${relationship.projection_edge_id}`}
+        </p>
+      )}
     </div>
   );
 }
@@ -355,14 +447,13 @@ function PublicationFooter({
 function ReadyView({
   heading,
   relationship,
-  explanation,
-  history,
+  payload,
 }: Readonly<{
   heading: string;
   relationship: ExplainableRelationship;
-  explanation: AssertionExplanation;
-  history: AssertionHistory;
+  payload: PublishedEdgeExplanationResponse;
 }>) {
+  const { explanation, history } = payload.assertion;
   return (
     <section
       aria-label="Relationship explanation"
@@ -379,11 +470,12 @@ function ReadyView({
       <ConfidenceAndTimeSummary
         explanation={explanation}
         strength={relationship.strength}
+        persistedStrength={payload.edge.strength}
       />
       <AuthoritySummary history={history} />
       <EvidenceSummary explanation={explanation} />
       <LifecycleHistory history={history} />
-      <PublicationFooter relationship={relationship} />
+      <PublicationFooter payload={payload} relationship={relationship} />
     </section>
   );
 }
@@ -393,6 +485,8 @@ async function fetchPublishedEdgeExplanation(
   projectionEdgeId: string,
   requestKey: string,
   signal: AbortSignal,
+  expectedRevisionId?: string | null,
+  expectedAssertionId?: string | null,
 ): Promise<PanelResult | null> {
   const response = await api.getPublishedEdgeExplanation(
     publicationId,
@@ -400,62 +494,47 @@ async function fetchPublishedEdgeExplanation(
     signal,
   );
   if (signal.aborted) return null;
+
+  // Defensive response-identity validation
+  if (
+    response.publication.publication_id !== publicationId ||
+    (expectedRevisionId && response.publication.revision_id !== expectedRevisionId) ||
+    response.edge.projection_edge_id !== projectionEdgeId ||
+    (expectedAssertionId && response.edge.assertion_id !== expectedAssertionId) ||
+    response.assertion.explanation.assertion_id !== response.edge.assertion_id ||
+    response.assertion.history.assertion_id !== response.edge.assertion_id
+  ) {
+    return { status: "unavailable", requestKey };
+  }
+
   return {
     status: "ready",
     requestKey,
-    explanation: response.assertion.explanation,
-    history: response.assertion.history,
+    payload: response,
   };
 }
 
-async function fetchLegacyAssertionExplanation(
-  assertionId: string,
-  requestKey: string,
-  signal: AbortSignal,
-): Promise<PanelResult | null> {
-  const asOf = { known_at: new Date().toISOString() };
-  const [explanation, history] = await Promise.all([
-    api.getAssertion(assertionId, asOf, signal),
-    api.getAssertionHistory(assertionId, asOf, signal),
-  ]);
-  if (signal.aborted) return null;
-  return { status: "ready", requestKey, explanation, history };
-}
-
 /**
- * Fetch the explanation and history for a governed assertion, resolving to a
- * settled `PanelResult` (or `null` if the request was aborted). Kept as its
- * own top-level function (rather than inline in an effect) so the fetch,
- * abort-handling, and error-classification logic contributes to its own
- * cyclomatic complexity budget, not the rendering component's.
+ * Fetch the explanation for a published governed edge, resolving to a settled `PanelResult`.
  */
 async function fetchAssertionResult(
-  assertionId: string | null,
   projectionEdgeId: string | null | undefined,
   publicationId: string | null | undefined,
+  expectedRevisionId: string | null | undefined,
+  expectedAssertionId: string | null | undefined,
   signal: AbortSignal,
 ): Promise<PanelResult | null> {
-  const requestKey =
-    publicationId && projectionEdgeId
-      ? `pub:${publicationId}:edge:${projectionEdgeId}`
-      : assertionId;
-
-  if (!requestKey) return null;
+  if (!publicationId || !projectionEdgeId) return null;
+  const requestKey = `pub:${publicationId}:edge:${projectionEdgeId}`;
 
   try {
-    if (publicationId && projectionEdgeId) {
-      return await fetchPublishedEdgeExplanation(
-        publicationId,
-        projectionEdgeId,
-        requestKey,
-        signal,
-      );
-    }
-    if (!assertionId) return null;
-    return await fetchLegacyAssertionExplanation(
-      assertionId,
+    return await fetchPublishedEdgeExplanation(
+      publicationId,
+      projectionEdgeId,
       requestKey,
       signal,
+      expectedRevisionId,
+      expectedAssertionId,
     );
   } catch (err) {
     if (signal.aborted) return null;
@@ -469,34 +548,36 @@ async function fetchAssertionResult(
 }
 
 function useAssertionResult(
-  assertionId: string | null,
   projectionEdgeId: string | null | undefined,
   publicationId: string | null | undefined,
+  expectedRevisionId: string | null | undefined,
+  expectedAssertionId: string | null | undefined,
 ): PanelResult | null {
   const [result, setResult] = useState<PanelResult | null>(null);
 
   const requestKey =
     publicationId && projectionEdgeId
       ? `pub:${publicationId}:edge:${projectionEdgeId}`
-      : assertionId;
+      : null;
 
   useEffect(() => {
-    if (!requestKey) {
+    if (!requestKey || !publicationId || !projectionEdgeId) {
       return;
     }
 
     const controller = new AbortController();
     fetchAssertionResult(
-      assertionId,
       projectionEdgeId,
       publicationId,
+      expectedRevisionId,
+      expectedAssertionId,
       controller.signal,
     ).then((settled) => {
       if (settled) setResult(settled);
     });
 
     return () => controller.abort();
-  }, [assertionId, projectionEdgeId, publicationId, requestKey]);
+  }, [requestKey, projectionEdgeId, publicationId, expectedRevisionId, expectedAssertionId]);
 
   return result?.requestKey === requestKey ? result : null;
 }
@@ -513,22 +594,11 @@ type ViewState =
       kind: "ready";
       heading: string;
       relationship: ExplainableRelationship;
-      explanation: AssertionExplanation;
-      history: AssertionHistory;
+      payload: PublishedEdgeExplanationResponse;
     }>;
 
-/** Resolve the governed assertion id (if any) that a relationship refers to. */
-function resolveAssertionId(
-  relationship: ExplainableRelationship | null,
-): string | null {
-  if (relationship?.governance_status !== "governed") return null;
-  return relationship.assertion_id ?? null;
-}
-
 /**
- * Pure derivation of the panel's view state from its inputs. Extracted so
- * `RelationshipExplanationPanel` itself only has to switch on the result,
- * rather than repeat this branching inline.
+ * Pure derivation of the panel's view state from its inputs.
  */
 function resolveViewState(
   relationship: ExplainableRelationship | null,
@@ -538,20 +608,18 @@ function resolveViewState(
   if (!relationship) return { kind: "empty" };
 
   const heading = relationshipHeading(relationship);
-  const assertionId = resolveAssertionId(relationship);
   if (relationship.governance_status !== "governed") {
     return { kind: "legacy", heading };
   }
-  if (!assertionId) return { kind: "pending", heading };
 
-  const requestKey =
-    publicationId && relationship.projection_edge_id
-      ? `pub:${publicationId}:edge:${relationship.projection_edge_id}`
-      : assertionId;
+  const projectionEdgeId = relationship.projection_edge_id;
+  if (!publicationId || !projectionEdgeId || !relationship.assertion_id || !relationship.revision_id) {
+    return { kind: "pending", heading };
+  }
 
-  // "Loading" is derived, not stored: if there is no settled result yet, or
-  // the settled result belongs to a superseded request key, treat it as
-  // loading rather than briefly flashing stale content.
+  const requestKey = `pub:${publicationId}:edge:${projectionEdgeId}`;
+
+  // "Loading" is derived, not stored
   if (result?.requestKey !== requestKey) return { kind: "loading", heading };
 
   if (result.status === "ready") {
@@ -559,8 +627,7 @@ function resolveViewState(
       kind: "ready",
       heading,
       relationship,
-      explanation: result.explanation,
-      history: result.history,
+      payload: result.payload,
     };
   }
 
@@ -568,9 +635,7 @@ function resolveViewState(
 }
 
 /**
- * Render the subcomponent matching a resolved `ViewState`. Kept as its own
- * function so the switch's branches contribute to this function's
- * complexity budget, not `RelationshipExplanationPanel`'s.
+ * Render the subcomponent matching a resolved `ViewState`.
  */
 function renderView(view: ViewState) {
   switch (view.kind) {
@@ -591,29 +656,27 @@ function renderView(view: ViewState) {
         <ReadyView
           heading={view.heading}
           relationship={view.relationship}
-          explanation={view.explanation}
-          history={view.history}
+          payload={view.payload}
         />
       );
   }
 }
 
 /**
- * Renders the governed explanation (evidence, authority, time, confidence,
- * supersession, and publication scope) for a selected relationship edge, or a
- * bounded legacy/unavailable/loading state when governance facts cannot be
- * shown. Never displays evidence bodies, restricted references, or invented
- * `CURRENT`/production-proof claims.
+ * Renders the governed explanation for a selected published edge, or a bounded
+ * state when governance facts cannot be shown.
  */
 export default function RelationshipExplanationPanel({
   relationship,
-  publicationId,
+  publication,
+  publicationId: publicationIdProp,
 }: RelationshipExplanationPanelProps) {
-  const assertionId = resolveAssertionId(relationship);
+  const publicationId = publication?.publication_id ?? publicationIdProp ?? null;
   const result = useAssertionResult(
-    assertionId,
     relationship?.projection_edge_id,
     publicationId,
+    relationship?.revision_id,
+    relationship?.assertion_id,
   );
   const view = resolveViewState(relationship, result, publicationId);
   return renderView(view);

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -177,9 +177,7 @@ function UnavailableView({ heading }: Readonly<{ heading: string }>) {
   );
 }
 
-function normalizeIdentifier(
-  value: string | null | undefined,
-): string | null {
+function normalizeIdentifier(value: string | null | undefined): string | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim();
   return normalized.length > 0 ? normalized : null;
@@ -360,8 +358,7 @@ function LifecycleHistory({
             {event.successor_assertion_id && (
               <span className="text-xs text-gray-500">
                 {" "}
-                {"—"} superseded by assertion{" "}
-                {event.successor_assertion_id}
+                {"—"} superseded by assertion {event.successor_assertion_id}
               </span>
             )}
           </li>

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -89,7 +89,7 @@ function findSupersessionEvent(
 }
 
 function relationshipHeading(relationship: ExplainableRelationship): string {
-  return `${relationship.source} \u2192 ${relationship.target} (${relationship.relationship_type})`;
+  return `${relationship.source} → ${relationship.target} (${relationship.relationship_type})`;
 }
 
 function PanelShell({
@@ -177,16 +177,35 @@ function UnavailableView({ heading }: Readonly<{ heading: string }>) {
   );
 }
 
+function normalizeIdentifier(
+  value: string | null | undefined,
+): string | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
 function buildRequestKey(
   publicationId: string | null | undefined,
   projectionEdgeId: string | null | undefined,
   revisionId?: string | null | undefined,
   assertionId?: string | null | undefined,
 ): string | null {
-  if (!publicationId || !projectionEdgeId || !revisionId || !assertionId) {
+  const normalizedPublicationId = normalizeIdentifier(publicationId);
+  const normalizedProjectionEdgeId = normalizeIdentifier(projectionEdgeId);
+  const normalizedRevisionId = normalizeIdentifier(revisionId);
+  const normalizedAssertionId = normalizeIdentifier(assertionId);
+
+  if (
+    normalizedPublicationId === null ||
+    normalizedProjectionEdgeId === null ||
+    normalizedRevisionId === null ||
+    normalizedAssertionId === null
+  ) {
     return null;
   }
-  return `pub:${publicationId}:edge:${projectionEdgeId}:rev:${revisionId}:assert:${assertionId}`;
+
+  return `pub:${normalizedPublicationId}:edge:${normalizedProjectionEdgeId}:rev:${normalizedRevisionId}:assert:${normalizedAssertionId}`;
 }
 
 function formatStrength(
@@ -236,7 +255,7 @@ function ConfidenceAndTimeSummary({
         <dd className="text-gray-800">
           {formatTimestamp(explanation.effective_from)}
           {explanation.effective_to
-            ? ` \u2013 ${formatTimestamp(explanation.effective_to)}`
+            ? ` – ${formatTimestamp(explanation.effective_to)}`
             : " (ongoing)"}
         </dd>
       </div>
@@ -268,7 +287,7 @@ function AuthoritySummary({
       <ul className="mt-1 space-y-1">
         {summary.proposer && (
           <li>
-            {AUTHORITY_LABELS.proposer} {"\u2014"}{" "}
+            {AUTHORITY_LABELS.proposer} {"—"}{" "}
             {formatTimestamp(summary.proposer.recorded_at)}
           </li>
         )}
@@ -276,7 +295,7 @@ function AuthoritySummary({
           <li>
             {AUTHORITY_LABELS[summary.determiner.authority] ??
               "Determining authority"}{" "}
-            {"\u2014"} {formatTimestamp(summary.determiner.recorded_at)}
+            {"—"} {formatTimestamp(summary.determiner.recorded_at)}
           </li>
         )}
       </ul>
@@ -332,7 +351,7 @@ function LifecycleHistory({
       <ul className="mt-1 space-y-1">
         {history.events.map((event) => (
           <li key={event.event_id}>
-            #{event.sequence} {event.from_state ?? "(none)"} {"\u2192"}{" "}
+            #{event.sequence} {event.from_state ?? "(none)"} {"→"}{" "}
             {event.to_state}{" "}
             <span className="text-xs text-gray-500">
               ({AUTHORITY_LABELS[event.authority] ?? event.authority},{" "}
@@ -341,7 +360,7 @@ function LifecycleHistory({
             {event.successor_assertion_id && (
               <span className="text-xs text-gray-500">
                 {" "}
-                {"\u2014"} superseded by assertion{" "}
+                {"—"} superseded by assertion{" "}
                 {event.successor_assertion_id}
               </span>
             )}
@@ -546,22 +565,28 @@ async function fetchAssertionResult({
   expectedAssertionId,
   signal,
 }: FetchAssertionResultOptions): Promise<PanelResult | null> {
+  const normalizedPublicationId = normalizeIdentifier(publicationId);
+  const normalizedProjectionEdgeId = normalizeIdentifier(projectionEdgeId);
+  const normalizedRevisionId = normalizeIdentifier(expectedRevisionId);
+  const normalizedAssertionId = normalizeIdentifier(expectedAssertionId);
   const requestKey = buildRequestKey(
-    publicationId,
-    projectionEdgeId,
-    expectedRevisionId,
-    expectedAssertionId,
+    normalizedPublicationId,
+    normalizedProjectionEdgeId,
+    normalizedRevisionId,
+    normalizedAssertionId,
   );
-  if (!requestKey || !publicationId || !projectionEdgeId) return null;
+  if (!requestKey || !normalizedPublicationId || !normalizedProjectionEdgeId) {
+    return null;
+  }
 
   try {
     return await fetchPublishedEdgeExplanation(
-      publicationId,
-      projectionEdgeId,
+      normalizedPublicationId,
+      normalizedProjectionEdgeId,
       requestKey,
       signal,
-      expectedRevisionId,
-      expectedAssertionId,
+      normalizedRevisionId,
+      normalizedAssertionId,
     );
   } catch (err) {
     if (signal.aborted) return null;

--- a/frontend/app/components/RelationshipExplanationPanel.tsx
+++ b/frontend/app/components/RelationshipExplanationPanel.tsx
@@ -498,10 +498,13 @@ async function fetchPublishedEdgeExplanation(
   // Defensive response-identity validation
   if (
     response.publication.publication_id !== publicationId ||
-    (expectedRevisionId && response.publication.revision_id !== expectedRevisionId) ||
+    (expectedRevisionId &&
+      response.publication.revision_id !== expectedRevisionId) ||
     response.edge.projection_edge_id !== projectionEdgeId ||
-    (expectedAssertionId && response.edge.assertion_id !== expectedAssertionId) ||
-    response.assertion.explanation.assertion_id !== response.edge.assertion_id ||
+    (expectedAssertionId &&
+      response.edge.assertion_id !== expectedAssertionId) ||
+    response.assertion.explanation.assertion_id !==
+      response.edge.assertion_id ||
     response.assertion.history.assertion_id !== response.edge.assertion_id
   ) {
     return { status: "unavailable", requestKey };
@@ -577,7 +580,13 @@ function useAssertionResult(
     });
 
     return () => controller.abort();
-  }, [requestKey, projectionEdgeId, publicationId, expectedRevisionId, expectedAssertionId]);
+  }, [
+    requestKey,
+    projectionEdgeId,
+    publicationId,
+    expectedRevisionId,
+    expectedAssertionId,
+  ]);
 
   return result?.requestKey === requestKey ? result : null;
 }
@@ -613,7 +622,12 @@ function resolveViewState(
   }
 
   const projectionEdgeId = relationship.projection_edge_id;
-  if (!publicationId || !projectionEdgeId || !relationship.assertion_id || !relationship.revision_id) {
+  if (
+    !publicationId ||
+    !projectionEdgeId ||
+    !relationship.assertion_id ||
+    !relationship.revision_id
+  ) {
     return { kind: "pending", heading };
   }
 
@@ -671,7 +685,8 @@ export default function RelationshipExplanationPanel({
   publication,
   publicationId: publicationIdProp,
 }: RelationshipExplanationPanelProps) {
-  const publicationId = publication?.publication_id ?? publicationIdProp ?? null;
+  const publicationId =
+    publication?.publication_id ?? publicationIdProp ?? null;
   const result = useAssertionResult(
     relationship?.projection_edge_id,
     publicationId,


### PR DESCRIPTION
## Programme Position
- **Parent:** #1581
- **Fixes / Closes:** #1583
- **Base SHA:** `27632e67c25` (`origin/main` post-#1584 merge)
- **Branch:** `fix/grac-v1-explanation-ui-publication-binding`
- **Blocks:** #1539

## Primary Objective
Complete and prove the publication-bound explanation UI (amended PR 8B scope), enforcing opaque server `edge_id` selection, bundled `(publication_id, projection_edge_id)` explanation fetching, complete publication provenance display, and zero fallback to generic assertion endpoints or client-side temporal authority.

## Upstream Source & Downstream Impact
- **Upstream Source:** `NetworkVisualization` component and `RelationshipList` trigger edge selection from Plotly 3D scatter `customdata` or keyboard list interaction.
- **Downstream Impact:** `RelationshipExplanationPanel` consumes the selected `edge_id` and publication envelope, issuing a single abortable request to `/api/publications/{pub_id}/edges/{proj_edge_id}/explanation`.
- **Failure Mode:** 404 (not-found) or 503 (unavailable) HTTP errors or defensive response-identity mismatches resolve to bounded, non-fatal UI states (`not-found` / `unavailable`), leaving graph rendering and selection fully usable.

## Triage & Scope Boundaries

### In Scope
1. **Opaque `edge_id` Selection**:
   - Removed `edgeKey(...)` client derivation.
   - `buildValidEdges(...)` enforces a non-empty `edge.edge_id` string and uses it directly as `PreparedEdge.key`. Malformed edges missing `edge_id` and duplicate edge ids are skipped.
   - Canonical and reverse edges with distinct server `edge_id` values select independently.

2. **Single Publication-Bound Explanation Request**:
   - `RelationshipExplanationPanel` fetches via `api.getPublishedEdgeExplanation(publicationId, projectionEdgeId, signal)`.
   - Eliminated legacy `fetchLegacyAssertionExplanation` fallback to `api.getAssertion`/`api.getAssertionHistory`.
   - Eliminated all client temporal authority calls.

3. **Defensive Response-Identity Validation**:
   - Validates that `publication_id`, `revision_id`, `projection_edge_id`, and `assertion_id` in response payload match expected request metadata. Mis-matches map safely to `unavailable` status.

4. **Complete Publication Provenance & Redaction**:
   - Renders publication provenance: `publication_id`, `revision_id`, `rebuild_job_id`, `execution_id`, `published_at`, `purpose`, `contract_version`, `projector_version`, `edge_set_hash`, `projection_hash`, and `governed_scopes`.
   - Preserves public evidence redaction (no evidence bodies or restricted references displayed) and role-only authority labels.

5. **Parent-to-Child Publication Envelope Integration Test**:
   - Added component integration test verifying publication envelope lifecycle: renders publication A, selects edge, verifies publication-A explanation, rerenders with publication B (with different edge IDs), verifies publication-A details disappear, no replacement edge is silently selected, and selecting B fetches/renders B's provenance correctly.

### Out of Scope
- Backend API contract modifications (PR 8B is strictly frontend conformance).
- Visual redesigns or layout changes outside governance explanation panels.

## Files Expected to Change
- `frontend/app/components/NetworkVisualization.tsx`
- `frontend/app/components/RelationshipExplanationPanel.tsx`
- `frontend/__tests__/components/NetworkVisualization.test.tsx`
- `frontend/__tests__/components/RelationshipExplanationPanel.test.tsx`
- `frontend/__tests__/test-utils.ts`
- `frontend/__tests__/test-utils.test.ts`
- `frontend/__tests__/integration/component-integration.test.tsx`

## Validation Actually Run
```bash
cd frontend && npm test -- --runInBand
# PASS 15/15 test suites, 511/511 tests passed

cd frontend && npm run lint
# 0 errors, 0 warnings

cd frontend && npm run build
# Compiled successfully in 9.5s

pytest
# 8,572 passed, 37 skipped, 0 failures
```

## Local Browser / Accessibility Verification
- **Exact Head SHA**: `ddd3ca1b947522a308b206a3b7ed11d9f331bd68`
- **Browser & Viewport**: Google Chrome (v124) / Desktop Viewport (1280x800)
- **Serving Mechanism**: Served locally using Next.js dev server on port `3000` with FastAPI on port `8000`.
- **Keyboard Interaction**: Verified tab focus and Space/Enter key selection on relationship items. Selected item correctly sets `aria-pressed="true"`.
- **Plot Click Selection**: Verified Plotly 3D node/edge onClick customdata handlers successfully trigger sidebar list updates and panel rendering.
- **Long Hashes Wrap**: Verified that `projection_hash` and `edge_set_hash` wrap cleanly with CSS `break-all` without overflow issues.
- **States Verified**: Checked layout rendering for empty, legacy, pending, loading, 404, 503, and ready panels.

## Merge Criteria
- 100% test pass rate across Jest (511 tests passed) and Pytest.
- Zero ESLint warnings or TypeScript errors.
- Verified exact-head branch pushed to `origin/fix/grac-v1-explanation-ui-publication-binding`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change moves relationship explanations to a publication-bound edge endpoint, adopts opaque edge IDs for visualization selection, validates explanation identity before rendering, and displays publication provenance.

No product defect was found.

## T-Rex validation blocked

A focused publication-history regression check could not run because the required Python package `numpy` is missing from the environment. An alternate route-test setup also lacked `httpx`/`httpx2`. The authored check would publish an Accepted assertion, transition it to Disputed, and verify that the published edge continues to show the publication-time Accepted explanation.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no blocking failure remains.

No final defects were identified. The unavailable local Python dependencies prevented one focused publication-history check from running but did not reveal a product failure.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted the authored persisted-publication regression check but could not run because numpy was missing during project import.
- An alternate FastAPI TestClient path also lacked httpx, preventing the regression test path from executing.
- The validation run captured the scripts and command outputs but did not perform publication, post-publication lifecycle transition, or explanation-route assertions.
- Artifact references were produced for the pre-change script, post-change script, and route-check script to define the validation scope and the intended mutations.
- The before-script and after-script logs were captured, showing dependency-related failures that blocked validation at runtime.

<a href="https://app.greptile.com/trex/runs/17293420/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["style: format code with Autopep8, Black,..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/67f42fa7e010bb13e89d84678d6f0080217446d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50140237)</sub>

<!-- /greptile_comment -->