### PR TITLE
fix(staging-proof): correct strict seed validation

### DIFF
--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -50,6 +50,7 @@ _ALLOWED_EVIDENCE_FILENAMES = frozenset(
 
 PROOF_RESULT_FILENAME = "staging-proof-result.json"
 AUTHZ_EVIDENCE_FILENAME = "authz-evidence.json"
+ERR_INVALID_SCOPE_PREDICATE = "Certified revision governed_scopes contains invalid or missing predicate_id entries"
 
 
 def validate_safe_path(path: str) -> pathlib.Path:
@@ -167,28 +168,22 @@ class ProofValidator:
             if isinstance(scope, str):
                 predicate_id = scope.strip()
                 if not predicate_id:
-                    self.add_error(
-                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
-                    )
+                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
                     return None
                 parsed.append(f"{predicate_id}::{expected_purpose}" if expected_purpose else predicate_id)
             elif isinstance(scope, dict):
                 if "predicate_id" not in scope or "purpose" not in scope:
-                    self.add_error(
-                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
-                    )
+                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
                     return None
                 if expected_purpose and scope["purpose"] != expected_purpose:
                     self.add_error("Certified revision governed_scopes contains entries with incorrect purpose")
                     return None
                 if not isinstance(scope["predicate_id"], str):
-                    self.add_error(
-                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
-                    )
+                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
                     return None
                 parsed.append(f"{scope['predicate_id'].strip()}::{scope['purpose']}")
             else:
-                self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
+                self.add_error(ERR_INVALID_SCOPE_PREDICATE)
                 return None
 
         return parsed

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -157,6 +157,25 @@ class ProofValidator:
             ok = False
         return ok
 
+    def _normalize_string_scope(self, scope: str, expected_purpose: str | None) -> str | None:
+        predicate_id = scope.strip()
+        if not predicate_id:
+            self.add_error(ERR_INVALID_SCOPE_PREDICATE)
+            return None
+        return f"{predicate_id}::{expected_purpose}" if expected_purpose else predicate_id
+
+    def _normalize_dict_scope(self, scope: dict[str, Any], expected_purpose: str | None) -> str | None:
+        if "predicate_id" not in scope or "purpose" not in scope:
+            self.add_error(ERR_INVALID_SCOPE_PREDICATE)
+            return None
+        if expected_purpose and scope["purpose"] != expected_purpose:
+            self.add_error("Certified revision governed_scopes contains entries with incorrect purpose")
+            return None
+        if not isinstance(scope["predicate_id"], str):
+            self.add_error(ERR_INVALID_SCOPE_PREDICATE)
+            return None
+        return f"{scope['predicate_id'].strip()}::{scope['purpose']}"
+
     def normalize_scopes(self, lst: Any, expected_purpose: str | None = None) -> list[str] | None:
         """Normalize a list of scopes into a canonical list of strings, validating structure."""
         if not isinstance(lst, list) or not lst:
@@ -166,25 +185,16 @@ class ProofValidator:
         parsed = []
         for scope in lst:
             if isinstance(scope, str):
-                predicate_id = scope.strip()
-                if not predicate_id:
-                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
-                    return None
-                parsed.append(f"{predicate_id}::{expected_purpose}" if expected_purpose else predicate_id)
+                normalized = self._normalize_string_scope(scope, expected_purpose)
             elif isinstance(scope, dict):
-                if "predicate_id" not in scope or "purpose" not in scope:
-                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
-                    return None
-                if expected_purpose and scope["purpose"] != expected_purpose:
-                    self.add_error("Certified revision governed_scopes contains entries with incorrect purpose")
-                    return None
-                if not isinstance(scope["predicate_id"], str):
-                    self.add_error(ERR_INVALID_SCOPE_PREDICATE)
-                    return None
-                parsed.append(f"{scope['predicate_id'].strip()}::{scope['purpose']}")
+                normalized = self._normalize_dict_scope(scope, expected_purpose)
             else:
                 self.add_error(ERR_INVALID_SCOPE_PREDICATE)
                 return None
+
+            if normalized is None:
+                return None
+            parsed.append(normalized)
 
         return parsed
 

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -165,7 +165,13 @@ class ProofValidator:
         parsed = []
         for scope in lst:
             if isinstance(scope, str):
-                parsed.append(scope)
+                predicate_id = scope.strip()
+                if not predicate_id:
+                    self.add_error(
+                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
+                    )
+                    return None
+                parsed.append(f"{predicate_id}::{expected_purpose}" if expected_purpose else predicate_id)
             elif isinstance(scope, dict):
                 if "predicate_id" not in scope or "purpose" not in scope:
                     self.add_error(
@@ -180,14 +186,10 @@ class ProofValidator:
                         "Certified revision governed_scopes contains invalid or missing predicate_id entries"
                     )
                     return None
-                parsed.append(f"{scope['predicate_id']}::{scope['purpose']}")
+                parsed.append(f"{scope['predicate_id'].strip()}::{scope['purpose']}")
             else:
                 self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
                 return None
-
-        if not all(isinstance(x, str) and x.strip() for x in parsed):
-            self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
-            return None
 
         return parsed
 
@@ -724,7 +726,7 @@ class ProofValidator:
             else:
                 self.add_error("Authz evidence required in strict mode")
 
-    def _query_restart_scopes_from_db(self, args: argparse.Namespace, db_url: str) -> str | None:
+    def _query_restart_scopes_from_db(self, args: argparse.Namespace, db_url: str) -> tuple[str, str | None] | None:
         """Query current scopes from database for the current rebuild job ID."""
         try:
             from sqlalchemy import create_engine
@@ -769,20 +771,25 @@ class ProofValidator:
                     self.add_error("Revision ID not found or invalid for publication")
                     return None
 
-                rev_stmt = select(RelationshipProjectionRevisionORM.governed_scopes).where(
-                    RelationshipProjectionRevisionORM.id == bindparam("restart_revision_id")
-                )
-                rev_scopes = conn.execute(
+                rev_stmt = select(
+                    RelationshipProjectionRevisionORM.governed_scopes, RelationshipProjectionRevisionORM.purpose
+                ).where(RelationshipProjectionRevisionORM.id == bindparam("restart_revision_id"))
+                rev_row = conn.execute(
                     rev_stmt,
                     {"restart_revision_id": revision_id},
-                ).scalar()
+                ).first()
+                if not rev_row:
+                    self.add_error(f"Revision {revision_id} cannot be found")
+                    return None
+
+                rev_scopes, rev_purpose = rev_row
                 if rev_scopes is None:
                     self.add_error(f"Revision {revision_id} cannot be found")
                     return None
 
                 try:
                     json.loads(rev_scopes)
-                    return str(rev_scopes)
+                    return str(rev_scopes), str(rev_purpose) if rev_purpose else None
                 except Exception:
                     self.add_error("governed_scopes is malformed")
                     return None
@@ -802,9 +809,11 @@ class ProofValidator:
                 self.add_error("Database URL required to observe current scopes in strict mode")
             return None
 
-        after_str = self._query_restart_scopes_from_db(args, db_url)
-        if after_str:
+        result = self._query_restart_scopes_from_db(args, db_url)
+        if result:
+            after_str, after_purpose = result
             args.after_scopes = after_str
+            args.scope_purpose = after_purpose
         return after_str
 
     def _validate_restart_scopes(self, args: argparse.Namespace) -> None:
@@ -823,7 +832,12 @@ class ProofValidator:
         try:
             before = json.loads(before_str)
             after = json.loads(after_str)
-            self.scopes_are_consistent(before, after, enforce_no_loss=True)
+            self.scopes_are_consistent(
+                before,
+                after,
+                enforce_no_loss=True,
+                expected_purpose=getattr(args, "scope_purpose", None),
+            )
             self.metadata["scopes_before"] = len(before) if isinstance(before, list) else 0
             self.metadata["scopes_after"] = len(after) if isinstance(after, list) else 0
         except Exception as e:

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -158,6 +158,7 @@ class ProofValidator:
         return ok
 
     def _normalize_string_scope(self, scope: str, expected_purpose: str | None) -> str | None:
+        """Normalize a string scope identifier."""
         predicate_id = scope.strip()
         if not predicate_id:
             self.add_error(ERR_INVALID_SCOPE_PREDICATE)
@@ -165,6 +166,7 @@ class ProofValidator:
         return f"{predicate_id}::{expected_purpose}" if expected_purpose else predicate_id
 
     def _normalize_dict_scope(self, scope: dict[str, Any], expected_purpose: str | None) -> str | None:
+        """Normalize an object-shaped scope, enforcing expected purpose."""
         if "predicate_id" not in scope or "purpose" not in scope:
             self.add_error(ERR_INVALID_SCOPE_PREDICATE)
             return None
@@ -859,6 +861,22 @@ class ProofValidator:
             return False
         return True
 
+    def _validate_assertion_actors_and_states(self, assertion_id: str, proposal: Any, determination: Any) -> bool:
+        """Validate the relationship between a proposal and determination event."""
+        if proposal.sequence >= determination.sequence:
+            self.add_error(f"Assertion {assertion_id} acceptance does not follow proposal")
+            return False
+        if determination.from_state != "Proposed":
+            self.add_error(f"Assertion {assertion_id} acceptance has invalid predecessor state")
+            return False
+        if not proposal.actor_id or not determination.actor_id:
+            self.add_error(f"Assertion {assertion_id} lifecycle actor is missing")
+            return False
+        if proposal.actor_id == determination.actor_id:
+            self.add_error(f"Assertion {assertion_id} proposer and determiner are not distinct")
+            return False
+        return True
+
     def _validate_reconstructed_assertion(
         self,
         assertion_id: str,
@@ -882,21 +900,7 @@ class ProofValidator:
             self.add_error(f"Assertion {assertion_id} must have exactly one proposer and one acceptance event")
             return False
 
-        proposal = proposed[0]
-        determination = accepted[0]
-        if proposal.sequence >= determination.sequence:
-            self.add_error(f"Assertion {assertion_id} acceptance does not follow proposal")
-            return False
-        if determination.from_state != "Proposed":
-            self.add_error(f"Assertion {assertion_id} acceptance has invalid predecessor state")
-            return False
-        if not proposal.actor_id or not determination.actor_id:
-            self.add_error(f"Assertion {assertion_id} lifecycle actor is missing")
-            return False
-        if proposal.actor_id == determination.actor_id:
-            self.add_error(f"Assertion {assertion_id} proposer and determiner are not distinct")
-            return False
-        return True
+        return self._validate_assertion_actors_and_states(assertion_id, proposed[0], accepted[0])
 
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
         """Reconstruct persisted lifecycle history for the certified revision."""

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -843,6 +843,17 @@ class ProofValidator:
         except Exception as e:
             self.add_error(f"Scope JSON error: {e}")
 
+    def _validate_assertion_sequences(self, assertion_id: str, events: Sequence[Any]) -> bool:
+        """Validate the order and uniqueness of lifecycle sequence numbers."""
+        sequences = [event.sequence for event in events]
+        if any(not isinstance(sequence, int) for sequence in sequences):
+            self.add_error(f"Assertion {assertion_id} has invalid lifecycle sequence values")
+            return False
+        if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
+            self.add_error(f"Assertion {assertion_id} lifecycle sequence is not strictly ordered")
+            return False
+        return True
+
     def _validate_reconstructed_assertion(
         self,
         assertion_id: str,
@@ -853,12 +864,7 @@ class ProofValidator:
             self.add_error(f"Assertion {assertion_id} has no persisted lifecycle events")
             return False
 
-        sequences = [event.sequence for event in events]
-        if any(not isinstance(sequence, int) for sequence in sequences):
-            self.add_error(f"Assertion {assertion_id} has invalid lifecycle sequence values")
-            return False
-        if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
-            self.add_error(f"Assertion {assertion_id} lifecycle sequence is not strictly ordered")
+        if not self._validate_assertion_sequences(assertion_id, events):
             return False
 
         proposed = [event for event in events if event.to_state == "Proposed" and event.authority == "proposer"]

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -180,7 +180,7 @@ class ProofValidator:
                         "Certified revision governed_scopes contains invalid or missing predicate_id entries"
                     )
                     return None
-                parsed.append(scope["predicate_id"])
+                parsed.append(f"{scope['predicate_id']}::{scope['purpose']}")
             else:
                 self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
                 return None

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -315,7 +315,7 @@ class ProofValidator:
                         f"expected {args.expected_revision_hash[:8]}..."
                     )
                 self.metadata["expected_revision"] = args.expected_revision_hash[:8] + "..."
-            elif args.strict:
+            elif args.strict and args.mode != "seed_and_publish":
                 self.add_error("Expected revision hash required in strict mode")
         elif args.strict:
             self.add_error("Revision hash required in strict mode")
@@ -444,15 +444,24 @@ class ProofValidator:
             return None
 
         if not isinstance(governed_scopes, list) or not governed_scopes:
-            self.add_error("Certified revision governed_scopes must be a non-empty list of identifiers")
+            self.add_error("Certified revision governed_scopes must be a non-empty list of identifiers or objects")
             return None
 
-        is_valid = all(isinstance(scope, str) and scope.strip() for scope in governed_scopes)
-        if not is_valid:
-            self.add_error("Certified revision governed_scopes must be a non-empty list of identifiers")
+        parsed_scopes = []
+        for scope in governed_scopes:
+            if isinstance(scope, str):
+                parsed_scopes.append(scope)
+            elif isinstance(scope, dict) and "predicate_id" in scope and isinstance(scope["predicate_id"], str):
+                parsed_scopes.append(scope["predicate_id"])
+            else:
+                self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
+                return None
+
+        if not all(scope.strip() for scope in parsed_scopes):
+            self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
             return None
 
-        return proj_hash, governed_scopes
+        return proj_hash, parsed_scopes
 
     def _populate_publication_and_revision_from_db(
         self, args: argparse.Namespace, conn: Any, rebuild_job_id: str

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -156,32 +156,58 @@ class ProofValidator:
             ok = False
         return ok
 
-    def _validate_scope_list(self, lst: Any) -> bool:
-        """Check if lst is a non-empty list of strings."""
-        if not isinstance(lst, list):
-            self.add_error("Scopes must be lists")
-            return False
-        if not lst:
-            self.add_error("Scope lists empty")
-            return False
-        if not all(isinstance(x, str) for x in lst):
-            self.add_error("Scopes must be lists of strings")
-            return False
-        return True
+    def normalize_scopes(self, lst: Any, expected_purpose: str | None = None) -> list[str] | None:
+        """Normalize a list of scopes into a canonical list of strings, validating structure."""
+        if not isinstance(lst, list) or not lst:
+            self.add_error("Certified revision governed_scopes must be a non-empty list of identifiers or objects")
+            return None
 
-    def scopes_are_consistent(self, before: list[str], after: list[str], enforce_no_loss: bool) -> bool:
+        parsed = []
+        for scope in lst:
+            if isinstance(scope, str):
+                parsed.append(scope)
+            elif isinstance(scope, dict):
+                if "predicate_id" not in scope or "purpose" not in scope:
+                    self.add_error(
+                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
+                    )
+                    return None
+                if expected_purpose and scope["purpose"] != expected_purpose:
+                    self.add_error("Certified revision governed_scopes contains entries with incorrect purpose")
+                    return None
+                if not isinstance(scope["predicate_id"], str):
+                    self.add_error(
+                        "Certified revision governed_scopes contains invalid or missing predicate_id entries"
+                    )
+                    return None
+                parsed.append(scope["predicate_id"])
+            else:
+                self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
+                return None
+
+        if not all(isinstance(x, str) and x.strip() for x in parsed):
+            self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
+            return None
+
+        return parsed
+
+    def scopes_are_consistent(
+        self, before: Any, after: Any, enforce_no_loss: bool, expected_purpose: str | None = None
+    ) -> bool:
         """Check scope consistency across transitions."""
-        if not self._validate_scope_list(before) or not self._validate_scope_list(after):
+        before_normalized = self.normalize_scopes(before, expected_purpose)
+        after_normalized = self.normalize_scopes(after, expected_purpose)
+        if before_normalized is None or after_normalized is None:
             return False
 
         if enforce_no_loss:
-            missing = set(before) - set(after)
+            missing = set(before_normalized) - set(after_normalized)
             if missing:
                 self.add_error(f"Scopes disappeared: {sorted(missing)[:3]}")
                 return False
         else:
-            if set(before) != set(after):
-                self.add_error(f"Scope mismatch: {len(before)} before, {len(after)} after")
+            if set(before_normalized) != set(after_normalized):
+                self.add_error(f"Scope mismatch: {len(before_normalized)} before, {len(after_normalized)} after")
                 return False
 
         return True
@@ -426,6 +452,7 @@ class ProofValidator:
         rev_query = select(
             RelationshipProjectionRevisionORM.projection_hash,
             RelationshipProjectionRevisionORM.governed_scopes,
+            RelationshipProjectionRevisionORM.purpose,
         ).where(
             RelationshipProjectionRevisionORM.id == clean_rev_id,
         )
@@ -434,7 +461,7 @@ class ProofValidator:
             self.add_error(f"Revision {clean_rev_id} not found in database")
             return None
 
-        proj_hash, governed_scopes_raw = rev_row
+        proj_hash, governed_scopes_raw, purpose = rev_row
         try:
             governed_scopes = (
                 json.loads(governed_scopes_raw) if isinstance(governed_scopes_raw, str) else governed_scopes_raw
@@ -443,22 +470,8 @@ class ProofValidator:
             self.add_error("Certified revision governed_scopes is malformed")
             return None
 
-        if not isinstance(governed_scopes, list) or not governed_scopes:
-            self.add_error("Certified revision governed_scopes must be a non-empty list of identifiers or objects")
-            return None
-
-        parsed_scopes = []
-        for scope in governed_scopes:
-            if isinstance(scope, str):
-                parsed_scopes.append(scope)
-            elif isinstance(scope, dict) and "predicate_id" in scope and isinstance(scope["predicate_id"], str):
-                parsed_scopes.append(scope["predicate_id"])
-            else:
-                self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
-                return None
-
-        if not all(scope.strip() for scope in parsed_scopes):
-            self.add_error("Certified revision governed_scopes contains invalid or missing predicate_id entries")
+        parsed_scopes = self.normalize_scopes(governed_scopes, expected_purpose=purpose)
+        if parsed_scopes is None:
             return None
 
         return proj_hash, parsed_scopes

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -101,12 +101,13 @@ def test_scopes_are_consistent_invalid_types() -> None:
     validator = ProofValidator({})
     # Test non-list inputs
     assert validator.scopes_are_consistent("not-a-list", ["scope1"], enforce_no_loss=True) is False  # type: ignore[arg-type]
-    assert "Scopes must be lists" in validator.errors
-
-    # Test non-string inputs (unhashable)
+    assert any("must be a non-empty list" in err for err in validator.errors)
     validator.errors.clear()
-    assert validator.scopes_are_consistent([{"unhashable": "dict"}], ["scope1"], enforce_no_loss=True) is False  # type: ignore[list-item]
-    assert "Scopes must be lists of strings" in validator.errors
+
+    # Test lists containing non-strings
+    assert validator.scopes_are_consistent([123], ["scope1"], enforce_no_loss=True) is False  # type: ignore[list-item]
+    assert any("invalid or missing predicate_id entries" in err for err in validator.errors)
+    validator.errors.clear()
 
 
 def test_actor_separated_validation() -> None:
@@ -247,36 +248,86 @@ def test_strict_mode_expected_revision_hash_requirement(mode: str, should_error:
 
 
 def test_validate_revision_scopes_malformed():
+    """Test that malformed governed scopes (e.g., dict instead of list) are rejected."""
     import json
     from unittest.mock import MagicMock
 
     validator = ProofValidator({})
     conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps({"not": "a list"}))
+    conn.execute().first.return_value = ("hash", json.dumps({"not": "a list"}), "testing")
     result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
     assert result is None
     assert any("must be a non-empty list" in err for err in validator.errors)
 
 
 def test_validate_revision_scopes_invalid_objects():
+    """Test that scopes missing a predicate_id or with an invalid predicate_id type are rejected."""
     import json
     from unittest.mock import MagicMock
 
     validator = ProofValidator({})
     conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": 123}]))
+    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": 123}]), "testing")
     result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
     assert result is None
     assert any("invalid or missing predicate_id" in err for err in validator.errors)
 
 
-def test_validate_revision_scopes_valid_objects():
+def test_validate_revision_scopes_missing_purpose():
+    """Test that object scopes missing a purpose are rejected."""
     import json
     from unittest.mock import MagicMock
 
     validator = ProofValidator({})
     conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": "scope-1"}, {"predicate_id": "scope-2"}]))
+    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": "scope-1"}]), "testing")
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result is None
+    assert any("invalid or missing predicate_id entries" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_wrong_purpose():
+    """Test that object scopes with a mismatched purpose are rejected."""
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = (
+        "hash",
+        json.dumps([{"predicate_id": "scope-1", "purpose": "other"}]),
+        "testing",
+    )
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result is None
+    assert any("incorrect purpose" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_blank_identifiers():
+    """Test that string scopes or object scopes with blank predicate_ids are rejected."""
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = ("hash", json.dumps([" "]), "testing")
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result is None
+    assert any("invalid or missing predicate_id" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_valid_objects_and_strings():
+    """Test that valid string scopes and valid object scopes with correct purposes are parsed properly."""
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = (
+        "hash",
+        json.dumps(["scope-1", {"predicate_id": "scope-2", "purpose": "testing"}]),
+        "testing",
+    )
     result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
     assert result == ("hash", ["scope-1", "scope-2"])
     assert not validator.errors

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -232,6 +232,7 @@ def test_restart_scopes_lookup_failures(monkeypatch: pytest.MonkeyPatch) -> None
     ],
 )
 def test_strict_mode_expected_revision_hash_requirement(mode: str, should_error: bool):
+    """Test that expected_revision_hash is required only for verify_after_restart mode."""
     validator = ProofValidator({})
     args = Namespace(
         strict=True,

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -247,47 +247,31 @@ def test_strict_mode_expected_revision_hash_requirement(mode: str, should_error:
         assert not validator.errors
 
 
-def test_validate_revision_scopes_malformed():
-    """Test that malformed governed scopes (e.g., dict instead of list) are rejected."""
-    import json
-    from unittest.mock import MagicMock
-
-    validator = ProofValidator({})
-    conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps({"not": "a list"}), "testing")
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result is None
-    assert any("must be a non-empty list" in err for err in validator.errors)
-
-
-def test_validate_revision_scopes_invalid_objects():
-    """Test that scopes missing a predicate_id or with an invalid predicate_id type are rejected."""
-    import json
-    from unittest.mock import MagicMock
-
-    validator = ProofValidator({})
-    conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": 123}]), "testing")
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result is None
-    assert any("invalid or missing predicate_id" in err for err in validator.errors)
-
-
-def test_validate_revision_scopes_missing_purpose():
-    """Test that object scopes missing a purpose are rejected."""
-    import json
-    from unittest.mock import MagicMock
-
-    validator = ProofValidator({})
-    conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": "scope-1"}]), "testing")
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result is None
-    assert any("invalid or missing predicate_id entries" in err for err in validator.errors)
-
-
-def test_validate_revision_scopes_wrong_purpose():
-    """Test that object scopes with a mismatched purpose are rejected."""
+@pytest.mark.parametrize(
+    ("scopes", "expected", "error_fragment"),
+    [
+        ({"not": "a list"}, None, "must be a non-empty list"),
+        ([{"predicate_id": 123}], None, "invalid or missing predicate_id"),
+        ([{"predicate_id": "scope-1"}], None, "invalid or missing predicate_id"),
+        (
+            [{"predicate_id": "scope-1", "purpose": "other"}],
+            None,
+            "incorrect purpose",
+        ),
+        ([" "], None, "invalid or missing predicate_id"),
+        (
+            ["scope-1", {"predicate_id": "scope-2", "purpose": "testing"}],
+            ("hash", ["scope-1::testing", "scope-2::testing"]),
+            None,
+        ),
+    ],
+)
+def test_validate_revision_scopes(
+    scopes: object,
+    expected: tuple[str, list[str]] | None,
+    error_fragment: str | None,
+) -> None:
+    """Validate supported and rejected governed-scope representations."""
     import json
     from unittest.mock import MagicMock
 
@@ -295,42 +279,20 @@ def test_validate_revision_scopes_wrong_purpose():
     conn = MagicMock()
     conn.execute().first.return_value = (
         "hash",
-        json.dumps([{"predicate_id": "scope-1", "purpose": "other"}]),
+        json.dumps(scopes),
         "testing",
     )
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result is None
-    assert any("incorrect purpose" in err for err in validator.errors)
 
-
-def test_validate_revision_scopes_blank_identifiers():
-    """Test that string scopes or object scopes with blank predicate_ids are rejected."""
-    import json
-    from unittest.mock import MagicMock
-
-    validator = ProofValidator({})
-    conn = MagicMock()
-    conn.execute().first.return_value = ("hash", json.dumps([" "]), "testing")
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result is None
-    assert any("invalid or missing predicate_id" in err for err in validator.errors)
-
-
-def test_validate_revision_scopes_valid_objects_and_strings():
-    """Test that valid string scopes and valid object scopes with correct purposes are parsed properly."""
-    import json
-    from unittest.mock import MagicMock
-
-    validator = ProofValidator({})
-    conn = MagicMock()
-    conn.execute().first.return_value = (
-        "hash",
-        json.dumps(["scope-1", {"predicate_id": "scope-2", "purpose": "testing"}]),
-        "testing",
+    result = validator._get_and_validate_revision_scopes(
+        conn=conn,
+        clean_rev_id="r",
     )
-    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result == ("hash", ["scope-1", "scope-2::testing"])
-    assert not validator.errors
+
+    assert result == expected
+    if error_fragment:
+        assert any(error_fragment in error for error in validator.errors)
+    else:
+        assert not validator.errors
 
 
 def test_scopes_are_consistent_purpose_mismatch():
@@ -342,3 +304,19 @@ def test_scopes_are_consistent_purpose_mismatch():
 
     assert validator.scopes_are_consistent(before, after, enforce_no_loss=True) is False
     assert any("Scopes disappeared" in err for err in validator.errors)
+
+
+def test_scopes_are_consistent_mixed_equivalent_representations() -> None:
+    """Treat equivalent string and canonical object scopes identically."""
+    validator = ProofValidator({})
+
+    before = ["scope-1"]
+    after = [{"predicate_id": "scope-1", "purpose": "testing"}]
+
+    assert validator.scopes_are_consistent(
+        before,
+        after,
+        enforce_no_loss=True,
+        expected_purpose="testing",
+    )
+    assert not validator.errors

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from argparse import Namespace
 from pathlib import Path
 from unittest.mock import patch
 
@@ -136,7 +137,6 @@ def test_restart_scopes_lookup_failures(monkeypatch: pytest.MonkeyPatch) -> None
     """Test that _validate_restart_scopes fails on missing, multiple, or malformed DB data."""
     import shutil
     import tempfile
-    from argparse import Namespace
 
     from src.data.database import create_engine_from_url, init_db
 
@@ -221,3 +221,63 @@ def test_restart_scopes_lookup_failures(monkeypatch: pytest.MonkeyPatch) -> None
     assert any("governed_scopes is malformed" in err for err in validator.errors)
     engine.dispose()
     shutil.rmtree(temp_dir)
+
+
+def test_strict_mode_seed_and_publish_no_expected_revision():
+    validator = ProofValidator({})
+    args = Namespace(
+        strict=True,
+        mode="seed_and_publish",
+        revision_hash="a" * 64,
+        expected_revision_hash=None,
+    )
+    validator._validate_revision(args)
+    assert not validator.errors
+
+
+def test_strict_mode_verify_after_restart_requires_expected_revision():
+    validator = ProofValidator({})
+    args = Namespace(
+        strict=True,
+        mode="verify_after_restart",
+        revision_hash="a" * 64,
+        expected_revision_hash=None,
+    )
+    validator._validate_revision(args)
+    assert any("Expected revision hash required" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_malformed():
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = ("hash", json.dumps({"not": "a list"}))
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result is None
+    assert any("must be a non-empty list" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_invalid_objects():
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": 123}]))
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result is None
+    assert any("invalid or missing predicate_id" in err for err in validator.errors)
+
+
+def test_validate_revision_scopes_valid_objects():
+    import json
+    from unittest.mock import MagicMock
+
+    validator = ProofValidator({})
+    conn = MagicMock()
+    conn.execute().first.return_value = ("hash", json.dumps([{"predicate_id": "scope-1"}, {"predicate_id": "scope-2"}]))
+    result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
+    assert result == ("hash", ["scope-1", "scope-2"])
+    assert not validator.errors

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -329,5 +329,16 @@ def test_validate_revision_scopes_valid_objects_and_strings():
         "testing",
     )
     result = validator._get_and_validate_revision_scopes(conn=conn, clean_rev_id="r")
-    assert result == ("hash", ["scope-1", "scope-2"])
+    assert result == ("hash", ["scope-1", "scope-2::testing"])
     assert not validator.errors
+
+
+def test_scopes_are_consistent_purpose_mismatch():
+    """Test that scopes_are_consistent rejects identical predicate_ids if the purpose differs."""
+    validator = ProofValidator({})
+
+    before = [{"predicate_id": "scope-1", "purpose": "purpose-a"}]
+    after = [{"predicate_id": "scope-1", "purpose": "purpose-b"}]
+
+    assert validator.scopes_are_consistent(before, after, enforce_no_loss=True) is False
+    assert any("Scopes disappeared" in err for err in validator.errors)

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -223,28 +223,27 @@ def test_restart_scopes_lookup_failures(monkeypatch: pytest.MonkeyPatch) -> None
     shutil.rmtree(temp_dir)
 
 
-def test_strict_mode_seed_and_publish_no_expected_revision():
+@pytest.mark.parametrize(
+    "mode, should_error",
+    [
+        ("seed_and_publish", False),
+        ("verify_after_restart", True),
+    ],
+)
+def test_strict_mode_expected_revision_hash_requirement(mode: str, should_error: bool):
     validator = ProofValidator({})
     args = Namespace(
         strict=True,
-        mode="seed_and_publish",
+        mode=mode,
         revision_hash="a" * 64,
         expected_revision_hash=None,
     )
     validator._validate_revision(args)
-    assert not validator.errors
 
-
-def test_strict_mode_verify_after_restart_requires_expected_revision():
-    validator = ProofValidator({})
-    args = Namespace(
-        strict=True,
-        mode="verify_after_restart",
-        revision_hash="a" * 64,
-        expected_revision_hash=None,
-    )
-    validator._validate_revision(args)
-    assert any("Expected revision hash required" in err for err in validator.errors)
+    if should_error:
+        assert any("Expected revision hash required" in err for err in validator.errors)
+    else:
+        assert not validator.errors
 
 
 def test_validate_revision_scopes_malformed():


### PR DESCRIPTION
## **User description**
This PR fixes two bugs in the staging proof validation script:
1. It removes the requirement for expected_revision_hash in strict mode when running in seed_and_publish mode.
2. It correctly parses governed_scopes which are stored as a list of dicts (with predicate_id) rather than a list of strings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes strict staging-proof validation and governed-scope continuity. In strict mode, `seed_and_publish` no longer requires `expected_revision_hash`, and restart now normalizes and compares scopes by predicate+purpose using the DB revision purpose; it accepts mixed string/object forms and returns clearer errors.

- **Bug Fixes**
  - In strict mode, require `expected_revision_hash` only for `verify_after_restart`; skip for `seed_and_publish`.
  - Normalize and compare governed scopes with the DB revision purpose: accept strings or `{predicate_id, purpose}`, canonicalize to `predicate_id::purpose`, enforce no-loss, and treat equivalent forms as equal; reject invalid entries and purpose mismatches; added tests.

- **Refactors**
  - Extracted assertion lifecycle validation into helpers (sequence and actors/states).
  - Reduced `normalize_scopes` complexity, centralized predicate error text, and resolved remaining DeepSource issues.

<sup>Written for commit 747386f16b92f756fa228cb8a9d80fb72b53a734. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Correct strict staging-proof validation for seed publishing and governed scopes

### What Changed
- Strict `seed_and_publish` validation no longer requires an expected revision hash.
- Governed scopes can be read from identifier strings or objects containing a predicate ID.
- Invalid or malformed scope entries now produce clear validation errors.
- Added coverage for strict-mode scenarios and supported scope formats.

### Impact
`✅ Fewer false failures when publishing seeded revisions`
`✅ Compatible validation for object-based governed scopes`
`✅ Clearer errors for invalid staging-proof data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change supports object-shaped governed scopes during strict proof validation, preserves revision purpose across restart checks, and adds contract coverage for mixed representations. The reported whitespace-only predicate issue was not retained: the executed SQLite check confirmed strict validation normalizes it to `::testing`, but also confirmed the projection canonicalizer accepts the same value rather than rejecting it, so the claimed cross-validator inconsistency does not occur.

<h3>Confidence Score: 5/5</h3>

The PR is safe to merge; no blocking failure remains.

The only reported failure mode was exercised and contradicted by the observed projection behavior, leaving no confirmed defects.

<sub>Reviews (5): Last reviewed commit: ["refactor(staging-proof): resolve remaini..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/747386f16b92f756fa228cb8a9d80fb72b53a734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50595338)</sub>

<!-- /greptile_comment -->