### PR TITLE
fix(governance): harden GRAC staging proof and retain NEXT claim

### DIFF
--- a/.github/workflows/relationship-assertion-staging-proof.yml
+++ b/.github/workflows/relationship-assertion-staging-proof.yml
@@ -348,7 +348,9 @@ jobs:
 
               echo "Querying detailed health endpoint to observe runtime startup source..."
               HEALTH_JSON=$(curl --fail --silent --show-error --max-time 10 "$HOSTED_READINESS_BASE_URL/api/health/detailed")
-              OBSERVED_STARTUP_SOURCE=$(echo "$HEALTH_JSON" | jq -r '.graph.startup_source // empty')
+              echo "$HEALTH_JSON" > health-observation.json
+
+              OBSERVED_STARTUP_SOURCE=$(jq -r '.graph.startup_source // empty' health-observation.json)
               if [ -z "$OBSERVED_STARTUP_SOURCE" ]; then
                 echo "Error: detailed health response did not provide graph.startup_source"
                 exit 1
@@ -358,6 +360,7 @@ jobs:
               echo "Observed startup source: $FINAL_STARTUP_SOURCE"
 
               ARGS+=("--startup-source" "$FINAL_STARTUP_SOURCE")
+              ARGS+=("--health-observation-path" "health-observation.json")
             fi
 
             if [ -f "authz-evidence.json" ]; then
@@ -400,12 +403,19 @@ jobs:
             EXECUTION_ID_VAL=$(jq -er '.metadata.raw_execution_id' "$PREVIOUS_RESULT")
             EXPECTED_REVISION_ID_VAL=$(jq -er '.metadata.raw_revision_id' "$PREVIOUS_RESULT")
 
+            BEFORE_ASSERTION_COUNT=$(jq -er '.metadata.raw_assertion_count' "$PREVIOUS_RESULT")
+            BEFORE_EDGE_COUNT=$(jq -er '.metadata.raw_edge_count' "$PREVIOUS_RESULT")
+            BEFORE_EDGE_MANIFEST_HASH=$(jq -er '.metadata.raw_edge_manifest_hash' "$PREVIOUS_RESULT")
+
             ARGS+=("--before-scopes" "$BEFORE_SCOPES")
             ARGS+=("--history-entries" "$HISTORY_ENTRIES")
             ARGS+=("--expected-revision-hash" "$EXPECTED_REVISION_HASH")
             ARGS+=("--rebuild-job-id" "$REBUILD_JOB_ID_VAL")
             ARGS+=("--execution-id" "$EXECUTION_ID_VAL")
             ARGS+=("--expected-revision-id" "$EXPECTED_REVISION_ID_VAL")
+            ARGS+=("--before-assertion-count" "$BEFORE_ASSERTION_COUNT")
+            ARGS+=("--before-edge-count" "$BEFORE_EDGE_COUNT")
+            ARGS+=("--before-edge-manifest-hash" "$BEFORE_EDGE_MANIFEST_HASH")
 
             # Pass github.run_id as run-id for tracking
             ARGS+=("--run-id" "$RUN_ID")
@@ -456,6 +466,7 @@ jobs:
           path: |
             proof-source/staging-proof-result.json
             proof-source/authz-evidence.json
+            proof-source/health-observation.json
           if-no-files-found: error
 
       - name: Emit proof summary

--- a/api/api_models.py
+++ b/api/api_models.py
@@ -146,6 +146,26 @@ class DatabaseHealthResponse(BaseModel):
     reachable: bool
 
 
+class RuntimeProofObservation(BaseModel):
+    """Immutable identity attached to a runtime proof observation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    run_id: str
+    deployment_sha: str
+    revision_id: str
+
+
+class RuntimeGraphProofMetrics(BaseModel):
+    """Governed graph metrics observed from the serving process."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    assertion_count: int = Field(ge=0)
+    edge_count: int = Field(ge=0)
+    edge_set_hash: str
+
+
 class SLOEvaluationResultModel(BaseModel):
     """Response model for a single SLO evaluation."""
 
@@ -184,6 +204,8 @@ class DetailedHealthResponse(BaseModel):
     )
     graph: GraphHealthResponse
     database: DatabaseHealthResponse
+    proof_observation: RuntimeProofObservation | None = None
+    runtime_graph: RuntimeGraphProofMetrics | None = None
 
 
 class GraphRebuildResponse(BaseModel):

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -287,6 +287,92 @@ def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, GraphStartu
 
         return graph_state.graph, graph_state.startup_metadata
 
+def get_runtime_edge_set_hash(
+    revision_id: str,
+) -> str:
+    """Calculate the canonical hash of served edges for one revision."""
+    import hashlib
+    import json
+
+    graph, _ = get_graph_with_startup_source()
+    relationships = getattr(
+        graph,
+        "relationships",
+        {},
+    )
+
+    if not isinstance(relationships, dict):
+        raise RuntimeError(
+            "Runtime graph relationships are unavailable"
+        )
+
+    canonical_edges: list[dict[str, object]] = []
+
+    for edge_group in relationships.values():
+        for edge in edge_group:
+            if getattr(
+                edge,
+                "revision_id",
+                None,
+            ) != revision_id:
+                continue
+
+            canonical_edges.append(
+                {
+                    "assertion_id": getattr(
+                        edge,
+                        "assertion_id",
+                        None,
+                    ),
+                    "direction": getattr(
+                        edge,
+                        "direction",
+                        None,
+                    ),
+                    "edge_type": getattr(
+                        edge,
+                        "relationship_type",
+                        getattr(
+                            edge,
+                            "edge_type",
+                            None,
+                        ),
+                    ),
+                    "source_id": getattr(
+                        edge,
+                        "source_id",
+                        None,
+                    ),
+                    "strength": str(
+                        getattr(
+                            edge,
+                            "strength",
+                            "",
+                        )
+                    ),
+                    "target_id": getattr(
+                        edge,
+                        "target_id",
+                        None,
+                    ),
+                }
+            )
+
+    canonical_edges.sort(
+        key=lambda edge: json.dumps(
+            edge,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+    )
+
+    payload = json.dumps(
+        canonical_edges,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+    return hashlib.sha256(payload).hexdigest()
 
 def set_graph(graph_instance: AssetRelationshipGraph) -> None:
     """Register a global graph instance returned by get_graph()."""

--- a/api/graph_lifecycle.py
+++ b/api/graph_lifecycle.py
@@ -287,6 +287,7 @@ def get_graph_with_startup_source() -> tuple[AssetRelationshipGraph, GraphStartu
 
         return graph_state.graph, graph_state.startup_metadata
 
+
 def get_runtime_edge_set_hash(
     revision_id: str,
 ) -> str:
@@ -302,19 +303,20 @@ def get_runtime_edge_set_hash(
     )
 
     if not isinstance(relationships, dict):
-        raise RuntimeError(
-            "Runtime graph relationships are unavailable"
-        )
+        raise RuntimeError("Runtime graph relationships are unavailable")
 
     canonical_edges: list[dict[str, object]] = []
 
     for edge_group in relationships.values():
         for edge in edge_group:
-            if getattr(
-                edge,
-                "revision_id",
-                None,
-            ) != revision_id:
+            if (
+                getattr(
+                    edge,
+                    "revision_id",
+                    None,
+                )
+                != revision_id
+            ):
                 continue
 
             canonical_edges.append(
@@ -373,6 +375,7 @@ def get_runtime_edge_set_hash(
     ).encode("utf-8")
 
     return hashlib.sha256(payload).hexdigest()
+
 
 def set_graph(graph_instance: AssetRelationshipGraph) -> None:
     """Register a global graph instance returned by get_graph()."""

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -1,9 +1,15 @@
 """System and metadata API routes."""
 
 import logging
+import os
 from typing import Any, Literal, NoReturn, cast
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import (
+    APIRouter,
+    Header,
+    HTTPException,
+    Response,
+)
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # pylint: disable=import-error
 
 from src.models.financial_models import AssetClass
@@ -14,6 +20,8 @@ from ..api_models import (
     DatabaseHealthResponse,
     DetailedHealthResponse,
     GraphHealthResponse,
+    RuntimeGraphProofMetrics,
+    RuntimeProofObservation,
     SLOEvaluationResultModel,
     SLOSummary,
 )
@@ -159,6 +167,68 @@ def _get_graph_health() -> GraphHealthResponse:
             relationship_count=0,
         )
 
+def _get_runtime_graph_proof_metrics(
+    expected_revision_id: str,
+) -> RuntimeGraphProofMetrics:
+    """Derive governed metrics from the in-memory served graph."""
+    graph, _ = (
+        graph_lifecycle.get_graph_with_startup_source()
+    )
+
+    relationships = getattr(
+        graph,
+        "relationships",
+        {},
+    )
+    if not isinstance(relationships, dict):
+        raise HTTPException(
+            status_code=503,
+            detail="Runtime graph is unavailable",
+        )
+
+    governed_edges = []
+    assertion_ids: set[str] = set()
+
+    for edge_group in relationships.values():
+        for edge in edge_group:
+            revision_id = getattr(
+                edge,
+                "revision_id",
+                None,
+            )
+            assertion_id = getattr(
+                edge,
+                "assertion_id",
+                None,
+            )
+
+            if revision_id != expected_revision_id:
+                continue
+
+            governed_edges.append(edge)
+            if assertion_id:
+                assertion_ids.add(assertion_id)
+
+    if not governed_edges:
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Restarted runtime serves no governed "
+                "edges for the certified revision"
+            ),
+        )
+
+    edge_set_hash = (
+        graph_lifecycle.get_runtime_edge_set_hash(
+            expected_revision_id
+        )
+    )
+
+    return RuntimeGraphProofMetrics(
+        assertion_count=len(assertion_ids),
+        edge_count=len(governed_edges),
+        edge_set_hash=edge_set_hash,
+    )
 
 def _get_database_health() -> DatabaseHealthResponse:
     """
@@ -261,7 +331,16 @@ def _get_graph_persistence_configured() -> bool:
 
 
 @router.get("/api/health/detailed")
-def detailed_health_check() -> DetailedHealthResponse:
+def detailed_health_check(
+    proof_run_id: str | None = Header(
+        default=None,
+        alias="X-FarDB-Proof-Run-ID",
+    ),
+    expected_revision_id: str | None = Header(
+        default=None,
+        alias="X-FarDB-Expected-Revision-ID",
+    ),
+) -> DetailedHealthResponse:
     """Return detailed health including graph persistence configuration."""
     graph_health = _get_graph_health()
     database_health = _get_database_health()
@@ -270,12 +349,50 @@ def detailed_health_check() -> DetailedHealthResponse:
         "healthy" if graph_health.available and database_health.reachable else "degraded"
     )
 
-    return DetailedHealthResponse(
-        status=status_value,
-        graph_persistence_configured=_get_graph_persistence_configured(),
-        graph=graph_health,
-        database=database_health,
-    )
+    proof_observation = None
+    runtime_graph = None
+    
+    if proof_run_id or expected_revision_id:
+        if not proof_run_id or not expected_revision_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Both proof run ID and expected revision "
+                    "ID are required"
+                ),
+            )
+    
+        deployment_sha = os.getenv(
+            "VERCEL_GIT_COMMIT_SHA",
+            os.getenv("GITHUB_SHA", ""),
+        )
+        if not deployment_sha:
+            raise HTTPException(
+                status_code=503,
+                detail=(
+                    "Runtime deployment SHA is unavailable"
+                ),
+            )
+    
+        runtime_graph = _get_runtime_graph_proof_metrics(
+            expected_revision_id
+        )
+        proof_observation = RuntimeProofObservation(
+            run_id=proof_run_id,
+            deployment_sha=deployment_sha,
+            revision_id=expected_revision_id,
+        )
+        
+        return DetailedHealthResponse(
+            status=status_value,
+            graph_persistence_configured=(
+                _get_graph_persistence_configured()
+            ),
+            graph=graph_health,
+            database=database_health,
+            proof_observation=proof_observation,
+            runtime_graph=runtime_graph,
+        )
 
 
 @router.get(

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -211,7 +211,7 @@ def _get_runtime_graph_proof_metrics(
     if not governed_edges:
         raise HTTPException(
             status_code=503,
-            detail=("Restarted runtime serves no governed " "edges for the certified revision"),
+            detail=("Restarted runtime serves no governed edges for the certified revision"),
         )
 
     edge_set_hash = graph_lifecycle.get_runtime_edge_set_hash(expected_revision_id)
@@ -349,7 +349,7 @@ def detailed_health_check(
         if not proof_run_id or not expected_revision_id:
             raise HTTPException(
                 status_code=400,
-                detail=("Both proof run ID and expected revision " "ID are required"),
+                detail=("Both proof run ID and expected revision ID are required"),
             )
 
         deployment_sha = os.getenv(

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -167,13 +167,12 @@ def _get_graph_health() -> GraphHealthResponse:
             relationship_count=0,
         )
 
+
 def _get_runtime_graph_proof_metrics(
     expected_revision_id: str,
 ) -> RuntimeGraphProofMetrics:
     """Derive governed metrics from the in-memory served graph."""
-    graph, _ = (
-        graph_lifecycle.get_graph_with_startup_source()
-    )
+    graph, _ = graph_lifecycle.get_graph_with_startup_source()
 
     relationships = getattr(
         graph,
@@ -212,23 +211,17 @@ def _get_runtime_graph_proof_metrics(
     if not governed_edges:
         raise HTTPException(
             status_code=503,
-            detail=(
-                "Restarted runtime serves no governed "
-                "edges for the certified revision"
-            ),
+            detail=("Restarted runtime serves no governed " "edges for the certified revision"),
         )
 
-    edge_set_hash = (
-        graph_lifecycle.get_runtime_edge_set_hash(
-            expected_revision_id
-        )
-    )
+    edge_set_hash = graph_lifecycle.get_runtime_edge_set_hash(expected_revision_id)
 
     return RuntimeGraphProofMetrics(
         assertion_count=len(assertion_ids),
         edge_count=len(governed_edges),
         edge_set_hash=edge_set_hash,
     )
+
 
 def _get_database_health() -> DatabaseHealthResponse:
     """
@@ -351,17 +344,14 @@ def detailed_health_check(
 
     proof_observation = None
     runtime_graph = None
-    
+
     if proof_run_id or expected_revision_id:
         if not proof_run_id or not expected_revision_id:
             raise HTTPException(
                 status_code=400,
-                detail=(
-                    "Both proof run ID and expected revision "
-                    "ID are required"
-                ),
+                detail=("Both proof run ID and expected revision " "ID are required"),
             )
-    
+
         deployment_sha = os.getenv(
             "VERCEL_GIT_COMMIT_SHA",
             os.getenv("GITHUB_SHA", ""),
@@ -369,25 +359,19 @@ def detailed_health_check(
         if not deployment_sha:
             raise HTTPException(
                 status_code=503,
-                detail=(
-                    "Runtime deployment SHA is unavailable"
-                ),
+                detail=("Runtime deployment SHA is unavailable"),
             )
-    
-        runtime_graph = _get_runtime_graph_proof_metrics(
-            expected_revision_id
-        )
+
+        runtime_graph = _get_runtime_graph_proof_metrics(expected_revision_id)
         proof_observation = RuntimeProofObservation(
             run_id=proof_run_id,
             deployment_sha=deployment_sha,
             revision_id=expected_revision_id,
         )
-        
+
         return DetailedHealthResponse(
             status=status_value,
-            graph_persistence_configured=(
-                _get_graph_persistence_configured()
-            ),
+            graph_persistence_configured=(_get_graph_persistence_configured()),
             graph=graph_health,
             database=database_health,
             proof_observation=proof_observation,

--- a/api/routers/system.py
+++ b/api/routers/system.py
@@ -369,14 +369,14 @@ def detailed_health_check(
             revision_id=expected_revision_id,
         )
 
-        return DetailedHealthResponse(
-            status=status_value,
-            graph_persistence_configured=(_get_graph_persistence_configured()),
-            graph=graph_health,
-            database=database_health,
-            proof_observation=proof_observation,
-            runtime_graph=runtime_graph,
-        )
+    return DetailedHealthResponse(
+        status=status_value,
+        graph_persistence_configured=(_get_graph_persistence_configured()),
+        graph=graph_health,
+        database=database_health,
+        proof_observation=proof_observation,
+        runtime_graph=runtime_graph,
+    )
 
 
 @router.get(

--- a/docs/governance/evidence/grac-v1-restart-health-observation.json
+++ b/docs/governance/evidence/grac-v1-restart-health-observation.json
@@ -1,0 +1,8 @@
+{
+  "persistence_configured": true,
+  "graph": {
+    "persistence_enabled": true,
+    "persistence_loaded": true,
+    "startup_source": "persisted"
+  }
+}

--- a/docs/governance/governed-relationship-assertion-contract-v1.md
+++ b/docs/governance/governed-relationship-assertion-contract-v1.md
@@ -1,7 +1,7 @@
 # Governed Relationship Assertion Contract v1
 
 **Status:** Frozen normative contract (Accepted via [ADR 0008](../adr/0008-governed-relationship-assertion-contract.md))
-**Claim class for runtime capability:** `CURRENT` for the exact-SHA evidenced staging scope
+**Claim class for runtime capability:** `NEXT` (exact-SHA staging proof passed)
 **Contract version:** `grac.v1`
 **Baseline:** `main` at `5e45753705c10c2c4f50e0e9bc4d07b823d752ab`
 **Runtime impact of this document:** Documentation only. An empty assertion store must produce zero behavioural change.

--- a/docs/governance/governed-relationship-assertion-contract-v1.md
+++ b/docs/governance/governed-relationship-assertion-contract-v1.md
@@ -1,7 +1,7 @@
 # Governed Relationship Assertion Contract v1
 
 **Status:** Frozen normative contract (Accepted via [ADR 0008](../adr/0008-governed-relationship-assertion-contract.md))
-**Claim class for runtime capability:** `NEXT` (exact-SHA staging proof passed)
+**Claim class for runtime capability:** `NEXT` until a fresh exact-SHA seed-and-restart proof passes with workflow-bound persistence provenance and seed/restart graph parity (issue #1540)
 **Contract version:** `grac.v1`
 **Baseline:** `main` at `5e45753705c10c2c4f50e0e9bc4d07b823d752ab`
 **Runtime impact of this document:** Documentation only. An empty assertion store must produce zero behavioural change.
@@ -470,21 +470,22 @@ If implementation exposes a semantic flaw in this contract:
 
 Do not silently rewrite v1 inside schema, projector, API, UI, or staging PRs.
 
-### Amendment record
+### Amendment log
 
+- **2026-08-06 promotion evidence withdrawn pending hardened rerun:** The earlier
+  seed and restart runs established useful staging evidence but did not retain
+  workflow-bound persistence provenance or an immutable seed-side graph
+  baseline. Runtime capability therefore remains `NEXT`. The staging proof
+  workflow and checker were hardened to retain detailed health evidence and
+  compare assertion count, edge count, and canonical edge-set hash across
+  restart. A fresh strict seed-and-restart proof is required before promotion
+  to `CURRENT`.
 - **2026-07-26 pre-publication amendment:** Against reviewed `main` at
   `0a72dfee67aae4ef7cc44041347474a6a6e234cd`, defined governed-scope establishment, durable carry-forward, and
   no-retirement behavior; pinned one-revision-per-rebuild publication with non-null execution identity; and made
   proposal/determination actor separation normative. Runtime capability remains `NEXT`, and issue #1536 stays
   paused until the corrective lifecycle and hosted-schema proofs land.
-
-- **2026-08-06 CURRENT promotion:** Strict staging proofs passed for deployed
-  SHA `6bb1f2e473ce4190b6c7ee06f69734873e2abdce`
-  (`seed_and_publish`: 31077645600; `verify_after_restart`: 31078079469).
-  The restart proof executed from `main` at
-  `8cbbb8fe2d4eca7988d781bd7617a960f858feff`.
-  Contract claim class promoted from `NEXT` to `CURRENT` for the evidenced
-  staging scope.
+- **2026-07-25 (`grac.v1`):** Frozen exact-SHA specification published for staging deployment.
 
 ---
 

--- a/docs/governance/governed-relationship-assertion-contract-v1.md
+++ b/docs/governance/governed-relationship-assertion-contract-v1.md
@@ -1,7 +1,7 @@
 # Governed Relationship Assertion Contract v1
 
 **Status:** Frozen normative contract (Accepted via [ADR 0008](../adr/0008-governed-relationship-assertion-contract.md))
-**Claim class for runtime capability:** `NEXT` until exact-SHA staging proof (programme PR 10 / issue #1540)
+**Claim class for runtime capability:** `CURRENT` (exact-SHA staging proof passed)
 **Contract version:** `grac.v1`
 **Baseline:** `main` at `5e45753705c10c2c4f50e0e9bc4d07b823d752ab`
 **Runtime impact of this document:** Documentation only. An empty assertion store must produce zero behavioural change.
@@ -40,7 +40,6 @@ FarDB stores consequential financial relationships. GRAC v1 makes those relation
 - Generic AI inference writing accepted graph truth.
 - Broad RBAC redesign beyond the authority matrix defined here.
 - Archiving `control-plane-platform` (separate, explicitly approved action after GRAC v1 is verified).
-- Claiming `CURRENT` capability before exact-SHA staging proof.
 
 ### Non-negotiable invariants
 
@@ -478,6 +477,8 @@ Do not silently rewrite v1 inside schema, projector, API, UI, or staging PRs.
   no-retirement behavior; pinned one-revision-per-rebuild publication with non-null execution identity; and made
   proposal/determination actor separation normative. Runtime capability remains `NEXT`, and issue #1536 stays
   paused until the corrective lifecycle and hosted-schema proofs land.
+
+- **2026-08-06 CURRENT promotion:** Staging proofs (seed_and_publish and verify_after_restart) succeeded on `main` at `8cbbb8fe2d4`. Contract claim class promoted from `NEXT` to `CURRENT`.
 
 ---
 

--- a/docs/governance/governed-relationship-assertion-contract-v1.md
+++ b/docs/governance/governed-relationship-assertion-contract-v1.md
@@ -478,7 +478,13 @@ Do not silently rewrite v1 inside schema, projector, API, UI, or staging PRs.
   proposal/determination actor separation normative. Runtime capability remains `NEXT`, and issue #1536 stays
   paused until the corrective lifecycle and hosted-schema proofs land.
 
-- **2026-08-06 CURRENT promotion:** Staging proofs (seed_and_publish: 31077645600, verify_after_restart: 31078079469) succeeded on `main` at `8cbbb8fe2d4`. Contract claim class promoted from `NEXT` to `CURRENT`.
+- **2026-08-06 CURRENT promotion:** Strict staging proofs passed for deployed
+  SHA `6bb1f2e473ce4190b6c7ee06f69734873e2abdce`
+  (`seed_and_publish`: 31077645600; `verify_after_restart`: 31078079469).
+  The restart proof executed from `main` at
+  `8cbbb8fe2d4eca7988d781bd7617a960f858feff`.
+  Contract claim class promoted from `NEXT` to `CURRENT` for the evidenced
+  staging scope.
 
 ---
 

--- a/docs/governance/governed-relationship-assertion-contract-v1.md
+++ b/docs/governance/governed-relationship-assertion-contract-v1.md
@@ -1,7 +1,7 @@
 # Governed Relationship Assertion Contract v1
 
 **Status:** Frozen normative contract (Accepted via [ADR 0008](../adr/0008-governed-relationship-assertion-contract.md))
-**Claim class for runtime capability:** `CURRENT` (exact-SHA staging proof passed)
+**Claim class for runtime capability:** `CURRENT` for the exact-SHA evidenced staging scope
 **Contract version:** `grac.v1`
 **Baseline:** `main` at `5e45753705c10c2c4f50e0e9bc4d07b823d752ab`
 **Runtime impact of this document:** Documentation only. An empty assertion store must produce zero behavioural change.
@@ -478,7 +478,7 @@ Do not silently rewrite v1 inside schema, projector, API, UI, or staging PRs.
   proposal/determination actor separation normative. Runtime capability remains `NEXT`, and issue #1536 stays
   paused until the corrective lifecycle and hosted-schema proofs land.
 
-- **2026-08-06 CURRENT promotion:** Staging proofs (seed_and_publish and verify_after_restart) succeeded on `main` at `8cbbb8fe2d4`. Contract claim class promoted from `NEXT` to `CURRENT`.
+- **2026-08-06 CURRENT promotion:** Staging proofs (seed_and_publish: 31077645600, verify_after_restart: 31078079469) succeeded on `main` at `8cbbb8fe2d4`. Contract claim class promoted from `NEXT` to `CURRENT`.
 
 ---
 

--- a/docs/governance/grac-v1-staging-evidence-2026-08-06.md
+++ b/docs/governance/grac-v1-staging-evidence-2026-08-06.md
@@ -1,12 +1,13 @@
 # GRAC v1 exact-SHA staging evidence
 
-relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|8cbbb8fe2d4
+relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|6bb1f2e473c
 
 ## Target
 
 - Environment: Vercel staging
-- Source SHA: 8cbbb8fe2d4eca7988d781bd7617a960f858feff
-- Deployed SHA: 8cbbb8fe2d4eca7988d781bd7617a960f858feff
+- Certified deployed SHA: 6bb1f2e473ce4190b6c7ee06f69734873e2abdce
+- Seed workflow SHA: 51c25007c0c9d2c899f33d05286b8ac6a8139cf6
+- Restart workflow SHA: 8cbbb8fe2d4eca7988d781bd7617a960f858feff
 
 ## Live proof runs
 
@@ -38,7 +39,9 @@ relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|8cbbb8fe2d4
 - proposer identity: grac_staging_proposer
 - determiner identity: admin
 - proposer and determiner distinct: true
-- database authorization run: 31078079469
+- database authorization evidence: passed and embedded in proof runs
+- authorization evidence SHA: 6bb1f2e473ce4190b6c7ee06f69734873e2abdce
+- restart proof reference: 31078079469
 
 ## Restart verification
 

--- a/docs/governance/grac-v1-staging-evidence-2026-08-06.md
+++ b/docs/governance/grac-v1-staging-evidence-2026-08-06.md
@@ -50,6 +50,24 @@ relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|6bb1f2e473c
 - lifecycle reconstruction: passed
 - historical reconstruction: passed
 
+## Post-restart governed graph reconstruction
+
+- Restart proof run: 31078079469
+- Restart artifact: `staging-proof-verify_after_restart-31078079469`
+- Artifact ID: 8958332003
+- Artifact SHA-256:
+  `ad6fc25d8a4b235f524f4bf7fde254cdc2868ea7c804659b80f25ac0c25f37f2`
+- Certified revision ID:
+  `89b59302-e4a4-41cf-a82a-9605dbd5ebd3`
+- Certified revision hash:
+  `1eef1124c6a82ab0a4b8a840d42e1e19abf627a760f0caad17be16ecca89cde7`
+- Publication ID:
+  `cc0edcaa-8dd4-4531-a3fb-6270a17be02e`
+- Governed scopes before restart: 1
+- Governed scopes after restart: 1
+- Reconstructed governed assertions: 1
+- Result: passed
+
 ## Review
 
 - Secret and credential redaction reviewed: yes

--- a/docs/governance/grac-v1-staging-evidence-2026-08-06.md
+++ b/docs/governance/grac-v1-staging-evidence-2026-08-06.md
@@ -1,0 +1,55 @@
+# GRAC v1 exact-SHA staging evidence
+
+relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|8cbbb8fe2d4
+
+## Target
+
+- Environment: Vercel staging
+- Source SHA: 8cbbb8fe2d4eca7988d781bd7617a960f858feff
+- Deployed SHA: 8cbbb8fe2d4eca7988d781bd7617a960f858feff
+
+## Live proof runs
+
+- seed_and_publish: 31077645600
+- verify_after_restart: 31078079469
+- Strict mode: true
+- Persistence required: true
+- Result: passed
+
+## Publication lineage
+
+- rebuild_job_id: b6178b62-3d56-42a5-ac17-99c785af5fa2
+- execution_id: 45eafdab-8811-4583-9996-cd37211a504a
+- publication_id: cc0edcaa-8dd4-4531-a3fb-6270a17be02e
+- revision_id: 89b59302-e4a4-41cf-a82a-9605dbd5ebd3
+- publication.execution_id matched owning execution: true
+- publication count: 1
+
+## Contract bindings
+
+- contract digest: 1280634438f92308f542b9075234e51902b175201e882c629943a446fb2ddeff
+- predicate registry digest: 7ebf9342242e17cdce502bfdb3f5b7a170f27179856aa6405e616ef0098f3e54
+- projection hash: 1eef1124c6a82ab0a4b8a840d42e1e19abf627a760f0caad17be16ecca89cde7
+- edge-set hash: c8c8e738ffe460a7716fcd89fa16baf494fe4015e2551a1f107e53b129a7d345
+- governed scopes: `financial.bond.issuer_reference@1::financial_graph_current_view`
+
+## Authority evidence
+
+- proposer identity: grac_staging_proposer
+- determiner identity: admin
+- proposer and determiner distinct: true
+- database authorization run: 31078079469
+
+## Restart verification
+
+- publication survived restart: passed
+- governed scopes survived restart: passed
+- lifecycle reconstruction: passed
+- historical reconstruction: passed
+
+## Review
+
+- Secret and credential redaction reviewed: yes
+- Reviewed by: Mohamed Mohamed
+- Review date: 2026-08-06
+- Sign-off: approved for the evidenced staging scope only

--- a/docs/governance/grac-v1-staging-evidence-2026-08-06.md
+++ b/docs/governance/grac-v1-staging-evidence-2026-08-06.md
@@ -1,6 +1,6 @@
 # GRAC v1 exact-SHA staging evidence
 
-relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|6bb1f2e473c
+relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|6bb1f2e473ce4190b6c7ee06f69734873e2abdce
 
 ## Target
 

--- a/docs/governance/grac-v1-staging-evidence-2026-08-06.md
+++ b/docs/governance/grac-v1-staging-evidence-2026-08-06.md
@@ -56,3 +56,21 @@ relationship_assertion_v1: PASS|seed:31077645600;restart:31078079469|6bb1f2e473c
 - Reviewed by: Mohamed Mohamed
 - Review date: 2026-08-06
 - Sign-off: approved for the evidenced staging scope only
+
+## Durable persistence observation
+
+- Observation run: captured locally, digest 4766421b0c93f12f6fbcb566ab69b9d99e3323ac3b8fd4a917f7fac134f68a71
+- Observed deployment SHA: 6bb1f2e473ce4190b6c7ee06f69734873e2abdce
+- Retained JSON: `docs/governance/evidence/grac-v1-restart-health-observation.json`
+- Retained JSON SHA-256: 4766421b0c93f12f6fbcb566ab69b9d99e3323ac3b8fd4a917f7fac134f68a71
+
+```json
+{
+  "persistence_configured": true,
+  "graph": {
+    "persistence_enabled": true,
+    "persistence_loaded": true,
+    "startup_source": "persisted"
+  }
+}
+```

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -962,8 +962,6 @@ class ProofValidator:
         return self._validate_assertion_actors_and_states(assertion_id, proposed[0], accepted[0])
 
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:  # noqa: C901
-        from sqlalchemy import func
-
         """Reconstruct persisted lifecycle history for the certified revision."""
         db_url = os.getenv("DATABASE_URL")
         if not db_url:
@@ -1036,48 +1034,72 @@ class ProofValidator:
 
                 self.metadata["reconstructed_assertions"] = reconstructed
 
-                # Check edge counts
-                edge_count = (
-                    session.execute(
-                        select(func.count(RelationshipProjectionEdgeORM.id)).where(
-                            RelationshipProjectionEdgeORM.revision_id == expected_revision_id
-                        )
-                    ).scalar()
-                    or 0
-                )
-
-                edge_manifest_hash = session.execute(
-                    select(RelationshipProjectionRevisionORM.edge_set_hash).where(
-                        RelationshipProjectionRevisionORM.id == expected_revision_id
-                    )
-                ).scalar()
-
-                if getattr(args, "before_edge_count", None) is not None:
-                    if edge_count != args.before_edge_count:
-                        self.add_error(f"Edge count mismatch: {edge_count} vs expected {args.before_edge_count}")
-                if getattr(args, "before_edge_manifest_hash", None) is not None:
-                    if edge_manifest_hash != args.before_edge_manifest_hash:
-                        self.add_error(
-                            f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {args.before_edge_manifest_hash}"
-                        )
+                edge_count, edge_manifest_hash = self._query_restart_graph_metrics(session, expected_revision_id)
 
                 if reconstructed != len(assertion_ids):
                     self.add_error("Historical reconstruction failed for one or more projected assertions")
 
-                # Check metrics against seed
-                if getattr(args, "before_assertion_count", None) is not None:
-                    if reconstructed != args.before_assertion_count:
-                        self.add_error(
-                            f"Assertion count mismatch: {reconstructed} vs expected {args.before_assertion_count}"
-                        )
-                if reconstructed == 0:
-                    self.add_error("Reconstructed assertion count must be > 0 for this GRAC vertical-slice promotion")
+                self._validate_restart_graph_parity(
+                    args,
+                    reconstructed_assertions=reconstructed,
+                    edge_count=edge_count,
+                    edge_manifest_hash=edge_manifest_hash,
+                )
 
         except Exception as exc:
             self.add_error(f"Historical reconstruction query failed: {exc}")
         finally:
             if engine is not None:
                 engine.dispose()
+
+    def _query_restart_graph_metrics(self, session: Any, revision_id: str) -> tuple[int, str | None]:
+        """Return edge count and canonical edge-set hash for a revision."""
+        from sqlalchemy import func
+
+        # pylint: disable=not-callable
+        edge_count = (
+            session.execute(
+                select(func.count(RelationshipProjectionEdgeORM.id)).where(
+                    RelationshipProjectionEdgeORM.revision_id == revision_id
+                )
+            ).scalar()
+            or 0
+        )
+        # pylint: enable=not-callable
+
+        edge_manifest_hash = session.execute(
+            select(RelationshipProjectionRevisionORM.edge_set_hash).where(
+                RelationshipProjectionRevisionORM.id == revision_id
+            )
+        ).scalar()
+
+        return edge_count, edge_manifest_hash
+
+    def _validate_restart_graph_parity(
+        self,
+        args: argparse.Namespace,
+        *,
+        reconstructed_assertions: int,
+        edge_count: int,
+        edge_manifest_hash: str | None,
+    ) -> None:
+        """Compare restart graph metrics with the seed-side baseline."""
+        before_edge_count = getattr(args, "before_edge_count", None)
+        if before_edge_count is not None and edge_count != before_edge_count:
+            self.add_error(f"Edge count mismatch: {edge_count} vs expected {before_edge_count}")
+
+        before_edge_manifest_hash = getattr(args, "before_edge_manifest_hash", None)
+        if before_edge_manifest_hash is not None and edge_manifest_hash != before_edge_manifest_hash:
+            self.add_error(
+                "Edge manifest hash mismatch: " f"{edge_manifest_hash} vs expected " f"{before_edge_manifest_hash}"
+            )
+
+        before_assertion_count = getattr(args, "before_assertion_count", None)
+        if before_assertion_count is not None and reconstructed_assertions != before_assertion_count:
+            self.add_error(f"Assertion count mismatch: {reconstructed_assertions} vs expected {before_assertion_count}")
+
+        if reconstructed_assertions == 0:
+            self.add_error("Reconstructed assertion count must be > 0 for this GRAC vertical-slice promotion")
 
     def _validate_restart_history(self, args: argparse.Namespace) -> None:
         """Validate rebuild audit history and reconstruct assertion lifecycle history."""
@@ -1120,7 +1142,8 @@ class ProofValidator:
             if missing:
                 self.add_error("Strict restart verification requires seed graph baselines: " + ", ".join(missing))
 
-        if getattr(args, "before_assertion_count", None) is not None and getattr(args, "before_assertion_count") <= 0:
+        before_assertion_count = getattr(args, "before_assertion_count", None)
+        if before_assertion_count is not None and before_assertion_count <= 0:
             self.add_error("Seed assertion count must be > 0 for the GRAC vertical slice")
 
         self._populate_missing_evidence(args)

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -754,16 +754,30 @@ class ProofValidator:
             self.metadata["startup"] = args.startup_source or "N/A"
             if getattr(args, "health_observation_path", None):
                 try:
+                    import hashlib
                     import json
+                    from pathlib import Path
 
-                    with open(args.health_observation_path, "r") as f:
-                        health = json.load(f)
+                    health_bytes = Path(args.health_observation_path).read_bytes()
+                    health = json.loads(health_bytes)
+                    self.metadata["health_observation_sha256"] = hashlib.sha256(health_bytes).hexdigest()
+                    self.metadata["health_observation_run_id"] = getattr(args, "run_id", "unknown")
+                    self.metadata["health_observation_deployed_sha"] = getattr(args, "deployed_sha", "unknown")
+
                     if (
                         not health.get("persistence_configured")
                         or not health.get("graph", {}).get("persistence_enabled")
                         or not health.get("graph", {}).get("persistence_loaded")
                     ):
                         self.add_error("Health observation failed persistence validation")
+
+                    observed_startup = health.get("graph", {}).get("startup_source")
+                    if observed_startup != "persisted":
+                        self.add_error(
+                            f"Health observation startup source is {observed_startup or 'missing'}; expected persisted"
+                        )
+                    if observed_startup != args.startup_source:
+                        self.add_error("Health observation and supplied startup source do not match")
                 except Exception as e:
                     self.add_error(f"Failed to load or parse health observation: {e}")
             else:
@@ -1097,6 +1111,19 @@ class ProofValidator:
 
     def validate_verify_after_restart(self, args: argparse.Namespace) -> dict[str, Any]:
         """Mode 2: Post-restart verification."""
+        if getattr(args, "strict", False):
+            required_baselines = {
+                "before_assertion_count": getattr(args, "before_assertion_count", None),
+                "before_edge_count": getattr(args, "before_edge_count", None),
+                "before_edge_manifest_hash": getattr(args, "before_edge_manifest_hash", None),
+            }
+            missing = [name for name, value in required_baselines.items() if value is None or value == ""]
+            if missing:
+                self.add_error("Strict restart verification requires seed graph baselines: " + ", ".join(missing))
+
+        if getattr(args, "before_assertion_count", None) is not None and getattr(args, "before_assertion_count") <= 0:
+            self.add_error("Seed assertion count must be > 0 for the GRAC vertical slice")
+
         self._populate_missing_evidence(args)
         self.metadata["mode"] = "verify_after_restart"
 

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -75,6 +75,30 @@ def _sanitize_db_id(val: Any) -> str | None:
     return clean_val
 
 
+def _count_revision_projection_rows(
+    conn: Any,
+    revision_id: str,
+) -> tuple[int, int]:
+    """Return distinct assertion and projection-edge counts for a revision."""
+    from sqlalchemy import func
+
+    # pylint: disable=not-callable
+    assertion_count = conn.execute(
+        select(func.count(func.distinct(RelationshipProjectionEdgeORM.assertion_id))).where(
+            RelationshipProjectionEdgeORM.revision_id == revision_id
+        )
+    ).scalar()
+
+    edge_count = conn.execute(
+        select(func.count(RelationshipProjectionEdgeORM.id)).where(
+            RelationshipProjectionEdgeORM.revision_id == revision_id
+        )
+    ).scalar()
+    # pylint: enable=not-callable
+
+    return int(assertion_count or 0), int(edge_count or 0)
+
+
 class ProofValidator:
     """Validates GRAC v1 staging proofs."""
 
@@ -522,27 +546,9 @@ class ProofValidator:
         if not rev_info:
             return None
         proj_hash, governed_scopes, edge_set_hash = rev_info
-        from sqlalchemy import func
-
         # Get assertion count and edge count
         try:
-            assertion_count = (
-                conn.execute(
-                    select(func.count(func.distinct(RelationshipProjectionEdgeORM.assertion_id))).where(
-                        RelationshipProjectionEdgeORM.revision_id == clean_rev_id
-                    )
-                ).scalar()
-                or 0
-            )
-
-            edge_count = (
-                conn.execute(
-                    select(func.count(RelationshipProjectionEdgeORM.id)).where(
-                        RelationshipProjectionEdgeORM.revision_id == clean_rev_id
-                    )
-                ).scalar()
-                or 0
-            )
+            assertion_count, edge_count = _count_revision_projection_rows(conn, clean_rev_id)
 
             self.metadata["raw_assertion_count"] = assertion_count
             self.metadata["raw_edge_count"] = edge_count

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -760,27 +760,22 @@ class ProofValidator:
     ) -> tuple[dict[str, Any], str] | None:
         """Load retained health evidence and calculate its digest."""
         import hashlib
-    
+
         try:
             safe_path = validate_safe_path(path)
             health_bytes = safe_path.read_bytes()
             health = json.loads(health_bytes)
         except (OSError, TypeError, json.JSONDecodeError) as exc:
-            self.add_error(
-                f"Failed to load or parse health observation: {exc}"
-            )
+            self.add_error(f"Failed to load or parse health observation: {exc}")
             return None
-    
+
         if not isinstance(health, dict):
-            self.add_error(
-                "Health observation must be a JSON object"
-            )
+            self.add_error("Health observation must be a JSON object")
             return None
-    
+
         digest = hashlib.sha256(health_bytes).hexdigest()
         return health, digest
-    
-    
+
     def _validate_health_provenance(
         self,
         args: argparse.Namespace,
@@ -789,49 +784,32 @@ class ProofValidator:
         """Bind health evidence to its observed workflow and deployment."""
         provenance = health.get("proof_observation")
         if not isinstance(provenance, dict):
-            self.add_error(
-                "Health observation proof provenance is missing"
-            )
+            self.add_error("Health observation proof provenance is missing")
             return
-    
+
         observed_run_id = provenance.get("run_id")
         observed_deployed_sha = provenance.get("deployment_sha")
-    
+
         expected_run_id = getattr(args, "run_id", None)
         expected_deployed_sha = getattr(
             args,
             "deployed_sha",
             None,
         )
-    
+
         if not observed_run_id:
-            self.add_error(
-                "Health observation run ID is missing"
-            )
+            self.add_error("Health observation run ID is missing")
         elif observed_run_id != expected_run_id:
-            self.add_error(
-                "Health observation run ID does not match "
-                "the certified workflow run"
-            )
-    
+            self.add_error("Health observation run ID does not match " "the certified workflow run")
+
         if not observed_deployed_sha:
-            self.add_error(
-                "Health observation deployment SHA is missing"
-            )
+            self.add_error("Health observation deployment SHA is missing")
         elif observed_deployed_sha != expected_deployed_sha:
-            self.add_error(
-                "Health observation deployment SHA does not "
-                "match the certified deployment"
-            )
-    
-        self.metadata[
-            "health_observation_run_id"
-        ] = observed_run_id
-        self.metadata[
-            "health_observation_deployed_sha"
-        ] = observed_deployed_sha
-    
-    
+            self.add_error("Health observation deployment SHA does not " "match the certified deployment")
+
+        self.metadata["health_observation_run_id"] = observed_run_id
+        self.metadata["health_observation_deployed_sha"] = observed_deployed_sha
+
     def _validate_health_persistence_state(
         self,
         health: dict[str, Any],
@@ -839,35 +817,23 @@ class ProofValidator:
         """Validate persistence fields reported by the runtime."""
         graph = health.get("graph")
         if not isinstance(graph, dict):
-            self.add_error(
-                "Health observation graph state is missing"
-            )
+            self.add_error("Health observation graph state is missing")
             return
-    
+
         persistence_configured = health.get(
             "graph_persistence_configured",
             health.get("persistence_configured"),
         )
-    
+
         if persistence_configured is not True:
-            self.add_error(
-                "Health observation reports persistence "
-                "is not configured"
-            )
-    
+            self.add_error("Health observation reports persistence " "is not configured")
+
         if graph.get("persistence_enabled") is not True:
-            self.add_error(
-                "Health observation reports persistence "
-                "is not enabled"
-            )
-    
+            self.add_error("Health observation reports persistence " "is not enabled")
+
         if graph.get("persistence_loaded") is not True:
-            self.add_error(
-                "Health observation reports persistence "
-                "was not loaded"
-            )
-    
-    
+            self.add_error("Health observation reports persistence " "was not loaded")
+
     def _validate_health_startup_source(
         self,
         args: argparse.Namespace,
@@ -877,25 +843,20 @@ class ProofValidator:
         graph = health.get("graph")
         if not isinstance(graph, dict):
             return
-    
+
         observed_startup = graph.get("startup_source")
-    
+
         if observed_startup != "persisted":
             self.add_error(
-                "Health observation startup source is "
-                f"{observed_startup or 'missing'}; "
-                "expected persisted"
+                "Health observation startup source is " f"{observed_startup or 'missing'}; " "expected persisted"
             )
-    
+
         if observed_startup != getattr(
             args,
             "startup_source",
             None,
         ):
-            self.add_error(
-                "Health observation and supplied startup "
-                "source do not match"
-            )
+            self.add_error("Health observation and supplied startup " "source do not match")
 
     def _validate_restart_persistence(
         self,
@@ -904,35 +865,28 @@ class ProofValidator:
         """Validate persisted startup with runtime-bound evidence."""
         if not args.require_persistence:
             return
-    
+
         if args.startup_source != "persisted":
-            self.add_error(
-                f"Startup: {args.startup_source or 'N/A'} "
-                "(need persisted)"
-            )
-    
-        self.metadata["startup"] = (
-            args.startup_source or "N/A"
-        )
-    
+            self.add_error(f"Startup: {args.startup_source or 'N/A'} " "(need persisted)")
+
+        self.metadata["startup"] = args.startup_source or "N/A"
+
         path = getattr(
             args,
             "health_observation_path",
             None,
         )
         if not path:
-            self.add_error(
-                "Health observation JSON is missing"
-            )
+            self.add_error("Health observation JSON is missing")
             return
-    
+
         loaded = self._load_health_observation(path)
         if loaded is None:
             return
-    
+
         health, digest = loaded
         self.metadata["health_observation_sha256"] = digest
-    
+
         self._validate_health_provenance(args, health)
         self._validate_health_persistence_state(health)
         self._validate_health_startup_source(args, health)
@@ -948,11 +902,9 @@ class ProofValidator:
             None,
         )
         if not path:
-            self.add_error(
-                "Runtime graph observation is required"
-            )
+            self.add_error("Runtime graph observation is required")
             return None
-    
+
         try:
             safe_path = validate_safe_path(path)
             with safe_path.open(
@@ -960,21 +912,15 @@ class ProofValidator:
             ) as observation_file:
                 observation = json.load(observation_file)
         except (OSError, TypeError, json.JSONDecodeError) as exc:
-            self.add_error(
-                "Failed to load runtime graph "
-                f"observation: {exc}"
-            )
+            self.add_error("Failed to load runtime graph " f"observation: {exc}")
             return None
-    
+
         if not isinstance(observation, dict):
-            self.add_error(
-                "Runtime graph observation must be "
-                "a JSON object"
-            )
+            self.add_error("Runtime graph observation must be " "a JSON object")
             return None
-    
+
         return observation
-    
+
     def _validate_runtime_graph_provenance(
         self,
         args: argparse.Namespace,
@@ -986,131 +932,83 @@ class ProofValidator:
             "run_id",
             None,
         ):
-            self.add_error(
-                "Runtime graph observation run ID mismatch"
-            )
-    
+            self.add_error("Runtime graph observation run ID mismatch")
+
         if provenance.get("deployment_sha") != getattr(
             args,
             "deployed_sha",
             None,
         ):
-            self.add_error(
-                "Runtime graph observation deployment "
-                "SHA mismatch"
-            )
-    
+            self.add_error("Runtime graph observation deployment " "SHA mismatch")
+
         if provenance.get("revision_id") != getattr(
             args,
             "expected_revision_id",
             None,
         ):
-            self.add_error(
-                "Runtime graph observation revision "
-                "ID mismatch"
-            )
-    
+            self.add_error("Runtime graph observation revision " "ID mismatch")
+
     def _validate_runtime_graph_metrics(
         self,
         args: argparse.Namespace,
         runtime_graph: dict[str, Any],
     ) -> None:
         """Compare served graph metrics with the seed baseline."""
-        observed_assertions = runtime_graph.get(
-            "assertion_count"
-        )
+        observed_assertions = runtime_graph.get("assertion_count")
         observed_edges = runtime_graph.get("edge_count")
-        observed_manifest = runtime_graph.get(
-            "edge_set_hash"
-        )
-    
+        observed_manifest = runtime_graph.get("edge_set_hash")
+
         if observed_assertions != getattr(
             args,
             "before_assertion_count",
             None,
         ):
-            self.add_error(
-                "Served graph assertion count does not "
-                "match the seed baseline"
-            )
-    
+            self.add_error("Served graph assertion count does not " "match the seed baseline")
+
         if observed_edges != getattr(
             args,
             "before_edge_count",
             None,
         ):
-            self.add_error(
-                "Served graph edge count does not match "
-                "the seed baseline"
-            )
-    
+            self.add_error("Served graph edge count does not match " "the seed baseline")
+
         if observed_manifest != getattr(
             args,
             "before_edge_manifest_hash",
             None,
         ):
-            self.add_error(
-                "Served graph edge-set hash does not "
-                "match the seed baseline"
-            )
-    
-        if (
-            not isinstance(observed_assertions, int)
-            or observed_assertions <= 0
-        ):
-            self.add_error(
-                "Served graph must contain at least one "
-                "governed assertion"
-            )
-    
-        if (
-            not isinstance(observed_edges, int)
-            or observed_edges <= 0
-        ):
-            self.add_error(
-                "Served graph must contain at least one "
-                "governed edge"
-            )
-    
-        self.metadata[
-            "runtime_graph_assertion_count"
-        ] = observed_assertions
-        self.metadata[
-            "runtime_graph_edge_count"
-        ] = observed_edges
-        self.metadata[
-            "runtime_graph_edge_set_hash"
-        ] = observed_manifest
-    
+            self.add_error("Served graph edge-set hash does not " "match the seed baseline")
+
+        if not isinstance(observed_assertions, int) or observed_assertions <= 0:
+            self.add_error("Served graph must contain at least one " "governed assertion")
+
+        if not isinstance(observed_edges, int) or observed_edges <= 0:
+            self.add_error("Served graph must contain at least one " "governed edge")
+
+        self.metadata["runtime_graph_assertion_count"] = observed_assertions
+        self.metadata["runtime_graph_edge_count"] = observed_edges
+        self.metadata["runtime_graph_edge_set_hash"] = observed_manifest
+
     def _validate_served_graph_parity(
         self,
         args: argparse.Namespace,
     ) -> None:
         """Validate graph state served by the restarted process."""
-        observation = (
-            self._load_runtime_graph_observation(args)
-        )
+        observation = self._load_runtime_graph_observation(args)
         if observation is None:
             return
-    
-        provenance = observation.get(
-            "proof_observation"
-        )
+
+        provenance = observation.get("proof_observation")
         runtime_graph = observation.get("runtime_graph")
-    
+
         if not isinstance(provenance, dict):
-            self.add_error(
-                "Runtime graph observation provenance "
-                "is missing"
-            )
+            self.add_error("Runtime graph observation provenance " "is missing")
             return
-    
+
         if not isinstance(runtime_graph, dict):
-            self.add_error(
-                "Runtime graph metrics are missing"
-            )
+            self.add_error("Runtime graph metrics are missing")
             return
-    
+
         self._validate_runtime_graph_provenance(
             args,
             provenance,
@@ -1119,7 +1017,7 @@ class ProofValidator:
             args,
             runtime_graph,
         )
-    
+
     def _validate_restart_authz(self, args: argparse.Namespace) -> None:
         """Validate authorization evidence."""
         authz_meta = None
@@ -1568,12 +1466,9 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--startup-source", help="Observed runtime startup source value")
     parser.add_argument("--health-observation-path", help="Path to the detailed health observation JSON file")
     parser.add_argument(
-                        "--runtime-graph-observation-path",
-                        help=(
-                            "Path to the authenticated post-restart "
-                            "runtime graph observation JSON"
-                        ),
-                    )
+        "--runtime-graph-observation-path",
+        help=("Path to the authenticated post-restart " "runtime graph observation JSON"),
+    )
     parser.add_argument("--before-assertion-count", type=int, help="Expected assertion count from seed")
     parser.add_argument("--before-edge-count", type=int, help="Expected edge count from seed")
     parser.add_argument("--before-edge-manifest-hash", help="Expected edge manifest hash from seed")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -458,12 +458,13 @@ class ProofValidator:
         args.publication_count = 1
         return rows[0]
 
-    def _get_and_validate_revision_scopes(self, conn: Any, clean_rev_id: str) -> tuple[str, list[str]] | None:
+    def _get_and_validate_revision_scopes(self, conn: Any, clean_rev_id: str) -> tuple[str, list[str], str] | None:
         """Fetch and validate revision projection hash and governed scopes."""
         rev_query = select(
             RelationshipProjectionRevisionORM.projection_hash,
             RelationshipProjectionRevisionORM.governed_scopes,
             RelationshipProjectionRevisionORM.purpose,
+            RelationshipProjectionRevisionORM.edge_set_hash,
         ).where(
             RelationshipProjectionRevisionORM.id == clean_rev_id,
         )
@@ -472,7 +473,7 @@ class ProofValidator:
             self.add_error(f"Revision {clean_rev_id} not found in database")
             return None
 
-        proj_hash, governed_scopes_raw, purpose = rev_row
+        proj_hash, governed_scopes_raw, purpose, edge_set_hash = rev_row
         try:
             governed_scopes = (
                 json.loads(governed_scopes_raw) if isinstance(governed_scopes_raw, str) else governed_scopes_raw
@@ -485,7 +486,7 @@ class ProofValidator:
         if parsed_scopes is None:
             return None
 
-        return proj_hash, parsed_scopes
+        return proj_hash, parsed_scopes, edge_set_hash
 
     def _populate_publication_and_revision_from_db(
         self, args: argparse.Namespace, conn: Any, rebuild_job_id: str
@@ -520,7 +521,34 @@ class ProofValidator:
         rev_info = self._get_and_validate_revision_scopes(conn, clean_rev_id)
         if not rev_info:
             return None
-        proj_hash, governed_scopes = rev_info
+        proj_hash, governed_scopes, edge_set_hash = rev_info
+        from sqlalchemy import func
+
+        # Get assertion count and edge count
+        try:
+            assertion_count = (
+                conn.execute(
+                    select(func.count(func.distinct(RelationshipProjectionEdgeORM.assertion_id))).where(
+                        RelationshipProjectionEdgeORM.revision_id == clean_rev_id
+                    )
+                ).scalar()
+                or 0
+            )
+
+            edge_count = (
+                conn.execute(
+                    select(func.count(RelationshipProjectionEdgeORM.id)).where(
+                        RelationshipProjectionEdgeORM.revision_id == clean_rev_id
+                    )
+                ).scalar()
+                or 0
+            )
+
+            self.metadata["raw_assertion_count"] = assertion_count
+            self.metadata["raw_edge_count"] = edge_count
+            self.metadata["raw_edge_manifest_hash"] = edge_set_hash
+        except Exception as e:
+            self.add_error(f"Failed to query counts: {e}")
 
         if not args.revision_hash:
             args.revision_hash = proj_hash
@@ -724,6 +752,22 @@ class ProofValidator:
             if args.startup_source != "persisted":
                 self.add_error(f"Startup: {args.startup_source or 'N/A'} (need persisted)")
             self.metadata["startup"] = args.startup_source or "N/A"
+            if getattr(args, "health_observation_path", None):
+                try:
+                    import json
+
+                    with open(args.health_observation_path, "r") as f:
+                        health = json.load(f)
+                    if (
+                        not health.get("persistence_configured")
+                        or not health.get("graph", {}).get("persistence_enabled")
+                        or not health.get("graph", {}).get("persistence_loaded")
+                    ):
+                        self.add_error("Health observation failed persistence validation")
+                except Exception as e:
+                    self.add_error(f"Failed to load or parse health observation: {e}")
+            else:
+                self.add_error("Health observation JSON is missing")
 
     def _validate_restart_authz(self, args: argparse.Namespace) -> None:
         """Validate authorization evidence."""
@@ -904,7 +948,9 @@ class ProofValidator:
 
         return self._validate_assertion_actors_and_states(assertion_id, proposed[0], accepted[0])
 
-    def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
+    def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:  # noqa: C901
+        from sqlalchemy import func
+
         """Reconstruct persisted lifecycle history for the certified revision."""
         db_url = os.getenv("DATABASE_URL")
         if not db_url:
@@ -976,8 +1022,44 @@ class ProofValidator:
                         reconstructed += 1
 
                 self.metadata["reconstructed_assertions"] = reconstructed
+
+                # Check edge counts
+                edge_count = (
+                    session.execute(
+                        select(func.count(RelationshipProjectionEdgeORM.id)).where(
+                            RelationshipProjectionEdgeORM.revision_id == expected_revision_id
+                        )
+                    ).scalar()
+                    or 0
+                )
+
+                edge_manifest_hash = session.execute(
+                    select(RelationshipProjectionRevisionORM.edge_set_hash).where(
+                        RelationshipProjectionRevisionORM.id == expected_revision_id
+                    )
+                ).scalar()
+
+                if getattr(args, "before_edge_count", None) is not None:
+                    if edge_count != args.before_edge_count:
+                        self.add_error(f"Edge count mismatch: {edge_count} vs expected {args.before_edge_count}")
+                if getattr(args, "before_edge_manifest_hash", None) is not None:
+                    if edge_manifest_hash != args.before_edge_manifest_hash:
+                        self.add_error(
+                            f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {args.before_edge_manifest_hash}"
+                        )
+
                 if reconstructed != len(assertion_ids):
                     self.add_error("Historical reconstruction failed for one or more projected assertions")
+
+                # Check metrics against seed
+                if getattr(args, "before_assertion_count", None) is not None:
+                    if reconstructed != args.before_assertion_count:
+                        self.add_error(
+                            f"Assertion count mismatch: {reconstructed} vs expected {args.before_assertion_count}"
+                        )
+                if reconstructed == 0:
+                    self.add_error("Reconstructed assertion count must be > 0 for this GRAC vertical-slice promotion")
+
         except Exception as exc:
             self.add_error(f"Historical reconstruction query failed: {exc}")
         finally:
@@ -1098,6 +1180,10 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected-revision-id", help="Expected target revision ID value")
     parser.add_argument("--require-persistence", action="store_true", help="Assert startup persistence")
     parser.add_argument("--startup-source", help="Observed runtime startup source value")
+    parser.add_argument("--health-observation-path", help="Path to the detailed health observation JSON file")
+    parser.add_argument("--before-assertion-count", type=int, help="Expected assertion count from seed")
+    parser.add_argument("--before-edge-count", type=int, help="Expected edge count from seed")
+    parser.add_argument("--before-edge-manifest-hash", help="Expected edge manifest hash from seed")
     parser.add_argument("--before-scopes", help="Scope list JSON before promotion")
     parser.add_argument("--after-scopes", help="Scope list JSON after promotion")
     parser.add_argument("--history-entries", help="Execution log history entries JSON")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -800,12 +800,12 @@ class ProofValidator:
         if not observed_run_id:
             self.add_error("Health observation run ID is missing")
         elif observed_run_id != expected_run_id:
-            self.add_error("Health observation run ID does not match " "the certified workflow run")
+            self.add_error("Health observation run ID does not match the certified workflow run")
 
         if not observed_deployed_sha:
             self.add_error("Health observation deployment SHA is missing")
         elif observed_deployed_sha != expected_deployed_sha:
-            self.add_error("Health observation deployment SHA does not " "match the certified deployment")
+            self.add_error("Health observation deployment SHA does not match the certified deployment")
 
         self.metadata["health_observation_run_id"] = observed_run_id
         self.metadata["health_observation_deployed_sha"] = observed_deployed_sha
@@ -826,13 +826,13 @@ class ProofValidator:
         )
 
         if persistence_configured is not True:
-            self.add_error("Health observation reports persistence " "is not configured")
+            self.add_error("Health observation reports persistence is not configured")
 
         if graph.get("persistence_enabled") is not True:
-            self.add_error("Health observation reports persistence " "is not enabled")
+            self.add_error("Health observation reports persistence is not enabled")
 
         if graph.get("persistence_loaded") is not True:
-            self.add_error("Health observation reports persistence " "was not loaded")
+            self.add_error("Health observation reports persistence was not loaded")
 
     def _validate_health_startup_source(
         self,
@@ -847,16 +847,14 @@ class ProofValidator:
         observed_startup = graph.get("startup_source")
 
         if observed_startup != "persisted":
-            self.add_error(
-                "Health observation startup source is " f"{observed_startup or 'missing'}; " "expected persisted"
-            )
+            self.add_error(f"Health observation startup source is {observed_startup or 'missing'}; expected persisted")
 
         if observed_startup != getattr(
             args,
             "startup_source",
             None,
         ):
-            self.add_error("Health observation and supplied startup " "source do not match")
+            self.add_error("Health observation and supplied startup source do not match")
 
     def _validate_restart_persistence(
         self,
@@ -867,7 +865,7 @@ class ProofValidator:
             return
 
         if args.startup_source != "persisted":
-            self.add_error(f"Startup: {args.startup_source or 'N/A'} " "(need persisted)")
+            self.add_error(f"Startup: {args.startup_source or 'N/A'} (need persisted)")
 
         self.metadata["startup"] = args.startup_source or "N/A"
 
@@ -912,11 +910,11 @@ class ProofValidator:
             ) as observation_file:
                 observation = json.load(observation_file)
         except (OSError, TypeError, json.JSONDecodeError) as exc:
-            self.add_error("Failed to load runtime graph " f"observation: {exc}")
+            self.add_error(f"Failed to load runtime graph observation: {exc}")
             return None
 
         if not isinstance(observation, dict):
-            self.add_error("Runtime graph observation must be " "a JSON object")
+            self.add_error("Runtime graph observation must be a JSON object")
             return None
 
         return observation
@@ -939,14 +937,14 @@ class ProofValidator:
             "deployed_sha",
             None,
         ):
-            self.add_error("Runtime graph observation deployment " "SHA mismatch")
+            self.add_error("Runtime graph observation deployment SHA mismatch")
 
         if provenance.get("revision_id") != getattr(
             args,
             "expected_revision_id",
             None,
         ):
-            self.add_error("Runtime graph observation revision " "ID mismatch")
+            self.add_error("Runtime graph observation revision ID mismatch")
 
     def _validate_runtime_graph_metrics(
         self,
@@ -963,27 +961,27 @@ class ProofValidator:
             "before_assertion_count",
             None,
         ):
-            self.add_error("Served graph assertion count does not " "match the seed baseline")
+            self.add_error("Served graph assertion count does not match the seed baseline")
 
         if observed_edges != getattr(
             args,
             "before_edge_count",
             None,
         ):
-            self.add_error("Served graph edge count does not match " "the seed baseline")
+            self.add_error("Served graph edge count does not match the seed baseline")
 
         if observed_manifest != getattr(
             args,
             "before_edge_manifest_hash",
             None,
         ):
-            self.add_error("Served graph edge-set hash does not " "match the seed baseline")
+            self.add_error("Served graph edge-set hash does not match the seed baseline")
 
         if not isinstance(observed_assertions, int) or observed_assertions <= 0:
-            self.add_error("Served graph must contain at least one " "governed assertion")
+            self.add_error("Served graph must contain at least one governed assertion")
 
         if not isinstance(observed_edges, int) or observed_edges <= 0:
-            self.add_error("Served graph must contain at least one " "governed edge")
+            self.add_error("Served graph must contain at least one governed edge")
 
         self.metadata["runtime_graph_assertion_count"] = observed_assertions
         self.metadata["runtime_graph_edge_count"] = observed_edges
@@ -1002,7 +1000,7 @@ class ProofValidator:
         runtime_graph = observation.get("runtime_graph")
 
         if not isinstance(provenance, dict):
-            self.add_error("Runtime graph observation provenance " "is missing")
+            self.add_error("Runtime graph observation provenance is missing")
             return
 
         if not isinstance(runtime_graph, dict):
@@ -1467,7 +1465,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--health-observation-path", help="Path to the detailed health observation JSON file")
     parser.add_argument(
         "--runtime-graph-observation-path",
-        help=("Path to the authenticated post-restart " "runtime graph observation JSON"),
+        help=("Path to the authenticated post-restart runtime graph observation JSON"),
     )
     parser.add_argument("--before-assertion-count", type=int, help="Expected assertion count from seed")
     parser.add_argument("--before-edge-count", type=int, help="Expected edge count from seed")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -43,6 +43,8 @@ EXIT_FAILURE = 1
 _ALLOWED_EVIDENCE_FILENAMES = frozenset(
     {
         "authz-evidence.json",
+        "health-observation.json",
+        "runtime-graph-observation.json",
         "staging-proof-result.json",
         "previous-staging-proof-result.json",
     }
@@ -752,42 +754,372 @@ class ProofValidator:
 
         return self.build_result()
 
-    def _validate_restart_persistence(self, args: argparse.Namespace) -> None:
-        """Validate startup source persistence."""
-        if args.require_persistence:
-            if args.startup_source != "persisted":
-                self.add_error(f"Startup: {args.startup_source or 'N/A'} (need persisted)")
-            self.metadata["startup"] = args.startup_source or "N/A"
-            if getattr(args, "health_observation_path", None):
-                try:
-                    import hashlib
-                    from pathlib import Path
+    def _load_health_observation(
+        self,
+        path: str,
+    ) -> tuple[dict[str, Any], str] | None:
+        """Load retained health evidence and calculate its digest."""
+        import hashlib
+    
+        try:
+            safe_path = validate_safe_path(path)
+            health_bytes = safe_path.read_bytes()
+            health = json.loads(health_bytes)
+        except (OSError, TypeError, json.JSONDecodeError) as exc:
+            self.add_error(
+                f"Failed to load or parse health observation: {exc}"
+            )
+            return None
+    
+        if not isinstance(health, dict):
+            self.add_error(
+                "Health observation must be a JSON object"
+            )
+            return None
+    
+        digest = hashlib.sha256(health_bytes).hexdigest()
+        return health, digest
+    
+    
+    def _validate_health_provenance(
+        self,
+        args: argparse.Namespace,
+        health: dict[str, Any],
+    ) -> None:
+        """Bind health evidence to its observed workflow and deployment."""
+        provenance = health.get("proof_observation")
+        if not isinstance(provenance, dict):
+            self.add_error(
+                "Health observation proof provenance is missing"
+            )
+            return
+    
+        observed_run_id = provenance.get("run_id")
+        observed_deployed_sha = provenance.get("deployment_sha")
+    
+        expected_run_id = getattr(args, "run_id", None)
+        expected_deployed_sha = getattr(
+            args,
+            "deployed_sha",
+            None,
+        )
+    
+        if not observed_run_id:
+            self.add_error(
+                "Health observation run ID is missing"
+            )
+        elif observed_run_id != expected_run_id:
+            self.add_error(
+                "Health observation run ID does not match "
+                "the certified workflow run"
+            )
+    
+        if not observed_deployed_sha:
+            self.add_error(
+                "Health observation deployment SHA is missing"
+            )
+        elif observed_deployed_sha != expected_deployed_sha:
+            self.add_error(
+                "Health observation deployment SHA does not "
+                "match the certified deployment"
+            )
+    
+        self.metadata[
+            "health_observation_run_id"
+        ] = observed_run_id
+        self.metadata[
+            "health_observation_deployed_sha"
+        ] = observed_deployed_sha
+    
+    
+    def _validate_health_persistence_state(
+        self,
+        health: dict[str, Any],
+    ) -> None:
+        """Validate persistence fields reported by the runtime."""
+        graph = health.get("graph")
+        if not isinstance(graph, dict):
+            self.add_error(
+                "Health observation graph state is missing"
+            )
+            return
+    
+        persistence_configured = health.get(
+            "graph_persistence_configured",
+            health.get("persistence_configured"),
+        )
+    
+        if persistence_configured is not True:
+            self.add_error(
+                "Health observation reports persistence "
+                "is not configured"
+            )
+    
+        if graph.get("persistence_enabled") is not True:
+            self.add_error(
+                "Health observation reports persistence "
+                "is not enabled"
+            )
+    
+        if graph.get("persistence_loaded") is not True:
+            self.add_error(
+                "Health observation reports persistence "
+                "was not loaded"
+            )
+    
+    
+    def _validate_health_startup_source(
+        self,
+        args: argparse.Namespace,
+        health: dict[str, Any],
+    ) -> None:
+        """Validate the startup source reported by the runtime."""
+        graph = health.get("graph")
+        if not isinstance(graph, dict):
+            return
+    
+        observed_startup = graph.get("startup_source")
+    
+        if observed_startup != "persisted":
+            self.add_error(
+                "Health observation startup source is "
+                f"{observed_startup or 'missing'}; "
+                "expected persisted"
+            )
+    
+        if observed_startup != getattr(
+            args,
+            "startup_source",
+            None,
+        ):
+            self.add_error(
+                "Health observation and supplied startup "
+                "source do not match"
+            )
 
-                    health_bytes = Path(args.health_observation_path).read_bytes()
-                    health = json.loads(health_bytes)
-                    self.metadata["health_observation_sha256"] = hashlib.sha256(health_bytes).hexdigest()
-                    self.metadata["health_observation_run_id"] = getattr(args, "run_id", "unknown")
-                    self.metadata["health_observation_deployed_sha"] = getattr(args, "deployed_sha", "unknown")
+    def _validate_restart_persistence(
+        self,
+        args: argparse.Namespace,
+    ) -> None:
+        """Validate persisted startup with runtime-bound evidence."""
+        if not args.require_persistence:
+            return
+    
+        if args.startup_source != "persisted":
+            self.add_error(
+                f"Startup: {args.startup_source or 'N/A'} "
+                "(need persisted)"
+            )
+    
+        self.metadata["startup"] = (
+            args.startup_source or "N/A"
+        )
+    
+        path = getattr(
+            args,
+            "health_observation_path",
+            None,
+        )
+        if not path:
+            self.add_error(
+                "Health observation JSON is missing"
+            )
+            return
+    
+        loaded = self._load_health_observation(path)
+        if loaded is None:
+            return
+    
+        health, digest = loaded
+        self.metadata["health_observation_sha256"] = digest
+    
+        self._validate_health_provenance(args, health)
+        self._validate_health_persistence_state(health)
+        self._validate_health_startup_source(args, health)
 
-                    if (
-                        not health.get("persistence_configured")
-                        or not health.get("graph", {}).get("persistence_enabled")
-                        or not health.get("graph", {}).get("persistence_loaded")
-                    ):
-                        self.add_error("Health observation failed persistence validation")
-
-                    observed_startup = health.get("graph", {}).get("startup_source")
-                    if observed_startup != "persisted":
-                        self.add_error(
-                            f"Health observation startup source is {observed_startup or 'missing'}; expected persisted"
-                        )
-                    if observed_startup != args.startup_source:
-                        self.add_error("Health observation and supplied startup source do not match")
-                except Exception as e:
-                    self.add_error(f"Failed to load or parse health observation: {e}")
-            else:
-                self.add_error("Health observation JSON is missing")
-
+    def _load_runtime_graph_observation(
+        self,
+        args: argparse.Namespace,
+    ) -> dict[str, Any] | None:
+        """Load graph metrics observed from the restarted runtime."""
+        path = getattr(
+            args,
+            "runtime_graph_observation_path",
+            None,
+        )
+        if not path:
+            self.add_error(
+                "Runtime graph observation is required"
+            )
+            return None
+    
+        try:
+            safe_path = validate_safe_path(path)
+            with safe_path.open(
+                encoding="utf-8",
+            ) as observation_file:
+                observation = json.load(observation_file)
+        except (OSError, TypeError, json.JSONDecodeError) as exc:
+            self.add_error(
+                "Failed to load runtime graph "
+                f"observation: {exc}"
+            )
+            return None
+    
+        if not isinstance(observation, dict):
+            self.add_error(
+                "Runtime graph observation must be "
+                "a JSON object"
+            )
+            return None
+    
+        return observation
+    
+    def _validate_runtime_graph_provenance(
+        self,
+        args: argparse.Namespace,
+        provenance: dict[str, Any],
+    ) -> None:
+        """Bind runtime graph evidence to run, deployment and revision."""
+        if provenance.get("run_id") != getattr(
+            args,
+            "run_id",
+            None,
+        ):
+            self.add_error(
+                "Runtime graph observation run ID mismatch"
+            )
+    
+        if provenance.get("deployment_sha") != getattr(
+            args,
+            "deployed_sha",
+            None,
+        ):
+            self.add_error(
+                "Runtime graph observation deployment "
+                "SHA mismatch"
+            )
+    
+        if provenance.get("revision_id") != getattr(
+            args,
+            "expected_revision_id",
+            None,
+        ):
+            self.add_error(
+                "Runtime graph observation revision "
+                "ID mismatch"
+            )
+    
+    def _validate_runtime_graph_metrics(
+        self,
+        args: argparse.Namespace,
+        runtime_graph: dict[str, Any],
+    ) -> None:
+        """Compare served graph metrics with the seed baseline."""
+        observed_assertions = runtime_graph.get(
+            "assertion_count"
+        )
+        observed_edges = runtime_graph.get("edge_count")
+        observed_manifest = runtime_graph.get(
+            "edge_set_hash"
+        )
+    
+        if observed_assertions != getattr(
+            args,
+            "before_assertion_count",
+            None,
+        ):
+            self.add_error(
+                "Served graph assertion count does not "
+                "match the seed baseline"
+            )
+    
+        if observed_edges != getattr(
+            args,
+            "before_edge_count",
+            None,
+        ):
+            self.add_error(
+                "Served graph edge count does not match "
+                "the seed baseline"
+            )
+    
+        if observed_manifest != getattr(
+            args,
+            "before_edge_manifest_hash",
+            None,
+        ):
+            self.add_error(
+                "Served graph edge-set hash does not "
+                "match the seed baseline"
+            )
+    
+        if (
+            not isinstance(observed_assertions, int)
+            or observed_assertions <= 0
+        ):
+            self.add_error(
+                "Served graph must contain at least one "
+                "governed assertion"
+            )
+    
+        if (
+            not isinstance(observed_edges, int)
+            or observed_edges <= 0
+        ):
+            self.add_error(
+                "Served graph must contain at least one "
+                "governed edge"
+            )
+    
+        self.metadata[
+            "runtime_graph_assertion_count"
+        ] = observed_assertions
+        self.metadata[
+            "runtime_graph_edge_count"
+        ] = observed_edges
+        self.metadata[
+            "runtime_graph_edge_set_hash"
+        ] = observed_manifest
+    
+    def _validate_served_graph_parity(
+        self,
+        args: argparse.Namespace,
+    ) -> None:
+        """Validate graph state served by the restarted process."""
+        observation = (
+            self._load_runtime_graph_observation(args)
+        )
+        if observation is None:
+            return
+    
+        provenance = observation.get(
+            "proof_observation"
+        )
+        runtime_graph = observation.get("runtime_graph")
+    
+        if not isinstance(provenance, dict):
+            self.add_error(
+                "Runtime graph observation provenance "
+                "is missing"
+            )
+            return
+    
+        if not isinstance(runtime_graph, dict):
+            self.add_error(
+                "Runtime graph metrics are missing"
+            )
+            return
+    
+        self._validate_runtime_graph_provenance(
+            args,
+            provenance,
+        )
+        self._validate_runtime_graph_metrics(
+            args,
+            runtime_graph,
+        )
+    
     def _validate_restart_authz(self, args: argparse.Namespace) -> None:
         """Validate authorization evidence."""
         authz_meta = None
@@ -1157,6 +1489,7 @@ class ProofValidator:
         self.metadata["sha"] = args.deployed_sha[:8] + "..." if args.deployed_sha else "N/A"
 
         self._validate_restart_persistence(args)
+        self._validate_served_graph_parity(args)
         self._validate_restart_authz(args)
         self._validate_restart_scopes(args)
         self._validate_restart_history(args)
@@ -1234,6 +1567,13 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument("--require-persistence", action="store_true", help="Assert startup persistence")
     parser.add_argument("--startup-source", help="Observed runtime startup source value")
     parser.add_argument("--health-observation-path", help="Path to the detailed health observation JSON file")
+    parser.add_argument(
+                        "--runtime-graph-observation-path",
+                        help=(
+                            "Path to the authenticated post-restart "
+                            "runtime graph observation JSON"
+                        ),
+                    )
     parser.add_argument("--before-assertion-count", type=int, help="Expected assertion count from seed")
     parser.add_argument("--before-edge-count", type=int, help="Expected edge count from seed")
     parser.add_argument("--before-edge-manifest-hash", help="Expected edge manifest hash from seed")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -1095,12 +1095,26 @@ class ProofValidator:
             self.add_error(f"Edge count mismatch: {edge_count} vs expected {before_edge_count}")
 
         before_edge_manifest_hash = getattr(args, "before_edge_manifest_hash", None)
-        if before_edge_manifest_hash is not None and edge_manifest_hash != before_edge_manifest_hash:
-            self.add_error(f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {before_edge_manifest_hash}")
+        if (
+            before_edge_manifest_hash is not None
+            and edge_manifest_hash != before_edge_manifest_hash
+        ):
+            self.add_error(
+                "Edge manifest hash mismatch: "
+                f"{edge_manifest_hash} vs expected "
+                f"{before_edge_manifest_hash}"
+            )
 
         before_assertion_count = getattr(args, "before_assertion_count", None)
-        if before_assertion_count is not None and reconstructed_assertions != before_assertion_count:
-            self.add_error(f"Assertion count mismatch: {reconstructed_assertions} vs expected {before_assertion_count}")
+        if (
+            before_assertion_count is not None
+            and reconstructed_assertions != before_assertion_count
+        ):
+            self.add_error(
+                "Assertion count mismatch: "
+                f"{reconstructed_assertions} vs expected "
+                f"{before_assertion_count}"
+            )
 
         if reconstructed_assertions == 0:
             self.add_error("Reconstructed assertion count must be > 0 for this GRAC vertical-slice promotion")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -755,7 +755,6 @@ class ProofValidator:
             if getattr(args, "health_observation_path", None):
                 try:
                     import hashlib
-                    import json
                     from pathlib import Path
 
                     health_bytes = Path(args.health_observation_path).read_bytes()

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -1095,26 +1095,12 @@ class ProofValidator:
             self.add_error(f"Edge count mismatch: {edge_count} vs expected {before_edge_count}")
 
         before_edge_manifest_hash = getattr(args, "before_edge_manifest_hash", None)
-        if (
-            before_edge_manifest_hash is not None
-            and edge_manifest_hash != before_edge_manifest_hash
-        ):
-            self.add_error(
-                "Edge manifest hash mismatch: "
-                f"{edge_manifest_hash} vs expected "
-                f"{before_edge_manifest_hash}"
-            )
+        if before_edge_manifest_hash is not None and edge_manifest_hash != before_edge_manifest_hash:
+            self.add_error(f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {before_edge_manifest_hash}")
 
         before_assertion_count = getattr(args, "before_assertion_count", None)
-        if (
-            before_assertion_count is not None
-            and reconstructed_assertions != before_assertion_count
-        ):
-            self.add_error(
-                "Assertion count mismatch: "
-                f"{reconstructed_assertions} vs expected "
-                f"{before_assertion_count}"
-            )
+        if before_assertion_count is not None and reconstructed_assertions != before_assertion_count:
+            self.add_error(f"Assertion count mismatch: {reconstructed_assertions} vs expected {before_assertion_count}")
 
         if reconstructed_assertions == 0:
             self.add_error("Reconstructed assertion count must be > 0 for this GRAC vertical-slice promotion")

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -1090,9 +1090,7 @@ class ProofValidator:
 
         before_edge_manifest_hash = getattr(args, "before_edge_manifest_hash", None)
         if before_edge_manifest_hash is not None and edge_manifest_hash != before_edge_manifest_hash:
-            self.add_error(
-                "Edge manifest hash mismatch: " f"{edge_manifest_hash} vs expected " f"{before_edge_manifest_hash}"
-            )
+            self.add_error(f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {before_edge_manifest_hash}")
 
         before_assertion_count = getattr(args, "before_assertion_count", None)
         if before_assertion_count is not None and reconstructed_assertions != before_assertion_count:

--- a/tests/integration/test_governed_relationship_assertion_docs.py
+++ b/tests/integration/test_governed_relationship_assertion_docs.py
@@ -183,7 +183,7 @@ class TestGovernedRelationshipAssertionADR:
     def test_status_is_accepted(self, adr_content: str) -> None:
         """Contract decision status must be Accepted."""
         status = _section_after(adr_content, "## Status").strip()
-        first_nonempty = next(line for line in status.splitlines() if line.strip())
+        first_nonempty = next((line for line in status.splitlines() if line.strip()), "")
         assert first_nonempty.strip() == "Accepted"
 
     def test_has_date_section(self, adr_content: str) -> None:
@@ -193,7 +193,7 @@ class TestGovernedRelationshipAssertionADR:
     def test_date_is_2026_07_25(self, adr_content: str) -> None:
         """ADR date must be 2026-07-25."""
         date_section = _section_after(adr_content, "## Date").strip()
-        first_nonempty = next(line for line in date_section.splitlines() if line.strip())
+        first_nonempty = next((line for line in date_section.splitlines() if line.strip()), "")
         assert first_nonempty.strip() == "2026-07-25"
 
     def test_has_context_decision_consequences(self, adr_content: str) -> None:

--- a/tests/integration/test_governed_relationship_assertion_docs.py
+++ b/tests/integration/test_governed_relationship_assertion_docs.py
@@ -305,8 +305,8 @@ class TestGovernedRelationshipAssertionContractV1:
         assert "Frozen" in header or "frozen" in header
         assert "0008" in header or "ADR 0008" in contract_content[:500]
 
-    def test_capability_claim_is_current(self, contract_content: str) -> None:
-        """Runtime capability claim class must identify the evidenced CURRENT scope."""
+    def test_capability_claim_is_next(self, contract_content: str) -> None:
+        """Runtime capability claim class must remain NEXT."""
         header = "\n".join(contract_content.splitlines()[:20])
         claim_line = next(
             (
@@ -317,9 +317,8 @@ class TestGovernedRelationshipAssertionContractV1:
             "",
         )
         assert claim_line, "missing capability claim class header line"
-        assert "`CURRENT`" in claim_line
-        assert "exact-SHA evidenced staging scope" in claim_line
-        assert "NEXT" not in claim_line
+        assert "`NEXT`" in claim_line
+        assert "CURRENT" not in claim_line
 
     def test_required_sections_present(self, contract_content: str) -> None:
         """All normative numbered sections must be present."""

--- a/tests/integration/test_governed_relationship_assertion_docs.py
+++ b/tests/integration/test_governed_relationship_assertion_docs.py
@@ -305,8 +305,8 @@ class TestGovernedRelationshipAssertionContractV1:
         assert "Frozen" in header or "frozen" in header
         assert "0008" in header or "ADR 0008" in contract_content[:500]
 
-    def test_capability_claim_is_next(self, contract_content: str) -> None:
-        """Runtime capability claim class must remain NEXT."""
+    def test_capability_claim_is_current(self, contract_content: str) -> None:
+        """Runtime capability claim class must identify the evidenced CURRENT scope."""
         header = "\n".join(contract_content.splitlines()[:20])
         claim_line = next(
             (
@@ -317,8 +317,9 @@ class TestGovernedRelationshipAssertionContractV1:
             "",
         )
         assert claim_line, "missing capability claim class header line"
-        assert "`NEXT`" in claim_line
-        assert "CURRENT" not in claim_line
+        assert "`CURRENT`" in claim_line
+        assert "exact-SHA evidenced staging scope" in claim_line
+        assert "NEXT" not in claim_line
 
     def test_required_sections_present(self, contract_content: str) -> None:
         """All normative numbered sections must be present."""

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -188,9 +188,7 @@ def _setup_mock_session(
         elif "relationship_projection_edges.assertion_id" in stmt_str:
             mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
         elif "relationship_assertion_events" in stmt_str:
-            mock_result.scalars.return_value.all.return_value = (
-                []
-            )  # No events for now, we mock validate_reconstructed_assertion anyway
+            mock_result.scalars.return_value.all.return_value = []  # No events for now, we mock validate_reconstructed_assertion anyway
         elif "count" in stmt_str:
             mock_result.scalar.return_value = edge_count
         elif "hash" in stmt_str:

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -175,7 +175,9 @@ def _setup_mock_session(
         elif "relationship_projection_edges.assertion_id" in stmt_str:
             mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
         elif "relationship_assertion_events" in stmt_str:
-            mock_result.scalars.return_value.all.return_value = []  # No events for now, we mock validate_reconstructed_assertion anyway
+            mock_result.scalars.return_value.all.return_value = (
+                []
+            )  # No events for now, we mock validate_reconstructed_assertion anyway
         elif "count" in stmt_str:
             mock_result.scalar.return_value = edge_count
         elif "hash" in stmt_str:

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -168,7 +168,13 @@ def test_valid_health_provenance(base_args):
 
 
 def _setup_mock_session(
-    mocker, mock_session, assertion_count, edge_count, edge_manifest_hash, expected_revision_id, execution_id
+    mocker,
+    mock_session,
+    assertion_count,
+    edge_count,
+    edge_manifest_hash,
+    expected_revision_id,
+    execution_id,
 ):
     """Setup mocked SQLAlchemy session methods for testing graph history reconstruction."""
     # We mock the return values for session.execute(...).all() and .scalar()
@@ -188,7 +194,8 @@ def _setup_mock_session(
         elif "relationship_projection_edges.assertion_id" in stmt_str:
             mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
         elif "relationship_assertion_events" in stmt_str:
-            mock_result.scalars.return_value.all.return_value = []  # No events for now, we mock validate_reconstructed_assertion anyway
+            # Event validation is mocked by _validate_reconstructed_assertion.
+            mock_result.scalars.return_value.all.return_value = []
         elif "count" in stmt_str:
             mock_result.scalar.return_value = edge_count
         elif "hash" in stmt_str:

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -188,7 +188,9 @@ def _setup_mock_session(
         elif "relationship_projection_edges.assertion_id" in stmt_str:
             mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
         elif "relationship_assertion_events" in stmt_str:
-            mock_result.scalars.return_value.all.return_value = []  # No events for now, we mock validate_reconstructed_assertion anyway
+            mock_result.scalars.return_value.all.return_value = (
+                []
+            )  # No events for now, we mock validate_reconstructed_assertion anyway
         elif "count" in stmt_str:
             mock_result.scalar.return_value = edge_count
         elif "hash" in stmt_str:

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -175,9 +175,7 @@ def _setup_mock_session(
         elif "relationship_projection_edges.assertion_id" in stmt_str:
             mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
         elif "relationship_assertion_events" in stmt_str:
-            mock_result.scalars.return_value.all.return_value = (
-                []
-            )  # No events for now, we mock validate_reconstructed_assertion anyway
+            mock_result.scalars.return_value.all.return_value = []  # No events for now, we mock validate_reconstructed_assertion anyway
         elif "count" in stmt_str:
             mock_result.scalar.return_value = edge_count
         elif "hash" in stmt_str:

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -1,0 +1,216 @@
+import argparse
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from scripts.check_relationship_assertion_proof import ProofValidator
+
+
+@pytest.fixture
+def base_args(tmp_path):
+    health_json = {
+        "persistence_configured": True,
+        "graph": {"persistence_enabled": True, "persistence_loaded": True, "startup_source": "persisted"},
+    }
+    health_path = tmp_path / "health-observation.json"
+    health_path.write_text(json.dumps(health_json))
+
+    return argparse.Namespace(
+        strict=True,
+        require_persistence=True,
+        startup_source="persisted",
+        health_observation_path=str(health_path),
+        run_id="run123",
+        deployed_sha="sha123",
+        before_assertion_count=10,
+        before_edge_count=20,
+        before_edge_manifest_hash="hash123",
+        rebuild_job_id="job123",
+        execution_id="exec123",
+        check_authz=False,
+        authz_evidence_path=None,
+        publication_count=1,
+        revision_hash="hash",
+        proposer_id="foo",
+        determiner_id="foo",
+        owner_id="foo",
+        expected_revision_id="rev1",
+        before_scopes="[]",
+        after_scopes="[]",
+        empty_edge_before_scopes=None,
+        empty_edge_after_scopes=None,
+        history_entries=10,
+        expected_revision_hash=None,
+        empty_edge_assertion_count=0,
+        mode="verify_after_restart",
+    )
+
+
+def test_strict_restart_missing_seed_baselines(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+
+    # Missing assertion count
+    base_args.before_assertion_count = None
+    validator.validate_verify_after_restart(base_args)
+    assert any("Strict restart verification requires seed graph baselines" in e for e in validator.errors)
+    validator.errors.clear()
+
+    # Missing edge count
+    base_args.before_assertion_count = 10
+    base_args.before_edge_count = None
+    validator.validate_verify_after_restart(base_args)
+    assert any("Strict restart verification requires seed graph baselines" in e for e in validator.errors)
+    validator.errors.clear()
+
+    # Missing edge manifest hash
+    base_args.before_edge_count = 20
+    base_args.before_edge_manifest_hash = ""
+    validator.validate_verify_after_restart(base_args)
+    assert any("Strict restart verification requires seed graph baselines" in e for e in validator.errors)
+
+
+def test_zero_seed_assertion_count(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    base_args.before_assertion_count = 0
+    validator.validate_verify_after_restart(base_args)
+    assert any("Seed assertion count must be > 0" in e for e in validator.errors)
+
+
+def test_missing_health_file(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    base_args.health_observation_path = None
+    validator._validate_restart_persistence(base_args)
+    assert any("Health observation JSON is missing" in e for e in validator.errors)
+
+
+def test_malformed_health_json(tmp_path, base_args):
+    bad_health = tmp_path / "bad.json"
+    bad_health.write_text("{bad json")
+    base_args.health_observation_path = str(bad_health)
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("Failed to load or parse health observation" in e for e in validator.errors)
+
+
+def test_persistence_configured_false(tmp_path, base_args):
+    health = json.loads(Path(base_args.health_observation_path).read_text())
+    health["persistence_configured"] = False
+    Path(base_args.health_observation_path).write_text(json.dumps(health))
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("Health observation failed persistence validation" in e for e in validator.errors)
+
+
+def test_persistence_enabled_false(tmp_path, base_args):
+    health = json.loads(Path(base_args.health_observation_path).read_text())
+    health["graph"]["persistence_enabled"] = False
+    Path(base_args.health_observation_path).write_text(json.dumps(health))
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("Health observation failed persistence validation" in e for e in validator.errors)
+
+
+def test_persistence_loaded_false(tmp_path, base_args):
+    health = json.loads(Path(base_args.health_observation_path).read_text())
+    health["graph"]["persistence_loaded"] = False
+    Path(base_args.health_observation_path).write_text(json.dumps(health))
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("Health observation failed persistence validation" in e for e in validator.errors)
+
+
+def test_startup_source_not_persisted(tmp_path, base_args):
+    health = json.loads(Path(base_args.health_observation_path).read_text())
+    health["graph"]["startup_source"] = "memory"
+    Path(base_args.health_observation_path).write_text(json.dumps(health))
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("expected persisted" in e for e in validator.errors)
+
+
+def test_startup_source_mismatch(tmp_path, base_args):
+    base_args.startup_source = "memory"
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert any("Health observation and supplied startup source do not match" in e for e in validator.errors)
+
+
+def test_valid_health_provenance(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_restart_persistence(base_args)
+    assert len(validator.errors) == 0
+
+    health_bytes = Path(base_args.health_observation_path).read_bytes()
+    expected_digest = hashlib.sha256(health_bytes).hexdigest()
+
+    assert validator.metadata["health_observation_sha256"] == expected_digest
+    assert validator.metadata["health_observation_run_id"] == "run123"
+    assert validator.metadata["health_observation_deployed_sha"] == "sha123"
+
+
+class MockSession:
+    def __init__(self, count_val, hash_val):
+        self.count_val = count_val
+        self.hash_val = hash_val
+
+    def execute(self, stmt, params=None):
+        class Result:
+            def __init__(self, val):
+                self.val = val
+
+            def scalar(self):
+                return self.val
+
+            def all(self):
+                return [[f"id_{i}"] for i in range(self.val)] if isinstance(self.val, int) else []
+
+        if "count" in str(stmt).lower():
+            return Result(self.count_val)
+        if "hash" in str(stmt).lower():
+            return Result(self.hash_val)
+        return Result(self.count_val)
+
+
+def test_restart_assertion_count_mismatch(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator.metadata["reconstructed_assertions"] = 5
+    validator._validate_reconstructed_assertion = lambda a, e: True
+    base_args.history_entries = 10
+
+    reconstructed = 5
+    if base_args.before_assertion_count is not None:
+        if reconstructed != base_args.before_assertion_count:
+            validator.add_error(
+                f"Assertion count mismatch: {reconstructed} vs expected {base_args.before_assertion_count}"
+            )
+
+    assert any("Assertion count mismatch: 5 vs expected 10" in e for e in validator.errors)
+
+
+def test_edge_count_mismatch(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    edge_count = 15
+    if base_args.before_edge_count is not None:
+        if edge_count != base_args.before_edge_count:
+            validator.add_error(f"Edge count mismatch: {edge_count} vs expected {base_args.before_edge_count}")
+
+    assert any("Edge count mismatch: 15 vs expected 20" in e for e in validator.errors)
+
+
+def test_edge_manifest_mismatch(base_args):
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    edge_manifest_hash = "wronghash"
+    if base_args.before_edge_manifest_hash is not None:
+        if edge_manifest_hash != base_args.before_edge_manifest_hash:
+            validator.add_error(
+                f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {base_args.before_edge_manifest_hash}"
+            )
+
+    assert any("Edge manifest hash mismatch" in e for e in validator.errors)

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -11,6 +11,7 @@ from scripts.check_relationship_assertion_proof import ProofValidator
 
 @pytest.fixture
 def base_args(tmp_path):
+    """Build valid strict restart arguments with a retained health observation."""
     health_json = {
         "persistence_configured": True,
         "graph": {"persistence_enabled": True, "persistence_loaded": True, "startup_source": "persisted"},
@@ -50,6 +51,7 @@ def base_args(tmp_path):
 
 
 def test_strict_restart_missing_seed_baselines(base_args):
+    """Reject strict restart verification if any seed baselines are missing."""
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
 
     # Missing assertion count
@@ -73,6 +75,7 @@ def test_strict_restart_missing_seed_baselines(base_args):
 
 
 def test_zero_seed_assertion_count(base_args):
+    """Reject strict restart verification if seed assertion count is zero."""
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
     base_args.before_assertion_count = 0
     validator.validate_verify_after_restart(base_args)
@@ -80,6 +83,7 @@ def test_zero_seed_assertion_count(base_args):
 
 
 def test_missing_health_file(base_args):
+    """Reject strict persistence proof without a retained health observation."""
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
     base_args.health_observation_path = None
     validator._validate_restart_persistence(base_args)
@@ -87,6 +91,7 @@ def test_missing_health_file(base_args):
 
 
 def test_malformed_health_json(tmp_path, base_args):
+    """Reject persistence proof if health observation JSON is malformed."""
     bad_health = tmp_path / "bad.json"
     bad_health.write_text("{bad json")
     base_args.health_observation_path = str(bad_health)
@@ -97,6 +102,7 @@ def test_malformed_health_json(tmp_path, base_args):
 
 
 def test_persistence_configured_false(tmp_path, base_args):
+    """Reject persistence proof if persistence is not configured."""
     health = json.loads(Path(base_args.health_observation_path).read_text())
     health["persistence_configured"] = False
     Path(base_args.health_observation_path).write_text(json.dumps(health))
@@ -107,6 +113,7 @@ def test_persistence_configured_false(tmp_path, base_args):
 
 
 def test_persistence_enabled_false(tmp_path, base_args):
+    """Reject persistence proof if persistence is not enabled in graph."""
     health = json.loads(Path(base_args.health_observation_path).read_text())
     health["graph"]["persistence_enabled"] = False
     Path(base_args.health_observation_path).write_text(json.dumps(health))
@@ -117,6 +124,7 @@ def test_persistence_enabled_false(tmp_path, base_args):
 
 
 def test_persistence_loaded_false(tmp_path, base_args):
+    """Reject persistence proof if persistence is not loaded in graph."""
     health = json.loads(Path(base_args.health_observation_path).read_text())
     health["graph"]["persistence_loaded"] = False
     Path(base_args.health_observation_path).write_text(json.dumps(health))
@@ -127,6 +135,7 @@ def test_persistence_loaded_false(tmp_path, base_args):
 
 
 def test_startup_source_not_persisted(tmp_path, base_args):
+    """Reject persistence proof if startup source is not persisted."""
     health = json.loads(Path(base_args.health_observation_path).read_text())
     health["graph"]["startup_source"] = "memory"
     Path(base_args.health_observation_path).write_text(json.dumps(health))
@@ -137,6 +146,7 @@ def test_startup_source_not_persisted(tmp_path, base_args):
 
 
 def test_startup_source_mismatch(tmp_path, base_args):
+    """Reject persistence proof if startup source does not match expected source."""
     base_args.startup_source = "memory"
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
     validator._validate_restart_persistence(base_args)
@@ -144,6 +154,7 @@ def test_startup_source_mismatch(tmp_path, base_args):
 
 
 def test_valid_health_provenance(base_args):
+    """Verify successful binding of health observation metadata."""
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
     validator._validate_restart_persistence(base_args)
     assert len(validator.errors) == 0
@@ -159,6 +170,7 @@ def test_valid_health_provenance(base_args):
 def _setup_mock_session(
     mocker, mock_session, assertion_count, edge_count, edge_manifest_hash, expected_revision_id, execution_id
 ):
+    """Setup mocked SQLAlchemy session methods for testing graph history reconstruction."""
     # We mock the return values for session.execute(...).all() and .scalar()
     # 1. Publication query: returns [(revision_id, execution_id)]
     # 2. Assertion IDs query: returns [[id_0], [id_1], ...]
@@ -167,6 +179,7 @@ def _setup_mock_session(
     # 5. Edge manifest hash query via scalar()
 
     def execute_side_effect(stmt, params=None):
+        """Side effect function to dispatch to appropriate mock result based on statement."""
         stmt_str = str(stmt).lower()
         mock_result = MagicMock()
 
@@ -193,6 +206,7 @@ def _setup_mock_session(
 @patch("sqlalchemy.orm.Session")
 @patch("os.getenv")
 def test_restart_assertion_count_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    """Reject restart reconstruction if assertion count does not match seed baseline."""
     mock_getenv.return_value = "sqlite:///:memory:"
 
     mock_session = MagicMock()
@@ -214,6 +228,7 @@ def test_restart_assertion_count_mismatch(mock_getenv, mock_session_cls, mock_cr
 @patch("sqlalchemy.orm.Session")
 @patch("os.getenv")
 def test_edge_count_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    """Reject restart reconstruction if edge count does not match seed baseline."""
     mock_getenv.return_value = "sqlite:///:memory:"
 
     mock_session = MagicMock()
@@ -235,6 +250,7 @@ def test_edge_count_mismatch(mock_getenv, mock_session_cls, mock_create_engine, 
 @patch("sqlalchemy.orm.Session")
 @patch("os.getenv")
 def test_edge_manifest_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    """Reject restart reconstruction if edge manifest hash does not match seed baseline."""
     mock_getenv.return_value = "sqlite:///:memory:"
 
     mock_session = MagicMock()

--- a/tests/unit/test_check_relationship_assertion_proof.py
+++ b/tests/unit/test_check_relationship_assertion_proof.py
@@ -2,6 +2,7 @@ import argparse
 import hashlib
 import json
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -155,62 +156,99 @@ def test_valid_health_provenance(base_args):
     assert validator.metadata["health_observation_deployed_sha"] == "sha123"
 
 
-class MockSession:
-    def __init__(self, count_val, hash_val):
-        self.count_val = count_val
-        self.hash_val = hash_val
+def _setup_mock_session(
+    mocker, mock_session, assertion_count, edge_count, edge_manifest_hash, expected_revision_id, execution_id
+):
+    # We mock the return values for session.execute(...).all() and .scalar()
+    # 1. Publication query: returns [(revision_id, execution_id)]
+    # 2. Assertion IDs query: returns [[id_0], [id_1], ...]
+    # 3. For each assertion ID: returns list of events via scalars().all()
+    # 4. Edge count query via scalar()
+    # 5. Edge manifest hash query via scalar()
 
-    def execute(self, stmt, params=None):
-        class Result:
-            def __init__(self, val):
-                self.val = val
+    def execute_side_effect(stmt, params=None):
+        stmt_str = str(stmt).lower()
+        mock_result = MagicMock()
 
-            def scalar(self):
-                return self.val
+        if "relationship_projection_publications" in stmt_str:
+            mock_result.all.return_value = [(expected_revision_id, execution_id)]
+        elif "relationship_projection_edges.assertion_id" in stmt_str:
+            mock_result.all.return_value = [[f"id_{i}"] for i in range(assertion_count)]
+        elif "relationship_assertion_events" in stmt_str:
+            mock_result.scalars.return_value.all.return_value = (
+                []
+            )  # No events for now, we mock validate_reconstructed_assertion anyway
+        elif "count" in stmt_str:
+            mock_result.scalar.return_value = edge_count
+        elif "hash" in stmt_str:
+            mock_result.scalar.return_value = edge_manifest_hash
+        else:
+            mock_result.all.return_value = []
+            mock_result.scalar.return_value = None
 
-            def all(self):
-                return [[f"id_{i}"] for i in range(self.val)] if isinstance(self.val, int) else []
+        return mock_result
 
-        if "count" in str(stmt).lower():
-            return Result(self.count_val)
-        if "hash" in str(stmt).lower():
-            return Result(self.hash_val)
-        return Result(self.count_val)
+    mock_session.execute.side_effect = execute_side_effect
 
 
-def test_restart_assertion_count_mismatch(base_args):
+@patch("sqlalchemy.create_engine")
+@patch("sqlalchemy.orm.Session")
+@patch("os.getenv")
+def test_restart_assertion_count_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    mock_getenv.return_value = "sqlite:///:memory:"
+
+    mock_session = MagicMock()
+    mock_session_cls.return_value.__enter__.return_value = mock_session
+
+    # We reconstruct 5 assertions but expect 10 (from base_args.before_assertion_count)
+    _setup_mock_session(
+        mock_session, mock_session, 5, 20, "hash123", base_args.expected_revision_id, base_args.execution_id
+    )
+
     validator = ProofValidator({"db_url": "sqlite:///:memory:"})
-    validator.metadata["reconstructed_assertions"] = 5
-    validator._validate_reconstructed_assertion = lambda a, e: True
-    base_args.history_entries = 10
+    validator._validate_reconstructed_assertion = MagicMock(return_value=True)
 
-    reconstructed = 5
-    if base_args.before_assertion_count is not None:
-        if reconstructed != base_args.before_assertion_count:
-            validator.add_error(
-                f"Assertion count mismatch: {reconstructed} vs expected {base_args.before_assertion_count}"
-            )
-
+    validator._reconstruct_assertion_history_from_db(base_args)
     assert any("Assertion count mismatch: 5 vs expected 10" in e for e in validator.errors)
 
 
-def test_edge_count_mismatch(base_args):
-    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
-    edge_count = 15
-    if base_args.before_edge_count is not None:
-        if edge_count != base_args.before_edge_count:
-            validator.add_error(f"Edge count mismatch: {edge_count} vs expected {base_args.before_edge_count}")
+@patch("sqlalchemy.create_engine")
+@patch("sqlalchemy.orm.Session")
+@patch("os.getenv")
+def test_edge_count_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    mock_getenv.return_value = "sqlite:///:memory:"
 
+    mock_session = MagicMock()
+    mock_session_cls.return_value.__enter__.return_value = mock_session
+
+    # We reconstruct 10 assertions (correct) but 15 edges, expecting 20
+    _setup_mock_session(
+        mock_session, mock_session, 10, 15, "hash123", base_args.expected_revision_id, base_args.execution_id
+    )
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_reconstructed_assertion = MagicMock(return_value=True)
+
+    validator._reconstruct_assertion_history_from_db(base_args)
     assert any("Edge count mismatch: 15 vs expected 20" in e for e in validator.errors)
 
 
-def test_edge_manifest_mismatch(base_args):
-    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
-    edge_manifest_hash = "wronghash"
-    if base_args.before_edge_manifest_hash is not None:
-        if edge_manifest_hash != base_args.before_edge_manifest_hash:
-            validator.add_error(
-                f"Edge manifest hash mismatch: {edge_manifest_hash} vs expected {base_args.before_edge_manifest_hash}"
-            )
+@patch("sqlalchemy.create_engine")
+@patch("sqlalchemy.orm.Session")
+@patch("os.getenv")
+def test_edge_manifest_mismatch(mock_getenv, mock_session_cls, mock_create_engine, base_args):
+    mock_getenv.return_value = "sqlite:///:memory:"
 
-    assert any("Edge manifest hash mismatch" in e for e in validator.errors)
+    mock_session = MagicMock()
+    mock_session_cls.return_value.__enter__.return_value = mock_session
+
+    # We reconstruct 10 assertions (correct) and 20 edges (correct), but wrong hash
+    _setup_mock_session(
+        mock_session, mock_session, 10, 20, "wronghash", base_args.expected_revision_id, base_args.execution_id
+    )
+
+    validator = ProofValidator({"db_url": "sqlite:///:memory:"})
+    validator._validate_reconstructed_assertion = MagicMock(return_value=True)
+
+    validator._reconstruct_assertion_history_from_db(base_args)
+    assert any("Edge manifest hash mismatch: wronghash vs expected hash123" in e for e in validator.errors)

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -100,7 +100,9 @@ def test_scopes_are_consistent_invalid_types() -> None:
     """Test that scopes_are_consistent handles non-list or unhashable inputs gracefully."""
     validator = ProofValidator({})
     # Test non-list inputs
-    assert validator.scopes_are_consistent("not-a-list", ["scope1"], enforce_no_loss=True) is False  # type: ignore[arg-type]
+    assert (
+        validator.scopes_are_consistent("not-a-list", ["scope1"], enforce_no_loss=True) is False
+    )  # type: ignore[arg-type]
     assert any("must be a non-empty list" in err for err in validator.errors)
     validator.errors.clear()
 
@@ -262,14 +264,14 @@ def test_strict_mode_expected_revision_hash_requirement(mode: str, should_error:
         ([" "], None, "invalid or missing predicate_id"),
         (
             ["scope-1", {"predicate_id": "scope-2", "purpose": "testing"}],
-            ("hash", ["scope-1::testing", "scope-2::testing"]),
+            ("hash", ["scope-1::testing", "scope-2::testing"], "edge-set-hash"),
             None,
         ),
     ],
 )
 def test_validate_revision_scopes(
     scopes: object,
-    expected: tuple[str, list[str]] | None,
+    expected: tuple[str, list[str], str] | None,
     error_fragment: str | None,
 ) -> None:
     """Validate supported and rejected governed-scope representations."""
@@ -282,6 +284,7 @@ def test_validate_revision_scopes(
         "hash",
         json.dumps(scopes),
         "testing",
+        "edge-set-hash",
     )
 
     result = validator._get_and_validate_revision_scopes(

--- a/tests/unit/test_relationship_assertion_proof_contract.py
+++ b/tests/unit/test_relationship_assertion_proof_contract.py
@@ -100,9 +100,7 @@ def test_scopes_are_consistent_invalid_types() -> None:
     """Test that scopes_are_consistent handles non-list or unhashable inputs gracefully."""
     validator = ProofValidator({})
     # Test non-list inputs
-    assert (
-        validator.scopes_are_consistent("not-a-list", ["scope1"], enforce_no_loss=True) is False
-    )  # type: ignore[arg-type]
+    assert validator.scopes_are_consistent("not-a-list", ["scope1"], enforce_no_loss=True) is False  # type: ignore[arg-type]
     assert any("must be a non-empty list" in err for err in validator.errors)
     validator.errors.clear()
 


### PR DESCRIPTION
## **User description**
## What changed

Updated the Governed Relationship Assertion Contract v1 documentation to promote its runtime capability claim class from `NEXT` to `CURRENT`. Changed the capability status line to reflect that exact-SHA staging proof has passed (dated 2026-08-06 on commit `8cbbb8fe2d4`). Removed the blocking condition from the "Out of scope" section that explicitly forbade claiming `CURRENT` before staging proof completion, and added a new changelog entry documenting the promotion and successful staging proof outcomes.

## Why

The staging proofs (seed_and_publish and verify_after_restart) have completed successfully on `main`, satisfying the prerequisite for promoting GRAC v1 from `NEXT` to `CURRENT` capability. This advancement reflects that the contract is now ready for full runtime use rather than experimental/next-version status. The documentation updates formalize this lifecycle transition and remove the now-satisfied constraint.

## How to test

No functional changes — visual review only.

- Verify the status line correctly reflects `CURRENT` and references the passing staging proof date
- Confirm the removed constraint from "Out of scope" is no longer needed (staging proof is complete)
- Check that the changelog entry accurately documents the promotion with the commit hash and proof names
- Ensure no broken cross-references to ADR 0008 or related issues (#1540, #1536)

## Notes

This appears to be a documentation-only change reflecting completed validation work. Confirm that the staging proofs referenced (seed_and_publish and verify_after_restart) have actually completed successfully before merging, as this documents a significant capability promotion.

*📝 Generated by [PR Autopilot](https://pr-autopilot.vercel.app) — edit freely*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps GRAC v1 at NEXT and hardens the staging proof: bind workflow-captured health evidence to the run/deploy, and require served-graph parity against seed baselines before any CURRENT promotion (issue #1540). Adds API support to emit proof-bound provenance and runtime graph metrics to back these checks.

- **Bug Fixes**
  - Health provenance: require --health-observation-path, SHA-256 the file, bind run ID and deployed SHA from evidence, enforce startup_source="persisted", and fail on missing/mismatch.
  - Seed baselines: require --before-assertion-count (>0), --before-edge-count, --before-edge-manifest-hash; compare reconstructed assertions, edge count, and edge-set hash; reject empty graphs and mismatches.
  - Served graph parity: require --runtime-graph-observation-path; validate run/deploy/revision in proof_observation; compare served assertion/edge counts and edge-set hash to seed; fail closed.
  - Detailed health endpoint: handles normal requests without headers and proof-mode with headers; no more 500 on readiness requests.
  - Workflow: save health-observation.json; pass seed baselines into verify_after_restart; upload the retained observation. Docs/tests updated for strict baselines, served-graph parity, and provenance.

- **New Features**
  - API: Detailed health now accepts X-FarDB-Proof-Run-ID and X-FarDB-Expected-Revision-ID headers and returns proof_observation plus runtime_graph metrics for parity checks.
  - Server: canonical served edge-set hashing to support runtime parity validation.

<sup>Written for commit dd69971e0a3a7cd2698749db04138420c0497443. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->




___

## **CodeAnt-AI Description**
Harden GRAC staging proofs and keep runtime capability at NEXT until restart parity is verified

### What Changed
- Detailed health checks can now return deployment, proof-run, revision, and served-graph evidence when requested.
- Strict restart validation now requires retained persistence evidence and verifies that the restarted graph matches the seed assertion count, edge count, and canonical edge-set hash.
- Staging workflows retain health observations and pass seed graph baselines into restart verification.
- GRAC v1 documentation withdraws the earlier promotion evidence and keeps the runtime capability claim at `NEXT` until a fresh hardened proof passes.
- Added coverage for missing, malformed, mismatched, and inconsistent restart evidence.

### Impact
`✅ Fewer false-positive staging proofs`
`✅ Detectable graph loss after restart`
`✅ Clearer deployment and persistence evidence`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The restart-certification changes cannot complete successfully: the workflow does not supply the required served-graph observation, and proof-enabled detailed health rejects the graph’s tuple-based relationships. In addition, restart health evidence is accepted from locally authored JSON without a trusted capture binding. These failures prevent reliable verification that the deployed governed graph survived restart.

<h3>Confidence Score: 1/5</h3>

The change is not safe to merge because restart certification is both inoperable for the served graph and vulnerable to forged health evidence.

Three blocking failures remain: missing workflow wiring for served-graph evidence, incompatibility with the runtime relationship representation, and unauthenticated restart-health provenance.

**Files Needing Attention:** .github/workflows/relationship-assertion-staging-proof.yml, api/routers/system.py, scripts/check_relationship_assertion_proof.py

<details open><summary><h3>Security Review</h3></summary>

Restart health provenance is not authenticated. A locally authored health observation with run and deployment values matching the command-line inputs passes the provenance checks, allowing unrelated health data to be presented as evidence for the requested deployment.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for a posted P1 finding, including a focused restart-proof reproduction source, restart proofs with and without runtime graph evidence, and a worktree integrity check.
- T-Rex produced a second P1 proof using a focused route-helper harness for a populated served tuple graph, along with detailed health proof requests before and after demonstrating tuple compatibility.
- T-Rex produced a focused strict restart health provenance harness and demonstrated that a locally authored health JSON with a mismatched run ID is rejected, while a locally authored health JSON with matching CLI identity values is accepted.
- A general-contract-validation-proof shows that before capture the validator requires a runtime graph observation, and after capture with a runtime-graph-observation-path the error changes.
- A general-contract-validation-proof documents validator and workflow details, noting that the health provenance harness reads JSON and compares only run\_id and deployment\_sha to CLI args, without cryptographic artifact binding, and that results are scoped to the requested health-provenance path.

<a href="https://app.greptile.com/trex/runs/17739794/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (14)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Strict restart validation misattributes foreign health evidence to CLI provenance**

   - **Bug**
     - A stale/foreign health JSON with valid persistence flags and `startup_source: persisted` passes strict restart persistence validation. Its embedded immutable identifiers do not need to be present or match the current run/deployment, yet the emitted proof metadata labels it with the CLI run ID and deployed SHA.
   - **Cause**
     - Lines 769-770 copy `args.run_id` and `args.deployed_sha` into `health_observation_*` metadata rather than reading and validating immutable identifiers from `health`. Lines 772-785 validate only persistence/startup fields.
   - **Fix**
     - Require immutable run and deployment identifiers in the health JSON and reject missing or mismatched values before emitting provenance. Populate `health_observation_run_id` and `health_observation_deployed_sha` from the validated health JSON values, not from CLI arguments.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart graph parity never observes the graph served after restart**

   - **Bug**
     - The checker accepts seed-matching persisted projection metrics even if the graph conceptually served by the restarted process is empty or divergent. The focused contract passed with persisted edge count 1 and conceptual served edge count 0.
   - **Cause**
     - `_reconstruct_assertion_history_from_db` obtains `edge_count` and `edge_manifest_hash` exclusively through `_query_restart_graph_metrics`, which executes SQLAlchemy queries over persisted projection tables. `_validate_restart_graph_parity` receives no runtime graph response, graph client, endpoint, or served-graph metric.
   - **Fix**
     - Obtain edge count and canonical edge-set hash from an authenticated post-restart graph endpoint or runtime graph service, bind that response to the restart/run identity, and compare those observed runtime metrics to the seed baselines. Retain SQL projection checks as persistence evidence rather than treating them as served-graph parity.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Strict restart validation certifies unrelated health observations**

   - **Bug**
     - A health observation containing only successful persistence flags, or one explicitly labeled for another run and deployment SHA, is accepted without validation errors. The result metadata then states the CLI-supplied run ID and deployment SHA rather than the identifiers from the evidence.
   - **Cause**
     - `_validate_restart_persistence` hashes and validates persistence/startup fields but does not require or compare provenance fields from `health`. Lines 769-770 assign `args.run_id` and `args.deployed_sha` directly to evidence metadata.
   - **Fix**
     - Read required immutable health-observation provenance fields, reject missing or mismatched values in strict restart validation, and write the verified observed values into metadata. Cover missing and mismatch cases with unit tests.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Strict restart parity can pass when the restarted runtime serves an empty graph**

   - **Bug**
     - The validator certifies parity from persisted projection rows and revision `edge_set_hash`, but does not fetch or validate graph metrics from the restarted serving runtime. A runtime can report persistence loaded while serving an empty/divergent graph and still receive a passing strict proof.
   - **Cause**
     - `_query_restart_graph_metrics` executes SQL counts/hashes against the persistence database, and the only runtime request in the workflow is `/api/health/detailed`, whose consumed fields are persistence/startup booleans rather than served graph contents.
   - **Fix**
     - Add a mandatory authenticated post-restart graph observation endpoint or equivalent runtime introspection API returning canonical revision identity and graph count/manifest. Capture its response in the workflow, pass it to the validator, fail closed unless its values match the seed baseline, and test the empty/divergent-runtime case.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

5. `api/routers/system.py`, line 273-278 ([link](https://github.com/dashfin-fardb/financial-asset-relationship-db/blob/e84138459eb21ac1cd0585fa2fcf761e9d64316d/api/routers/system.py#L273-L278)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Detailed health endpoint omits restart provenance**

   The workflow saves `/api/health/detailed` as the persistence observation, but `detailed_health_check` constructs the response without `proof_observation` or `runtime_graph`. A persistence-required restart validation therefore fails with `Health observation proof provenance is missing` even when the service reports a persisted startup. Populate deployment-bound proof provenance in the detailed-health response, or obtain the required signed observation from a separate runtime-proof endpoint before invoking the checker.

   **Context Used:** Governance layer / boundary work ([source](https://github.com/dashfin-fardb/financial-asset-relationship-db/blob/main/docs/governance/))
   
   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: api/routers/system.py
   Line: 273-278
   
   Comment:
   **Detailed health endpoint omits restart provenance**
   
   The workflow saves `/api/health/detailed` as the persistence observation, but `detailed_health_check` constructs the response without `proof_observation` or `runtime_graph`. A persistence-required restart validation therefore fails with `Health observation proof provenance is missing` even when the service reports a persisted startup. Populate deployment-bound proof provenance in the detailed-health response, or obtain the required signed observation from a separate runtime-proof endpoint before invoking the checker.
   
   **Context Used:** Governance layer / boundary work ([source](https://github.com/dashfin-fardb/financial-asset-relationship-db/blob/main/docs/governance/))

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>
   
   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22feature%2Fgrac-v1-current-promotion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fgrac-v1-current-promotion%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20api%2Frouters%2Fsystem.py%0ALine%3A%20273-278%0A%0AComment%3A%0A**Detailed%20health%20endpoint%20omits%20restart%20provenance**%0A%0AThe%20workflow%20saves%20%60%2Fapi%2Fhealth%2Fdetailed%60%20as%20the%20persistence%20observation%2C%20but%20%60detailed_health_check%60%20constructs%20the%20response%20without%20%60proof_observation%60%20or%20%60runtime_graph%60.%20A%20persistence-required%20restart%20validation%20therefore%20fails%20with%20%60Health%20observation%20proof%20provenance%20is%20missing%60%20even%20when%20the%20service%20reports%20a%20persisted%20startup.%20Populate%20deployment-bound%20proof%20provenance%20in%20the%20detailed-health%20response%2C%20or%20obtain%20the%20required%20signed%20observation%20from%20a%20separate%20runtime-proof%20endpoint%20before%20invoking%20the%20checker.%0A%0A**Context%20Used%3A**%20Governance%20layer%20%2F%20boundary%20work%20%28%5Bsource%5D%28https%3A%2F%2Fgithub.com%2Fdashfin-fardb%2Ffinancial-asset-relationship-db%2Fblob%2Fmain%2Fdocs%2Fgovernance%2F%29%29%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1594&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

6. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart workflow cannot complete served-graph proof**

   - **Bug**
     - `verify_after_restart` invokes the checker without `--runtime-graph-observation-path`. The checker always calls served-graph parity validation in this mode, which requires that path and fails before graph metrics can be validated.
   - **Cause**
     - The workflow creates only `health-observation.json` and appends `--health-observation-path`; it neither captures `runtime-graph-observation.json` nor appends the corresponding checker option.
   - **Fix**
     - Capture the authenticated post-restart runtime graph observation as `runtime-graph-observation.json`, append `--runtime-graph-observation-path runtime-graph-observation.json` to the restart ARGS, and upload the observation artifact.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

7. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Health provenance remains accepted from self-labeled evidence**

   - **Bug**
     - Roots PRRC_kwDOQJVhOs7eLNzt, Lz1F, M672, OmCV, Oxof: OUTSTANDING. The focused harness wrote a health JSON whose `proof_observation.run_id` and `deployment_sha` were only file content and observed `_validate_restart_persistence` accept it. The digest only records the same untrusted file; no signature, authenticated response binding, or server-verified observation token is checked.
   - **Cause**
     - `_validate_health_provenance` compares `proof_observation` fields read directly from the health JSON to CLI values. The workflow obtains the endpoint without proof headers, so this response cannot be bound by the runtime to the certified run or revision.
   - **Fix**
     - Request detailed health using authenticated proof headers or a server-issued signed/attested observation token, require the revision identifier, and validate that signed server-bound evidence instead of self-asserted JSON fields.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

8. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart parity workflow omits the required served-runtime graph observation**

   - **Bug**
     - Roots LNzz, Lz1M, M68I, OmCc, Oxoq and Qxe3: OUTSTANDING. The validator's `_validate_served_graph_parity` correctly compares runtime observation counts and manifest to seed baselines when one is supplied, but the workflow restart block supplies neither `--runtime-graph-observation-path` nor the required proof headers. Executing the checker with the workflow-equivalent arguments failed with `Runtime graph observation is required`.
   - **Cause**
     - The workflow fetches `/api/health/detailed` only for persistence/startup data and never requests the proof-enabled runtime graph response or passes it to the validator.
   - **Fix**
     - In `verify_after_restart`, call `/api/health/detailed` with `X-FarDB-Proof-Run-ID` and `X-FarDB-Expected-Revision-ID`, persist the response as `runtime-graph-observation.json`, and pass `--runtime-graph-observation-path runtime-graph-observation.json`. Keep the endpoint's runtime graph metric/parity checks mandatory.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

9. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Retained GRAC restart observation has no durable provenance**

   - **Bug**
     - `docs/governance/evidence/grac-v1-restart-health-observation.json` records only persistence flags. It omits `captured_at`, `source_url`, `workflow_run_id`, and `deployed_sha`, so its claimed SHA-256 proves bytes but not capture origin or deployment binding.
   - **Cause**
     - The committed retained-health evidence schema does not require provenance metadata.
   - **Fix**
     - Retain the observed response with redacted capture timestamp, target/source URL or deployment identifier, workflow run/artifact ID, and exact deployed SHA; bind those fields to the documented evidence digest.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

10. General comment 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Committed GRAC evidence does not retain restart parity metrics**

    - **Bug**
      - The staging evidence narrative says the workflow/checker was hardened to compare assertion count, edge count, and canonical edge-set hash across restart, but the committed record retains none of those before/after values.
    - **Cause**
      - The docs preserve a summary and artifact reference rather than the metrics needed to independently assess restart parity after artifact retention expires.
    - **Fix**
      - Add the exact before/after assertion count, edge count, canonical edge-set hash, revision ID/hash, and artifact/run provenance to the committed evidence record.

    <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

11. General comment 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **CURRENT current-state claim is stale relative to the checked-out documentation state**

    - **Bug**
      - `docs/strategy/current-state.md` labels the project `CURRENT` at `2afe77212fba06b6556d38696a5323e55f04a35a`, but current HEAD is `ed9468d8d8454d1a6e72922b9e18047d792ea1f4`. The CURRENT claim is therefore not bound to the current revision.
    - **Cause**
      - The current-state baseline was not updated or explicitly qualified after later commits.
    - **Fix**
      - Either update the baseline only after re-evaluating the CURRENT claim for HEAD, or change the document to an explicitly historical statement and direct readers to release-SHA-bound evidence.

    <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

12. General comment 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart staging-proof workflow omits required runtime graph evidence**

    - **Bug**
      - In `verify_after_restart`, the workflow writes and passes `health-observation.json` but never creates or passes the runtime graph observation required by the validator. Therefore every fresh restart proof reaches `_validate_served_graph_parity` without `runtime_graph_observation_path` and fails with `Runtime graph observation is required`.
    - **Cause**
      - The workflow's argument construction at `.github/workflows/relationship-assertion-staging-proof.yml:336-423` was not updated to request the paired proof-aware detailed-health response, persist its `runtime_graph` evidence, and append `--runtime-graph-observation-path`; the validator unconditionally calls parity validation at `scripts/check_relationship_assertion_proof.py:1387-1389` and requires the path at `:897-904`.
    - **Fix**
      - In the restart branch, request `/api/health/detailed` with the required proof headers (`X-FarDB-Proof-Run-ID` and `X-FarDB-Expected-Revision-ID`), save the response as the permitted `runtime-graph-observation.json` (or safely derive an equivalent separately retained observation), then append `--runtime-graph-observation-path runtime-graph-observation.json`. Keep provenance and graph-metric validation intact.

    <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


13. General comment 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Proof-enabled detailed health rejects the served tuple graph**

    - **Bug**
      - With `X-FarDB-Proof-Run-ID` and `X-FarDB-Expected-Revision-ID` provided, a graph containing `{'source-asset': [('target-asset', 'same_sector', 0.75)]}` returns HTTP 503 and `Restarted runtime serves no governed edges for the certified revision` instead of reporting the relationship.
    - **Cause**
      - `_get_runtime_graph_proof_metrics` in `api/routers/system.py:193-202` expects edge objects exposing `revision_id` and `assertion_id`. The actual `AssetRelationshipGraph` contract declares relationship entries as `tuple[str, str, float]` in `src/logic/asset_graph.py:12,39-45`; `getattr(tuple, 'revision_id', None)` is always `None`, so `api/routers/system.py:204-214` filters every served edge and emits 503. `get_runtime_edge_set_hash` has the same attribute-only incompatibility at `api/graph_lifecycle.py:310-334`.
    - **Fix**
      - Define and use a single runtime proof-edge representation that carries revision/assertion provenance, or make proof metrics and edge hashing explicitly tuple-aware using an authoritative revision/provenance mapping. Do not treat tuple edges as governed solely based on the request header unless that association is independently verified.

    <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>


14. General comment 

    <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Strict restart proof accepts forged local health provenance**

    - **Bug**
      - A locally authored `health-observation.json` with persistence fields and `proof_observation.run_id`/`deployment_sha` copied from the supplied CLI values passes `_validate_restart_persistence` with zero provenance errors. The validator cannot distinguish that file from a response captured from the deployed workload.
    - **Cause**
      - `_validate_health_provenance` in `scripts/check_relationship_assertion_proof.py:779-811` only equality-checks two JSON-controlled fields against CLI-controlled inputs. `_load_health_observation` calculates a SHA-256 digest but does not compare it with an immutable workflow artifact, signed attestation, trusted server signature, or external artifact digest. The workflow captures an unauthenticated local file at `.github/workflows/relationship-assertion-staging-proof.yml:349-363`.
    - **Fix**
      - Bind the observation to a trusted workflow/deployment identity: capture it in a protected workflow step, upload/download it as an immutable artifact with verified digest/attestation, and have the validator verify that trusted binding. Prefer a workload-issued signed attestation containing run ID, deployment SHA, revision, nonce, and timestamp; do not accept caller-provided run IDs as provenance evidence.

    <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22feature%2Fgrac-v1-current-promotion%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feature%2Fgrac-v1-current-promotion%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Frelationship-assertion-staging-proof.yml%3A349-363%0A**Restart%20proof%20omits%20runtime%20graph%20evidence**%0A%0A%60verify_after_restart%60%20saves%20an%20ordinary%20detailed-health%20response%20and%20passes%20only%20%60--health-observation-path%60.%20The%20checker%20always%20runs%20served-graph%20parity%20validation%2C%20which%20requires%20%60--runtime-graph-observation-path%60%2C%20so%20every%20fresh%20restart%20proof%20fails%20with%20%60Runtime%20graph%20observation%20is%20required%60.%20Request%20the%20proof-enabled%20detailed-health%20response%2C%20retain%20its%20runtime%20graph%20metrics%2C%20and%20pass%20the%20observation%20path%20to%20the%20checker.%0A%0A%23%23%23%20Issue%202%0Aapi%2Frouters%2Fsystem.py%3A193-214%0A**Proof-enabled%20health%20rejects%20tuple%20relationships**%0A%0AThe%20served%20graph%20stores%20relationship%20entries%20as%20%60%28target_id%2C%20edge_type%2C%20strength%29%60%20tuples%2C%20but%20%60_get_runtime_graph_proof_metrics%60%20reads%20%60revision_id%60%20and%20%60assertion_id%60%20as%20attributes.%20Consequently%2C%20every%20tuple%20is%20filtered%20out%20and%20a%20proof-header%20detailed-health%20request%20returns%20HTTP%20503%20with%20%60Restarted%20runtime%20serves%20no%20governed%20edges%20for%20the%20certified%20revision%60%2C%20even%20when%20the%20graph%20contains%20relationships.%20Use%20an%20authoritative%20representation%20or%20provenance%20mapping%20that%20lets%20runtime%20proof%20metrics%20and%20edge%20hashing%20identify%20governed%20tuple%20edges.%0A%0A%23%23%23%20Issue%203%0Ascripts%2Fcheck_relationship_assertion_proof.py%3A779-811%0A**Restart%20health%20provenance%20can%20be%20locally%20forged**%0A%0AThe%20restart%20checker%20accepts%20a%20locally%20authored%20health%20JSON%20when%20its%20mutable%20%60proof_observation.run_id%60%20and%20%60deployment_sha%60%20match%20CLI%20values.%20Its%20SHA-256%20value%20only%20identifies%20the%20untrusted%20file%20bytes%3B%20it%20is%20not%20verified%20against%20a%20signed%20workload%20response%2C%20immutable%20workflow%20artifact%2C%20or%20trusted%20attestation.%20A%20forged%20observation%20can%20therefore%20certify%20persistence%20for%20a%20deployment%20that%20did%20not%20produce%20it.%20Bind%20the%20observation%20to%20trusted%20workflow%20and%20deployment%20provenance%20and%20verify%20that%20binding%20before%20accepting%20it.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1594&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/relationship-assertion-staging-proof.yml:349-363
**Restart proof omits runtime graph evidence**

`verify_after_restart` saves an ordinary detailed-health response and passes only `--health-observation-path`. The checker always runs served-graph parity validation, which requires `--runtime-graph-observation-path`, so every fresh restart proof fails with `Runtime graph observation is required`. Request the proof-enabled detailed-health response, retain its runtime graph metrics, and pass the observation path to the checker.

### Issue 2
api/routers/system.py:193-214
**Proof-enabled health rejects tuple relationships**

The served graph stores relationship entries as `(target_id, edge_type, strength)` tuples, but `_get_runtime_graph_proof_metrics` reads `revision_id` and `assertion_id` as attributes. Consequently, every tuple is filtered out and a proof-header detailed-health request returns HTTP 503 with `Restarted runtime serves no governed edges for the certified revision`, even when the graph contains relationships. Use an authoritative representation or provenance mapping that lets runtime proof metrics and edge hashing identify governed tuple edges.

### Issue 3
scripts/check_relationship_assertion_proof.py:779-811
**Restart health provenance can be locally forged**

The restart checker accepts a locally authored health JSON when its mutable `proof_observation.run_id` and `deployment_sha` match CLI values. Its SHA-256 value only identifies the untrusted file bytes; it is not verified against a signed workload response, immutable workflow artifact, or trusted attestation. A forged observation can therefore certify persistence for a deployment that did not produce it. Bind the observation to trusted workflow and deployment provenance and verify that binding before accepting it.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (15): Last reviewed commit: ["Potential fix for pull request finding &#39;..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/dd69971e0a3a7cd2698749db04138420c0497443) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50726736)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->