### PR TITLE
fix(staging-proof): allow legal reacceptance in restart history

### DIFF
--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -879,6 +879,46 @@ class ProofValidator:
             return False
         return True
 
+    def _select_initial_assertion_events(
+        self,
+        assertion_id: str,
+        events: Sequence[Any],
+    ) -> tuple[Any, Any] | None:
+        """Select the unique proposal and initial Proposed -> Accepted determination."""
+        proposed = [event for event in events if event.to_state == "Proposed" and event.authority == "proposer"]
+        initial_acceptances = [
+            event
+            for event in events
+            if (event.from_state, event.to_state) == ("Proposed", "Accepted")
+            and event.authority in {"determiner", "reviewer", "acceptor"}
+        ]
+        if len(proposed) != 1 or len(initial_acceptances) != 1:
+            self.add_error(f"Assertion {assertion_id} must have exactly one proposer and one initial acceptance event")
+            return None
+        return proposed[0], initial_acceptances[0]
+
+    def _validate_reacceptance_events(
+        self,
+        assertion_id: str,
+        events: Sequence[Any],
+        proposal: Any,
+        initial_acceptance: Any,
+    ) -> bool:
+        """Allow only contract-valid Disputed -> Accepted entries after initial acceptance."""
+        for event in events:
+            if event.to_state != "Accepted" or event.from_state == "Proposed":
+                continue
+            if (event.from_state, event.authority) != ("Disputed", "acceptor"):
+                self.add_error(f"Assertion {assertion_id} has invalid transition into Accepted")
+                return False
+            if event.sequence <= initial_acceptance.sequence:
+                self.add_error(f"Assertion {assertion_id} reacceptance does not follow initial acceptance")
+                return False
+            if not event.actor_id or event.actor_id == proposal.actor_id:
+                self.add_error(f"Assertion {assertion_id} reacceptance actor is missing or not distinct from proposer")
+                return False
+        return True
+
     def _validate_reconstructed_assertion(
         self,
         assertion_id: str,
@@ -892,19 +932,14 @@ class ProofValidator:
         if not self._validate_assertion_sequences(assertion_id, events):
             return False
 
-        proposed = [event for event in events if event.to_state == "Proposed" and event.authority == "proposer"]
-        initial_acceptances = [
-            event
-            for event in events
-            if event.from_state == "Proposed"
-            and event.to_state == "Accepted"
-            and event.authority in {"determiner", "reviewer", "acceptor"}
-        ]
-        if len(proposed) != 1 or len(initial_acceptances) != 1:
-            self.add_error(f"Assertion {assertion_id} must have exactly one proposer and one initial acceptance event")
+        selected = self._select_initial_assertion_events(assertion_id, events)
+        if selected is None:
             return False
+        proposal, initial_acceptance = selected
 
-        return self._validate_assertion_actors_and_states(assertion_id, proposed[0], initial_acceptances[0])
+        return self._validate_assertion_actors_and_states(
+            assertion_id, proposal, initial_acceptance
+        ) and self._validate_reacceptance_events(assertion_id, events, proposal, initial_acceptance)
 
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
         """Reconstruct persisted lifecycle history for the certified revision."""

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -870,18 +870,14 @@ class ProofValidator:
     ) -> bool:
         """Validate continuity between consecutive persisted lifecycle events."""
         if events[0].from_state is not None:
-            self.add_error(
-                f"Assertion {assertion_id} initial lifecycle event has a predecessor state"
-            )
+            self.add_error(f"Assertion {assertion_id} initial lifecycle event has a predecessor state")
             return False
-    
+
         for previous, current in zip(events, events[1:]):
             if current.from_state != previous.to_state:
-                self.add_error(
-                    f"Assertion {assertion_id} lifecycle state chain is discontinuous"
-                )
+                self.add_error(f"Assertion {assertion_id} lifecycle state chain is discontinuous")
                 return False
-    
+
         return True
 
     def _validate_assertion_actors_and_states(self, assertion_id: str, proposal: Any, determination: Any) -> bool:

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -873,7 +873,7 @@ class ProofValidator:
             self.add_error(f"Assertion {assertion_id} initial lifecycle event has a predecessor state")
             return False
 
-        or previous, current in zip(events, events[1:], strict=False):
+        for previous, current in zip(events, events[1:], strict=False):
             if current.from_state != previous.to_state:
                 self.add_error(f"Assertion {assertion_id} lifecycle state chain is discontinuous")
                 return False

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -873,7 +873,7 @@ class ProofValidator:
             self.add_error(f"Assertion {assertion_id} initial lifecycle event has a predecessor state")
             return False
 
-        for previous, current in zip(events, events[1:]):
+        or previous, current in zip(events, events[1:], strict=False):
             if current.from_state != previous.to_state:
                 self.add_error(f"Assertion {assertion_id} lifecycle state chain is discontinuous")
                 return False

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -893,16 +893,18 @@ class ProofValidator:
             return False
 
         proposed = [event for event in events if event.to_state == "Proposed" and event.authority == "proposer"]
-        accepted = [
+        initial_acceptances = [
             event
             for event in events
-            if event.to_state == "Accepted" and event.authority in {"determiner", "reviewer", "acceptor"}
+            if event.from_state == "Proposed"
+            and event.to_state == "Accepted"
+            and event.authority in {"determiner", "reviewer", "acceptor"}
         ]
-        if len(proposed) != 1 or len(accepted) != 1:
-            self.add_error(f"Assertion {assertion_id} must have exactly one proposer and one acceptance event")
+        if len(proposed) != 1 or len(initial_acceptances) != 1:
+            self.add_error(f"Assertion {assertion_id} must have exactly one proposer and one initial acceptance event")
             return False
 
-        return self._validate_assertion_actors_and_states(assertion_id, proposed[0], accepted[0])
+        return self._validate_assertion_actors_and_states(assertion_id, proposed[0], initial_acceptances[0])
 
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
         """Reconstruct persisted lifecycle history for the certified revision."""
@@ -1042,7 +1044,7 @@ class ProofValidator:
 def display_result(result: dict[str, Any], write_output: bool) -> None:
     """Show validation result."""
     if write_output:
-        # Validate output path to prevent path traversal (CWE-22)
+        # Validate output path to prevent path traversal attacks (CWE-22)
         safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -1044,7 +1044,7 @@ class ProofValidator:
 def display_result(result: dict[str, Any], write_output: bool) -> None:
     """Show validation result."""
     if write_output:
-        # Validate output path to prevent path traversal attacks (CWE-22)
+        # Validate output path to prevent path traversal (CWE-22)
         safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -863,6 +863,27 @@ class ProofValidator:
             return False
         return True
 
+    def _validate_assertion_state_chain(
+        self,
+        assertion_id: str,
+        events: Sequence[Any],
+    ) -> bool:
+        """Validate continuity between consecutive persisted lifecycle events."""
+        if events[0].from_state is not None:
+            self.add_error(
+                f"Assertion {assertion_id} initial lifecycle event has a predecessor state"
+            )
+            return False
+    
+        for previous, current in zip(events, events[1:]):
+            if current.from_state != previous.to_state:
+                self.add_error(
+                    f"Assertion {assertion_id} lifecycle state chain is discontinuous"
+                )
+                return False
+    
+        return True
+
     def _validate_assertion_actors_and_states(self, assertion_id: str, proposal: Any, determination: Any) -> bool:
         """Validate the relationship between a proposal and determination event."""
         if proposal.sequence >= determination.sequence:
@@ -930,6 +951,9 @@ class ProofValidator:
             return False
 
         if not self._validate_assertion_sequences(assertion_id, events):
+            return False
+
+        if not self._validate_assertion_state_chain(assertion_id, events):
             return False
 
         selected = self._select_initial_assertion_events(assertion_id, events)

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -76,3 +76,34 @@ def test_reconstructed_assertion_rejects_proposer_reacceptance() -> None:
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
     assert validator.errors == ["Assertion assertion-1 reacceptance actor is missing or not distinct from proposer"]
+
+
+def test_reconstructed_assertion_rejects_discontinuous_reacceptance_chain() -> None:
+    """A claimed reacceptance must follow a persisted event that actually entered Disputed."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Accepted", "Withdrawn"), "withdrawer", "acceptor-1"),
+        _event(4, ("Disputed", "Accepted"), "acceptor", "acceptor-1"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
+    assert validator.errors == [
+        "Assertion assertion-1 lifecycle state chain is discontinuous"
+    ]
+
+
+def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() -> None:
+    """A Disputed -> Accepted event cannot appear unless the preceding event entered Disputed."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Disputed", "Accepted"), "acceptor", "acceptor-1"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
+    assert validator.errors == [
+        "Assertion assertion-1 lifecycle state chain is discontinuous"
+    ]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -89,9 +89,7 @@ def test_reconstructed_assertion_rejects_discontinuous_reacceptance_chain() -> N
     ]
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
-    assert validator.errors == [
-        "Assertion assertion-1 lifecycle state chain is discontinuous"
-    ]
+    assert validator.errors == ["Assertion assertion-1 lifecycle state chain is discontinuous"]
 
 
 def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() -> None:
@@ -104,6 +102,4 @@ def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() ->
     ]
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
-    assert validator.errors == [
-        "Assertion assertion-1 lifecycle state chain is discontinuous"
-    ]
+    assert validator.errors == ["Assertion assertion-1 lifecycle state chain is discontinuous"]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -49,3 +49,30 @@ def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
     assert validator.errors == ["Assertion assertion-1 must have exactly one proposer and one initial acceptance event"]
+
+
+def test_reconstructed_assertion_rejects_illegal_transition_into_accepted() -> None:
+    """Only Proposed or Disputed may transition into Accepted during reconstruction."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Accepted", "Accepted"), "acceptor", "acceptor-1"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
+    assert validator.errors == ["Assertion assertion-1 has invalid transition into Accepted"]
+
+
+def test_reconstructed_assertion_rejects_proposer_reacceptance() -> None:
+    """Reacceptance keeps the proposer/acceptor separation-of-duties boundary."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Accepted", "Disputed"), "disputer", "acceptor-1"),
+        _event(4, ("Disputed", "Accepted"), "acceptor", "proposer-1"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
+    assert validator.errors == ["Assertion assertion-1 reacceptance actor is missing or not distinct from proposer"]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
-from types import SimpleNamespace
+from dataclasses import dataclass
+
+import pytest
 
 from scripts.check_relationship_assertion_proof import ProofValidator
+
+
+@dataclass
+class _LifecycleEvent:
+    """Lifecycle event fields consumed by the proof validator."""
+
+    sequence: int
+    from_state: str | None
+    to_state: str
+    authority: str
+    actor_id: str
 
 
 def _event(
@@ -12,10 +25,10 @@ def _event(
     transition: tuple[str | None, str],
     authority: str,
     actor_id: str,
-) -> SimpleNamespace:
+) -> _LifecycleEvent:
     """Build the lifecycle fields consumed by the proof validator."""
     from_state, to_state = transition
-    return SimpleNamespace(
+    return _LifecycleEvent(
         sequence=sequence,
         from_state=from_state,
         to_state=to_state,

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -24,6 +24,7 @@ def _event(
     )
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_allows_reacceptance_after_dispute() -> None:
     """A legal Accepted -> Disputed -> Accepted cycle must not look like duplicate initial acceptance."""
     validator = ProofValidator({})
@@ -38,6 +39,7 @@ def test_reconstructed_assertion_allows_reacceptance_after_dispute() -> None:
     assert validator.errors == []
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
     """Cardinality remains fail-closed for two Proposed -> Accepted determinations."""
     validator = ProofValidator({})
@@ -51,6 +53,7 @@ def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
     assert validator.errors == ["Assertion assertion-1 must have exactly one proposer and one initial acceptance event"]
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_rejects_illegal_transition_into_accepted() -> None:
     """Only Proposed or Disputed may transition into Accepted during reconstruction."""
     validator = ProofValidator({})
@@ -64,6 +67,7 @@ def test_reconstructed_assertion_rejects_illegal_transition_into_accepted() -> N
     assert validator.errors == ["Assertion assertion-1 has invalid transition into Accepted"]
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_rejects_proposer_reacceptance() -> None:
     """Reacceptance keeps the proposer/acceptor separation-of-duties boundary."""
     validator = ProofValidator({})
@@ -78,6 +82,7 @@ def test_reconstructed_assertion_rejects_proposer_reacceptance() -> None:
     assert validator.errors == ["Assertion assertion-1 reacceptance actor is missing or not distinct from proposer"]
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_rejects_discontinuous_reacceptance_chain() -> None:
     """A claimed reacceptance must follow a persisted event that actually entered Disputed."""
     validator = ProofValidator({})
@@ -92,6 +97,7 @@ def test_reconstructed_assertion_rejects_discontinuous_reacceptance_chain() -> N
     assert validator.errors == ["Assertion assertion-1 lifecycle state chain is discontinuous"]
 
 
+@pytest.mark.unit
 def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() -> None:
     """A Disputed -> Accepted event cannot appear unless the preceding event entered Disputed."""
     validator = ProofValidator({})
@@ -103,3 +109,18 @@ def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() ->
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
     assert validator.errors == ["Assertion assertion-1 lifecycle state chain is discontinuous"]
+
+
+@pytest.mark.unit
+def test_select_initial_assertion_events_rejects_duplicate_initial_acceptance() -> None:
+    validator = ProofValidator({})
+    events = [
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Proposed", "Accepted"), "acceptor", "acceptor-2"),
+    ]
+
+    assert validator._select_initial_assertion_events("assertion-1", events) is None
+    assert validator.errors == [
+        "Assertion assertion-1 must have exactly one proposer and one initial acceptance event"
+    ]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -3,19 +3,18 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
-from typing import Any
 
 from scripts.check_relationship_assertion_proof import ProofValidator
 
 
 def _event(
     sequence: int,
-    from_state: str | None,
-    to_state: str,
+    transition: tuple[str | None, str],
     authority: str,
     actor_id: str,
-) -> Any:
+) -> SimpleNamespace:
     """Build the lifecycle fields consumed by the proof validator."""
+    from_state, to_state = transition
     return SimpleNamespace(
         sequence=sequence,
         from_state=from_state,
@@ -29,10 +28,10 @@ def test_reconstructed_assertion_allows_reacceptance_after_dispute() -> None:
     """A legal Accepted -> Disputed -> Accepted cycle must not look like duplicate initial acceptance."""
     validator = ProofValidator({})
     events = [
-        _event(1, None, "Proposed", "proposer", "proposer-1"),
-        _event(2, "Proposed", "Accepted", "acceptor", "acceptor-1"),
-        _event(3, "Accepted", "Disputed", "disputer", "acceptor-1"),
-        _event(4, "Disputed", "Accepted", "acceptor", "acceptor-1"),
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Accepted", "Disputed"), "disputer", "acceptor-1"),
+        _event(4, ("Disputed", "Accepted"), "acceptor", "acceptor-1"),
     ]
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is True
@@ -43,9 +42,9 @@ def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
     """Cardinality remains fail-closed for two Proposed -> Accepted determinations."""
     validator = ProofValidator({})
     events = [
-        _event(1, None, "Proposed", "proposer", "proposer-1"),
-        _event(2, "Proposed", "Accepted", "acceptor", "acceptor-1"),
-        _event(3, "Proposed", "Accepted", "acceptor", "acceptor-2"),
+        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
+        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
+        _event(3, ("Proposed", "Accepted"), "acceptor", "acceptor-2"),
     ]
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -53,20 +53,6 @@ def test_reconstructed_assertion_allows_reacceptance_after_dispute() -> None:
 
 
 @pytest.mark.unit
-def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
-    """Cardinality remains fail-closed for two Proposed -> Accepted determinations."""
-    validator = ProofValidator({})
-    events = [
-        _event(1, (None, "Proposed"), "proposer", "proposer-1"),
-        _event(2, ("Proposed", "Accepted"), "acceptor", "acceptor-1"),
-        _event(3, ("Proposed", "Accepted"), "acceptor", "acceptor-2"),
-    ]
-
-    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
-    assert validator.errors == ["Assertion assertion-1 must have exactly one proposer and one initial acceptance event"]
-
-
-@pytest.mark.unit
 def test_reconstructed_assertion_rejects_illegal_transition_into_accepted() -> None:
     """Only Proposed or Disputed may transition into Accepted during reconstruction."""
     validator = ProofValidator({})
@@ -126,6 +112,7 @@ def test_reconstructed_assertion_rejects_reacceptance_without_dispute_event() ->
 
 @pytest.mark.unit
 def test_select_initial_assertion_events_rejects_duplicate_initial_acceptance() -> None:
+    """Initial acceptance selection remains fail-closed for duplicate determinations."""
     validator = ProofValidator({})
     events = [
         _event(1, (None, "Proposed"), "proposer", "proposer-1"),

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -1,0 +1,54 @@
+"""Regression tests for GRAC staging-proof historical reconstruction."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from scripts.check_relationship_assertion_proof import ProofValidator
+
+
+def _event(
+    sequence: int,
+    from_state: str | None,
+    to_state: str,
+    authority: str,
+    actor_id: str,
+) -> Any:
+    """Build the lifecycle fields consumed by the proof validator."""
+    return SimpleNamespace(
+        sequence=sequence,
+        from_state=from_state,
+        to_state=to_state,
+        authority=authority,
+        actor_id=actor_id,
+    )
+
+
+def test_reconstructed_assertion_allows_reacceptance_after_dispute() -> None:
+    """A legal Accepted -> Disputed -> Accepted cycle must not look like duplicate initial acceptance."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, None, "Proposed", "proposer", "proposer-1"),
+        _event(2, "Proposed", "Accepted", "acceptor", "acceptor-1"),
+        _event(3, "Accepted", "Disputed", "disputer", "acceptor-1"),
+        _event(4, "Disputed", "Accepted", "acceptor", "acceptor-1"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is True
+    assert validator.errors == []
+
+
+def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
+    """Cardinality remains fail-closed for two Proposed -> Accepted determinations."""
+    validator = ProofValidator({})
+    events = [
+        _event(1, None, "Proposed", "proposer", "proposer-1"),
+        _event(2, "Proposed", "Accepted", "acceptor", "acceptor-1"),
+        _event(3, "Proposed", "Accepted", "acceptor", "acceptor-2"),
+    ]
+
+    assert validator._validate_reconstructed_assertion("assertion-1", events) is False
+    assert validator.errors == [
+        "Assertion assertion-1 must have exactly one proposer and one initial acceptance event"
+    ]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -49,6 +49,4 @@ def test_reconstructed_assertion_rejects_duplicate_initial_acceptance() -> None:
     ]
 
     assert validator._validate_reconstructed_assertion("assertion-1", events) is False
-    assert validator.errors == [
-        "Assertion assertion-1 must have exactly one proposer and one initial acceptance event"
-    ]
+    assert validator.errors == ["Assertion assertion-1 must have exactly one proposer and one initial acceptance event"]

--- a/tests/unit/test_relationship_assertion_proof_reacceptance.py
+++ b/tests/unit/test_relationship_assertion_proof_reacceptance.py
@@ -121,6 +121,4 @@ def test_select_initial_assertion_events_rejects_duplicate_initial_acceptance() 
     ]
 
     assert validator._select_initial_assertion_events("assertion-1", events) is None
-    assert validator.errors == [
-        "Assertion assertion-1 must have exactly one proposer and one initial acceptance event"
-    ]
+    assert validator.errors == ["Assertion assertion-1 must have exactly one proposer and one initial acceptance event"]


### PR DESCRIPTION
## **User description**
## Decision

Correct the staging proof checker so a legal GRAC v1 reacceptance does not fail historical reconstruction.

## Failure evidence

Strict `verify_after_restart` run **31176673578** reached the proof validator after all prerequisite boundaries passed:

- exact-SHA checkout and ancestor validation
- PostgreSQL authorization check
- seed artifact **31170175486** download and validation
- non-empty governed-scope baseline
- hosted restart observation with `startup_source=persisted`

The validator then rejected successor assertion `grac-v1-aapl-bond-issuer-20260807-02`, whose persisted lifecycle is:

`Proposed -> Accepted -> Disputed -> Accepted`

GRAC v1 permits `Disputed -> Accepted` under `acceptor` authority. The checker incorrectly counted every transition into `Accepted` as an initial determination, so the legal restoration looked like duplicate acceptance evidence.

## Change

- identify the initial acceptance specifically as `Proposed -> Accepted`
- retain exactly-one proposer / exactly-one initial-acceptance cardinality
- retain the existing proposer/determiner ordering and separation checks
- add regression coverage proving:
  - `Proposed -> Accepted -> Disputed -> Accepted` passes reconstruction
  - two `Proposed -> Accepted` events still fail closed

## Scope

Changed only:

- `scripts/check_relationship_assertion_proof.py`
- `tests/unit/test_relationship_assertion_proof_reacceptance.py`

No runtime, API, schema, migration, workflow, authorization, deployment, or staging-data changes.

Corrective follow-up to #1539. **#1540 remains evidence/sign-off only.**

## Evidence references

- failing restart proof: https://github.com/DashFin-FarDb/financial-asset-relationship-db/actions/runs/31176673578
- seed proof: https://github.com/DashFin-FarDb/financial-asset-relationship-db/actions/runs/31170175486
- exact deployed/source SHA exercised by those proofs: `8cbbb8fe2d4eca7988d781bd7617a960f858feff`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the staging-proof validator to enforce a contiguous lifecycle and allow legal GRAC v1 reacceptance. Only the first `Proposed -> Accepted` counts as initial acceptance; a later `Disputed -> Accepted` by the `acceptor` is allowed.

- **Bug Fixes**
  - Enforce contiguous state chain: initial event has no predecessor; each `from_state` matches the prior `to_state`.
  - Select exactly one proposal and one initial `Proposed -> Accepted`; allow only `Disputed -> Accepted` reacceptance by `acceptor` after the initial acceptance; require a present, non‑proposer actor; reject `Accepted -> Accepted`.

- **Tests**
  - Add typed regressions for allowed reacceptance, discontinuities/missing dispute, duplicate initial acceptance, proposer/missing‑actor reacceptance, and invalid `Accepted -> Accepted`.
  - Narrow the duplicate‑acceptance regression to focus on duplicate initial acceptance only.

<sup>Written for commit 0dabc723240fbde3f0b5ca065acc943aaa5f193d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Allow legal assertion reacceptance during history validation

### What Changed
- Historical validation now treats only the first `Proposed → Accepted` transition as the initial acceptance
- Legal `Accepted → Disputed → Accepted` lifecycles now pass reconstruction
- Multiple initial acceptance transitions still fail validation
- Added regression coverage for both reacceptance and duplicate initial acceptance

### Impact
`✅ Valid GRAC reacceptance histories`
`✅ Fewer false staging-proof failures`
`✅ Duplicate initial acceptances remain blocked`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The lifecycle reconstruction changes add continuity checks and distinguish initial acceptance from reacceptance. However, an unauthorized `Accepted -> Disputed` transition can still be included in a certified history when it is followed by a valid reacceptance.

<h3>Confidence Score: 3/5</h3>

The lifecycle validator still accepts a certified history containing an unauthorized dispute transition.

One security-relevant authorization failure remains in the reconstructed lifecycle path.

**Files Needing Attention:** scripts/check_relationship_assertion_proof.py

<details open><summary><h3>Security Review</h3></summary>

The reconstructed lifecycle does not enforce the required authority for `Accepted -> Disputed`. This permits an actor such as a reviewer to create a dispute that should require the `disputer` authority, compromising the integrity of certified relationship history.
</details>


<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran a focused lifecycle validation script to exercise the lifecycle checks and capture baseline and candidate validations, producing the corresponding logs.
- T-Rex posted an additional P1 finding-comment-proof.
- T-Rex executed a general contract validation, confirming the candidate run exited 0 with dispute\_authority=reviewer, result=True, and errors=\[\], and checked the state-continuity checks and reacceptance-event handling in the relevant code paths.

<a href="https://app.greptile.com/trex/runs/17806482/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (3)</h3>

1. `scripts/check_relationship_assertion_proof.py`, line 1426-1430 ([link](https://github.com/dashfin-fardb/financial-asset-relationship-db/blob/50e63cb00a9972dd4856c42a45a9021fe587c7dd/scripts/check_relationship_assertion_proof.py#L1426-L1430)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart verification skips lifecycle reconstruction**

   `_verify_scopes_and_history()` sets `historical_reconstruction_passed` from the rebuild job's `succeeded` status and never reads assertion events. Consequently, `run_verify_after_restart()` reports historical reconstruction as successful even if the persisted lifecycle chain was corrupted after the rebuild completed. Invoke the certified-lineage reconstruction here, or share its result with this path, so missing or invalid lifecycle events fail restart verification.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Lifecycle reconstruction fail-open reproduction script](https://app.greptile.com/trex/artifacts/c1f2a4fd-fc47-4b47-8a46-70bfeb26e1a5)**

   - Focused executable script that seeds a real SQLite lifecycle, optionally corrupts the persisted determination transition, and compares the restart helper with authoritative reconstruction.

   **[Valid lifecycle restart verification](https://app.greptile.com/trex/artifacts/72197d8d-e1c3-41de-be5e-3f892a131367)**

   - Executed the focused script with an intact seeded lifecycle; both the restart helper and authoritative reconstruction reported success.

   **[Corrupted lifecycle restart verification](https://app.greptile.com/trex/artifacts/612378d0-e2de-4525-a275-d0386545e22e)**

   - Executed the focused script after changing the persisted determination to Disputed to Accepted; the restart helper still reported success while authoritative reconstruction rejected the discontinuous chain.

   <a href="https://app.greptile.com/trex/runs/17804468/artifacts?artifact=c1f2a4fd-fc47-4b47-8a46-70bfeb26e1a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: scripts/check_relationship_assertion_proof.py
   Line: 1426-1430

   Comment:
   **Restart verification skips lifecycle reconstruction**

   `_verify_scopes_and_history()` sets `historical_reconstruction_passed` from the rebuild job's `succeeded` status and never reads assertion events. Consequently, `run_verify_after_restart()` reports historical reconstruction as successful even if the persisted lifecycle chain was corrupted after the rebuild completed. Invoke the certified-lineage reconstruction here, or share its result with this path, so missing or invalid lifecycle events fail restart verification.

   ---

   For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22fix%2Fgrac-v1-restart-history-reaccept%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgrac-v1-restart-history-reaccept%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20scripts%2Fcheck_relationship_assertion_proof.py%0ALine%3A%201426-1430%0A%0AComment%3A%0A**Restart%20verification%20skips%20lifecycle%20reconstruction**%0A%0A%60_verify_scopes_and_history%28%29%60%20sets%20%60historical_reconstruction_passed%60%20from%20the%20rebuild%20job's%20%60succeeded%60%20status%20and%20never%20reads%20assertion%20events.%20Consequently%2C%20%60run_verify_after_restart%28%29%60%20reports%20historical%20reconstruction%20as%20successful%20even%20if%20the%20persisted%20lifecycle%20chain%20was%20corrupted%20after%20the%20rebuild%20completed.%20Invoke%20the%20certified-lineage%20reconstruction%20here%2C%20or%20share%20its%20result%20with%20this%20path%2C%20so%20missing%20or%20invalid%20lifecycle%20events%20fail%20restart%20verification.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1596&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Restart verification reports successful historical reconstruction without reconstructing lifecycle events**

   - **Bug**
     - A seeded valid lifecycle and a lifecycle corrupted in the database both yield `historical_reconstruction_passed=True` through `run_verify_after_restart()`. The same corrupted database is rejected by the authoritative reconstruction routine with `lifecycle state chain is discontinuous` and `Historical reconstruction failed for one or more projected assertions`.
   - **Cause**
     - `_verify_scopes_and_history()` sets `historical_reconstruction_passed = bool(job and job.status == "succeeded")`, so it treats rebuild-job status as evidence of lifecycle reconstruction and never reads assertion events.
   - **Fix**
     - Make `run_verify_after_restart()` invoke the certified-lineage lifecycle reconstruction (or share a single reconstruction function) and set `historical_reconstruction_passed` from its result; fail closed on missing lineage, no projected assertions, query errors, or any invalid event chain.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Reconstructed lifecycle accepts disputes by an unauthorized authority**

   - **Bug**
     - A contiguous `Proposed -> Accepted -> Disputed -> Accepted` sequence is accepted when the dispute event authority is `reviewer` rather than `disputer`, provided the reacceptance is `Disputed -> Accepted` by `acceptor`.
   - **Cause**
     - `_validate_reconstructed_assertion` delegates only to sequence/state continuity, initial acceptance checks, and `_validate_reacceptance_events`. `_validate_reacceptance_events` validates only events whose destination is `Accepted`, so it never enforces authority on an `Accepted -> Disputed` event.
   - **Fix**
     - Add an explicit lifecycle-transition/authority validation for `Accepted -> Disputed` (requiring authority `disputer`) before accepting the reconstructed assertion.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22fix%2Fgrac-v1-restart-history-reaccept%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fgrac-v1-restart-history-reaccept%22.%0A%0A%23%23%23%20Issue%201%0Ascripts%2Fcheck_relationship_assertion_proof.py%3A925-937%0A**Dispute%20authority%20is%20never%20enforced**%0A%0AA%20contiguous%20%60Proposed%20-%3E%20Accepted%20-%3E%20Disputed%20-%3E%20Accepted%60%20history%20is%20accepted%20even%20when%20the%20%60Accepted%20-%3E%20Disputed%60%20event%20uses%20%60reviewer%60%20rather%20than%20%60disputer%60.%20State-chain%20validation%20verifies%20only%20adjacent%20state%20values%2C%20while%20this%20method%20checks%20only%20transitions%20ending%20in%20%60Accepted%60%3B%20consequently%2C%20an%20unauthorized%20dispute%20can%20become%20part%20of%20a%20reconstructed%20lifecycle%20that%20is%20certified.%20Validate%20the%20authority%20matrix%20for%20%60Accepted%20-%3E%20Disputed%60%20before%20accepting%20the%20history.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1596&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
scripts/check_relationship_assertion_proof.py:925-937
**Dispute authority is never enforced**

A contiguous `Proposed -> Accepted -> Disputed -> Accepted` history is accepted even when the `Accepted -> Disputed` event uses `reviewer` rather than `disputer`. State-chain validation verifies only adjacent state values, while this method checks only transitions ending in `Accepted`; consequently, an unauthorized dispute can become part of a reconstructed lifecycle that is certified. Validate the authority matrix for `Accepted -> Disputed` before accepting the history.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (5): Last reviewed commit: ["test(staging-proof): keep duplicate acce..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/0dabc723240fbde3f0b5ca065acc943aaa5f193d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51154925)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->