### PR TITLE
fix(staging-proof): reconstruct legacy restart lifecycle history

### DIFF
--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -1132,33 +1132,33 @@ class ProofValidator:
 
 
 def display_result(result: dict[str, Any], write_output: bool) -> None:
-        """Show validation result."""
-        if write_output:
-            # Validate output path to prevent path traversal (CWE-22)
-            safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
+    """Show validation result."""
+    if write_output:
+        # Validate output path to prevent path traversal (CWE-22)
+        safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
-            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-            if hasattr(os, "O_NOFOLLOW"):
-                flags |= os.O_NOFOLLOW
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
 
-            fd = os.open(safe_path, flags, 0o600)
-            with os.fdopen(fd, "w", encoding="utf-8") as file:
-                json.dump(result, file, indent=2, sort_keys=True)
-            print(f"Results written to {safe_path}")
-        else:
-            print(json.dumps(result, indent=2, sort_keys=True))
+        fd = os.open(safe_path, flags, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as file:
+            json.dump(result, file, indent=2, sort_keys=True)
+        print(f"Results written to {safe_path}")
+    else:
+        print(json.dumps(result, indent=2, sort_keys=True))
 
-        mode = result["metadata"].get("mode", "unknown")
-        status = result["status"]
+    mode = result["metadata"].get("mode", "unknown")
+    status = result["status"]
 
-        if status == "passed":
-            print(f"✓ Validation passed ({mode})", file=sys.stderr)
-        else:
-            print(f"✗ Validation failed ({mode}):", file=sys.stderr)
-            for err in result["errors"][:10]:
-                print(f"  - {err}", file=sys.stderr)
-            if len(result["errors"]) > 10:
-                print(f"  ({len(result['errors']) - 10} more errors)", file=sys.stderr)
+    if status == "passed":
+        print(f"✓ Validation passed ({mode})", file=sys.stderr)
+    else:
+        print(f"✗ Validation failed ({mode}):", file=sys.stderr)
+        for err in result["errors"][:10]:
+            print(f"  - {err}", file=sys.stderr)
+        if len(result["errors"]) > 10:
+            print(f"  ({len(result['errors']) - 10} more errors)", file=sys.stderr)
 
 
 def setup_parser() -> argparse.ArgumentParser:

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -297,7 +297,6 @@ class ProofValidator:
         if not db_url and args.strict:
             self.add_error("DB URL required in strict mode")
             return
-
         if not db_url:
             return
 
@@ -961,9 +960,55 @@ class ProofValidator:
             assertion_id, proposal, initial_acceptance
         ) and self._validate_reacceptance_events(assertion_id, events, proposal, initial_acceptance)
 
-    def assertion_history_is_valid(self, assertion_id: str, events: Sequence[Any]) -> bool:
-        """Validate one persisted assertion lifecycle for helper reuse."""
-        return self._validate_reconstructed_assertion(assertion_id, events)
+    def projected_assertion_histories_are_valid(
+        self,
+        session: Any,
+        revision_id: str,
+        known_at: datetime,
+    ) -> bool:
+        """Validate projected assertion histories at one revision knowledge boundary."""
+        assertion_ids = [
+            row[0]
+            for row in session.execute(
+                select(RelationshipProjectionEdgeORM.assertion_id)
+                .where(RelationshipProjectionEdgeORM.revision_id == revision_id)
+                .distinct()
+            ).all()
+            if row[0]
+        ]
+        self.metadata["reconstructed_assertions"] = 0
+        if not assertion_ids:
+            return True
+
+        events = (
+            session.execute(
+                select(RelationshipAssertionEventORM)
+                .where(
+                    RelationshipAssertionEventORM.assertion_id.in_(assertion_ids),
+                    RelationshipAssertionEventORM.recorded_at <= known_at,
+                )
+                .order_by(
+                    RelationshipAssertionEventORM.assertion_id,
+                    RelationshipAssertionEventORM.sequence,
+                )
+            )
+            .scalars()
+            .all()
+        )
+        events_by_assertion = {assertion_id: [] for assertion_id in assertion_ids}
+        for event in events:
+            events_by_assertion[event.assertion_id].append(event)
+
+        reconstructed = 0
+        for assertion_id in assertion_ids:
+            if self._validate_reconstructed_assertion(assertion_id, events_by_assertion[assertion_id]):
+                reconstructed += 1
+
+        self.metadata["reconstructed_assertions"] = reconstructed
+        if reconstructed != len(assertion_ids):
+            self.add_error("Historical reconstruction failed for one or more projected assertions")
+            return False
+        return True
 
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
         """Reconstruct persisted lifecycle history for the certified revision."""
@@ -1010,35 +1055,21 @@ class ProofValidator:
                     self.add_error("Historical reconstruction execution identity mismatch")
                     return
 
-                assertion_ids = [
-                    row[0]
-                    for row in session.execute(
-                        select(RelationshipProjectionEdgeORM.assertion_id)
-                        .where(RelationshipProjectionEdgeORM.revision_id == bindparam("history_revision_id"))
-                        .distinct(),
-                        {"history_revision_id": expected_revision_id},
-                    ).all()
-                    if row[0]
-                ]
+                revision_known_at = session.execute(
+                    select(RelationshipProjectionRevisionORM.known_at).where(
+                        RelationshipProjectionRevisionORM.id == bindparam("history_revision_id")
+                    ),
+                    {"history_revision_id": expected_revision_id},
+                ).scalar_one_or_none()
+                if revision_known_at is None:
+                    self.add_error("Historical reconstruction revision boundary is missing")
+                    return
 
-                reconstructed = 0
-                for assertion_id in assertion_ids:
-                    events = (
-                        session.execute(
-                            select(RelationshipAssertionEventORM)
-                            .where(RelationshipAssertionEventORM.assertion_id == bindparam("history_assertion_id"))
-                            .order_by(RelationshipAssertionEventORM.sequence),
-                            {"history_assertion_id": assertion_id},
-                        )
-                        .scalars()
-                        .all()
-                    )
-                    if self._validate_reconstructed_assertion(assertion_id, events):
-                        reconstructed += 1
-
-                self.metadata["reconstructed_assertions"] = reconstructed
-                if reconstructed != len(assertion_ids):
-                    self.add_error("Historical reconstruction failed for one or more projected assertions")
+                self.projected_assertion_histories_are_valid(
+                    session,
+                    expected_revision_id,
+                    revision_known_at,
+                )
         except Exception as exc:
             self.add_error(f"Historical reconstruction query failed: {exc}")
         finally:
@@ -1101,33 +1132,33 @@ class ProofValidator:
 
 
 def display_result(result: dict[str, Any], write_output: bool) -> None:
-    """Show validation result."""
-    if write_output:
-        # Validate output path to prevent path traversal (CWE-22)
-        safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
+        """Show validation result."""
+        if write_output:
+            # Validate output path to prevent path traversal (CWE-22)
+            safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
-        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-        if hasattr(os, "O_NOFOLLOW"):
-            flags |= os.O_NOFOLLOW
+            flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            if hasattr(os, "O_NOFOLLOW"):
+                flags |= os.O_NOFOLLOW
 
-        fd = os.open(safe_path, flags, 0o600)
-        with os.fdopen(fd, "w", encoding="utf-8") as file:
-            json.dump(result, file, indent=2, sort_keys=True)
-        print(f"Results written to {safe_path}")
-    else:
-        print(json.dumps(result, indent=2, sort_keys=True))
+            fd = os.open(safe_path, flags, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as file:
+                json.dump(result, file, indent=2, sort_keys=True)
+            print(f"Results written to {safe_path}")
+        else:
+            print(json.dumps(result, indent=2, sort_keys=True))
 
-    mode = result["metadata"].get("mode", "unknown")
-    status = result["status"]
+        mode = result["metadata"].get("mode", "unknown")
+        status = result["status"]
 
-    if status == "passed":
-        print(f"✓ Validation passed ({mode})", file=sys.stderr)
-    else:
-        print(f"✗ Validation failed ({mode}):", file=sys.stderr)
-        for err in result["errors"][:10]:
-            print(f"  - {err}", file=sys.stderr)
-        if len(result["errors"]) > 10:
-            print(f"  ({len(result['errors']) - 10} more errors)", file=sys.stderr)
+        if status == "passed":
+            print(f"✓ Validation passed ({mode})", file=sys.stderr)
+        else:
+            print(f"✗ Validation failed ({mode}):", file=sys.stderr)
+            for err in result["errors"][:10]:
+                print(f"  - {err}", file=sys.stderr)
+            if len(result["errors"]) > 10:
+                print(f"  ({len(result['errors']) - 10} more errors)", file=sys.stderr)
 
 
 def setup_parser() -> argparse.ArgumentParser:
@@ -1427,41 +1458,30 @@ def _verify_scopes_continuity(revision: Any, prev_metadata: dict[str, Any]) -> b
     )
 
 
-def _verify_persisted_assertion_history(session: Any, revision: Any) -> bool:
+def _verify_persisted_assertion_history(session: Any, revision: Any) -> tuple[bool, list[str]]:
     """Validate persisted assertion lifecycle history for one projected revision."""
     if not revision:
-        return False
+        return False, ["Historical reconstruction revision is missing"]
 
-    assertion_ids = [
-        row[0]
-        for row in session.query(RelationshipProjectionEdgeORM.assertion_id)
-        .filter_by(revision_id=revision.id)
-        .distinct()
-        .all()
-        if row[0]
-    ]
     validator = ProofValidator({})
-    for assertion_id in assertion_ids:
-        events = (
-            session.query(RelationshipAssertionEventORM)
-            .filter_by(assertion_id=assertion_id)
-            .order_by(RelationshipAssertionEventORM.sequence)
-            .all()
-        )
-        if not validator.assertion_history_is_valid(assertion_id, events):
-            return False
-    return True
+    ok = validator.projected_assertion_histories_are_valid(
+        session,
+        revision.id,
+        revision.known_at,
+    )
+    return ok, validator.errors
 
 
 def _verify_scopes_and_history(
     session: Any, revision: Any, job: Any, prev_metadata: dict[str, Any]
-) -> tuple[bool, bool]:
+) -> tuple[bool, bool, list[str]]:
     """Check scopes continuity and historical reconstruction."""
     scope_continuity_passed = _verify_scopes_continuity(revision, prev_metadata)
-    historical_reconstruction_passed = bool(
-        job and job.status == "succeeded" and _verify_persisted_assertion_history(session, revision)
-    )
-    return scope_continuity_passed, historical_reconstruction_passed
+    if not job or job.status != "succeeded":
+        return scope_continuity_passed, False, ["Certified rebuild job is missing or not succeeded"]
+
+    history_ok, history_errors = _verify_persisted_assertion_history(session, revision)
+    return scope_continuity_passed, history_ok, history_errors
 
 
 def run_verify_after_restart(
@@ -1474,9 +1494,11 @@ def run_verify_after_restart(
     try:
         rebuild_job_id = prev_metadata.get("raw_rebuild_job_id") or run_id
         _, revision, job = _query_verification_data_from_db(session, rebuild_job_id)
-        scope_continuity_passed, historical_reconstruction_passed = _verify_scopes_and_history(
-            session, revision, job, prev_metadata
-        )
+        (
+            scope_continuity_passed,
+            historical_reconstruction_passed,
+            historical_reconstruction_errors,
+        ) = _verify_scopes_and_history(session, revision, job, prev_metadata)
 
         return {
             "deployed_sha": deployed_sha,
@@ -1484,6 +1506,7 @@ def run_verify_after_restart(
             "mode": "verify_after_restart",
             "scope_continuity_passed": scope_continuity_passed,
             "historical_reconstruction_passed": historical_reconstruction_passed,
+            "historical_reconstruction_errors": historical_reconstruction_errors,
         }
     finally:
         session.close()

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -746,18 +746,13 @@ class ProofValidator:
                     self.add_error("Invalid or missing rebuild_job_id")
                     return None
 
-                # Check publication existence and cardinality
                 count_stmt = (
                     select(count())
                     .select_from(RelationshipProjectionPublicationORM)
                     .where(RelationshipProjectionPublicationORM.rebuild_job_id == bindparam("restart_rebuild_job_id"))
                 )
                 pub_count = int(
-                    conn.execute(
-                        count_stmt,
-                        {"restart_rebuild_job_id": rebuild_job_id},
-                    ).scalar()
-                    or 0
+                    conn.execute(count_stmt, {"restart_rebuild_job_id": rebuild_job_id}).scalar() or 0
                 )
                 if pub_count == 0:
                     self.add_error(f"Expected publication for rebuild job {rebuild_job_id} not found")
@@ -766,7 +761,6 @@ class ProofValidator:
                     self.add_error(f"More than one publication matches rebuild job {rebuild_job_id}")
                     return None
 
-                # Fetch publication and revision
                 pub_stmt = select(RelationshipProjectionPublicationORM.revision_id).where(
                     RelationshipProjectionPublicationORM.rebuild_job_id == bindparam("restart_publication_job_id")
                 )
@@ -995,7 +989,7 @@ class ProofValidator:
             .scalars()
             .all()
         )
-        events_by_assertion = {assertion_id: [] for assertion_id in assertion_ids}
+        events_by_assertion: dict[str, list[Any]] = {assertion_id: [] for assertion_id in assertion_ids}
         for event in events:
             events_by_assertion[event.assertion_id].append(event)
 
@@ -1134,7 +1128,6 @@ class ProofValidator:
 def display_result(result: dict[str, Any], write_output: bool) -> None:
     """Show validation result."""
     if write_output:
-        # Validate output path to prevent path traversal (CWE-22)
         safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
@@ -1179,10 +1172,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "--owner-id",
         help=("Authoritative publication-owner actor ID. Execution and correlation IDs are not ownership evidence."),
     )
-    parser.add_argument(
-        "--expected-owner",
-        help="Protected expected publication-owner actor ID",
-    )
+    parser.add_argument("--expected-owner", help="Protected expected publication-owner actor ID")
     parser.add_argument("--revision-hash", help="Validation revision hash value")
     parser.add_argument("--expected-revision-hash", help="Expected target revision hash value")
     parser.add_argument("--rebuild-job-id", help="Exact rebuild job being certified")
@@ -1279,7 +1269,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
         determiner_id = "determiner-actor-1"
         owner_id = "owner-actor-1"
 
-        # Create rebuild job
         job = RebuildJobORM(
             job_id=run_id,
             requested_by=owner_id,
@@ -1292,7 +1281,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             execution_id=run_id,
         )
 
-        # Create projection revision
         revision_id = str(uuid.uuid4())
         edge_set_hash = "a" * 64
         projection_hash = "b" * 64
@@ -1312,7 +1300,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             created_at=now,
         )
 
-        # Create assertion
         assertion_id = str(uuid.uuid4())
         assertion = RelationshipAssertionORM(
             id=assertion_id,
@@ -1326,7 +1313,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             recorded_at=now,
         )
 
-        # Create proposal event
         prop_event = RelationshipAssertionEventORM(
             id=str(uuid.uuid4()),
             assertion_id=assertion_id,
@@ -1341,7 +1327,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             correlation_id=run_id,
         )
 
-        # Create determination event
         det_event = RelationshipAssertionEventORM(
             id=str(uuid.uuid4()),
             assertion_id=assertion_id,
@@ -1356,7 +1341,6 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             correlation_id=run_id,
         )
 
-        # Create projection edge linking revision to assertion
         edge = RelationshipProjectionEdgeORM(
             id=str(uuid.uuid4()),
             revision_id=revision_id,
@@ -1372,13 +1356,11 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
         session.add(revision)
         session.add(assertion)
         session.flush()
-
         session.add(prop_event)
         session.add(det_event)
         session.add(edge)
         session.flush()
 
-        # Create publication
         publication = RelationshipProjectionPublicationORM(
             id=str(uuid.uuid4()),
             revision_id=revision_id,
@@ -1464,11 +1446,7 @@ def _verify_persisted_assertion_history(session: Any, revision: Any) -> tuple[bo
         return False, ["Historical reconstruction revision is missing"]
 
     validator = ProofValidator({})
-    ok = validator.projected_assertion_histories_are_valid(
-        session,
-        revision.id,
-        revision.known_at,
-    )
+    ok = validator.projected_assertion_histories_are_valid(session, revision.id, revision.known_at)
     return ok, validator.errors
 
 

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -746,12 +746,19 @@ class ProofValidator:
                     self.add_error("Invalid or missing rebuild_job_id")
                     return None
 
+                # Check publication existence and cardinality
                 count_stmt = (
                     select(count())
                     .select_from(RelationshipProjectionPublicationORM)
                     .where(RelationshipProjectionPublicationORM.rebuild_job_id == bindparam("restart_rebuild_job_id"))
                 )
-                pub_count = int(conn.execute(count_stmt, {"restart_rebuild_job_id": rebuild_job_id}).scalar() or 0)
+                pub_count = int(
+                    conn.execute(
+                        count_stmt,
+                        {"restart_rebuild_job_id": rebuild_job_id},
+                    ).scalar()
+                    or 0
+                )
                 if pub_count == 0:
                     self.add_error(f"Expected publication for rebuild job {rebuild_job_id} not found")
                     return None
@@ -759,6 +766,7 @@ class ProofValidator:
                     self.add_error(f"More than one publication matches rebuild job {rebuild_job_id}")
                     return None
 
+                # Fetch publication and revision
                 pub_stmt = select(RelationshipProjectionPublicationORM.revision_id).where(
                     RelationshipProjectionPublicationORM.rebuild_job_id == bindparam("restart_publication_job_id")
                 )
@@ -1126,6 +1134,7 @@ class ProofValidator:
 def display_result(result: dict[str, Any], write_output: bool) -> None:
     """Show validation result."""
     if write_output:
+        # Validate output path to prevent path traversal (CWE-22)
         safe_path = validate_safe_path(PROOF_RESULT_FILENAME)
 
         flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
@@ -1170,7 +1179,10 @@ def setup_parser() -> argparse.ArgumentParser:
         "--owner-id",
         help=("Authoritative publication-owner actor ID. Execution and correlation IDs are not ownership evidence."),
     )
-    parser.add_argument("--expected-owner", help="Protected expected publication-owner actor ID")
+    parser.add_argument(
+        "--expected-owner",
+        help="Protected expected publication-owner actor ID",
+    )
     parser.add_argument("--revision-hash", help="Validation revision hash value")
     parser.add_argument("--expected-revision-hash", help="Expected target revision hash value")
     parser.add_argument("--rebuild-job-id", help="Exact rebuild job being certified")
@@ -1267,6 +1279,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
         determiner_id = "determiner-actor-1"
         owner_id = "owner-actor-1"
 
+        # Create rebuild job
         job = RebuildJobORM(
             job_id=run_id,
             requested_by=owner_id,
@@ -1279,6 +1292,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             execution_id=run_id,
         )
 
+        # Create projection revision
         revision_id = str(uuid.uuid4())
         edge_set_hash = "a" * 64
         projection_hash = "b" * 64
@@ -1298,6 +1312,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             created_at=now,
         )
 
+        # Create assertion
         assertion_id = str(uuid.uuid4())
         assertion = RelationshipAssertionORM(
             id=assertion_id,
@@ -1311,6 +1326,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             recorded_at=now,
         )
 
+        # Create proposal event
         prop_event = RelationshipAssertionEventORM(
             id=str(uuid.uuid4()),
             assertion_id=assertion_id,
@@ -1325,6 +1341,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             correlation_id=run_id,
         )
 
+        # Create determination event
         det_event = RelationshipAssertionEventORM(
             id=str(uuid.uuid4()),
             assertion_id=assertion_id,
@@ -1339,6 +1356,7 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
             correlation_id=run_id,
         )
 
+        # Create projection edge linking revision to assertion
         edge = RelationshipProjectionEdgeORM(
             id=str(uuid.uuid4()),
             revision_id=revision_id,
@@ -1354,11 +1372,13 @@ def run_seed_and_publish(db_url: str, deployed_sha: str, run_id: str) -> dict[st
         session.add(revision)
         session.add(assertion)
         session.flush()
+
         session.add(prop_event)
         session.add(det_event)
         session.add(edge)
         session.flush()
 
+        # Create publication
         publication = RelationshipProjectionPublicationORM(
             id=str(uuid.uuid4()),
             revision_id=revision_id,
@@ -1444,7 +1464,11 @@ def _verify_persisted_assertion_history(session: Any, revision: Any) -> tuple[bo
         return False, ["Historical reconstruction revision is missing"]
 
     validator = ProofValidator({})
-    ok = validator.projected_assertion_histories_are_valid(session, revision.id, revision.known_at)
+    ok = validator.projected_assertion_histories_are_valid(
+        session,
+        revision.id,
+        revision.known_at,
+    )
     return ok, validator.errors
 
 

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -751,9 +751,7 @@ class ProofValidator:
                     .select_from(RelationshipProjectionPublicationORM)
                     .where(RelationshipProjectionPublicationORM.rebuild_job_id == bindparam("restart_rebuild_job_id"))
                 )
-                pub_count = int(
-                    conn.execute(count_stmt, {"restart_rebuild_job_id": rebuild_job_id}).scalar() or 0
-                )
+                pub_count = int(conn.execute(count_stmt, {"restart_rebuild_job_id": rebuild_job_id}).scalar() or 0)
                 if pub_count == 0:
                     self.add_error(f"Expected publication for rebuild job {rebuild_job_id} not found")
                     return None

--- a/scripts/check_relationship_assertion_proof.py
+++ b/scripts/check_relationship_assertion_proof.py
@@ -961,6 +961,10 @@ class ProofValidator:
             assertion_id, proposal, initial_acceptance
         ) and self._validate_reacceptance_events(assertion_id, events, proposal, initial_acceptance)
 
+    def assertion_history_is_valid(self, assertion_id: str, events: Sequence[Any]) -> bool:
+        """Validate one persisted assertion lifecycle for helper reuse."""
+        return self._validate_reconstructed_assertion(assertion_id, events)
+
     def _reconstruct_assertion_history_from_db(self, args: argparse.Namespace) -> None:
         """Reconstruct persisted lifecycle history for the certified revision."""
         db_url = os.getenv("DATABASE_URL")
@@ -1423,10 +1427,40 @@ def _verify_scopes_continuity(revision: Any, prev_metadata: dict[str, Any]) -> b
     )
 
 
-def _verify_scopes_and_history(revision: Any, job: Any, prev_metadata: dict[str, Any]) -> tuple[bool, bool]:
+def _verify_persisted_assertion_history(session: Any, revision: Any) -> bool:
+    """Validate persisted assertion lifecycle history for one projected revision."""
+    if not revision:
+        return False
+
+    assertion_ids = [
+        row[0]
+        for row in session.query(RelationshipProjectionEdgeORM.assertion_id)
+        .filter_by(revision_id=revision.id)
+        .distinct()
+        .all()
+        if row[0]
+    ]
+    validator = ProofValidator({})
+    for assertion_id in assertion_ids:
+        events = (
+            session.query(RelationshipAssertionEventORM)
+            .filter_by(assertion_id=assertion_id)
+            .order_by(RelationshipAssertionEventORM.sequence)
+            .all()
+        )
+        if not validator.assertion_history_is_valid(assertion_id, events):
+            return False
+    return True
+
+
+def _verify_scopes_and_history(
+    session: Any, revision: Any, job: Any, prev_metadata: dict[str, Any]
+) -> tuple[bool, bool]:
     """Check scopes continuity and historical reconstruction."""
     scope_continuity_passed = _verify_scopes_continuity(revision, prev_metadata)
-    historical_reconstruction_passed = bool(job and job.status == "succeeded")
+    historical_reconstruction_passed = bool(
+        job and job.status == "succeeded" and _verify_persisted_assertion_history(session, revision)
+    )
     return scope_continuity_passed, historical_reconstruction_passed
 
 
@@ -1441,7 +1475,7 @@ def run_verify_after_restart(
         rebuild_job_id = prev_metadata.get("raw_rebuild_job_id") or run_id
         _, revision, job = _query_verification_data_from_db(session, rebuild_job_id)
         scope_continuity_passed, historical_reconstruction_passed = _verify_scopes_and_history(
-            revision, job, prev_metadata
+            session, revision, job, prev_metadata
         )
 
         return {

--- a/tests/integration/test_relationship_assertion_proof.py
+++ b/tests/integration/test_relationship_assertion_proof.py
@@ -57,19 +57,24 @@ def test_staging_proof_flow_sqlite(test_db_url: str) -> None:
     assert metadata_verify["historical_reconstruction_errors"] == []
 
 
-@patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
-@patch("scripts.check_relationship_assertion_proof.verify_deployed_sha", _no_op)
-@patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
-def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> None:
-    """Reject restart history when persisted assertion events form a discontinuous chain."""
+def _seed_discontinuous_reacceptance(
+    test_db_url: str,
+    run_id: str,
+    *,
+    after_revision_known_at: bool,
+) -> tuple[str, dict[str, Any]]:
+    """Seed one discontinuous reacceptance at or after the revision boundary."""
     import uuid
+    from datetime import timedelta
 
     from sqlalchemy.orm import sessionmaker
 
-    from src.data.relationship_assertion_db_models import RelationshipAssertionEventORM
+    from src.data.relationship_assertion_db_models import (
+        RelationshipAssertionEventORM,
+        RelationshipProjectionRevisionORM,
+    )
 
     deployed_sha = "a" * 40
-    run_id = "test-run-corrupt-history"
     metadata = run_seed_and_publish(test_db_url, deployed_sha, run_id)
 
     engine = create_engine_from_url(test_db_url)
@@ -78,6 +83,11 @@ def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> Non
         with Session() as session:
             seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
             assert seeded_event is not None
+            recorded_at = seeded_event.recorded_at
+            if after_revision_known_at:
+                revision = session.query(RelationshipProjectionRevisionORM).filter_by(id=metadata["raw_revision_id"]).one()
+                recorded_at = revision.known_at + timedelta(seconds=1)
+
             session.add(
                 RelationshipAssertionEventORM(
                     id=str(uuid.uuid4()),
@@ -89,13 +99,28 @@ def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> Non
                     actor_id="determiner-actor-1",
                     rationale="Injected discontinuous reacceptance",
                     policy_version="v1",
-                    recorded_at=seeded_event.recorded_at,
+                    recorded_at=recorded_at,
                     correlation_id=run_id,
                 )
             )
             session.commit()
     finally:
         engine.dispose()
+
+    return deployed_sha, metadata
+
+
+@patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
+@patch("scripts.check_relationship_assertion_proof.verify_deployed_sha", _no_op)
+@patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
+def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> None:
+    """Reject restart history when persisted assertion events form a discontinuous chain."""
+    run_id = "test-run-corrupt-history"
+    deployed_sha, metadata = _seed_discontinuous_reacceptance(
+        test_db_url,
+        run_id,
+        after_revision_known_at=False,
+    )
 
     metadata_verify = run_verify_after_restart(test_db_url, deployed_sha, run_id, metadata)
 
@@ -112,45 +137,12 @@ def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> Non
 @patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
 def test_restart_helper_ignores_events_after_revision_known_at(test_db_url: str) -> None:
     """Ignore lifecycle events recorded after the verified revision knowledge boundary."""
-    import uuid
-    from datetime import timedelta
-
-    from sqlalchemy.orm import sessionmaker
-
-    from src.data.relationship_assertion_db_models import (
-        RelationshipAssertionEventORM,
-        RelationshipProjectionRevisionORM,
-    )
-
-    deployed_sha = "a" * 40
     run_id = "test-run-late-history"
-    metadata = run_seed_and_publish(test_db_url, deployed_sha, run_id)
-
-    engine = create_engine_from_url(test_db_url)
-    Session = sessionmaker(bind=engine)
-    try:
-        with Session() as session:
-            seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
-            revision = session.query(RelationshipProjectionRevisionORM).filter_by(id=metadata["raw_revision_id"]).one()
-            assert seeded_event is not None
-            session.add(
-                RelationshipAssertionEventORM(
-                    id=str(uuid.uuid4()),
-                    assertion_id=seeded_event.assertion_id,
-                    sequence=3,
-                    from_state="Disputed",
-                    to_state="Accepted",
-                    authority="acceptor",
-                    actor_id="determiner-actor-1",
-                    rationale="Post-revision discontinuous reacceptance",
-                    policy_version="v1",
-                    recorded_at=revision.known_at + timedelta(seconds=1),
-                    correlation_id=run_id,
-                )
-            )
-            session.commit()
-    finally:
-        engine.dispose()
+    deployed_sha, metadata = _seed_discontinuous_reacceptance(
+        test_db_url,
+        run_id,
+        after_revision_known_at=True,
+    )
 
     metadata_verify = run_verify_after_restart(test_db_url, deployed_sha, run_id, metadata)
 

--- a/tests/integration/test_relationship_assertion_proof.py
+++ b/tests/integration/test_relationship_assertion_proof.py
@@ -59,6 +59,54 @@ def test_staging_proof_flow_sqlite(test_db_url: str) -> None:
 @patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
 @patch("scripts.check_relationship_assertion_proof.verify_deployed_sha", _no_op)
 @patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
+def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> None:
+    """Reject restart history when persisted assertion events form a discontinuous chain."""
+    import uuid
+    from datetime import datetime, timezone
+
+    from sqlalchemy.orm import sessionmaker
+
+    from src.data.relationship_assertion_db_models import RelationshipAssertionEventORM
+
+    deployed_sha = "a" * 40
+    run_id = "test-run-corrupt-history"
+    metadata = run_seed_and_publish(test_db_url, deployed_sha, run_id)
+
+    engine = create_engine_from_url(test_db_url)
+    Session = sessionmaker(bind=engine)
+    session = Session()
+    try:
+        seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
+        assert seeded_event is not None
+        session.add(
+            RelationshipAssertionEventORM(
+                id=str(uuid.uuid4()),
+                assertion_id=seeded_event.assertion_id,
+                sequence=3,
+                from_state="Disputed",
+                to_state="Accepted",
+                authority="acceptor",
+                actor_id="determiner-actor-1",
+                rationale="Injected discontinuous reacceptance",
+                policy_version="v1",
+                recorded_at=datetime.now(timezone.utc),
+                correlation_id=run_id,
+            )
+        )
+        session.commit()
+    finally:
+        session.close()
+        engine.dispose()
+
+    metadata_verify = run_verify_after_restart(test_db_url, deployed_sha, run_id, metadata)
+
+    assert metadata_verify["scope_continuity_passed"] is True
+    assert metadata_verify["historical_reconstruction_passed"] is False
+
+
+@patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
+@patch("scripts.check_relationship_assertion_proof.verify_deployed_sha", _no_op)
+@patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
 def test_proof_validator_populates_from_db(test_db_url: str, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that ProofValidator correctly populates proposer, determiner, owner, and pub_count from DB."""
     from argparse import Namespace

--- a/tests/integration/test_relationship_assertion_proof.py
+++ b/tests/integration/test_relationship_assertion_proof.py
@@ -85,7 +85,9 @@ def _seed_discontinuous_reacceptance(
             assert seeded_event is not None
             recorded_at = seeded_event.recorded_at
             if after_revision_known_at:
-                revision = session.query(RelationshipProjectionRevisionORM).filter_by(id=metadata["raw_revision_id"]).one()
+                revision = (
+                    session.query(RelationshipProjectionRevisionORM).filter_by(id=metadata["raw_revision_id"]).one()
+                )
                 recorded_at = revision.known_at + timedelta(seconds=1)
 
             session.add(

--- a/tests/integration/test_relationship_assertion_proof.py
+++ b/tests/integration/test_relationship_assertion_proof.py
@@ -54,6 +54,7 @@ def test_staging_proof_flow_sqlite(test_db_url: str) -> None:
     assert metadata_verify["mode"] == "verify_after_restart"
     assert metadata_verify["scope_continuity_passed"] is True
     assert metadata_verify["historical_reconstruction_passed"] is True
+    assert metadata_verify["historical_reconstruction_errors"] == []
 
 
 @patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
@@ -62,7 +63,6 @@ def test_staging_proof_flow_sqlite(test_db_url: str) -> None:
 def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> None:
     """Reject restart history when persisted assertion events form a discontinuous chain."""
     import uuid
-    from datetime import datetime, timezone
 
     from sqlalchemy.orm import sessionmaker
 
@@ -74,34 +74,93 @@ def test_restart_helper_rejects_discontinuous_lifecycle(test_db_url: str) -> Non
 
     engine = create_engine_from_url(test_db_url)
     Session = sessionmaker(bind=engine)
-    session = Session()
     try:
-        seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
-        assert seeded_event is not None
-        session.add(
-            RelationshipAssertionEventORM(
-                id=str(uuid.uuid4()),
-                assertion_id=seeded_event.assertion_id,
-                sequence=3,
-                from_state="Disputed",
-                to_state="Accepted",
-                authority="acceptor",
-                actor_id="determiner-actor-1",
-                rationale="Injected discontinuous reacceptance",
-                policy_version="v1",
-                recorded_at=datetime.now(timezone.utc),
-                correlation_id=run_id,
+        with Session() as session:
+            seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
+            assert seeded_event is not None
+            session.add(
+                RelationshipAssertionEventORM(
+                    id=str(uuid.uuid4()),
+                    assertion_id=seeded_event.assertion_id,
+                    sequence=3,
+                    from_state="Disputed",
+                    to_state="Accepted",
+                    authority="acceptor",
+                    actor_id="determiner-actor-1",
+                    rationale="Injected discontinuous reacceptance",
+                    policy_version="v1",
+                    recorded_at=seeded_event.recorded_at,
+                    correlation_id=run_id,
+                )
             )
-        )
-        session.commit()
+            session.commit()
     finally:
-        session.close()
         engine.dispose()
 
     metadata_verify = run_verify_after_restart(test_db_url, deployed_sha, run_id, metadata)
 
     assert metadata_verify["scope_continuity_passed"] is True
     assert metadata_verify["historical_reconstruction_passed"] is False
+    assert any(
+        "lifecycle state chain is discontinuous" in error
+        for error in metadata_verify["historical_reconstruction_errors"]
+    )
+
+
+@patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)
+@patch("scripts.check_relationship_assertion_proof.verify_deployed_sha", _no_op)
+@patch("scripts.check_relationship_assertion_proof.check_schema_authz_evidence", _no_op)
+def test_restart_helper_ignores_events_after_revision_known_at(test_db_url: str) -> None:
+    """Ignore lifecycle events recorded after the verified revision knowledge boundary."""
+    import uuid
+    from datetime import timedelta
+
+    from sqlalchemy.orm import sessionmaker
+
+    from src.data.relationship_assertion_db_models import (
+        RelationshipAssertionEventORM,
+        RelationshipProjectionRevisionORM,
+    )
+
+    deployed_sha = "a" * 40
+    run_id = "test-run-late-history"
+    metadata = run_seed_and_publish(test_db_url, deployed_sha, run_id)
+
+    engine = create_engine_from_url(test_db_url)
+    Session = sessionmaker(bind=engine)
+    try:
+        with Session() as session:
+            seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
+            revision = (
+                session.query(RelationshipProjectionRevisionORM)
+                .filter_by(id=metadata["raw_revision_id"])
+                .one()
+            )
+            assert seeded_event is not None
+            session.add(
+                RelationshipAssertionEventORM(
+                    id=str(uuid.uuid4()),
+                    assertion_id=seeded_event.assertion_id,
+                    sequence=3,
+                    from_state="Disputed",
+                    to_state="Accepted",
+                    authority="acceptor",
+                    actor_id="determiner-actor-1",
+                    rationale="Post-revision discontinuous reacceptance",
+                    policy_version="v1",
+                    recorded_at=revision.known_at + timedelta(seconds=1),
+                    correlation_id=run_id,
+                )
+            )
+            session.commit()
+    finally:
+        engine.dispose()
+
+    metadata_verify = run_verify_after_restart(test_db_url, deployed_sha, run_id, metadata)
+
+    assert metadata_verify["scope_continuity_passed"] is True
+    assert metadata_verify["historical_reconstruction_passed"] is True
+    assert metadata_verify["historical_reconstruction_errors"] == []
 
 
 @patch("scripts.check_relationship_assertion_proof.check_postgresql_proof", _no_op)

--- a/tests/integration/test_relationship_assertion_proof.py
+++ b/tests/integration/test_relationship_assertion_proof.py
@@ -131,11 +131,7 @@ def test_restart_helper_ignores_events_after_revision_known_at(test_db_url: str)
     try:
         with Session() as session:
             seeded_event = session.query(RelationshipAssertionEventORM).filter_by(correlation_id=run_id).first()
-            revision = (
-                session.query(RelationshipProjectionRevisionORM)
-                .filter_by(id=metadata["raw_revision_id"])
-                .one()
-            )
+            revision = session.query(RelationshipProjectionRevisionORM).filter_by(id=metadata["raw_revision_id"]).one()
             assert seeded_event is not None
             session.add(
                 RelationshipAssertionEventORM(


### PR DESCRIPTION
## **User description**
## Decision

Make the legacy/integration `run_verify_after_restart()` helper derive historical reconstruction from persisted assertion lifecycle events rather than rebuild-job success alone.

## Origin

Follow-up to the Greptile finding raised during #1596. PR #1596 is merged and the production staging-proof CLI path already reconstructs lifecycle history through `ProofValidator.validate_verify_after_restart()` → `_validate_restart_history()` → `_reconstruct_assertion_history_from_db()`.

The remaining defect is limited to the older module-level helper used by integration coverage.

## Change

- reuse the lifecycle validation hardened and merged in #1596 rather than duplicate GRAC transition rules
- expose a small `ProofValidator.assertion_history_is_valid()` wrapper for helper reuse
- load assertion IDs projected by the verified revision
- load each assertion's persisted lifecycle events in sequence order
- require every projected assertion history to pass lifecycle reconstruction before setting `historical_reconstruction_passed=True`
- retain the existing rebuild-job success and scope-continuity checks

## Regression proof

The integration regression seeds the normal valid proof fixture, then appends a sequence-3 `Disputed -> Accepted` event after the persisted sequence-2 `Proposed -> Accepted` event. This respects the append-only persistence boundary but creates a deliberately discontinuous claimed reacceptance.

Expected result:

- `scope_continuity_passed == True`
- `historical_reconstruction_passed == False`

This directly reproduces and closes the fail-open identified in review.

## Scope

Changed only:

- `scripts/check_relationship_assertion_proof.py`
- `tests/integration/test_relationship_assertion_proof.py`

No runtime, API, schema, migration, workflow, authorization, deployment, staging-data, or #1540 evidence/sign-off changes.

Follow-up to #1596.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix legacy restart verification by reconstructing each projected assertion’s lifecycle from persisted events bounded by the revision’s `known_at`. Later events no longer affect earlier revisions, and failures return clear errors.

- **Bug Fixes**
  - Reuse `ProofValidator` to validate projected assertion history; add `projected_assertion_histories_are_valid(...)`.
  - Bound lifecycle event queries to `recorded_at <= revision.known_at`.
  - Require a succeeded rebuild job; include `historical_reconstruction_errors` in output.
  - Add integration tests for discontinuous chains and ignoring post-revision events.

- **Refactors**
  - Automated formatting and minimal typing tweaks (`Any` for sessions/events); no behavior change.

<sup>Written for commit 4513889d916611faf285b0ec9e702948376f33fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Reject legacy restart verification when persisted assertion events are invalid

### What Changed
- Legacy restart verification now reconstructs each assertion’s lifecycle from persisted events before passing historical validation
- Only events known by the verified revision are considered, preventing later events from affecting an earlier revision check
- Missing or failed rebuild jobs and invalid lifecycle chains now produce explicit reconstruction errors
- Added a regression test for discontinuous reacceptance events that previously passed incorrectly

### Impact
`✅ Fewer false-positive restart validations`
`✅ Revision-accurate historical checks`
`✅ Clearer reconstruction failure errors`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Restart verification now evaluates assertion lifecycle history at the published revision’s knowledge boundary. The SQLite integration checks confirm that corruption present by that boundary is rejected and that later lifecycle events do not alter the historical result.

<h3>Confidence Score: 5/5</h3>

No blocking failure remains.

The exercised lifecycle-boundary behavior correctly rejects invalid history known to the revision and excludes events recorded afterward.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the paired pytest command for relationship assertion proofs; the run completed with 2 tests passing in 0.27 seconds.
- The discontinuous lifecycle event at or before the revision boundary failed reconstruction, while the identical event post-boundary after known\_at was ignored and reconstruction passed.
- Pytest reported one non-blocking configuration warning about asyncio\_mode.

<a href="https://app.greptile.com/trex/runs/17825568/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(staging-proof): keep history typing ..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/4513889d916611faf285b0ec9e702948376f33fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51198795)</sub>

<!-- /greptile_comment -->