### PR TITLE
fix(ci): constrain actionlint ignore regex to models permission

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -61,8 +61,10 @@ jobs:
           # Super-Linter v7 bundles actionlint 1.7.1, which does not know the
           # newer GitHub Models permission yet.
           # Space-free regex: Super-Linter splits *_COMMAND_ARGS on spaces
-          # without quote handling (AddOptionsToCommand).
-          GITHUB_ACTIONS_COMMAND_ARGS: -ignore unknown.permission.scope..models.
+          # without quote handling (AddOptionsToCommand). Use \s and escaped
+          # quotes so unescaped "." cannot suppress other unknown-scope
+          # diagnostics such as unknown permission scope "modelsx".
+          GITHUB_ACTIONS_COMMAND_ARGS: -ignore unknown\spermission\sscope\s\"models\"
           # YAML_PRETTIER currently flags broad legacy workflow formatting debt.
           # Keep dedicated workflow semantics checks elsewhere until #1496.
           VALIDATE_YAML_PRETTIER: false

--- a/tests/unit/test_super_linter_workflow.py
+++ b/tests/unit/test_super_linter_workflow.py
@@ -1,0 +1,80 @@
+"""Unit tests for Super-Linter workflow actionlint ignore arguments."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SUPER_LINTER_WORKFLOW = PROJECT_ROOT / ".github" / "workflows" / "super-linter.yml"
+MODELS_PERMISSION_DIAGNOSTIC = 'unknown permission scope "models"'
+MODELSX_PERMISSION_DIAGNOSTIC = 'unknown permission scope "modelsx"'
+
+
+def _github_actions_command_args(workflow: dict) -> str:
+    """Return GITHUB_ACTIONS_COMMAND_ARGS from the Super-Linter run-lint job.
+
+    Args:
+        workflow: Parsed Super-Linter workflow mapping.
+
+    Returns:
+        The command-args string passed through to actionlint.
+
+    Raises:
+        AssertionError: If the env value is missing or not a string.
+    """
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    run_lint = jobs["run-lint"]
+    assert isinstance(run_lint, dict)
+    steps = run_lint["steps"]
+    assert isinstance(steps, list)
+
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        env = step.get("env")
+        if not isinstance(env, dict):
+            continue
+        command_args = env.get("GITHUB_ACTIONS_COMMAND_ARGS")
+        if command_args is not None:
+            assert isinstance(command_args, str)
+            return command_args
+
+    raise AssertionError("GITHUB_ACTIONS_COMMAND_ARGS is not set on any run-lint step")
+
+
+def _actionlint_ignore_pattern(command_args: str) -> str:
+    """Extract the space-free actionlint -ignore regex from command args.
+
+    Super-Linter splits *_COMMAND_ARGS on spaces without quote handling, so the
+    ignore pattern must be a single token after ``-ignore``.
+
+    Args:
+        command_args: Raw GITHUB_ACTIONS_COMMAND_ARGS value.
+
+    Returns:
+        The regular expression passed to actionlint ``-ignore``.
+    """
+    parts = command_args.split()
+    assert parts == ["-ignore", parts[1]], command_args
+    pattern = parts[1]
+    assert " " not in pattern
+    return pattern
+
+
+def test_actionlint_ignore_matches_models_permission_only() -> None:
+    """Ignore the models compatibility diagnostic without hiding modelsx."""
+    with SUPER_LINTER_WORKFLOW.open(encoding="utf-8") as handle:
+        workflow = yaml.safe_load(handle)
+
+    assert isinstance(workflow, dict)
+    pattern = _actionlint_ignore_pattern(_github_actions_command_args(workflow))
+    ignore = re.compile(pattern)
+
+    assert ignore.search(MODELS_PERMISSION_DIAGNOSTIC)
+    assert ignore.search(f"{MODELS_PERMISSION_DIAGNOSTIC}. all available permission scopes are")
+    assert ignore.search(MODELSX_PERMISSION_DIAGNOSTIC) is None
+    assert ignore.search('unknown permission scope "contents"') is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Architectural Alignment

- Backend: FastAPI (production path)
- Frontend: Next.js (production path)
- Gradio: non-production (demo/testing only)

CI-only follow-up. No production runtime or architecture changes.

## Primary Objective

Constrain Super-Linter's actionlint `-ignore` regex so it suppresses only the known `models` permission compatibility diagnostic, not other unknown-scope errors.

## Scope

### In Scope

- Replace the unescaped `unknown.permission.scope..models.` pattern with a space-free regex that uses `\s` and escaped quotes
- Keep a single-token `-ignore` argument compatible with Super-Linter `AddOptionsToCommand` space splitting
- Add a unit test that the ignore pattern matches `unknown permission scope "models"` and does not match `"modelsx"`

### Out of Scope

- Upgrading Super-Linter or bundled actionlint past v7 / 1.7.1
- Changing GitHub Models permission usage in workflows
- Re-enabling other Super-Linter validators

### Files Expected to Change

- `.github/workflows/super-linter.yml` — constrain `GITHUB_ACTIONS_COMMAND_ARGS`
- `tests/unit/test_super_linter_workflow.py` — lock in models-only ignore behavior

## Validation Commands

```bash
pytest tests/unit/test_super_linter_workflow.py -v
pre-commit run --files .github/workflows/super-linter.yml tests/unit/test_super_linter_workflow.py
```

Also verified with actionlint v1.7.1 against a fixture workflow containing both `models` and `modelsx` permissions: the previous dotted pattern suppressed both diagnostics; the new pattern leaves `unknown permission scope "modelsx"` visible.

## Merge Criteria

- [x] Scope is tightly aligned to the Primary Objective
- [x] Validation commands pass locally or in CI
- [x] Changes align with production architecture (FastAPI + Next.js)

## Checklist

### Scope Compliance

- [x] This PR makes one primary decision only (see Primary Objective)
- [x] I have explicitly listed what is out of scope
- [x] I have verified the branch, base branch, and referenced PR/commit/ref context before concluding merge status or PR necessity
- [x] I have checked this PR against the production architecture (`FastAPI` backend + `Next.js` frontend)
- [x] I have checked this PR against `.github/AUTOMATION_SCOPE_POLICY.md`

This addresses the review on #1605: unescaped `.` in the actionlint ignore regex was an unanchored wildcard and also suppressed `unknown permission scope "modelsx"`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44c4d217-ef7c-4372-9457-fe52c5318674?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44c4d217-ef7c-4372-9457-fe52c5318674&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Constrain the `actionlint` ignore regex so CI suppresses only the known “unknown permission scope "models"” diagnostic and stops hiding unrelated errors like “modelsx”.

- Update `.github/workflows/super-linter.yml` to set `GITHUB_ACTIONS_COMMAND_ARGS` to `-ignore unknown\spermission\sscope\s\"models\"`, keeping a single-token pattern compatible with `Super-Linter` space splitting.
- Add `tests/unit/test_super_linter_workflow.py` to assert the pattern matches `"models"` diagnostics and does not match `"modelsx"` or other scopes.
- CI-only; no runtime changes. Super-Linter v7 bundles `actionlint` 1.7.1, so this targets that compatibility diagnostic only.

<sup>Written for commit 0a45b3a28ee8e509cc8d230e9da6c8d60f3711b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change narrows the actionlint suppression for the GitHub Models permission diagnostic and adds coverage for the intended match boundary. Runtime validation found that the escaping is removed before actionlint receives the expression, so workflows using `models: read` still fail Super-Linter.

<h3>Confidence Score: 4/5</h3>

Not safe to merge until the Super-Linter argument survives its shell-processing path and suppresses the intended Models permission diagnostic.

An executable comparison of the previous and current workflow configuration reproduced the failure with actionlint 1.7.1 and the Super-Linter v7 GNU Parallel invocation shape. The current unit test passes but does not exercise that invocation behavior.

**Files Needing Attention:** .github/workflows/super-linter.yml needs an argument representation that remains intact through GNU Parallel; tests/unit/test_super_linter_workflow.py should validate that runtime argument path.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex executed the Super-Linter actionlint ignore reproducer source and reviewed the related logs to validate the posted P1 finding.
- T-Rex produced a second finding-proof for the posted P1 finding.
- T-Rex performed a general-contract-validation-proof showing that the suppression for models no longer holds after GNU Parallel processes backslash escapes.

<a href="https://app.greptile.com/trex/runs/18704346/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Escaped actionlint ignore pattern is stripped before execution and no longer suppresses models**

   - **Bug**
     - `.github/workflows/super-linter.yml:67` supplies `-ignore unknown\spermission\sscope\s\"models\"` as one Super-Linter command-array element. Super-Linter v7 passes that element to GNU Parallel, which builds a shell command; shell processing removes the backslashes. Actionlint 1.7.1 therefore receives the regex `unknownspermissionsscopes"models"`, which cannot match its space-separated `unknown permission scope "models"` diagnostic. The focused runtime repro emitted the `models` diagnostic with exit 1 on HEAD.
   - **Cause**
     - The PR test assumes `GITHUB_ACTIONS_COMMAND_ARGS.split()` directly produces actionlint argv. In the pinned Super-Linter v7 implementation, the whole environment value is appended as one array element and GNU Parallel subsequently shell-parses it, changing the escaped regex before actionlint receives it.
   - **Fix**
     - Pass an ignore argument representation that survives GNU Parallel’s shell parsing and verify it through the real Super-Linter/GNU Parallel command path; update the unit test to exercise that path rather than Python regex matching alone.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22cursor%2Fescape-actionlint-ignore-regex-8674%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fescape-actionlint-ignore-regex-8674%22.%0A%0AGreploop%20dashfin-fardb%2Ffinancial-asset-relationship-db%20PR%20%231630%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1630&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22cursor%2Fescape-actionlint-ignore-regex-8674%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22cursor%2Fescape-actionlint-ignore-regex-8674%22.%0A%0A%23%23%23%20Issue%201%0A.github%2Fworkflows%2Fsuper-linter.yml%3A67%0A**Escaped%20actionlint%20pattern%20is%20stripped%20before%20execution**%0A%0ASuper-Linter%20v7%20passes%20this%20command%20argument%20through%20GNU%20Parallel%2C%20whose%20shell%20processing%20removes%20the%20backslashes.%20Actionlint%201.7.1%20consequently%20receives%20a%20pattern%20equivalent%20to%20%60unknownspermissionsscopes%5C%22models%5C%22%60%2C%20which%20cannot%20match%20%60unknown%20permission%20scope%20%22models%22%60.%20A%20workflow%20declaring%20%60models%3A%20read%60%20will%20therefore%20still%20emit%20the%20diagnostic%20and%20fail%20Super-Linter.%20Use%20an%20argument%20representation%20that%20survives%20this%20processing%20layer%2C%20and%20cover%20the%20actual%20invocation%20path%20rather%20than%20only%20Python%20%60split%28%29%60%2Fregex%20behavior.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1630&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
.github/workflows/super-linter.yml:67
**Escaped actionlint pattern is stripped before execution**

Super-Linter v7 passes this command argument through GNU Parallel, whose shell processing removes the backslashes. Actionlint 1.7.1 consequently receives a pattern equivalent to `unknownspermissionsscopes\"models\"`, which cannot match `unknown permission scope "models"`. A workflow declaring `models: read` will therefore still emit the diagnostic and fail Super-Linter. Use an argument representation that survives this processing layer, and cover the actual invocation path rather than only Python `split()`/regex behavior.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): constrain actionlint ignore reg..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/0a45b3a28ee8e509cc8d230e9da6c8d60f3711b7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52973211)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->