### PR TITLE
docs(cq-03): clarify restricted provider receipt

### DIFF
--- a/docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md
+++ b/docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md
@@ -167,7 +167,8 @@ separately authorized provider login-membership handoff whose role identities an
 operator material. Its public ledger file preserves the exact timestamp, approved purpose, transaction policy, and
 bounded receipt provenance, but contains no executable membership statement, login identity, OID, DSN, or credential.
 This is a sanitized external-action receipt, not placeholder schema SQL: the provider membership remains outside the
-schema ledger, is not run by `db reset`, and is verified only through the existing restricted runtime-authority checks.
+schema ledger; `supabase db reset` processes the comments-only file as a no-op and never executes the omitted provider
+action; the end state is verified only through the existing restricted runtime-authority checks.
 
 Schema state not explained by the replayable receipts belongs in a later, reviewed reconciliation migration. The
 existing six receipts need no history repair; only that new reconciliation timestamp can become the separately
@@ -216,7 +217,8 @@ already equals the reviewed ledger state.
   executable ledger SQL.
 - A sanitized external-action receipt may preserve an already-recorded provider timestamp only when the action is
   outside repository schema authority, its executable statement would disclose restricted operator identities, the
-  public file is explicitly non-executable, and restricted verification proves the intended end state. Such a receipt
+  public file contains comments only and no executable SQL, and restricted verification proves the intended end
+  state. Such a receipt
   cannot satisfy a schema migration, create a role, grant membership, or authorize provider mutation.
 
 ## Forward and rollback policy

--- a/docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md
+++ b/docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md
@@ -162,10 +162,18 @@ hosted-history adoption as separate decisions while preventing a second PostgreS
 
 The six observed provider receipts retain their exact timestamp identities as six immutable ledger entries in
 `supabase/migrations/`. CQ-03B must recover and review the SQL for each receipt; it must not collapse them into one
-synthetic baseline or create placeholder SQL. Schema state not explained by those six entries belongs in a later,
-reviewed reconciliation migration. The existing six receipts need no history repair; only that new reconciliation
-timestamp can become the separately approved Phase C history-only adoption candidate. If any receipt SQL cannot be
-recovered or proven, CQ-03B stops and returns to human decision.
+synthetic baseline. Five receipts contain replayable schema or capability-role SQL. The remaining receipt records a
+separately authorized provider login-membership handoff whose role identities and credential topology are restricted
+operator material. Its public ledger file preserves the exact timestamp, approved purpose, transaction policy, and
+bounded receipt provenance, but contains no executable membership statement, login identity, OID, DSN, or credential.
+This is a sanitized external-action receipt, not placeholder schema SQL: the provider membership remains outside the
+schema ledger, is not run by `db reset`, and is verified only through the existing restricted runtime-authority checks.
+
+Schema state not explained by the replayable receipts belongs in a later, reviewed reconciliation migration. The
+existing six receipts need no history repair; only that new reconciliation timestamp can become the separately
+approved Phase C history-only adoption candidate. If any replayable receipt SQL cannot be recovered or proven, or the
+restricted membership receipt cannot be reconciled by bounded operator evidence, CQ-03B stops and returns to human
+decision.
 
 ### Phase B — prove the repository ledger and drift gate (CQ-03B/C)
 
@@ -204,7 +212,12 @@ already equals the reviewed ledger state.
 - A migration header states its control issue, managed schemas, transaction policy, lock expectation, data/backfill
   behavior, rollback or restore path, and whether a provider capability is required.
 - SQL must be deterministic and must not interpolate secrets or environment-specific object identities.
-- Seed/demo data, live data copies, login roles, passwords, and connection details never enter the ledger.
+- Seed/demo data, live data copies, login roles, role memberships, OIDs, passwords, and connection details never enter
+  executable ledger SQL.
+- A sanitized external-action receipt may preserve an already-recorded provider timestamp only when the action is
+  outside repository schema authority, its executable statement would disclose restricted operator identities, the
+  public file is explicitly non-executable, and restricted verification proves the intended end state. Such a receipt
+  cannot satisfy a schema migration, create a role, grant membership, or authorize provider mutation.
 
 ## Forward and rollback policy
 


### PR DESCRIPTION
## Primary Objective

Clarify accepted ADR 0009 so CQ-03B can reconcile the sixth provider migration receipt without publishing restricted runtime login identities or pretending provider membership is replayable schema SQL.

Work-programme ID: **CQ-03 / ADR clarification**

Exact base: `main@37966ff386a3ce6cf2c0164a8b4fd53179ec2ddd`

## In Scope

- Preserve all six observed provider timestamp identities.
- Define the sixth entry as a sanitized, non-executable external-action receipt.
- Keep provider login creation and membership outside repository schema authority.
- Require bounded restricted evidence to verify the external membership end state.
- Preserve the CQ-03D separate provider-history approval boundary.

## Out of Scope

- No migration files or executable SQL.
- No login names, OIDs, DSNs, passwords, provider topology, or credential-bearing commands.
- No Supabase schema/history/role/credential mutation.
- No runtime, migration-command, dependency, CI, Compose, or deployment change.
- No CQ-03B implementation or CQ-03D adoption.

## Files Expected to Change

- `docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md` — clarify the already-accepted recovery boundary.

## Validation Commands

Local shell validation was unavailable because this desktop task cannot start its WSL runner. Connector-based exact-ref validation completed:

- exact compare against `main@37966ff386a3ce6cf2c0164a8b4fd53179ec2ddd`;
- one changed file, 18 additions and 5 deletions;
- restricted-identifier scan confirmed no runtime login names, OIDs, or operator identity were introduced;
- live Supabase catalog corroboration was read-only and made no provider change.

CI and review on this PR must provide formatting and governed-document validation.

## Merge Criteria

- [ ] Review confirms the sanitized receipt is provenance, not executable or placeholder schema SQL.
- [ ] No restricted operational identifiers are disclosed.
- [ ] Provider login creation/membership remains a human-controlled operation.
- [ ] CQ-03B can preserve timestamp parity without replaying or publishing credential topology.
- [ ] All substantive review threads and authoritative CI gates clear.

Closes no issue; unblocks the bounded CQ-03B implementation under #1633.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies ADR 0009 so five provider receipts remain replayable SQL and the sixth is a sanitized, non-executable external-action receipt; `supabase db reset` treats the sixth as a no-op. This keeps restricted login/membership out of the ledger while preserving timestamp parity for CQ-03B.

- Updates `docs/adr/0009-postgresql-migration-ledger-and-drift-contract.md` to define the sanitized external-action receipt: timestamp, approved purpose, transaction policy, bounded provenance only; no executable membership, login identities, OIDs, DSNs, or credentials.
- Clarifies `supabase db reset` behavior: the comments-only receipt is processed as a no-op and never executes the omitted provider action.
- Restates ledger boundaries and sanitized-receipt constraints: seed/demo data, login roles, role memberships, OIDs, passwords, and connection details never enter executable ledger SQL; a sanitized receipt is comments-only, outside repository schema authority, requires restricted verification, and cannot satisfy a schema migration or grant membership.
- Sets CQ-03B expectations: recover and review the five replayable receipts; reconcile the restricted receipt via bounded operator evidence; halt if recovery or verification fails. No migrations, runtime changes, or provider mutations.

<sup>Written for commit e3478dd1d981888cd8fd306ff543083b99c8508a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/DashFin-FarDb/financial-asset-relationship-db/pull/1636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This documentation-only change defines how CQ-03B can preserve six provider migration timestamps while keeping restricted provider login-membership details outside executable repository migrations. It clarifies that the restricted entry is a comments-only external-action receipt, requires restricted end-state verification, and retains CQ-03D as the separate approval boundary for hosted-history adoption.

No author-actionable defects were found.

## T-Rex validation blocked

The behavior claimed for comments-only migration files could not be executed because the local container service is missing: Docker and an alternative container runtime were unavailable. Supabase CLI started successfully, but `supabase db reset` failed during local-service inspection before it could process the migration fixture. This should be exercised in CI or another disposable Docker-enabled environment before CQ-03B operationally relies on that behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge as a documentation-only clarification with no reported defects.

The changed ADR boundaries consistently preserve restricted provider details outside the public executable ledger, and no defect was demonstrated.

**Files Needing Attention:** No file requires changes in this pull request. Before CQ-03B uses the documented receipt pattern operationally, validate the comments-only migration reset behavior in a Docker-enabled environment.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A disposable Supabase fixture with a timestamped comments-only migration was prepared and a reset was attempted using the Supabase CLI 2.114.0, but the process exited during local-service inspection because no Docker or container runtime was available, so no‑op verification could not be exercised.
- The observed reset result showed the command terminated during service inspection with exit code 1, reflecting the absence of a running container runtime.
- T-Rex produced a proof for the posted P1 finding.
- Artifacts documenting the test setup and results were attached to enable review of the fixture, the observed reset result, and the tooling status.

<a href="https://app.greptile.com/trex/runs/18757973/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<!-- greptile_failed_comments -->
<h3>Comments Outside Diff (1)</h3>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Comments-only migration receipt claim is unverified because the local Supabase runtime is unavailable**

   - **Bug**
     - The minimal fixture could not reach migration execution, so there is no executed proof that `supabase db reset` accepts a comments-only SQL file as a no-op.
   - **Cause**
     - The environment has no `docker` or alternative container runtime (`docker: not found`; `podman` absent). Supabase CLI therefore fails during local service inspection before applying migrations.
   - **Fix**
     - Run the same fixture in CI or a disposable host with Docker/Compose available, then retain paired reset output showing a successful reset and the applied migration receipt.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["docs(cq-03): clarify receipt reset behav..."](https://github.com/dashfin-fardb/financial-asset-relationship-db/commit/e3478dd1d981888cd8fd306ff543083b99c8508a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53082396)</sub>

<!-- /greptile_comment -->