### PR TITLE
ci(vercel): skip knowledge-only preview builds

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"knowledge/architecture-expert\" ]; then exit 0; else exit 1; fi",
   "builds": [
     {
       "src": "api/main.py",


### PR DESCRIPTION
## **User description**
## Primary Objective

Suppress Vercel build execution for the generated `knowledge/architecture-expert` branch only.

## Work programme

QH-01 — exclude generated architecture-memory pushes from Vercel previews.

**Exact base:** `main@03412bc31755c4f2f74a87a115855c09c8db989b`

## In scope

- Add Vercel's repository-controlled `ignoreCommand`.
- Return exit code 0 only when `VERCEL_GIT_COMMIT_REF` is exactly `knowledge/architecture-expert`.
- Preserve production (`main`), every other preview branch, routes, build definitions, and runtime behavior.

## Out of scope

- Database, API, frontend, secret, provider credential, and deployment changes.
- Changing the Architecture Compound workflow or the knowledge-branch generator.
- Other preview filtering, monorepo optimizations, or Vercel dashboard mutations.

## Verification

- `vercel.json` parses as JSON.
- The command's two outcomes are explicit: exit 0 for the generated knowledge branch; exit 1 for all other refs.
- After Vercel evaluates this PR, verify that its own preview proceeds and that a subsequent knowledge-branch push is skipped.

## Completion

This is complete only when Vercel records the knowledge branch as ignored while `main` and ordinary PR preview deployments remain eligible.

___

## **CodeAnt-AI Description**
Skip Vercel previews for generated knowledge-only updates

### What Changed
- Vercel now skips builds when the update comes from the `knowledge/architecture-expert` branch
- Production builds and previews from all other branches remain eligible to run

### Impact
`✅ Fewer unnecessary preview builds`
`✅ Lower CI and deployment usage for knowledge updates`
`✅ Unchanged previews for application branches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip Vercel preview builds for the generated knowledge/architecture-expert branch to reduce noise. Previously, Vercel built previews for every branch; now it ignores only this branch and keeps main and all other previews unchanged.

- Adds `ignoreCommand` in `vercel.json`: exit 0 for `knowledge/architecture-expert`, exit 1 for all others.
- No changes to routes, build definitions, runtime, or production deploys.
- Verify this PR’s preview builds, and a push to `knowledge/architecture-expert` is ignored.
- Satisfies QH-01 requirement to exclude generated architecture-memory pushes from Vercel previews.

<sup>Written for commit 629451335f081fcfa7732eab8df1d4ea9f2eac7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This change refreshes pinned GitHub Actions versions, skips the secret-dependent Snyk container scan for Dependabot pull requests, and prevents Vercel from deploying the generated `knowledge/architecture-expert` branch.

The changed workflow and Vercel configuration parsed successfully. The checkout v7.0.1 updates do not introduce a privileged checkout of untrusted pull-request code: the two changed workflows using that pin are push-only. The Vercel command was executed with both relevant references and correctly skips only `knowledge/architecture-expert` while allowing an ordinary preview ref to proceed.

No defects were found. The change is safe to merge.

<h3>Confidence Score: 5/5</h3>

The workflow pin updates and Vercel branch filter preserve the intended CI and deployment behavior.

The changed configuration was parsed, the checkout trigger and settings were inspected, and the exact Vercel ignore command was executed for both the excluded branch and an ordinary preview branch.

**Files Needing Attention:** No files need follow-up attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A baseline configuration validation against origin/main was performed and found no changed workflows and no ignore command.
- A head PR validation run for PR #1632 completed successfully, with YAML/JSON parsing passing, privileged/untrusted checkout count of 0, and both Vercel exit-code checks passing.
- Validation concluded that there were no applicable findings to inspect further.

<a href="https://app.greptile.com/trex/runs/18711067/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22dashfin-fardb%2Ffinancial-asset-relationship-db%22%20on%20the%20existing%20branch%20%22codex%2Fqh-01-ignore-knowledge-previews%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fqh-01-ignore-knowledge-previews%22.%0A%0AGreploop%20dashfin-fardb%2Ffinancial-asset-relationship-db%20PR%20%231632%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AAFTER%20THE%20LOOP%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF&repo=dashfin-fardb%2Ffinancial-asset-relationship-db&pr=1632&platform=github"><img alt="Fix All in Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=1"></a>

<sub>Reviews (1): Last reviewed commit: ["ci(vercel): skip knowledge-only preview ..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/629451335f081fcfa7732eab8df1d4ea9f2eac7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52985221)</sub>

<!-- /greptile_comment -->